### PR TITLE
mac: emulate middle click with option/command-click

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Mouse:
   horizontal in-view axis (hold Shift or Ctrl for a line plot)
 - Right click: vertical line plot (2-D); in 3-D moves the slice along the
   vertical in-view axis (hold Shift or Ctrl for a line plot)
+- On macOS, Option-click or Command-click acts as a middle click
 - Mouse wheel: zoom; double click: refit to the window
 
 Keys: B toggles grid boxes, 0 fits to the window, 1-6 pick fixed scales

--- a/src/qt/ImageView.cpp
+++ b/src/qt/ImageView.cpp
@@ -70,6 +70,7 @@ void ImageView::setImage(const QImage& image)
     m_cellHighlightItem = nullptr;
     m_lineGuide = nullptr;
     m_lineDragButton = Qt::NoButton;
+    m_lineDragEmulated = false;
     m_image = image;
     m_item = m_scene->addPixmap(QPixmap::fromImage(m_image));
     m_scene->setSceneRect(m_item->boundingRect());
@@ -404,10 +405,28 @@ void ImageView::mousePressEvent(QMouseEvent* event)
     if (event->button() == Qt::LeftButton) {
         m_pressPosition = event->position().toPoint();
     }
-    if ((event->button() == Qt::MiddleButton || event->button() == Qt::RightButton)
+    auto button = event->button();
+    auto emulated = false;
+#ifdef Q_OS_MAC
+    // Mac pointing devices often have no middle button (Magic Mouse,
+    // trackpads): Option-click or Command-click emulates one. On macOS those
+    // keys report as AltModifier and ControlModifier respectively.
+    if (button == Qt::LeftButton
+        && (event->modifiers() & (Qt::AltModifier | Qt::ControlModifier))) {
+        button = Qt::MiddleButton;
+        emulated = true;
+    }
+#endif
+    if ((button == Qt::MiddleButton || button == Qt::RightButton)
         && hasImage()) {
-        m_lineDragButton = event->button();
+        m_lineDragButton = button;
+        m_lineDragEmulated = emulated;
         m_linePressPosition = event->position().toPoint();
+        if (emulated) {
+            // Swallow the physical left press so RubberBandDrag does not
+            // start a rubber-band zoom under the emulated middle drag.
+            return;
+        }
     }
     QGraphicsView::mousePressEvent(event);
 }
@@ -415,9 +434,14 @@ void ImageView::mousePressEvent(QMouseEvent* event)
 void ImageView::mouseReleaseEvent(QMouseEvent* event)
 {
     QGraphicsView::mouseReleaseEvent(event);
-    if (event->button() == m_lineDragButton && m_lineDragButton != Qt::NoButton) {
+    const auto lineDragRelease = m_lineDragButton != Qt::NoButton
+        && (event->button() == m_lineDragButton
+            || (m_lineDragEmulated && event->button() == Qt::LeftButton));
+    if (lineDragRelease) {
         const auto button = m_lineDragButton;
+        const auto emulated = m_lineDragEmulated;
         m_lineDragButton = Qt::NoButton;
+        m_lineDragEmulated = false;
         clearLineGuide();
         if (!hasImage()) {
             return;
@@ -430,10 +454,17 @@ void ImageView::mouseReleaseEvent(QMouseEvent* event)
             0, m_image.width() - 1);
         const auto y = std::clamp(static_cast<int>(std::floor(imagePosition.y())),
             0, m_image.height() - 1);
+        auto modifiers = event->modifiers();
+        if (emulated) {
+            // The modifier that stood in for the middle button must not count
+            // toward the Shift/Ctrl line-plot override below.
+            modifiers &= ~(Qt::AltModifier | Qt::ControlModifier);
+        }
         const auto linePlotModifiers
             = Qt::ShiftModifier | Qt::ControlModifier;
+        event->accept();
         if (m_sliceMoveEnabled
-            && (event->modifiers() & linePlotModifiers) == Qt::NoModifier) {
+            && (modifiers & linePlotModifiers) == Qt::NoModifier) {
             emit sliceMoveRequested(x, y, button);
         } else {
             emit linePlotRequested(x, y, button);
@@ -447,6 +478,7 @@ void ImageView::mouseReleaseEvent(QMouseEvent* event)
     const auto drag = releasePosition - m_pressPosition;
     constexpr int minimumDrag = 4;
     if (std::abs(drag.x()) > minimumDrag && std::abs(drag.y()) > minimumDrag) {
+        event->accept();
         emit rubberBandSelected(QRectF(mapToScene(m_pressPosition),
             mapToScene(releasePosition)).normalized());
         return;
@@ -455,6 +487,7 @@ void ImageView::mouseReleaseEvent(QMouseEvent* event)
     const auto x = static_cast<int>(std::floor(imagePosition.x()));
     const auto y = static_cast<int>(std::floor(imagePosition.y()));
     if (x >= 0 && y >= 0 && x < m_image.width() && y < m_image.height()) {
+        event->accept();
         emit probeClicked(x, y);
     }
 }

--- a/src/qt/ImageView.hpp
+++ b/src/qt/ImageView.hpp
@@ -122,6 +122,10 @@ private:
     QString m_indicatorV;
     QPoint m_pressPosition;
     Qt::MouseButton m_lineDragButton = Qt::NoButton;
+    // True when the line drag was started by an emulated middle click (macOS
+    // Option/Command-click), so the physical button differs from
+    // m_lineDragButton and the emulation modifier is not a line-plot override.
+    bool m_lineDragEmulated = false;
     QPoint m_linePressPosition;
     QGraphicsLineItem* m_lineGuide = nullptr;
     bool m_sliceMoveEnabled = false;

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -1825,6 +1825,9 @@ void MainWindow::showKeyboardMouseReference()
     add(tr("Right click (3-D)"),
         tr("Move the slice along the vertical axis "
            "(hold Shift or Ctrl for a line plot)"));
+#ifdef Q_OS_MAC
+    add(tr("Option/Command click"), tr("Emulate a middle click"));
+#endif
     add(tr("Wheel / double click"), tr("Zoom in or out / refit to the window"));
     add(tr("B"), tr("Toggle AMR grid boxes"));
     add(tr("0"), tr("Fit to the window"));

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -62,6 +62,28 @@ add_executable(fixture_materializer fixture_materializer/main.cpp)
 target_link_libraries(fixture_materializer PRIVATE Amrvis::warnings)
 
 if(TARGET amrvis_qt)
+    # Widget-level test for ImageView; compiles the view standalone so its
+    # event handlers can be exercised without the full application.
+    find_package(Qt6 6.4 REQUIRED COMPONENTS Test)
+    add_executable(test_image_view
+        unit/test_image_view.cpp
+        "${CMAKE_CURRENT_SOURCE_DIR}/../src/qt/ImageView.cpp"
+    )
+    set_target_properties(test_image_view PROPERTIES AUTOMOC ON)
+    target_include_directories(test_image_view
+        PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../src/qt"
+    )
+    target_link_libraries(test_image_view
+        PRIVATE Amrvis::warnings Qt6::Test Qt6::Widgets
+    )
+    target_compile_features(test_image_view PRIVATE cxx_std_20)
+    add_test(
+        NAME image_view
+        COMMAND "${CMAKE_COMMAND}" -E env QT_QPA_PLATFORM=offscreen
+            "$<TARGET_FILE:test_image_view>"
+    )
+    set_tests_properties(image_view PROPERTIES TIMEOUT 30)
+
     add_test(
         NAME qt_metadata_smoke
         COMMAND "${CMAKE_COMMAND}" -E env QT_QPA_PLATFORM=offscreen

--- a/tests/unit/test_image_view.cpp
+++ b/tests/unit/test_image_view.cpp
@@ -1,0 +1,212 @@
+// ABOUTME: Tests ImageView mouse gestures through delivered events: probes,
+// ABOUTME: line plots, slice moves, and the macOS middle-click emulation.
+
+#include "ImageView.hpp"
+
+#include <QCoreApplication>
+#include <QImage>
+#include <QPoint>
+#include <QSignalSpy>
+#include <QtTest>
+
+using amrvis::qt::ImageView;
+
+namespace {
+
+QImage solidImage()
+{
+    QImage image(64, 64, QImage::Format_ARGB32_Premultiplied);
+    image.fill(Qt::darkGray);
+    return image;
+}
+
+bool showView(ImageView& view)
+{
+    view.resize(400, 400);
+    view.show();
+    return QTest::qWaitForWindowExposed(&view);
+}
+
+QPoint viewCenter(const ImageView& view)
+{
+    return view.viewport()->rect().center();
+}
+
+} // namespace
+
+class TestImageView final : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void leftClickProbes();
+    void middleClickRequestsLinePlot();
+    void middleClickMovesSliceWhenSliceMoveEnabled();
+    void middleClickWithControlKeepsLinePlotOverride();
+#ifdef Q_OS_MAC
+    void emulatedClickRequestsLinePlot_data();
+    void emulatedClickRequestsLinePlot();
+    void emulatedClickMovesSliceWhenSliceMoveEnabled_data();
+    void emulatedClickMovesSliceWhenSliceMoveEnabled();
+    void shiftOptionClickKeepsLinePlotOverride();
+    void modifierReleasedBeforeButtonStillEmits();
+    void emulatedDragSuppressesRubberBand();
+#endif
+};
+
+void TestImageView::leftClickProbes()
+{
+    ImageView view;
+    view.setImage(solidImage());
+    QVERIFY(showView(view));
+    QSignalSpy probeSpy(&view, &ImageView::probeClicked);
+    QSignalSpy lineSpy(&view, &ImageView::linePlotRequested);
+    QTest::mouseClick(view.viewport(), Qt::LeftButton, Qt::NoModifier,
+        viewCenter(view));
+    QTRY_COMPARE(probeSpy.count(), 1);
+    QCoreApplication::processEvents();
+    QCOMPARE(lineSpy.count(), 0);
+}
+
+void TestImageView::middleClickRequestsLinePlot()
+{
+    ImageView view;
+    view.setImage(solidImage());
+    QVERIFY(showView(view));
+    QSignalSpy lineSpy(&view, &ImageView::linePlotRequested);
+    QTest::mouseClick(view.viewport(), Qt::MiddleButton, Qt::NoModifier,
+        viewCenter(view));
+    QTRY_COMPARE(lineSpy.count(), 1);
+    QCOMPARE(lineSpy.takeFirst().at(2).value<Qt::MouseButton>(), Qt::MiddleButton);
+}
+
+void TestImageView::middleClickMovesSliceWhenSliceMoveEnabled()
+{
+    ImageView view;
+    view.setImage(solidImage());
+    view.setSliceMoveEnabled(true);
+    QVERIFY(showView(view));
+    QSignalSpy sliceSpy(&view, &ImageView::sliceMoveRequested);
+    QSignalSpy lineSpy(&view, &ImageView::linePlotRequested);
+    QTest::mouseClick(view.viewport(), Qt::MiddleButton, Qt::NoModifier,
+        viewCenter(view));
+    QTRY_COMPARE(sliceSpy.count(), 1);
+    QCOMPARE(sliceSpy.takeFirst().at(2).value<Qt::MouseButton>(), Qt::MiddleButton);
+    QCoreApplication::processEvents();
+    QCOMPARE(lineSpy.count(), 0);
+}
+
+void TestImageView::middleClickWithControlKeepsLinePlotOverride()
+{
+    ImageView view;
+    view.setImage(solidImage());
+    view.setSliceMoveEnabled(true);
+    QVERIFY(showView(view));
+    QSignalSpy sliceSpy(&view, &ImageView::sliceMoveRequested);
+    QSignalSpy lineSpy(&view, &ImageView::linePlotRequested);
+    QTest::mouseClick(view.viewport(), Qt::MiddleButton, Qt::ControlModifier,
+        viewCenter(view));
+    QTRY_COMPARE(lineSpy.count(), 1);
+    QCoreApplication::processEvents();
+    QCOMPARE(sliceSpy.count(), 0);
+}
+
+#ifdef Q_OS_MAC
+void TestImageView::emulatedClickRequestsLinePlot_data()
+{
+    QTest::addColumn<Qt::KeyboardModifiers>("modifiers");
+    QTest::newRow("option-click") << Qt::KeyboardModifiers(Qt::AltModifier);
+    QTest::newRow("command-click") << Qt::KeyboardModifiers(Qt::ControlModifier);
+}
+
+void TestImageView::emulatedClickRequestsLinePlot()
+{
+    QFETCH(Qt::KeyboardModifiers, modifiers);
+    ImageView view;
+    view.setImage(solidImage());
+    QVERIFY(showView(view));
+    QSignalSpy probeSpy(&view, &ImageView::probeClicked);
+    QSignalSpy lineSpy(&view, &ImageView::linePlotRequested);
+    QTest::mouseClick(view.viewport(), Qt::LeftButton, modifiers, viewCenter(view));
+    QTRY_COMPARE(lineSpy.count(), 1);
+    QCOMPARE(lineSpy.takeFirst().at(2).value<Qt::MouseButton>(), Qt::MiddleButton);
+    QCoreApplication::processEvents();
+    QCOMPARE(probeSpy.count(), 0);
+}
+
+void TestImageView::emulatedClickMovesSliceWhenSliceMoveEnabled_data()
+{
+    QTest::addColumn<Qt::KeyboardModifiers>("modifiers");
+    QTest::newRow("option-click") << Qt::KeyboardModifiers(Qt::AltModifier);
+    QTest::newRow("command-click") << Qt::KeyboardModifiers(Qt::ControlModifier);
+}
+
+void TestImageView::emulatedClickMovesSliceWhenSliceMoveEnabled()
+{
+    QFETCH(Qt::KeyboardModifiers, modifiers);
+    ImageView view;
+    view.setImage(solidImage());
+    view.setSliceMoveEnabled(true);
+    QVERIFY(showView(view));
+    QSignalSpy sliceSpy(&view, &ImageView::sliceMoveRequested);
+    QSignalSpy lineSpy(&view, &ImageView::linePlotRequested);
+    QTest::mouseClick(view.viewport(), Qt::LeftButton, modifiers, viewCenter(view));
+    // A plain emulated middle click must act like a plain middle click even
+    // though Command reports as ControlModifier, the line-plot override.
+    QTRY_COMPARE(sliceSpy.count(), 1);
+    QCOMPARE(sliceSpy.takeFirst().at(2).value<Qt::MouseButton>(), Qt::MiddleButton);
+    QCoreApplication::processEvents();
+    QCOMPARE(lineSpy.count(), 0);
+}
+
+void TestImageView::shiftOptionClickKeepsLinePlotOverride()
+{
+    ImageView view;
+    view.setImage(solidImage());
+    view.setSliceMoveEnabled(true);
+    QVERIFY(showView(view));
+    QSignalSpy sliceSpy(&view, &ImageView::sliceMoveRequested);
+    QSignalSpy lineSpy(&view, &ImageView::linePlotRequested);
+    QTest::mouseClick(view.viewport(), Qt::LeftButton,
+        Qt::AltModifier | Qt::ShiftModifier, viewCenter(view));
+    QTRY_COMPARE(lineSpy.count(), 1);
+    QCOMPARE(lineSpy.takeFirst().at(2).value<Qt::MouseButton>(), Qt::MiddleButton);
+    QCoreApplication::processEvents();
+    QCOMPARE(sliceSpy.count(), 0);
+}
+
+void TestImageView::modifierReleasedBeforeButtonStillEmits()
+{
+    ImageView view;
+    view.setImage(solidImage());
+    QVERIFY(showView(view));
+    QSignalSpy lineSpy(&view, &ImageView::linePlotRequested);
+    QTest::mousePress(view.viewport(), Qt::LeftButton, Qt::AltModifier,
+        viewCenter(view));
+    QTest::mouseRelease(view.viewport(), Qt::LeftButton, Qt::NoModifier,
+        viewCenter(view));
+    QTRY_COMPARE(lineSpy.count(), 1);
+    QCOMPARE(lineSpy.takeFirst().at(2).value<Qt::MouseButton>(), Qt::MiddleButton);
+}
+
+void TestImageView::emulatedDragSuppressesRubberBand()
+{
+    ImageView view;
+    view.setImage(solidImage());
+    QVERIFY(showView(view));
+    QSignalSpy rubberBandSpy(&view, &ImageView::rubberBandSelected);
+    QSignalSpy lineSpy(&view, &ImageView::linePlotRequested);
+    const auto center = viewCenter(view);
+    QTest::mousePress(view.viewport(), Qt::LeftButton, Qt::AltModifier,
+        center - QPoint(40, 40));
+    QTest::mouseMove(view.viewport(), center + QPoint(40, 40));
+    QTest::mouseRelease(view.viewport(), Qt::LeftButton, Qt::AltModifier,
+        center + QPoint(40, 40));
+    QTRY_COMPARE(lineSpy.count(), 1);
+    QCoreApplication::processEvents();
+    QCOMPARE(rubberBandSpy.count(), 0);
+}
+#endif
+
+QTEST_MAIN(TestImageView)
+#include "test_image_view.moc"


### PR DESCRIPTION
Emulates middle click with option-click or command-click, following the behavior of X11 on Mac.

Useful for trackpads.