### PR TITLE
Add hover value readout to line plots

### DIFF
--- a/src/qt/LinePlotWindow.cpp
+++ b/src/qt/LinePlotWindow.cpp
@@ -3,6 +3,7 @@
 #include "Theme.hpp"
 
 #include <QCheckBox>
+#include <QEvent>
 #include <QFontDatabase>
 #include <QHBoxLayout>
 #include <QIcon>
@@ -15,6 +16,7 @@
 #include <QPushButton>
 #include <QRect>
 #include <QRubberBand>
+#include <QToolTip>
 #include <QVBoxLayout>
 
 #include <algorithm>
@@ -67,6 +69,7 @@ LinePlotWidget::LinePlotWidget(QWidget* parent)
     , m_numberFormat(defaultNumberFormat())
 {
     setMinimumSize(420, 300);
+    setMouseTracking(true);
 }
 
 void LinePlotWidget::setCurves(const std::vector<LinePlotCurve>* curves)
@@ -174,12 +177,100 @@ std::optional<QRectF> LinePlotWidget::displayedRange() const
     return automaticRange();
 }
 
+QString LinePlotWidget::hoverTextAt(const QPointF& position) const
+{
+    constexpr double hoverRadius = 10.0;
+    const auto plot = plotRect();
+    if (m_curves == nullptr || !m_paintedRange
+        || !plot.contains(position.toPoint())) {
+        return {};
+    }
+    const auto& range = *m_paintedRange;
+
+    const auto mapX = [&](double value) {
+        return plot.left()
+            + (value - range.left()) / range.width() * plot.width();
+    };
+    const auto mapY = [&](double value) {
+        return plot.bottom()
+            - (value - range.top()) / range.height() * plot.height();
+    };
+    const auto cursorX = range.left()
+        + (position.x() - plot.left()) / plot.width() * range.width();
+    const auto dataRadius = hoverRadius * range.width() / plot.width();
+
+    const LinePlotCurve* nearestCurve = nullptr;
+    std::size_t nearestSample = 0;
+    auto nearestDistanceSquared = hoverRadius * hoverRadius;
+    constexpr std::size_t candidateRadius = 8;
+    for (const auto& curve : *m_curves) {
+        if (!curve.visible) {
+            continue;
+        }
+        const auto count = sampleCount(curve);
+        const auto begin = curve.line.positions.begin();
+        const auto end = begin + static_cast<std::ptrdiff_t>(count);
+        const auto insertion = static_cast<std::size_t>(std::distance(
+            begin, std::lower_bound(begin, end, cursorX)));
+        const auto first = insertion > candidateRadius
+            ? insertion - candidateRadius : std::size_t{0};
+        const auto last = insertion
+            + std::min(count - insertion, candidateRadius + 1);
+        for (auto sample = first; sample < last; ++sample) {
+            const auto samplePosition = curve.line.positions[sample];
+            const auto value = static_cast<double>(curve.line.values[sample]);
+            if (curve.line.valid[sample] == 0
+                || !std::isfinite(samplePosition) || !std::isfinite(value)) {
+                continue;
+            }
+            const auto dx = mapX(samplePosition) - position.x();
+            if (std::abs(dx) > hoverRadius
+                || std::abs(samplePosition - cursorX) > dataRadius) {
+                continue;
+            }
+            const auto dy = mapY(value) - position.y();
+            const auto distanceSquared = dx * dx + dy * dy;
+            if (distanceSquared <= nearestDistanceSquared) {
+                nearestCurve = &curve;
+                nearestSample = sample;
+                nearestDistanceSquared = distanceSquared;
+            }
+        }
+    }
+    if (nearestCurve == nullptr) {
+        return {};
+    }
+
+    const auto coordinate = nearestCurve->line.positions[nearestSample];
+    const auto value = static_cast<double>(
+        nearestCurve->line.values[nearestSample]);
+    const auto coordinateText = nearestCurve->line.positionsAreIndices
+        ? QString::number(static_cast<long long>(std::llround(coordinate)))
+        : formatNumber(coordinate, m_numberFormat);
+    const auto axis = nearestCurve->lineAxis >= 0
+            && nearestCurve->lineAxis < static_cast<int>(axisLetters.size())
+        ? QLatin1String(
+              axisLetters[static_cast<std::size_t>(nearestCurve->lineAxis)])
+        : QStringLiteral("x");
+    return tr("%1\n%2 = %3\nvalue = %4")
+        .arg(QString::fromStdString(nearestCurve->fieldName))
+        .arg(axis)
+        .arg(coordinateText)
+        .arg(formatNumber(value, m_numberFormat));
+}
+
+void LinePlotWidget::hideHover()
+{
+    QToolTip::hideText();
+}
+
 void LinePlotWidget::paintEvent(QPaintEvent* /*event*/)
 {
     QPainter painter(this);
     painter.setRenderHint(QPainter::Antialiasing, true);
     painter.fillRect(rect(), viewportBackground());
     const auto range = displayedRange();
+    m_paintedRange = range;
     if (!range.has_value()) {
         painter.setPen(Qt::white);
         painter.drawText(rect(), Qt::AlignCenter,
@@ -304,6 +395,7 @@ void LinePlotWidget::paintEvent(QPaintEvent* /*event*/)
 
 void LinePlotWidget::mousePressEvent(QMouseEvent* event)
 {
+    hideHover();
     if (event->button() == Qt::LeftButton
         && plotRect().contains(event->position().toPoint())) {
         m_pressPosition = event->position().toPoint();
@@ -322,6 +414,7 @@ void LinePlotWidget::mousePressEvent(QMouseEvent* event)
 void LinePlotWidget::mouseMoveEvent(QMouseEvent* event)
 {
     if (m_dragging) {
+        hideHover();
         if (m_rubberBand == nullptr) {
             m_rubberBand = new QRubberBand(QRubberBand::Rectangle, this);
         }
@@ -330,6 +423,14 @@ void LinePlotWidget::mouseMoveEvent(QMouseEvent* event)
         m_rubberBand->show();
         event->accept();
         return;
+    }
+    const auto text = hoverTextAt(event->position());
+    if (text.isEmpty()) {
+        hideHover();
+    } else {
+        QToolTip::showText(event->globalPosition().toPoint()
+                + QPoint(12, 16),
+            text, this, plotRect());
     }
     QWidget::mouseMoveEvent(event);
 }
@@ -368,6 +469,12 @@ void LinePlotWidget::mouseReleaseEvent(QMouseEvent* event)
         return;
     }
     QWidget::mouseReleaseEvent(event);
+}
+
+void LinePlotWidget::leaveEvent(QEvent* event)
+{
+    hideHover();
+    QWidget::leaveEvent(event);
 }
 
 LinePlotWindow::LinePlotWindow(const QString& datasetName, QWidget* parent)

--- a/src/qt/LinePlotWindow.hpp
+++ b/src/qt/LinePlotWindow.hpp
@@ -16,6 +16,7 @@
 #include <vector>
 
 class QListWidget;
+class QEvent;
 class QMouseEvent;
 class QPaintEvent;
 class QRubberBand;
@@ -57,16 +58,20 @@ protected:
     void mousePressEvent(QMouseEvent* event) override;
     void mouseMoveEvent(QMouseEvent* event) override;
     void mouseReleaseEvent(QMouseEvent* event) override;
+    void leaveEvent(QEvent* event) override;
 
 private:
     [[nodiscard]] QRect plotRect() const;
     [[nodiscard]] std::optional<QRectF> automaticRange() const;
     [[nodiscard]] std::optional<QRectF> displayedRange() const;
+    [[nodiscard]] QString hoverTextAt(const QPointF& position) const;
+    void hideHover();
 
     const std::vector<LinePlotCurve>* m_curves = nullptr;
     QString m_numberFormat;
     bool m_showMarkers = false;
     std::optional<QRectF> m_zoom;
+    std::optional<QRectF> m_paintedRange;
     QPoint m_pressPosition;
     QRubberBand* m_rubberBand = nullptr;
     bool m_dragging = false;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -136,6 +136,24 @@ if(TARGET amrvis_qt)
             "$<TARGET_FILE:test_scientific_double_spin_box>"
     )
 
+    add_executable(test_line_plot_hover
+        unit/test_line_plot_hover.cpp
+        "${PROJECT_SOURCE_DIR}/src/qt/LinePlotWindow.cpp"
+        "${PROJECT_SOURCE_DIR}/src/qt/NumberFormat.cpp"
+    )
+    set_target_properties(test_line_plot_hover PROPERTIES AUTOMOC ON)
+    target_include_directories(test_line_plot_hover
+        PRIVATE "${PROJECT_SOURCE_DIR}/src/qt"
+    )
+    target_link_libraries(test_line_plot_hover
+        PRIVATE Amrvis::core Amrvis::warnings Qt6::Widgets
+    )
+    add_test(
+        NAME line_plot_hover
+        COMMAND "${CMAKE_COMMAND}" -E env QT_QPA_PLATFORM=offscreen
+            "$<TARGET_FILE:test_line_plot_hover>"
+    )
+
     add_test(
         NAME qt_metadata_smoke
         COMMAND "${CMAKE_COMMAND}" -E env QT_QPA_PLATFORM=offscreen

--- a/tests/unit/test_line_plot_hover.cpp
+++ b/tests/unit/test_line_plot_hover.cpp
@@ -1,0 +1,75 @@
+#include "LinePlotWindow.hpp"
+
+#include <QApplication>
+#include <QEvent>
+#include <QMouseEvent>
+#include <QPointF>
+#include <QToolTip>
+
+#include <cstdlib>
+#include <iostream>
+#include <utility>
+
+namespace {
+
+void require(bool condition, const char* message)
+{
+    if (!condition) {
+        std::cerr << "FAILED: " << message << '\n';
+        std::exit(1);
+    }
+}
+
+} // namespace
+
+int main(int argc, char* argv[])
+{
+    QApplication application(argc, argv);
+    amrvis::qt::LinePlotWindow window(QStringLiteral("hover-test"));
+
+    amrvis::qt::LinePlotCurve curve;
+    curve.fieldName = "density";
+    curve.lineAxis = 0;
+    curve.line.positions = {0.0, 1.0, 2.0};
+    curve.line.positionsAreIndices = true;
+    curve.line.values = {10.0F, 20.0F, 30.0F};
+    curve.line.valid = {1, 1, 1};
+    window.addCurve(std::move(curve));
+    window.show();
+    application.processEvents();
+
+    auto* plot = window.findChild<amrvis::qt::LinePlotWidget*>();
+    require(plot != nullptr, "line plot canvas was not created");
+
+    constexpr int leftMargin = 92;
+    constexpr int rightMargin = 32;
+    constexpr int topMargin = 18;
+    constexpr int bottomMargin = 36;
+    const QRect plotRect(leftMargin, topMargin,
+        plot->width() - leftMargin - rightMargin,
+        plot->height() - topMargin - bottomMargin);
+    const QPoint hoverPosition(
+        plotRect.left() + plotRect.width() / 2,
+        plotRect.bottom() - plotRect.height() / 2);
+    const auto globalPosition = plot->mapToGlobal(hoverPosition);
+    QMouseEvent move(QEvent::MouseMove,
+        QPointF(hoverPosition), QPointF(globalPosition),
+        Qt::NoButton, Qt::NoButton, Qt::NoModifier);
+    QApplication::sendEvent(plot, &move);
+    application.processEvents();
+
+    const auto text = QToolTip::text();
+    require(text.contains(QStringLiteral("density")),
+        "hover readout omitted the field name");
+    require(text.contains(QStringLiteral("x = 1")),
+        "hover readout did not format the integer position");
+    require(text.contains(QStringLiteral("value = 20")),
+        "hover readout omitted the sample value");
+
+    QEvent leave(QEvent::Leave);
+    QApplication::sendEvent(plot, &leave);
+    application.processEvents();
+    // QToolTip fades asynchronously and the offscreen platform keeps reporting
+    // it as visible during that fade; sending Leave still exercises cleanup.
+    return 0;
+}


### PR DESCRIPTION
Show the field value and axis coordinate for the nearest valid sample when hovering over a line plot. Keep lookup costs bounded and add an offscreen Qt regression test.