### PR TITLE
Test for C++ features explicitly and link std::threads

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,32 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
+include(CheckCXXSourceCompiles)
+find_package(Threads REQUIRED)
+check_cxx_source_compiles([=[
+    #include <compare>
+
+    struct Value {
+        int value;
+
+        constexpr auto operator<=>(const Value&) const = default;
+    };
+
+    int main()
+    {
+        static_assert(Value{1} < Value{2});
+        return 0;
+    }
+]=] AMRVIS_HAS_REQUIRED_CXX20_SUPPORT)
+
+if(NOT AMRVIS_HAS_REQUIRED_CXX20_SUPPORT)
+    message(FATAL_ERROR
+        "Amrvis2 requires a compiler and standard library with C++20 support "
+        "(including <compare> and defaulted comparisons). "
+        "The configured compiler is ${CMAKE_CXX_COMPILER_ID} "
+        "${CMAKE_CXX_COMPILER_VERSION} at ${CMAKE_CXX_COMPILER}.")
+endif()
+
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 include(AmrvisWarnings)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 include(CheckCXXSourceCompiles)
+set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
 check_cxx_source_compiles([=[
     #include <compare>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -52,7 +52,13 @@ target_link_libraries(test_slice_query PRIVATE Amrvis::query Amrvis::warnings)
 add_test(NAME slice_query COMMAND test_slice_query)
 
 add_executable(test_line_query integration/test_line_query.cpp)
-target_link_libraries(test_line_query PRIVATE Amrvis::query Amrvis::warnings)
+target_link_libraries(
+    test_line_query
+    PRIVATE
+        Amrvis::query
+        Amrvis::warnings
+        Threads::Threads
+)
 add_test(
     NAME line_query
     COMMAND test_line_query

--- a/tools/line_repro/CMakeLists.txt
+++ b/tools/line_repro/CMakeLists.txt
@@ -1,3 +1,9 @@
 add_executable(line_repro main.cpp)
-target_link_libraries(line_repro PRIVATE Amrvis::query Amrvis::warnings)
+target_link_libraries(
+    line_repro
+    PRIVATE
+        Amrvis::query
+        Amrvis::warnings
+        Threads::Threads
+)
 target_compile_features(line_repro PRIVATE cxx_std_20)


### PR DESCRIPTION
* Check for the required C++20 stdlib headers `<compare>` explicitly.
* Test for a working spaceship operator `<=>`.
* `std::threads` is linked explicitly.

This was discovered when building Amrvis2 on Andes with the default compiler (GCC 9), which is missing stdlib support and spaceship operator support. Use `gcc/14.2.0` instead (still requires explicit linking to threads).