### PR TITLE
Fixed non-finite data handling consistently

### DIFF
--- a/src/qt/DatasetExtract.hpp
+++ b/src/qt/DatasetExtract.hpp
@@ -36,8 +36,9 @@ struct DatasetLevelExtract {
     int sliceIndex = 0;                // normal-axis cell index (3-D)
     std::vector<float> values;
     std::vector<std::uint8_t> covered;
-    double minimum = 0.0;              // over covered cells only
+    double minimum = 0.0;              // over finite covered cells only
     double maximum = 0.0;
+    bool hasFiniteValues = false;       // minimum/maximum are meaningful
     bool truncatedX = false;           // region exceeded maxExtent, axis 0
     bool truncatedY = false;           // region exceeded maxExtent, axis 1
 };
@@ -254,14 +255,17 @@ inline std::size_t fabValueOffset(const IntBox& box, int i, int j, int k,
                     + static_cast<std::size_t>(extract.nx) * valueY;
                 extract.values[offset] = static_cast<float>(value);
                 extract.covered[offset] = std::uint8_t{1};
-                minimum = std::min(minimum, value);
-                maximum = std::max(maximum, value);
+                if (std::isfinite(value)) {
+                    minimum = std::min(minimum, value);
+                    maximum = std::max(maximum, value);
+                }
             }
         }
     }
     if (std::isfinite(minimum) && std::isfinite(maximum)) {
         extract.minimum = minimum;
         extract.maximum = maximum;
+        extract.hasFiniteValues = true;
     }
     return extract;
 }

--- a/src/qt/DatasetWindow.cpp
+++ b/src/qt/DatasetWindow.cpp
@@ -172,11 +172,17 @@ void DatasetWindow::populateTabs()
 
         auto* page = new QWidget(m_tabs);
         auto* info = new QLabel(page);
-        info->setText(tr("min=%1 max=%2  (%3 x %4 samples)")
-            .arg(formatNumber(extract.minimum, m_numberFormat))
-            .arg(formatNumber(extract.maximum, m_numberFormat))
-            .arg(extract.nx)
-            .arg(extract.ny));
+        if (extract.hasFiniteValues) {
+            info->setText(tr("min=%1 max=%2  (%3 x %4 samples)")
+                .arg(formatNumber(extract.minimum, m_numberFormat))
+                .arg(formatNumber(extract.maximum, m_numberFormat))
+                .arg(extract.nx)
+                .arg(extract.ny));
+        } else {
+            info->setText(tr("no finite values  (%1 x %2 samples)")
+                .arg(extract.nx)
+                .arg(extract.ny));
+        }
         auto* table = new QTableWidget(extract.ny, extract.nx, page);
         table->setEditTriggers(QAbstractItemView::NoEditTriggers);
         QStringList columnLabels;

--- a/src/qt/LinePlotWindow.cpp
+++ b/src/qt/LinePlotWindow.cpp
@@ -123,13 +123,14 @@ std::optional<QRectF> LinePlotWidget::automaticRange() const
             if (curve.line.valid[sample] == 0) {
                 continue;
             }
+            const auto position = curve.line.positions[sample];
             const auto value = static_cast<double>(curve.line.values[sample]);
-            if (!std::isfinite(value)) {
+            if (!std::isfinite(position) || !std::isfinite(value)) {
                 continue;
             }
             any = true;
-            xMinimum = std::min(xMinimum, curve.line.positions[sample]);
-            xMaximum = std::max(xMaximum, curve.line.positions[sample]);
+            xMinimum = std::min(xMinimum, position);
+            xMaximum = std::max(xMaximum, position);
             yMinimum = std::min(yMinimum, value);
             yMaximum = std::max(yMaximum, value);
         }
@@ -264,12 +265,14 @@ void LinePlotWidget::paintEvent(QPaintEvent* /*event*/)
             run.clear();
         };
         for (std::size_t sample = 0; sample < count; ++sample) {
-            if (curve.line.valid[sample] == 0) {
+            const auto position = curve.line.positions[sample];
+            const auto value = static_cast<double>(curve.line.values[sample]);
+            if (curve.line.valid[sample] == 0
+                || !std::isfinite(position) || !std::isfinite(value)) {
                 flushRun();
                 continue;
             }
-            run.append(QPointF(mapX(curve.line.positions[sample]),
-                mapY(static_cast<double>(curve.line.values[sample]))));
+            run.append(QPointF(mapX(position), mapY(value)));
         }
         flushRun();
         if (m_showMarkers) {
@@ -284,12 +287,15 @@ void LinePlotWidget::paintEvent(QPaintEvent* /*event*/)
             markerPen.setCapStyle(Qt::RoundCap);
             painter.setPen(markerPen);
             for (std::size_t sample = 0; sample < count; ++sample) {
-                if (curve.line.valid[sample] == 0) {
+                const auto position = curve.line.positions[sample];
+                const auto value
+                    = static_cast<double>(curve.line.values[sample]);
+                if (curve.line.valid[sample] == 0
+                    || !std::isfinite(position) || !std::isfinite(value)) {
                     continue;
                 }
-                painter.drawPoint(QPointF(mapX(curve.line.positions[sample]),
-                    mapY(static_cast<double>(curve.line.values[sample]))
-                        - markerLift));
+                painter.drawPoint(
+                    QPointF(mapX(position), mapY(value) - markerLift));
             }
         }
     }

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -347,10 +347,9 @@ std::pair<double, double> resolveRange(
             }
         }
     }
-    const auto visibleRange = finiteRange(plane);
     auto [minimum, maximum] = selectedRange
         ? *selectedRange
-        : visibleRange.value_or(logarithmic
+        : finiteRange(plane).value_or(logarithmic
               ? std::pair{1.0, 10.0}
               : std::pair{0.0, 1.0});
     if (minimum == maximum) {

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -223,7 +223,8 @@ QString exceptionMessage(const std::exception& error)
     return QString::fromUtf8(error.what());
 }
 
-std::pair<double, double> finiteRange(const ScalarPlane& plane)
+std::optional<std::pair<double, double>> finiteRange(
+    const ScalarPlane& plane)
 {
     auto minimum = std::numeric_limits<double>::infinity();
     auto maximum = -std::numeric_limits<double>::infinity();
@@ -239,14 +240,14 @@ std::pair<double, double> finiteRange(const ScalarPlane& plane)
         maximum = std::max(maximum, value);
     }
     if (!std::isfinite(minimum) || !std::isfinite(maximum)) {
-        throw std::runtime_error("slice contains no finite field values");
+        return std::nullopt;
     }
     if (minimum == maximum) {
         const auto padding = std::max(std::abs(minimum), 1.0) * 1.0e-6;
         minimum -= padding;
         maximum += padding;
     }
-    return {minimum, maximum};
+    return std::pair{minimum, maximum};
 }
 
 std::optional<ValueRange> selectedMetadataRange(
@@ -346,8 +347,12 @@ std::pair<double, double> resolveRange(
             }
         }
     }
+    const auto visibleRange = finiteRange(plane);
     auto [minimum, maximum] = selectedRange
-        ? *selectedRange : finiteRange(plane);
+        ? *selectedRange
+        : visibleRange.value_or(logarithmic
+              ? std::pair{1.0, 10.0}
+              : std::pair{0.0, 1.0});
     if (minimum == maximum) {
         if (logarithmic && minimum > 0.0) {
             minimum /= 1.0 + 1.0e-6;
@@ -407,10 +412,10 @@ std::array<int, 2> finestNativeOutputSize(
 }
 
 // Like resolveRange, but if a logarithmic scale is requested and the range
-// is not strictly positive (a Visible/Level/File/User minimum <= 0, or no
-// finite values), it falls back to a linear range and reports
-// logarithmic=false so the caller renders linearly instead of failing the
-// whole slice.
+// is not strictly positive (a Visible/Level/File/User minimum <= 0), it falls
+// back to a linear range and reports logarithmic=false so the caller renders
+// linearly instead of failing the whole slice. A slice with no finite values
+// uses a neutral positive range and can therefore remain logarithmic.
 struct ResolvedRange {
     double minimum;
     double maximum;
@@ -911,11 +916,22 @@ InitialSliceResult executeFrameLoad(const std::filesystem::path& path,
                 double globalMin = std::numeric_limits<double>::infinity();
                 double globalMax = -std::numeric_limits<double>::infinity();
                 for (const auto& d : result.displays) {
-                    const auto [lo, hi] = finiteRange(d.slice.plane);
-                    globalMin = std::min(globalMin, lo);
-                    globalMax = std::max(globalMax, hi);
+                    const auto range = finiteRange(d.slice.plane);
+                    if (range) {
+                        globalMin = std::min(globalMin, range->first);
+                        globalMax = std::max(globalMax, range->second);
+                    }
                 }
                 const auto logarithmic = spec.logarithmic;
+                if (!std::isfinite(globalMin) || !std::isfinite(globalMax)) {
+                    if (logarithmic) {
+                        globalMin = 1.0;
+                        globalMax = 10.0;
+                    } else {
+                        globalMin = 0.0;
+                        globalMax = 1.0;
+                    }
+                }
                 if (globalMin == globalMax) {
                     if (logarithmic && globalMin > 0.0) {
                         globalMin /= 1.0 + 1.0e-6;

--- a/src/render2d/ScalarRenderer.cpp
+++ b/src/render2d/ScalarRenderer.cpp
@@ -80,7 +80,8 @@ ImageBuffer renderScalarPlane(
             continue;
         }
         const auto value = static_cast<double>(plane.values[pixel]);
-        if (std::isnan(value) || (settings.logarithmic && !(value > 0.0))) {
+        if (!std::isfinite(value)
+            || (settings.logarithmic && !(value > 0.0))) {
             image.rgba[pixel] = settings.nanColor;
             continue;
         }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -186,6 +186,17 @@ if(TARGET amrvis_qt)
     )
     set_tests_properties(qt_multifab_missing_range PROPERTIES TIMEOUT 30)
     add_test(
+        NAME qt_multifab_non_finite
+        COMMAND "${CMAKE_COMMAND}"
+            "-DMATERIALIZER=$<TARGET_FILE:fixture_materializer>"
+            "-DAMRVIS_QT=$<TARGET_FILE:amrvis_qt>"
+            "-DSOURCE=${CMAKE_CURRENT_SOURCE_DIR}/data/plotfile_2d"
+            "-DWORK=${CMAKE_CURRENT_BINARY_DIR}/fixtures_non_finite"
+            -DMODE=non-finite
+            -P "${CMAKE_CURRENT_SOURCE_DIR}/qt_smoke_driver.cmake"
+    )
+    set_tests_properties(qt_multifab_non_finite PROPERTIES TIMEOUT 30)
+    add_test(
         NAME qt_raw_fab_selector
         COMMAND "${CMAKE_COMMAND}"
             "-DMATERIALIZER=$<TARGET_FILE:fixture_materializer>"

--- a/tests/fixture_materializer/main.cpp
+++ b/tests/fixture_materializer/main.cpp
@@ -6,7 +6,7 @@
 //
 // Usage:
 //   fixture_materializer <sourceFixtureDir> <destDir>
-//       [newTime] [--no-statistics]
+//       [newTime] [--no-statistics] [--non-finite]
 //
 // Copies the fixture into destDir and writes each level's Cell_D_* payloads
 // at the FabOnDisk offsets its Cell_H records. An optional time value replaces
@@ -19,6 +19,7 @@
 #include <filesystem>
 #include <fstream>
 #include <iostream>
+#include <limits>
 #include <optional>
 #include <sstream>
 #include <string>
@@ -140,7 +141,8 @@ std::vector<BlockRecord> readCellHeader(
 // density, 3-D q(i, j, k) = (i + j + k) / 9, where i/j/k are cell indices at
 // the level storing the grid.
 std::vector<double> blockValues(
-    const BlockRecord& block, int dimension, int fieldCount)
+    const BlockRecord& block, int dimension, int fieldCount,
+    bool nonFiniteValues)
 {
     const auto lower = [&block](int axis) {
         return block.indices[static_cast<std::size_t>(axis)];
@@ -157,7 +159,25 @@ std::vector<double> blockValues(
                     const auto base = dimension == 2
                         ? 0.5 * static_cast<double>(i + j)
                         : static_cast<double>(i + j + k) / 9.0;
-                    values.push_back(component == 0 ? base : 100.0 + base);
+                    if (nonFiniteValues) {
+                        switch (values.size() % 3) {
+                        case 0:
+                            values.push_back(
+                                std::numeric_limits<double>::quiet_NaN());
+                            break;
+                        case 1:
+                            values.push_back(
+                                std::numeric_limits<double>::infinity());
+                            break;
+                        default:
+                            values.push_back(
+                                -std::numeric_limits<double>::infinity());
+                            break;
+                        }
+                    } else {
+                        values.push_back(
+                            component == 0 ? base : 100.0 + base);
+                    }
                 }
             }
         }
@@ -169,7 +189,7 @@ std::vector<double> blockValues(
 // test_line_query.cpp's writeFab: an ASCII header line followed by
 // little-endian doubles.
 void writeFab(const std::filesystem::path& path, BlockRecord& block,
-    int dimension, int fieldCount)
+    int dimension, int fieldCount, bool nonFiniteValues)
 {
     if (block.offset == 0) {
         std::ofstream create(path, std::ios::binary | std::ios::trunc);
@@ -182,7 +202,8 @@ void writeFab(const std::filesystem::path& path, BlockRecord& block,
         + block.boxText + " " + std::to_string(fieldCount) + "\n";
     output << header;
     block.payloadOffset = block.offset + header.size();
-    const auto values = blockValues(block, dimension, fieldCount);
+    const auto values = blockValues(
+        block, dimension, fieldCount, nonFiniteValues);
     output.write(reinterpret_cast<const char*>(values.data()),
         static_cast<std::streamsize>(values.size() * sizeof(double)));
     require(static_cast<bool>(output), "could not write a fixture FAB payload");
@@ -213,19 +234,24 @@ void writeHeaderWithoutStatistics(const std::filesystem::path& path,
 
 int main(int argc, char* argv[])
 {
-    require(argc >= 3 && argc <= 5,
+    require(argc >= 3 && argc <= 6,
         "usage: fixture_materializer <sourceFixtureDir> <destDir> "
-        "[newTime] [--no-statistics]");
+        "[newTime] [--no-statistics] [--non-finite]");
     const std::filesystem::path source(argv[1]);
     const std::filesystem::path destination(argv[2]);
     std::optional<std::string> newTime;
     bool omitStatistics = false;
+    bool nonFiniteValues = false;
     for (int argument = 3; argument < argc; ++argument) {
         const std::string value(argv[argument]);
         if (value == "--no-statistics") {
             require(!omitStatistics,
                 "--no-statistics was specified more than once");
             omitStatistics = true;
+        } else if (value == "--non-finite") {
+            require(!nonFiniteValues,
+                "--non-finite was specified more than once");
+            nonFiniteValues = true;
         } else {
             require(!newTime.has_value(), "more than one new time was specified");
             newTime = value;
@@ -265,7 +291,7 @@ int main(int argc, char* argv[])
         auto blocks = readCellHeader(levelDir / "Cell_H", header.dimension);
         for (auto& block : blocks) {
             writeFab(levelDir / block.fileName, block,
-                header.dimension, header.fieldCount);
+                header.dimension, header.fieldCount, nonFiniteValues);
         }
         if (omitStatistics) {
             writeHeaderWithoutStatistics(

--- a/tests/qt_smoke_driver.cmake
+++ b/tests/qt_smoke_driver.cmake
@@ -5,7 +5,8 @@
 #   AMRVIS_QT     path to the amrvis_qt executable
 #   SOURCE        fixture source directory (e.g. tests/data/plotfile_2d)
 #   WORK          directory the materialized copies are written into
-#   MODE          slice | sequence | missing-range | raw-fab | multifab-fab
+#   MODE          slice | sequence | missing-range | non-finite | raw-fab |
+#                 multifab-fab
 foreach(argument MATERIALIZER AMRVIS_QT SOURCE WORK MODE)
     if(NOT DEFINED ${argument})
         message(FATAL_ERROR "qt_smoke_driver.cmake requires -D${argument}=...")
@@ -35,6 +36,11 @@ elseif(MODE STREQUAL "sequence")
         "${WORK}/plt00000" "${WORK}/plt00010")
 elseif(MODE STREQUAL "missing-range")
     run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt" "--no-statistics")
+    run_or_die("${AMRVIS_QT}" --missing-range-smoke-test
+        "${WORK}/plt/Level_0/Cell")
+elseif(MODE STREQUAL "non-finite")
+    run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt"
+        "--no-statistics" "--non-finite")
     run_or_die("${AMRVIS_QT}" --missing-range-smoke-test
         "${WORK}/plt/Level_0/Cell")
 elseif(MODE STREQUAL "raw-fab")

--- a/tests/unit/test_scalar_renderer.cpp
+++ b/tests/unit/test_scalar_renderer.cpp
@@ -45,6 +45,26 @@ int main()
     require(logarithmic.rgba[3] == settings.nanColor,
         "non-positive logarithmic value color mismatch");
 
+    plane.values = {
+        std::numeric_limits<float>::infinity(),
+        -std::numeric_limits<float>::infinity(),
+        std::numeric_limits<float>::quiet_NaN(),
+        1.0F
+    };
+    plane.valid = {1, 1, 1, 0};
+    settings.minimum = 0.0;
+    settings.maximum = 1.0;
+    settings.logarithmic = false;
+    const auto nonFinite = amrvis::renderScalarPlane(plane, settings);
+    require(nonFinite.rgba[0] == settings.nanColor,
+        "positive infinity pixel color mismatch");
+    require(nonFinite.rgba[1] == settings.nanColor,
+        "negative infinity pixel color mismatch");
+    require(nonFinite.rgba[2] == settings.nanColor,
+        "NaN pixel color mismatch");
+    require(nonFinite.rgba[3] == settings.invalidColor,
+        "invalid mask did not take precedence over value");
+
     amrvis::ScalarPlane tooWide;
     tooWide.width = std::numeric_limits<int>::max();
     tooWide.height = 1;


### PR DESCRIPTION
- NaN and ±Inf render with the NaN color instead of clipping to palette endpoints.
- Autoscaling excludes all non-finite values.
- Entirely non-finite slices now open using a neutral fallback range.
- Line plots break at non-finite samples and omit their markers.
- Dataset tables report “no finite values” instead of a misleading min=0 max=0.
- Added renderer coverage and an end-to-end all-non-finite raw MultiFab test.