### PR TITLE
Allow reading large plotfiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,5 +136,15 @@ amrvis2 --slice-smoke-test <plotfile>  # metadata + initial slice
 amrvis2 --sequence-smoke-test <pltA> <pltB>
 ```
 
+Each open dataset gets a 1 GiB LRU cache by default. Set
+`AMRVIS_CACHE_SIZE_MB` to a positive integer number of megabytes (MiB) to
+change its initial size:
+
+```bash
+AMRVIS_CACHE_SIZE_MB=2048 amrvis2 plotfile-dir  # 2 GiB
+```
+
+An unset, invalid, or zero value retains the 1 GiB default.
+
 Preferences persist through QSettings (organization and application name
 Amrvis2), e.g. `~/.config/Amrvis2/Amrvis2.conf` on Linux.

--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_executable(amrvis_qt
     AnimationPanel.cpp
     AnimationPanel.hpp
+    CacheConfig.hpp
     ColorBarWidget.cpp
     ColorBarWidget.hpp
     DatasetExtract.hpp

--- a/src/qt/CacheConfig.hpp
+++ b/src/qt/CacheConfig.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <charconv>
+#include <cstddef>
 #include <cstdint>
 #include <cstdlib>
 #include <limits>
@@ -15,9 +16,7 @@ inline constexpr std::string_view cacheSizeEnvironmentVariable
     = "AMRVIS_CACHE_SIZE_MB";
 inline constexpr std::uint64_t bytesPerMegabyte = 1024ULL * 1024ULL;
 
-inline std::uint64_t initialCacheBudget(
-    const char* configuredValue
-    = std::getenv(cacheSizeEnvironmentVariable.data())) noexcept
+inline std::uint64_t initialCacheBudget(const char* configuredValue) noexcept
 {
     if (configuredValue == nullptr) {
         return defaultInitialCacheBudget;
@@ -33,6 +32,23 @@ inline std::uint64_t initialCacheBudget(
         return defaultInitialCacheBudget;
     }
     return megabytes * bytesPerMegabyte;
+}
+
+inline std::uint64_t initialCacheBudget() noexcept
+{
+#if defined(_MSC_VER)
+    char* configuredValue = nullptr;
+    std::size_t configuredValueSize = 0;
+    const auto readError = ::_dupenv_s(&configuredValue,
+        &configuredValueSize, cacheSizeEnvironmentVariable.data());
+    const auto budget = readError == 0
+        ? initialCacheBudget(configuredValue) : defaultInitialCacheBudget;
+    std::free(configuredValue);
+    return budget;
+#else
+    return initialCacheBudget(
+        std::getenv(cacheSizeEnvironmentVariable.data()));
+#endif
 }
 
 } // namespace amrvis::qt

--- a/src/qt/CacheConfig.hpp
+++ b/src/qt/CacheConfig.hpp
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <charconv>
+#include <cstdint>
+#include <cstdlib>
+#include <limits>
+#include <string_view>
+#include <system_error>
+
+namespace amrvis::qt {
+
+inline constexpr std::uint64_t defaultInitialCacheBudget
+    = 1ULL * 1024ULL * 1024ULL * 1024ULL;
+inline constexpr std::string_view cacheSizeEnvironmentVariable
+    = "AMRVIS_CACHE_SIZE_MB";
+inline constexpr std::uint64_t bytesPerMegabyte = 1024ULL * 1024ULL;
+
+inline std::uint64_t initialCacheBudget(
+    const char* configuredValue
+    = std::getenv(cacheSizeEnvironmentVariable.data())) noexcept
+{
+    if (configuredValue == nullptr) {
+        return defaultInitialCacheBudget;
+    }
+
+    const std::string_view text(configuredValue);
+    std::uint64_t megabytes = 0;
+    const auto [end, error]
+        = std::from_chars(text.data(), text.data() + text.size(), megabytes);
+    if (error != std::errc{} || end != text.data() + text.size()
+        || megabytes == 0
+        || megabytes > std::numeric_limits<std::uint64_t>::max() / bytesPerMegabyte) {
+        return defaultInitialCacheBudget;
+    }
+    return megabytes * bytesPerMegabyte;
+}
+
+} // namespace amrvis::qt

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -95,7 +95,7 @@
 namespace amrvis::qt {
 namespace {
 
-constexpr std::uint64_t initialCacheBudget = 256ULL * 1024ULL * 1024ULL;
+constexpr std::uint64_t initialCacheBudget = 1ULL * 1024ULL * 1024ULL * 1024ULL;
 
 // Sequence frame loads and prefetches get dataset ids from a dedicated range
 // so they never collide with the ids openDataset derives from m_generation.
@@ -630,6 +630,31 @@ LevelSelection decodeLevelData(int data, int finestLevel)
     return {CompositionPolicy::ExactLevel, data};
 }
 
+QString cacheFallbackMessage(const InitialSliceResult& result)
+{
+    return QObject::tr(
+        "The finest slice exceeded the 1 GiB cache budget. "
+        "The plotfile was opened using levels 0 through %1 instead of "
+        "levels 0 through %2; higher-resolution levels were omitted.")
+        .arg(result.cacheFallbackToLevel)
+        .arg(result.cacheFallbackFromLevel);
+}
+
+void selectCacheFallbackLevel(
+    QComboBox* selector, const InitialSliceResult& result)
+{
+    if (result.cacheFallbackToLevel < 0) {
+        return;
+    }
+    const auto data = result.cacheFallbackToLevel == 0
+        ? 0 : kUpdateToLevelOffset + result.cacheFallbackToLevel;
+    const auto index = selector->findData(data);
+    if (index >= 0) {
+        const QSignalBlocker blocker(selector);
+        selector->setCurrentIndex(index);
+    }
+}
+
 void populateLevelCombo(QComboBox* combo, int finestLevel)
 {
     combo->clear();
@@ -714,6 +739,9 @@ InitialSliceResult executeFrameLoad(const std::filesystem::path& path,
                     <= metadata.finestLevel)
             ? spec.levelSelection
             : -1;
+    const auto selectedLevel = decodeLevelData(
+        levelSelection, metadata.finestLevel);
+    auto attemptMaximumLevel = selectedLevel.maximumLevel;
     std::array<double, 3> positions{0.0, 0.0, 0.0};
     for (std::size_t axis = 0; axis < 3; ++axis) {
         const auto lower = metadata.physicalDomain.lower[axis];
@@ -729,99 +757,120 @@ InitialSliceResult executeFrameLoad(const std::filesystem::path& path,
     // keeps its single y-normal display plane.
     const std::vector<int> normals = metadata.dimension == 3
         ? std::vector<int>{0, 1, 2} : std::vector<int>{1};
-    result.displays.reserve(normals.size());
-    for (std::size_t entry = 0; entry < normals.size(); ++entry) {
-        const auto normal = normals[entry];
-        SliceRequest request;
-        request.dataset = datasetId;
-        request.field = FieldId{field};
-        request.normalDirection = normal;
-        // A preserved zoom region is clipped to the new frame's domain; if
-        // it no longer intersects at all, fall back to the whole domain.
-        auto region = entry < spec.visibleRegions.size()
-            && spec.visibleRegions[entry].has_value()
-                ? *spec.visibleRegions[entry] : metadata.physicalDomain;
-        for (int axis = 0; axis < metadata.dimension; ++axis) {
-            const auto index = static_cast<std::size_t>(axis);
-            auto lower = std::max(region.lower[index],
-                metadata.physicalDomain.lower[index]);
-            auto upper = std::min(region.upper[index],
-                metadata.physicalDomain.upper[index]);
-            if (!(lower < upper)) {
-                lower = metadata.physicalDomain.lower[index];
-                upper = metadata.physicalDomain.upper[index];
+    for (;;) {
+        try {
+            result.displays.clear();
+            result.displays.reserve(normals.size());
+            for (std::size_t entry = 0; entry < normals.size(); ++entry) {
+                const auto normal = normals[entry];
+                SliceRequest request;
+                request.dataset = datasetId;
+                request.field = FieldId{field};
+                request.normalDirection = normal;
+                // A preserved zoom region is clipped to the new frame's domain; if
+                // it no longer intersects at all, fall back to the whole domain.
+                auto region = entry < spec.visibleRegions.size()
+                    && spec.visibleRegions[entry].has_value()
+                        ? *spec.visibleRegions[entry] : metadata.physicalDomain;
+                for (int axis = 0; axis < metadata.dimension; ++axis) {
+                    const auto index = static_cast<std::size_t>(axis);
+                    auto lower = std::max(region.lower[index],
+                        metadata.physicalDomain.lower[index]);
+                    auto upper = std::min(region.upper[index],
+                        metadata.physicalDomain.upper[index]);
+                    if (!(lower < upper)) {
+                        lower = metadata.physicalDomain.lower[index];
+                        upper = metadata.physicalDomain.upper[index];
+                    }
+                    region.lower[index] = lower;
+                    region.upper[index] = upper;
+                }
+                request.visibleRegion = region;
+                request.outputSize = finestNativeOutputSize(
+                    metadata, request.visibleRegion, request.normalDirection);
+                request.composition = selectedLevel.composition;
+                request.maximumLevel = attemptMaximumLevel;
+                if (metadata.dimension == 3) {
+                    request.physicalPosition = positions[static_cast<std::size_t>(normal)];
+                }
+                auto display = executeSlice(result.dataset, request, spec.rangeMode,
+                    spec.userRange, spec.logarithmic, spec.palette, cancellation);
+                display.mode = spec.displayMode;
+                display.contourCount = spec.contourCount;
+                if (isContourMode(spec.displayMode)) {
+                    appendContours(result.dataset, request, spec.contourCount,
+                        display.minimum, display.maximum, display.logarithmic,
+                        cancellation, display);
+                }
+                if (spec.displayMode == DisplayMode::VelocityVectors) {
+                    const auto u = std::min(spec.vectorUField, fieldCount - 1);
+                    const auto v = std::min(spec.vectorVField, fieldCount - 1);
+                    const auto w = std::min(spec.vectorWField, fieldCount - 1);
+                    auto [f1, f2] = (metadata.dimension == 3)
+                        ? (normal == 0 ? std::pair{v, w}
+                           : normal == 1 ? std::pair{u, w}
+                           : std::pair{u, v})
+                        : std::pair{u, v};
+                    display.vectorUField = f1;
+                    display.vectorVField = f2;
+                    appendVectorGlyphs(result.dataset, request,
+                        FieldId{f1}, FieldId{f2},
+                        spec.contourCount, cancellation, display);
+                }
+                result.displays.push_back(std::move(display));
             }
-            region.lower[index] = lower;
-            region.upper[index] = upper;
-        }
-        request.visibleRegion = region;
-        request.outputSize = finestNativeOutputSize(
-            metadata, request.visibleRegion, request.normalDirection);
-        const auto [composition, maximumLevel] = decodeLevelData(
-            levelSelection, metadata.finestLevel);
-        request.composition = composition;
-        request.maximumLevel = maximumLevel;
-        if (metadata.dimension == 3) {
-            request.physicalPosition = positions[static_cast<std::size_t>(normal)];
-        }
-        auto display = executeSlice(result.dataset, request, spec.rangeMode,
-            spec.userRange, spec.logarithmic, spec.palette, cancellation);
-        display.mode = spec.displayMode;
-        display.contourCount = spec.contourCount;
-        if (isContourMode(spec.displayMode)) {
-            appendContours(result.dataset, request, spec.contourCount,
-                display.minimum, display.maximum, display.logarithmic,
-                cancellation, display);
-        }
-        if (spec.displayMode == DisplayMode::VelocityVectors) {
-            const auto u = std::min(spec.vectorUField, fieldCount - 1);
-            const auto v = std::min(spec.vectorVField, fieldCount - 1);
-            const auto w = std::min(spec.vectorWField, fieldCount - 1);
-            auto [f1, f2] = (metadata.dimension == 3)
-                ? (normal == 0 ? std::pair{v, w}
-                   : normal == 1 ? std::pair{u, w}
-                   : std::pair{u, v})
-                : std::pair{u, v};
-            display.vectorUField = f1;
-            display.vectorVField = f2;
-            appendVectorGlyphs(result.dataset, request,
-                FieldId{f1}, FieldId{f2},
-                spec.contourCount, cancellation, display);
-        }
-        result.displays.push_back(std::move(display));
-    }
-    // In 3-D, every views' "Visible" range must agree so the single color bar
-    // maps all three panels consistently. Compute the union of finite extrema
-    // across all three planes and re-render each display with the shared range.
-    if (result.displays.size() == 3 && spec.rangeMode == RangeMode::Visible) {
-        double globalMin = std::numeric_limits<double>::infinity();
-        double globalMax = -std::numeric_limits<double>::infinity();
-        for (const auto& d : result.displays) {
-            const auto [lo, hi] = finiteRange(d.slice.plane);
-            globalMin = std::min(globalMin, lo);
-            globalMax = std::max(globalMax, hi);
-        }
-        const auto logarithmic = spec.logarithmic;
-        if (globalMin == globalMax) {
-            if (logarithmic && globalMin > 0.0) {
-                globalMin /= 1.0 + 1.0e-6;
-                globalMax *= 1.0 + 1.0e-6;
-            } else {
-                const auto pad = std::max(std::abs(globalMin), 1.0) * 1.0e-6;
-                globalMin -= pad;
-                globalMax += pad;
+            // In 3-D, every views' "Visible" range must agree so the single color bar
+            // maps all three panels consistently. Compute the union of finite extrema
+            // across all three planes and re-render each display with the shared range.
+            if (result.displays.size() == 3 && spec.rangeMode == RangeMode::Visible) {
+                double globalMin = std::numeric_limits<double>::infinity();
+                double globalMax = -std::numeric_limits<double>::infinity();
+                for (const auto& d : result.displays) {
+                    const auto [lo, hi] = finiteRange(d.slice.plane);
+                    globalMin = std::min(globalMin, lo);
+                    globalMax = std::max(globalMax, hi);
+                }
+                const auto logarithmic = spec.logarithmic;
+                if (globalMin == globalMax) {
+                    if (logarithmic && globalMin > 0.0) {
+                        globalMin /= 1.0 + 1.0e-6;
+                        globalMax *= 1.0 + 1.0e-6;
+                    } else {
+                        const auto pad = std::max(std::abs(globalMin), 1.0) * 1.0e-6;
+                        globalMin -= pad;
+                        globalMax += pad;
+                    }
+                }
+                for (auto& d : result.displays) {
+                    d.minimum = globalMin;
+                    d.maximum = globalMax;
+                    d.image = renderScalarPlane(d.slice.plane,
+                        ScalarRenderSettings{
+                            .minimum = globalMin,
+                            .maximum = globalMax,
+                            .logarithmic = d.logarithmic,
+                            .palette = &spec.palette
+                        });
+                }
             }
-        }
-        for (auto& d : result.displays) {
-            d.minimum = globalMin;
-            d.maximum = globalMax;
-            d.image = renderScalarPlane(d.slice.plane,
-                ScalarRenderSettings{
-                    .minimum = globalMin,
-                    .maximum = globalMax,
-                    .logarithmic = d.logarithmic,
-                    .palette = &spec.palette
-                });
+            break;
+        } catch (const CacheBudgetExceeded&) {
+            result.displays.clear();
+            result.dataset->clearUnpinnedCache();
+            if (selectedLevel.composition != CompositionPolicy::FinestAvailable) {
+                throw std::runtime_error(
+                    "The selected slice level cannot fit in the 1 GiB cache. "
+                    "Choose a lower level or rebuild with a larger cache budget.");
+            }
+            if (attemptMaximumLevel == 0) {
+                throw std::runtime_error(
+                    "The slice cannot fit in the 1 GiB cache, even at level 0. "
+                    "Try a smaller plotfile or rebuild with a larger cache budget.");
+            }
+            if (result.cacheFallbackFromLevel < 0) {
+                result.cacheFallbackFromLevel = attemptMaximumLevel;
+            }
+            result.cacheFallbackToLevel = --attemptMaximumLevel;
         }
     }
     return result;
@@ -3385,6 +3434,7 @@ void MainWindow::requestInitialSlice(
                 if (generation == m_generation) {
                     m_dataset = result.dataset;
                     configureSliceControls();
+                    selectCacheFallbackLevel(m_levelSelector, result);
                     if (result.displays.size() != views.size()) {
                         throw std::runtime_error(
                             "initial slice count does not match the view set");
@@ -3401,6 +3451,10 @@ void MainWindow::requestInitialSlice(
                     m_cacheResidentBytes = cache.residentBytes;
                     m_cachePinnedBytes = cache.pinnedBytes;
                     m_cacheEvictions = cache.evictions;
+                    if (result.cacheFallbackToLevel >= 0) {
+                        QMessageBox::warning(this, tr("Reduced level detail"),
+                            cacheFallbackMessage(result));
+                    }
                     emit initialSliceFinished(true);
                 } else {
                     ++m_staleResults;
@@ -4372,6 +4426,7 @@ void MainWindow::displayFrameResult(InitialSliceResult& result,
     showMetadata(frameMetadata, m_datasetPath);
 
     configureSequenceControls(defaultPositions);
+    selectCacheFallbackLevel(m_levelSelector, result);
     const auto views = currentViews();
     if (result.displays.size() != views.size()) {
         throw std::runtime_error("frame slice count does not match the view set");
@@ -4385,6 +4440,10 @@ void MainWindow::displayFrameResult(InitialSliceResult& result,
     m_cachePinnedBytes = cache.pinnedBytes;
     m_cacheEvictions = cache.evictions;
     validateVectorMode();
+    if (result.cacheFallbackToLevel >= 0) {
+        QMessageBox::warning(this, tr("Reduced level detail"),
+            cacheFallbackMessage(result));
+    }
 }
 
 void MainWindow::configureSequenceControls(bool defaultPositions)

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -1,5 +1,6 @@
 #include "MainWindow.hpp"
 #include "AnimationPanel.hpp"
+#include "CacheConfig.hpp"
 #include "ColorBarWidget.hpp"
 #include "DatasetWindow.hpp"
 #include "ImageView.hpp"
@@ -94,8 +95,6 @@
 
 namespace amrvis::qt {
 namespace {
-
-constexpr std::uint64_t initialCacheBudget = 1ULL * 1024ULL * 1024ULL * 1024ULL;
 
 // Sequence frame loads and prefetches get dataset ids from a dedicated range
 // so they never collide with the ids openDataset derives from m_generation.
@@ -630,12 +629,32 @@ LevelSelection decodeLevelData(int data, int finestLevel)
     return {CompositionPolicy::ExactLevel, data};
 }
 
+QString cacheBudgetDescription(std::uint64_t bytes)
+{
+    constexpr std::uint64_t kibibyte = 1024;
+    constexpr std::uint64_t mebibyte = 1024 * kibibyte;
+    constexpr std::uint64_t gibibyte = 1024 * mebibyte;
+    if (bytes % gibibyte == 0) {
+        return QObject::tr("%1 GiB").arg(bytes / gibibyte);
+    }
+    if (bytes % mebibyte == 0) {
+        return QObject::tr("%1 MiB").arg(bytes / mebibyte);
+    }
+    if (bytes % kibibyte == 0) {
+        return QObject::tr("%1 KiB").arg(bytes / kibibyte);
+    }
+    return QObject::tr("%1 bytes").arg(bytes);
+}
+
 QString cacheFallbackMessage(const InitialSliceResult& result)
 {
+    const auto budget = cacheBudgetDescription(
+        result.dataset->cacheMetrics().budgetBytes);
     return QObject::tr(
-        "The finest slice exceeded the 1 GiB cache budget. "
-        "The plotfile was opened using levels 0 through %1 instead of "
-        "levels 0 through %2; higher-resolution levels were omitted.")
+        "The finest slice exceeded the %1 cache budget. "
+        "The plotfile was opened using levels 0 through %2 instead of "
+        "levels 0 through %3; higher-resolution levels were omitted.")
+        .arg(budget)
         .arg(result.cacheFallbackToLevel)
         .arg(result.cacheFallbackFromLevel);
 }
@@ -712,8 +731,9 @@ InitialSliceResult executeFrameLoad(const std::filesystem::path& path,
     DatasetId datasetId, const FrameSliceSpec& spec, std::stop_token cancellation)
 {
     InitialSliceResult result;
+    const auto cacheBudget = initialCacheBudget();
     result.dataset = std::make_shared<PlotfileDataset>(
-        path, datasetId, initialCacheBudget);
+        path, datasetId, cacheBudget);
     const auto& metadata = result.dataset->metadata();
     if (metadata.fields.empty()) {
         throw std::runtime_error("dataset has no scalar fields to display");
@@ -858,14 +878,18 @@ InitialSliceResult executeFrameLoad(const std::filesystem::path& path,
             result.displays.clear();
             result.dataset->clearUnpinnedCache();
             if (selectedLevel.composition != CompositionPolicy::FinestAvailable) {
-                throw std::runtime_error(
-                    "The selected slice level cannot fit in the 1 GiB cache. "
-                    "Choose a lower level or rebuild with a larger cache budget.");
+                throw std::runtime_error(QObject::tr(
+                    "The selected slice level cannot fit in the %1 cache. "
+                    "Choose a lower level or increase AMRVIS_CACHE_SIZE_MB.")
+                        .arg(cacheBudgetDescription(cacheBudget))
+                        .toStdString());
             }
             if (attemptMaximumLevel == 0) {
-                throw std::runtime_error(
-                    "The slice cannot fit in the 1 GiB cache, even at level 0. "
-                    "Try a smaller plotfile or rebuild with a larger cache budget.");
+                throw std::runtime_error(QObject::tr(
+                    "The slice cannot fit in the %1 cache, even at level 0. "
+                    "Try a smaller plotfile or increase AMRVIS_CACHE_SIZE_MB.")
+                        .arg(cacheBudgetDescription(cacheBudget))
+                        .toStdString());
             }
             if (result.cacheFallbackFromLevel < 0) {
                 result.cacheFallbackFromLevel = attemptMaximumLevel;

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -659,19 +659,21 @@ QString cacheFallbackMessage(const InitialSliceResult& result)
         .arg(result.cacheFallbackFromLevel);
 }
 
-void selectCacheFallbackLevel(
+bool selectCacheFallbackLevel(
     QComboBox* selector, const InitialSliceResult& result)
 {
     if (result.cacheFallbackToLevel < 0) {
-        return;
+        return false;
     }
     const auto data = result.cacheFallbackToLevel == 0
         ? 0 : kUpdateToLevelOffset + result.cacheFallbackToLevel;
     const auto index = selector->findData(data);
-    if (index >= 0) {
-        const QSignalBlocker blocker(selector);
-        selector->setCurrentIndex(index);
+    if (index < 0) {
+        return false;
     }
+    const QSignalBlocker blocker(selector);
+    selector->setCurrentIndex(index);
+    return true;
 }
 
 void populateLevelCombo(QComboBox* combo, int finestLevel)
@@ -3458,7 +3460,10 @@ void MainWindow::requestInitialSlice(
                 if (generation == m_generation) {
                     m_dataset = result.dataset;
                     configureSliceControls();
-                    selectCacheFallbackLevel(m_levelSelector, result);
+                    if (selectCacheFallbackLevel(m_levelSelector, result)) {
+                        configureSlicePositionControls();
+                        syncMenuChecks();
+                    }
                     if (result.displays.size() != views.size()) {
                         throw std::runtime_error(
                             "initial slice count does not match the view set");
@@ -4450,7 +4455,10 @@ void MainWindow::displayFrameResult(InitialSliceResult& result,
     showMetadata(frameMetadata, m_datasetPath);
 
     configureSequenceControls(defaultPositions);
-    selectCacheFallbackLevel(m_levelSelector, result);
+    if (selectCacheFallbackLevel(m_levelSelector, result)) {
+        configureSlicePositionControls();
+        syncMenuChecks();
+    }
     const auto views = currentViews();
     if (result.displays.size() != views.size()) {
         throw std::runtime_error("frame slice count does not match the view set");
@@ -4465,8 +4473,7 @@ void MainWindow::displayFrameResult(InitialSliceResult& result,
     m_cacheEvictions = cache.evictions;
     validateVectorMode();
     if (result.cacheFallbackToLevel >= 0) {
-        QMessageBox::warning(this, tr("Reduced level detail"),
-            cacheFallbackMessage(result));
+        statusBar()->showMessage(cacheFallbackMessage(result));
     }
 }
 

--- a/src/qt/MainWindow.hpp
+++ b/src/qt/MainWindow.hpp
@@ -108,6 +108,10 @@ struct InitialSliceResult {
     // First line of the plotfile Header when the path is a plotfile
     // directory; empty for standalone datasets.
     std::string fileVersion;
+    // Set when a Finest Available load exceeded the cache budget and was
+    // retried with a lower composite maximum level.
+    int cacheFallbackFromLevel = -1;
+    int cacheFallbackToLevel = -1;
 };
 
 // Everything needed to render one frame's slice(s) off the GUI thread. The

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,6 +14,9 @@ add_executable(test_cache_config unit/test_cache_config.cpp)
 target_include_directories(test_cache_config PRIVATE "${CMAKE_SOURCE_DIR}/src/qt")
 target_link_libraries(test_cache_config PRIVATE Amrvis::warnings)
 add_test(NAME cache_config COMMAND test_cache_config)
+set_tests_properties(cache_config PROPERTIES
+    ENVIRONMENT "AMRVIS_CACHE_SIZE_MB=768"
+)
 
 add_executable(test_scalar_renderer unit/test_scalar_renderer.cpp)
 target_link_libraries(test_scalar_renderer PRIVATE Amrvis::render2d Amrvis::warnings)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,6 +10,11 @@ add_executable(test_byte_lru_cache unit/test_byte_lru_cache.cpp)
 target_link_libraries(test_byte_lru_cache PRIVATE Amrvis::cache Amrvis::warnings)
 add_test(NAME byte_lru_cache COMMAND test_byte_lru_cache)
 
+add_executable(test_cache_config unit/test_cache_config.cpp)
+target_include_directories(test_cache_config PRIVATE "${CMAKE_SOURCE_DIR}/src/qt")
+target_link_libraries(test_cache_config PRIVATE Amrvis::warnings)
+add_test(NAME cache_config COMMAND test_cache_config)
+
 add_executable(test_scalar_renderer unit/test_scalar_renderer.cpp)
 target_link_libraries(test_scalar_renderer PRIVATE Amrvis::render2d Amrvis::warnings)
 add_test(NAME scalar_renderer COMMAND test_scalar_renderer)

--- a/tests/unit/test_cache_config.cpp
+++ b/tests/unit/test_cache_config.cpp
@@ -23,6 +23,9 @@ int main()
     using amrvis::qt::defaultInitialCacheBudget;
     using amrvis::qt::initialCacheBudget;
 
+    require(initialCacheBudget() == 768ULL * 1024ULL * 1024ULL,
+        "cache size environment variable was not read");
+
     require(initialCacheBudget(nullptr) == defaultInitialCacheBudget,
         "unset cache size did not use the default");
     require(initialCacheBudget("2048") == 2048ULL * 1024ULL * 1024ULL,

--- a/tests/unit/test_cache_config.cpp
+++ b/tests/unit/test_cache_config.cpp
@@ -1,0 +1,50 @@
+#include "CacheConfig.hpp"
+
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
+#include <limits>
+#include <string>
+
+namespace {
+
+void require(bool condition, const char* message)
+{
+    if (!condition) {
+        std::cerr << "FAILED: " << message << '\n';
+        std::exit(1);
+    }
+}
+
+} // namespace
+
+int main()
+{
+    using amrvis::qt::defaultInitialCacheBudget;
+    using amrvis::qt::initialCacheBudget;
+
+    require(initialCacheBudget(nullptr) == defaultInitialCacheBudget,
+        "unset cache size did not use the default");
+    require(initialCacheBudget("2048") == 2048ULL * 1024ULL * 1024ULL,
+        "valid cache size was not parsed");
+    require(initialCacheBudget("1") == 1024ULL * 1024ULL,
+        "minimum positive cache size was not accepted");
+    require(initialCacheBudget("0") == defaultInitialCacheBudget,
+        "zero cache size did not use the default");
+    require(initialCacheBudget("-1") == defaultInitialCacheBudget,
+        "negative cache size did not use the default");
+    require(initialCacheBudget("1 MiB") == defaultInitialCacheBudget,
+        "cache size with trailing text did not use the default");
+    require(initialCacheBudget("") == defaultInitialCacheBudget,
+        "empty cache size did not use the default");
+
+    const auto maximumMegabytes
+        = std::numeric_limits<std::uint64_t>::max() / (1024ULL * 1024ULL);
+    const auto maximum = std::to_string(maximumMegabytes);
+    require(initialCacheBudget(maximum.c_str())
+            == maximumMegabytes * 1024ULL * 1024ULL,
+        "maximum cache size in megabytes was not accepted");
+    const auto overflow = std::to_string(maximumMegabytes + 1);
+    require(initialCacheBudget(overflow.c_str()) == defaultInitialCacheBudget,
+        "overflowing cache size did not use the default");
+}


### PR DESCRIPTION
* Adjusts cache behavior to fallback to reading fewer levels when reading all levels up to `finest_level` would exceed the LRU cache.
* Also, increases the initial cache size to 1 GiB.
* Allows users to set the initial cache size with an environment variable, e.g.:
   ```
   AMRVIS_CACHE_SIZE_MB=2048
   ```