### PR TITLE
Improve user range input handling

### DIFF
--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -17,6 +17,8 @@ add_executable(amrvis_qt
     MainWindow.hpp
     NumberFormat.cpp
     NumberFormat.hpp
+    ScientificDoubleSpinBox.cpp
+    ScientificDoubleSpinBox.hpp
     SetContoursDialog.cpp
     SetContoursDialog.hpp
     Theme.hpp

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -6,6 +6,7 @@
 #include "IsoWidget.hpp"
 #include "LinePlotRequest.hpp"
 #include "LinePlotWindow.hpp"
+#include "ScientificDoubleSpinBox.hpp"
 #include "SetContoursDialog.hpp"
 #include "Theme.hpp"
 
@@ -966,10 +967,9 @@ MainWindow::MainWindow(QWidget* parent)
     m_rangeMode->addItem(tr("Visible"), static_cast<int>(RangeMode::Visible));
     m_rangeMode->addItem(tr("User"), static_cast<int>(RangeMode::User));
     rangeToolbar->addWidget(m_rangeMode);
-    m_rangeMinimum = new QDoubleSpinBox(rangeToolbar);
-    m_rangeMaximum = new QDoubleSpinBox(rangeToolbar);
+    m_rangeMinimum = new ScientificDoubleSpinBox(rangeToolbar);
+    m_rangeMaximum = new ScientificDoubleSpinBox(rangeToolbar);
     for (auto* range : {m_rangeMinimum, m_rangeMaximum}) {
-        range->setDecimals(8);
         range->setRange(-std::numeric_limits<double>::max(),
             std::numeric_limits<double>::max());
         range->setMinimumWidth(110);
@@ -1749,6 +1749,8 @@ void MainWindow::applyNumberFormat(const QString& format)
         return;
     }
     m_numberFormat = format;
+    m_rangeMinimum->setNumberFormat(format);
+    m_rangeMaximum->setNumberFormat(format);
     m_colorBar->setNumberFormat(format);
     // Open child windows repaint against the stored format; a null pointer
     // means the window picks the format up when it is next created.
@@ -2607,6 +2609,8 @@ void MainWindow::restoreSettings()
             defaultNumberFormat()).toString();
         m_numberFormat = isValidNumberFormat(format) ? format
             : defaultNumberFormat();
+        m_rangeMinimum->setNumberFormat(m_numberFormat);
+        m_rangeMaximum->setNumberFormat(m_numberFormat);
         m_colorBar->setNumberFormat(m_numberFormat);
     }
     m_animationPanel->setSpeedValue(

--- a/src/qt/MainWindow.hpp
+++ b/src/qt/MainWindow.hpp
@@ -35,7 +35,6 @@ class QCloseEvent;
 class QColor;
 class QComboBox;
 class QDockWidget;
-class QDoubleSpinBox;
 class QLabel;
 class QSpinBox;
 class QLineF;
@@ -64,6 +63,7 @@ class DatasetWindow;
 class ImageView;
 class IsoWidget;
 class LinePlotWindow;
+class ScientificDoubleSpinBox;
 
 enum class RangeMode {
     Visible,
@@ -378,8 +378,8 @@ private:
     QComboBox* m_rangeMode = nullptr;
     QComboBox* m_paletteSelector = nullptr;
     QCheckBox* m_logarithmic = nullptr;
-    QDoubleSpinBox* m_rangeMinimum = nullptr;
-    QDoubleSpinBox* m_rangeMaximum = nullptr;
+    ScientificDoubleSpinBox* m_rangeMinimum = nullptr;
+    ScientificDoubleSpinBox* m_rangeMaximum = nullptr;
     // Per-field range state for the current dataset. m_trackedField is the
     // field the range widgets currently represent; the field selector swaps
     // snapshots through this map when the user changes fields.

--- a/src/qt/ScientificDoubleSpinBox.cpp
+++ b/src/qt/ScientificDoubleSpinBox.cpp
@@ -1,0 +1,148 @@
+#include "ScientificDoubleSpinBox.hpp"
+#include "NumberFormat.hpp"
+
+#include <QDoubleValidator>
+#include <QLineEdit>
+#include <QLocale>
+#include <QSignalBlocker>
+
+#include <algorithm>
+#include <limits>
+
+namespace amrvis::qt {
+namespace {
+
+QLocale cNumberLocale()
+{
+    auto result = QLocale::c();
+    result.setNumberOptions(QLocale::RejectGroupSeparator);
+    return result;
+}
+
+QString conversionSpecifier(const QString& format)
+{
+    const auto bytes = format.toUtf8();
+    for (qsizetype index = 0; index < bytes.size(); ++index) {
+        if (bytes[index] != '%') {
+            continue;
+        }
+        const auto start = index++;
+        if (index >= bytes.size() || bytes[index] == '%') {
+            continue;
+        }
+        while (index < bytes.size() && (bytes[index] == '-'
+                || bytes[index] == '+' || bytes[index] == '0'
+                || bytes[index] == ' ' || bytes[index] == '#')) {
+            ++index;
+        }
+        while (index < bytes.size()
+            && bytes[index] >= '0' && bytes[index] <= '9') {
+            ++index;
+        }
+        if (index < bytes.size() && bytes[index] == '.') {
+            ++index;
+            while (index < bytes.size()
+                && bytes[index] >= '0' && bytes[index] <= '9') {
+                ++index;
+            }
+        }
+        if (index < bytes.size()) {
+            return QString::fromLatin1(
+                bytes.constData() + start, index - start + 1);
+        }
+    }
+    return defaultNumberFormat();
+}
+
+QValidator::State validateNumber(const QString& text, int position,
+    double minimum, double maximum, const QLocale& locale)
+{
+    QDoubleValidator validator(minimum, maximum,
+        std::numeric_limits<double>::max_exponent10
+            + std::numeric_limits<double>::digits10);
+    validator.setLocale(locale);
+    validator.setNotation(QDoubleValidator::ScientificNotation);
+    auto candidate = text;
+    return validator.validate(candidate, position);
+}
+
+} // namespace
+
+ScientificDoubleSpinBox::ScientificDoubleSpinBox(QWidget* parent)
+    : QDoubleSpinBox(parent)
+    , m_numberFormat(defaultNumberFormat())
+{
+    // This is the largest decimal precision QDoubleSpinBox supports. It keeps
+    // the stored value precise while textFromValue controls the visible digits.
+    setDecimals(std::numeric_limits<double>::max_exponent10
+        + std::numeric_limits<double>::digits10);
+    setKeyboardTracking(false);
+}
+
+void ScientificDoubleSpinBox::setNumberFormat(const QString& format)
+{
+    if (!isValidNumberFormat(format)) {
+        return;
+    }
+    const auto numberFormat = conversionSpecifier(format);
+    if (m_numberFormat == numberFormat) {
+        return;
+    }
+    m_numberFormat = numberFormat;
+    const QSignalBlocker blocker(this);
+    lineEdit()->setText(prefix() + textFromValue(value()) + suffix());
+    lineEdit()->setModified(false);
+}
+
+QString ScientificDoubleSpinBox::textFromValue(double value) const
+{
+    return formatNumber(value, m_numberFormat);
+}
+
+double ScientificDoubleSpinBox::valueFromText(const QString& text) const
+{
+    const auto number = numberText(text);
+    if (!lineEdit()->isModified()
+        && number == formatNumber(value(), m_numberFormat).trimmed()) {
+        return value();
+    }
+    bool ok = false;
+    const auto cValue = cNumberLocale().toDouble(number, &ok);
+    if (ok) {
+        return cValue;
+    }
+    const auto localizedValue = locale().toDouble(number, &ok);
+    return ok ? localizedValue : QDoubleSpinBox::valueFromText(text);
+}
+
+QValidator::State ScientificDoubleSpinBox::validate(
+    QString& input, int& position) const
+{
+    const auto number = numberText(input);
+    const auto prefixLength = input.startsWith(prefix())
+        ? static_cast<int>(prefix().size()) : 0;
+    const auto numberPosition = std::clamp(position - prefixLength,
+        0, static_cast<int>(number.size()));
+
+    const auto cState = validateNumber(
+        number, numberPosition, minimum(), maximum(), cNumberLocale());
+    if (cState != QValidator::Invalid) {
+        return cState;
+    }
+    return validateNumber(
+        number, numberPosition, minimum(), maximum(), locale());
+}
+
+QString ScientificDoubleSpinBox::numberText(const QString& text) const
+{
+    auto result = text;
+    if (!prefix().isEmpty() && result.startsWith(prefix())) {
+        result.remove(0, prefix().size());
+    }
+    if (!suffix().isEmpty() && result.endsWith(suffix())) {
+        result.chop(suffix().size());
+    }
+    return result.trimmed();
+}
+
+} // namespace amrvis::qt

--- a/src/qt/ScientificDoubleSpinBox.hpp
+++ b/src/qt/ScientificDoubleSpinBox.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <QDoubleSpinBox>
+#include <QValidator>
+
+namespace amrvis::qt {
+
+// A double spin box that accepts decimal scientific notation. Keyboard
+// tracking is disabled so partially entered values are not committed.
+class ScientificDoubleSpinBox : public QDoubleSpinBox {
+public:
+    explicit ScientificDoubleSpinBox(QWidget* parent = nullptr);
+
+    // Uses the format's floating conversion; surrounding literal text is
+    // omitted so the displayed value remains directly editable.
+    void setNumberFormat(const QString& format);
+
+protected:
+    [[nodiscard]] QString textFromValue(double value) const override;
+    [[nodiscard]] double valueFromText(const QString& text) const override;
+    QValidator::State validate(QString& input, int& position) const override;
+
+private:
+    [[nodiscard]] QString numberText(const QString& text) const;
+
+    QString m_numberFormat;
+};
+
+} // namespace amrvis::qt

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -73,6 +73,23 @@ add_executable(fixture_materializer fixture_materializer/main.cpp)
 target_link_libraries(fixture_materializer PRIVATE Amrvis::warnings)
 
 if(TARGET amrvis_qt)
+    add_executable(test_scientific_double_spin_box
+        unit/test_scientific_double_spin_box.cpp
+        "${PROJECT_SOURCE_DIR}/src/qt/NumberFormat.cpp"
+        "${PROJECT_SOURCE_DIR}/src/qt/ScientificDoubleSpinBox.cpp"
+    )
+    target_include_directories(test_scientific_double_spin_box
+        PRIVATE "${PROJECT_SOURCE_DIR}/src/qt"
+    )
+    target_link_libraries(test_scientific_double_spin_box
+        PRIVATE Amrvis::warnings Qt6::Widgets
+    )
+    add_test(
+        NAME scientific_double_spin_box
+        COMMAND "${CMAKE_COMMAND}" -E env QT_QPA_PLATFORM=offscreen
+            "$<TARGET_FILE:test_scientific_double_spin_box>"
+    )
+
     add_test(
         NAME qt_metadata_smoke
         COMMAND "${CMAKE_COMMAND}" -E env QT_QPA_PLATFORM=offscreen

--- a/tests/unit/test_scientific_double_spin_box.cpp
+++ b/tests/unit/test_scientific_double_spin_box.cpp
@@ -1,0 +1,98 @@
+#include "ScientificDoubleSpinBox.hpp"
+
+#include <QApplication>
+#include <QLineEdit>
+#include <QString>
+
+#include <cstdlib>
+#include <iostream>
+#include <limits>
+
+namespace {
+
+class TestScientificDoubleSpinBox : public amrvis::qt::ScientificDoubleSpinBox {
+public:
+    using ScientificDoubleSpinBox::validate;
+    using ScientificDoubleSpinBox::valueFromText;
+
+    [[nodiscard]] QLineEdit* editor() const
+    {
+        return lineEdit();
+    }
+};
+
+void require(bool condition, const char* message)
+{
+    if (!condition) {
+        std::cerr << "FAILED: " << message << '\n';
+        std::exit(1);
+    }
+}
+
+QValidator::State validationState(
+    TestScientificDoubleSpinBox& spinBox, QString text)
+{
+    auto position = static_cast<int>(text.size());
+    return spinBox.validate(text, position);
+}
+
+} // namespace
+
+int main(int argc, char* argv[])
+{
+    [[maybe_unused]] QApplication application(argc, argv);
+
+    TestScientificDoubleSpinBox spinBox;
+    spinBox.setRange(-std::numeric_limits<double>::max(),
+        std::numeric_limits<double>::max());
+    spinBox.setPrefix(QStringLiteral("min "));
+
+    require(!spinBox.keyboardTracking(),
+        "range input should not commit while the user is typing");
+    require(validationState(spinBox, QStringLiteral("min 1.2e-6"))
+            == QValidator::Acceptable,
+        "lowercase scientific notation should be accepted");
+    require(validationState(spinBox, QStringLiteral("min +1.2E+6"))
+            == QValidator::Acceptable,
+        "uppercase scientific notation should be accepted");
+    require(validationState(spinBox, QStringLiteral("min 1.2e-"))
+            == QValidator::Intermediate,
+        "an unfinished exponent should remain editable");
+    require(validationState(spinBox, QStringLiteral("min 1.2e--6"))
+            == QValidator::Invalid,
+        "a malformed exponent should be rejected");
+    require(spinBox.valueFromText(QStringLiteral("min 1.2e-6")) == 1.2e-6,
+        "scientific notation should convert to the expected value");
+
+    auto valueChanges = 0;
+    QObject::connect(&spinBox, qOverload<double>(&QDoubleSpinBox::valueChanged),
+        [&valueChanges](double) { ++valueChanges; });
+    spinBox.editor()->setText(QStringLiteral("min 2.5e-6"));
+    spinBox.editor()->setModified(true);
+    QApplication::processEvents();
+    require(spinBox.value() == 0.0 && valueChanges == 0,
+        "editing should not apply an otherwise valid partial value");
+    spinBox.interpretText();
+    require(spinBox.value() == 2.5e-6 && valueChanges == 1,
+        "finishing an edit should apply the completed value once");
+
+    spinBox.setNumberFormat(QStringLiteral("%.3e"));
+    constexpr double tinyValue = 1.2e-100;
+    spinBox.setValue(tinyValue);
+    require(spinBox.value() == tinyValue,
+        "display formatting should not change the stored value");
+    require(spinBox.cleanText() == QStringLiteral("1.200e-100"),
+        "range display should use the configured number format");
+
+    spinBox.setNumberFormat(QStringLiteral("%g"));
+    constexpr double preciseValue = 1.23456789012345;
+    spinBox.setValue(preciseValue);
+    spinBox.interpretText();
+    require(spinBox.value() == preciseValue,
+        "committing unchanged display text should preserve the stored value");
+
+    spinBox.setNumberFormat(QStringLiteral("value=%.2e units"));
+    spinBox.setValue(1.25);
+    require(spinBox.cleanText() == QStringLiteral("1.25e+00"),
+        "range display should ignore surrounding format text");
+}


### PR DESCRIPTION
Delay applying range values until editing is complete, and accept scientific notation in the range controls. Preserve very small values with compact formatting and add tests for committed, incomplete, and invalid exponent input.