### PR TITLE
Fix contours

### DIFF
--- a/include/amrvis/render2d/Contours.hpp
+++ b/include/amrvis/render2d/Contours.hpp
@@ -23,9 +23,10 @@ struct ContourPolyline {
     bool closed = false;
 };
 
-// Legacy Amrvis contour placement: count lines at
-// value_i = minimum + (0.5 + i) / count * (maximum - minimum).
-[[nodiscard]] std::vector<double> contourValues(double minimum, double maximum, int count);
+// Places count lines at the midpoint of equal-width intervals in either
+// linear value space or logarithmic value space.
+[[nodiscard]] std::vector<double> contourValues(
+    double minimum, double maximum, int count, bool logarithmic = false);
 
 // Refines a scalar plane by bilinear interpolation so contour extraction on
 // the result produces genuinely smooth iso-lines instead of cell-scale

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -501,7 +501,7 @@ void appendVectorGlyphs(const std::shared_ptr<PlotfileDataset>& dataset,
 // refreshCachedSlice).
 void appendContours(const std::shared_ptr<PlotfileDataset>& dataset,
     const SliceRequest& request, int contourCount, double minimum, double maximum,
-    std::stop_token cancellation, SliceDisplayResult& result)
+    bool logarithmic, std::stop_token cancellation, SliceDisplayResult& result)
 {
     const auto& metadata = dataset->metadata();
     const auto level = std::min(request.maximumLevel, metadata.finestLevel);
@@ -536,7 +536,8 @@ void appendContours(const std::shared_ptr<PlotfileDataset>& dataset,
     // the fine plane too so refreshCachedSlice can reuse it.
     result.contourFinePlane = result.contourPlane;
     result.contourFineFactor = 1;
-    const auto values = contourValues(minimum, maximum, contourCount);
+    const auto values = contourValues(
+        minimum, maximum, contourCount, logarithmic);
     result.contourPolylines = contourPolylinesForDisplay(
         result.contourFinePlane, 1, values, displayWidth, displayHeight);
 }
@@ -588,7 +589,8 @@ SliceDisplayResult refreshCachedSlice(
         result.contourPlane = std::move(contourPlane);
         result.contourFinePlane = std::move(contourFinePlane);
         result.contourFineFactor = contourFineFactor;
-        const auto values = contourValues(range.minimum, range.maximum, contourCount);
+        const auto values = contourValues(
+            range.minimum, range.maximum, contourCount, range.logarithmic);
         result.contourPolylines = contourPolylinesForDisplay(
             result.contourFinePlane, contourFineFactor, values,
             request.outputSize[0], request.outputSize[1]);
@@ -759,7 +761,8 @@ InitialSliceResult executeFrameLoad(const std::filesystem::path& path,
         display.contourCount = spec.contourCount;
         if (isContourMode(spec.displayMode)) {
             appendContours(result.dataset, request, spec.contourCount,
-                display.minimum, display.maximum, cancellation, display);
+                display.minimum, display.maximum, display.logarithmic,
+                cancellation, display);
         }
         if (spec.displayMode == DisplayMode::VelocityVectors) {
             const auto u = std::min(spec.vectorUField, fieldCount - 1);
@@ -3688,7 +3691,7 @@ void MainWindow::requestSlice(PlaneViewState& state, bool rasterDirty)
             result.contourCount = contourCount;
             if (isContourMode(displayMode)) {
                 appendContours(dataset, request, contourCount, result.minimum,
-                    result.maximum, cancellation, result);
+                    result.maximum, result.logarithmic, cancellation, result);
             }
             if (displayMode == DisplayMode::VelocityVectors) {
                 appendVectorGlyphs(dataset, request, FieldId{vectorUField},

--- a/src/render2d/Contours.cpp
+++ b/src/render2d/Contours.cpp
@@ -14,7 +14,8 @@
 
 namespace amrvis {
 
-std::vector<double> contourValues(double minimum, double maximum, int count)
+std::vector<double> contourValues(
+    double minimum, double maximum, int count, bool logarithmic)
 {
     if (count < 1) {
         throw std::invalid_argument("contour count must be positive");
@@ -22,11 +23,18 @@ std::vector<double> contourValues(double minimum, double maximum, int count)
     if (!(minimum < maximum)) {
         throw std::invalid_argument("contour range must have positive extent");
     }
+    if (logarithmic && !(minimum > 0.0)) {
+        throw std::invalid_argument("logarithmic contour range must be positive");
+    }
     std::vector<double> values(static_cast<std::size_t>(count));
-    const double span = maximum - minimum;
+    const double rangeMinimum = logarithmic ? std::log(minimum) : minimum;
+    const double rangeMaximum = logarithmic ? std::log(maximum) : maximum;
+    const double span = rangeMaximum - rangeMinimum;
     for (int i = 0; i < count; ++i) {
+        const auto value = rangeMinimum
+            + (0.5 + static_cast<double>(i)) / count * span;
         values[static_cast<std::size_t>(i)] =
-            minimum + (0.5 + static_cast<double>(i)) / count * span;
+            logarithmic ? std::exp(value) : value;
     }
     return values;
 }

--- a/src/render2d/Contours.cpp
+++ b/src/render2d/Contours.cpp
@@ -156,9 +156,9 @@ std::vector<ContourSegment> generateContours(
     // the contour levels collapse onto that single value and marching squares
     // marks every edge of every cell as crossed, tiling the image with spurious
     // saddle segments. Detect the flat case from the actual data instead. The
-    // threshold mirrors the range padding in resolveRange (1e-6 of the field
-    // scale); a field varying less than that is effectively constant, and its
-    // contours would be a visually solid mass anyway.
+    // Treat variation below 1e-6 of the field's own magnitude as effectively
+    // constant. Do not impose an absolute scale floor: fields such as density
+    // routinely have meaningful variation entirely below 1e-20.
     double dataMinimum = 0.0;
     double dataMaximum = 0.0;
     bool hasFinite = false;
@@ -183,7 +183,7 @@ std::vector<ContourSegment> generateContours(
         return segments;
     }
     const auto scale = std::max(
-        {std::fabs(dataMinimum), std::fabs(dataMaximum), 1.0});
+        std::fabs(dataMinimum), std::fabs(dataMaximum));
     if (dataMaximum - dataMinimum <= 1.0e-6 * scale) {
         return segments;
     }

--- a/tests/unit/test_contours.cpp
+++ b/tests/unit/test_contours.cpp
@@ -122,20 +122,39 @@ int main()
     require(nearlyEqual(values.back(), 0.95), "last contour value mismatch");
     require(nearlyEqual(values[5] - values[4], 0.1), "contour spacing mismatch");
 
+    const auto logValues = amrvis::contourValues(1.0, 1000.0, 3, true);
+    require(logValues.size() == 3, "log contourValues returned the wrong count");
+    require(nearlyEqual(logValues[0], std::sqrt(10.0)),
+        "first logarithmic contour value mismatch");
+    require(nearlyEqual(logValues[1], std::sqrt(1000.0)),
+        "middle logarithmic contour value mismatch");
+    require(nearlyEqual(logValues[2], 100.0 * std::sqrt(10.0)),
+        "last logarithmic contour value mismatch");
+    require(nearlyEqual(logValues[1] / logValues[0], 10.0)
+            && nearlyEqual(logValues[2] / logValues[1], 10.0),
+        "logarithmic contours are not evenly spaced by ratio");
+
     bool threw = false;
     try {
-        (void)amrvis::contourValues(0.0, 1.0, 0);
+        (void)amrvis::contourValues(0.0, 1.0, 0, false);
     } catch (const std::invalid_argument&) {
         threw = true;
     }
     require(threw, "contourValues accepted a zero count");
     threw = false;
     try {
-        (void)amrvis::contourValues(1.0, 1.0, 4);
+        (void)amrvis::contourValues(1.0, 1.0, 4, false);
     } catch (const std::invalid_argument&) {
         threw = true;
     }
     require(threw, "contourValues accepted an empty range");
+    threw = false;
+    try {
+        (void)amrvis::contourValues(0.0, 1.0, 4, true);
+    } catch (const std::invalid_argument&) {
+        threw = true;
+    }
+    require(threw, "contourValues accepted a non-positive logarithmic range");
 
     // Cells whose value range brackets 2.5: (0,0), (1,0), (2,0), (0,1).
     const auto plane = makePlane();

--- a/tests/unit/test_contours.cpp
+++ b/tests/unit/test_contours.cpp
@@ -146,6 +146,15 @@ int main()
         require(nearlyEqual(segment.value, 2.5), "segment value field mismatch");
     }
 
+    auto tinyPlane = makePlane();
+    for (auto& value : tinyPlane.values) {
+        value *= 1.0e-24F;
+    }
+    const auto tinySegments =
+        amrvis::generateContours(tinyPlane, {2.5e-24});
+    require(tinySegments.size() == 4,
+        "small-magnitude varying field was treated as constant");
+
     // Invalidating corner (1, 1) must suppress the four cells touching it,
     // leaving only cell (2, 0).
     auto masked = makePlane();


### PR DESCRIPTION
This has two fixes for contour plotting:
* small values (field magnitudes < 1e-6) can now be contoured. We have very small density values in cgs units.
* contours are equally spaced in log when a log-spaced colorbar is used