### PR TITLE
Fix a batch of small UI and tool bugs

### DIFF
--- a/include/amrexplorer/render2d/VectorGlyphs.hpp
+++ b/include/amrexplorer/render2d/VectorGlyphs.hpp
@@ -19,8 +19,10 @@ struct VectorSegment {
 // (i + 0.5, j + 0.5) in plane pixel coordinates (x = column, y = row,
 // row 0 at the bottom of the plane, so a positive v component points toward
 // increasing y). Arrow components are scaled by arrowMax / maxSpeed, where
-// maxSpeed is the maximum speed over the plane and arrowMax = 1.25 * stride
-// length, so the fastest sample gets an arrow of length arrowMax. The arrow
+// maxSpeed is the maximum speed over the plane and arrowMax = 1.25 *
+// (longestSide / count), so the fastest sample gets an arrow of length
+// arrowMax; the sampling stride is the integer floor of longestSide / count
+// (at least 1). The arrow
 // head is two short barbs from the tip, each set back 0.25 of the arrow
 // vector and offset 0.125 of it to either side (~26.6 degrees off the shaft,
 // the legacy constants). Samples that are invalid or non-finite in either

--- a/src/qt/ImageView.cpp
+++ b/src/qt/ImageView.cpp
@@ -356,8 +356,26 @@ QImage ImageView::composedImage(qreal scaleFactor) const
     painter.setRenderHint(QPainter::Antialiasing, true);
     // Render the whole scene (pixmap + grid boxes + overlays) from the image's
     // own pixel rect, so the export matches the on-screen composition, scaled.
+    // Transient interaction overlays (line-plot guide, cell highlight) must not
+    // be baked into the export, so hide them for this render and restore them.
+    const bool guideVisible =
+        m_lineGuide != nullptr && m_lineGuide->isVisible();
+    const bool cellVisible =
+        m_cellHighlightItem != nullptr && m_cellHighlightItem->isVisible();
+    if (m_lineGuide != nullptr) {
+        m_lineGuide->setVisible(false);
+    }
+    if (m_cellHighlightItem != nullptr) {
+        m_cellHighlightItem->setVisible(false);
+    }
     m_scene->render(&painter, QRectF(0.0, 0.0, outWidth, outHeight),
         QRectF(m_image.rect()));
+    if (m_lineGuide != nullptr) {
+        m_lineGuide->setVisible(guideVisible);
+    }
+    if (m_cellHighlightItem != nullptr) {
+        m_cellHighlightItem->setVisible(cellVisible);
+    }
     return out;
 }
 
@@ -580,8 +598,13 @@ void ImageView::wheelEvent(QWheelEvent* event)
         QGraphicsView::wheelEvent(event);
         return;
     }
+    const auto vertical = event->angleDelta().y();
+    if (vertical == 0) {
+        QGraphicsView::wheelEvent(event);
+        return;
+    }
     constexpr double zoomStep = 1.15;
-    const auto factor = event->angleDelta().y() >= 0 ? zoomStep : 1.0 / zoomStep;
+    const auto factor = vertical > 0 ? zoomStep : 1.0 / zoomStep;
     scale(factor, factor);
     m_fitOnResize = false;
     event->accept();

--- a/src/qt/ImageView.hpp
+++ b/src/qt/ImageView.hpp
@@ -81,9 +81,10 @@ public:
     // when the scene fits the window). When zoomed into a subregion, the
     // drag shifts the visible data window (see panDrag* signals).
     void panViewport(const QPoint& delta);
-    // When enabled (the 3-D slice views), a middle/right click (or drag)
-    // without Shift or Control emits sliceMoveRequested instead of
-    // linePlotRequested; with either modifier held it stays a line plot.
+    // When enabled (the 3-D slice views): a plain right click emits
+    // sliceMoveRequested; a Shift+middle/right click or drag, or a right
+    // drag, arms a line-plot request. A plain middle click is a no-op.
+    // (Only Shift is honored; Control is not.)
     void setSliceMoveEnabled(bool enabled) noexcept;
     // Highlight (or clear) a coloured border indicating the active panel.
     void setActiveBorder(bool active);

--- a/src/qt/ImageView.hpp
+++ b/src/qt/ImageView.hpp
@@ -83,7 +83,7 @@ public:
     void panViewport(const QPoint& delta);
     // When enabled (the 3-D slice views): a plain right click emits
     // sliceMoveRequested; a Shift+middle/right click or drag, or a right
-    // drag, arms a line-plot request. A plain middle click is a no-op.
+    // drag, arms a line-plot request. A plain middle click or drag is a no-op.
     // (Only Shift is honored; Control is not.)
     void setSliceMoveEnabled(bool enabled) noexcept;
     // Highlight (or clear) a coloured border indicating the active panel.

--- a/src/qt/IsoWidget.cpp
+++ b/src/qt/IsoWidget.cpp
@@ -272,9 +272,13 @@ void IsoWidget::wheelEvent(QWheelEvent* event)
         QWidget::wheelEvent(event);
         return;
     }
+    const auto vertical = event->angleDelta().y();
+    if (vertical == 0) {
+        QWidget::wheelEvent(event);
+        return;
+    }
     constexpr double zoomStep = 1.15;
-    const auto factor = event->angleDelta().y() >= 0
-        ? zoomStep : 1.0 / zoomStep;
+    const auto factor = vertical > 0 ? zoomStep : 1.0 / zoomStep;
     m_zoom = std::clamp(m_zoom * factor, 0.1, 10.0);
     update();
     event->accept();

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -1632,22 +1632,26 @@ void MainWindow::rebuildLevelMenu()
         });
         m_levelMenu->addAction(action);
     }
-    for (int level = 0; level <= metadata.finestLevel; ++level) {
-        auto* action = new QAction(tr("Level %1 only").arg(level), m_levelMenu);
-        action->setCheckable(true);
-        action->setActionGroup(m_levelGroup);
-        action->setData(level);
-        if (level < 10) {
-            action->setShortcut(QKeySequence(
-                Qt::ALT | static_cast<Qt::Key>(Qt::Key_0 + level)));
-        }
-        connect(action, &QAction::triggered, this, [this, level] {
-            const auto index = m_levelSelector->findData(level);
-            if (index >= 0) {
-                m_levelSelector->setCurrentIndex(index);
+    // "Level N only" is redundant for a single-level dataset (mirrors
+    // populateLevelCombo, which also drops these for finestLevel == 0).
+    if (metadata.finestLevel > 0) {
+        for (int level = 0; level <= metadata.finestLevel; ++level) {
+            auto* action = new QAction(tr("Level %1 only").arg(level), m_levelMenu);
+            action->setCheckable(true);
+            action->setActionGroup(m_levelGroup);
+            action->setData(level);
+            if (level < 10) {
+                action->setShortcut(QKeySequence(
+                    Qt::ALT | static_cast<Qt::Key>(Qt::Key_0 + level)));
             }
-        });
-        m_levelMenu->addAction(action);
+            connect(action, &QAction::triggered, this, [this, level] {
+                const auto index = m_levelSelector->findData(level);
+                if (index >= 0) {
+                    m_levelSelector->setCurrentIndex(index);
+                }
+            });
+            m_levelMenu->addAction(action);
+        }
     }
     syncMenuChecks();
 }
@@ -3244,10 +3248,8 @@ void MainWindow::onExportFrameDisplayed(int index)
             if (panelView == nullptr || !panelView->hasImage()) {
                 continue;
             }
-            const qreal scale = std::max(1.0,
-                panelView->transform().m11());
             const QImage frame = composeExportFrame(
-                panelView, m_exportAnim.includeColorBar, scale);
+                panelView, m_exportAnim.includeColorBar, m_exportAnim.scale);
             if (frame.isNull()) {
                 endExportAnimation(false,
                     tr("A frame could not be rendered."));
@@ -4700,6 +4702,13 @@ void MainWindow::goToSequenceFrame(int index)
     m_sliceDebounce->stop();
     // The dataset window shows the previous frame's raw values; drop it.
     closeDatasetWindow();
+    // Line plot curves are snapshots of this dataset; drop the window so its
+    // title and curves do not go stale across the frame switch.
+    auto* linePlotWindow = m_linePlotWindow;
+    m_linePlotWindow = nullptr;
+    if (linePlotWindow != nullptr) {
+        linePlotWindow->close();
+    }
     const auto generation = ++m_generation;
     m_sequenceIndex = index;
     m_sequenceInFlight = true;
@@ -4750,9 +4759,14 @@ void MainWindow::startFrameLoad(int index, std::uint64_t generation)
                 if (generation == m_generation && index == m_sequenceIndex) {
                     m_sequenceInFlight = false;
                     statusBar()->showMessage(tr("Frame load failed"));
+                    // During animation export the failure is reported by the
+                    // export handler (endExportAnimation); avoid a second dialog.
+                    const bool wasExporting = m_exportAnim.active;
                     emit sequenceFrameFailed();
-                    QMessageBox::critical(this, tr("Cannot load frame"),
-                        exceptionMessage(error));
+                    if (!wasExporting) {
+                        QMessageBox::critical(this, tr("Cannot load frame"),
+                            exceptionMessage(error));
+                    }
                 } else {
                     ++m_staleResults;
                 }
@@ -4773,9 +4787,14 @@ void MainWindow::finishFrameLoad(InitialSliceResult result, bool defaultPosition
     } catch (const std::exception& error) {
         m_sequenceInFlight = false;
         statusBar()->showMessage(tr("Frame load failed"));
+        // During animation export the failure is reported by the export
+        // handler (endExportAnimation); avoid a second dialog.
+        const bool wasExporting = m_exportAnim.active;
         emit sequenceFrameFailed();
-        QMessageBox::critical(this, tr("Cannot load frame"),
-            exceptionMessage(error));
+        if (!wasExporting) {
+            QMessageBox::critical(this, tr("Cannot load frame"),
+                exceptionMessage(error));
+        }
         updateDiagnostics();
         return;
     }

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -3203,6 +3203,9 @@ void MainWindow::exportAnimation()
     m_exportAnim.includeColorBar = includeColorBar;
     // Freeze the export zoom from the current view so every frame renders at the
     // same dimensions even if a frame's image size changes and refits the view.
+    // In 3-D this single scale is shared by all three panels, so a panel whose
+    // fitted zoom differs from the active view exports at the active view's
+    // scale -- constant across frames, which is the goal.
     m_exportAnim.scale = std::max(1.0, view->transform().m11());
     m_exportAnim.hasFfmpeg = probeFfmpeg();
     m_exportAnim.totalFrames = total;

--- a/src/qt/main.cpp
+++ b/src/qt/main.cpp
@@ -78,7 +78,10 @@ void ensureDesktopEntry()
         const QString dir = dataDir + QString("/icons/hicolor/%1x%1/apps").arg(size);
         const QString path = QDir(dir).filePath("amrexplorer.png");
         if (QFileInfo::exists(path)) {
-            continue;  // already installed; skip the no-op rewrite
+            // Already installed: skip the no-op rewrite. Conscious trade-off
+            // -- this also means a changed bundled icon won't reach an existing
+            // install; delete the file to force a refresh.
+            continue;
         }
         QDir().mkpath(dir);
         QFile in(QStringLiteral(":/amrexplorer-%1.png").arg(size));
@@ -89,6 +92,10 @@ void ensureDesktopEntry()
         }
     }
     QDir().mkpath(dataDir + "/applications");
+    // Rewritten wholesale when the binary moved (the Exec line must track the
+    // running binary), which discards user edits to the other fields. That is
+    // intentional for this install-on-startup helper; a surgical Exec-only
+    // patch would preserve edits but is out of scope.
     QFile desktop(desktopPath);
     if (desktop.open(QIODevice::WriteOnly | QIODevice::Truncate | QIODevice::Text)) {
         QTextStream out(&desktop);

--- a/src/qt/main.cpp
+++ b/src/qt/main.cpp
@@ -37,6 +37,12 @@ namespace {
 // resources/install-desktop-entry.sh does the same thing by hand.
 void ensureDesktopEntry()
 {
+#ifndef Q_OS_LINUX
+    // Desktop entry + hicolor icons are a GNOME/KDE (Linux) mechanism. On
+    // other platforms the writes land in nonsensical locations and the
+    // cache-refresh helpers do not exist, so do nothing.
+    return;
+#endif
     static constexpr int kSizes[] = {16, 32, 64, 128, 256};
     const QString dataDir =
         QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation);
@@ -70,9 +76,13 @@ void ensureDesktopEntry()
 
     for (int size : kSizes) {
         const QString dir = dataDir + QString("/icons/hicolor/%1x%1/apps").arg(size);
+        const QString path = QDir(dir).filePath("amrexplorer.png");
+        if (QFileInfo::exists(path)) {
+            continue;  // already installed; skip the no-op rewrite
+        }
         QDir().mkpath(dir);
         QFile in(QStringLiteral(":/amrexplorer-%1.png").arg(size));
-        QFile out(QDir(dir).filePath("amrexplorer.png"));
+        QFile out(path);
         if (in.open(QIODevice::ReadOnly)
             && out.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
             out.write(in.readAll());

--- a/src/render2d/VectorGlyphs.cpp
+++ b/src/render2d/VectorGlyphs.cpp
@@ -61,10 +61,11 @@ std::vector<VectorSegment> generateVectorGlyphs(
         return segments;
     }
 
-    // Legacy partitions the longest side with integer division before
-    // truncating again to the stride (AmrPicture::DrawVectorField).
+    // Partition the longest side, then truncate to the stride. Floating-point
+    // division keeps sight (and thus arrowMax) nonzero when count exceeds the
+    // longest side, so small planes still draw glyphs instead of vanishing.
     const int longestSide = std::max(uComponent.width, uComponent.height);
-    const double sight = static_cast<double>(longestSide / count);
+    const double sight = static_cast<double>(longestSide) / count;
     const int stride = std::max(1, static_cast<int>(sight));
     const double arrowMax = 1.25 * sight;
 

--- a/tests/unit/test_vector_glyphs.cpp
+++ b/tests/unit/test_vector_glyphs.cpp
@@ -93,6 +93,16 @@ int main()
     const auto zero = amrvis::generateVectorGlyphs(zeroU, zeroV, 10);
     require(zero.empty(), "zero field produced segments");
 
+    // count > longestSide used to give sight = 0 (integer division) and thus
+    // zero glyphs; floating-point division keeps sight nonzero. stride is
+    // floor(8/10) clamped to 1, so every one of the 8x8 = 64 cells draws an
+    // arrow of 3 segments -> 192 total (pins both the zero-glyph regression
+    // and the stride=1 density).
+    const auto smallU = makePlane(8, 8, 1.0F);
+    const auto smallV = makePlane(8, 8, 0.0F);
+    const auto dense = amrvis::generateVectorGlyphs(smallU, smallV, 10);
+    require(dense.size() == 192, "count > longestSide produced wrong glyph count");
+
     const auto mismatched = makePlane(10, 10, 0.0F);
     bool threw = false;
     try {

--- a/tools/line_repro/main.cpp
+++ b/tools/line_repro/main.cpp
@@ -14,6 +14,7 @@
 #include <cstdint>
 #include <filesystem>
 #include <iostream>
+#include <memory>
 #include <mutex>
 #include <string>
 #include <thread>
@@ -22,29 +23,34 @@ namespace {
 
 // Run fn() on a worker; if it does not finish within timeoutSeconds, report a
 // hang and return false (the worker is abandoned; process exit reclaims it).
+// Shared state is heap-allocated and captured by value (shared_ptr) so a
+// detached worker never touches stack locals that have gone out of scope.
 template <typename Fn>
 bool runWithTimeout(Fn fn, int timeoutSeconds)
 {
-    std::mutex m;
-    std::condition_variable cv;
-    bool done = false;
+    struct State {
+        std::mutex mutex;
+        std::condition_variable cv;
+        bool done = false;
+    };
+    const auto state = std::make_shared<State>();
 
-    std::thread worker([&] {
+    std::thread worker([state, fn = std::move(fn)] {
         try {
             fn();
         } catch (const std::exception& error) {
             std::cerr << "  worker threw: " << error.what() << '\n';
         }
         {
-            std::lock_guard<std::mutex> lock(m);
-            done = true;
+            std::lock_guard<std::mutex> lock(state->mutex);
+            state->done = true;
         }
-        cv.notify_one();
+        state->cv.notify_one();
     });
 
-    std::unique_lock<std::mutex> lock(m);
-    const bool ok = cv.wait_for(lock, std::chrono::seconds(timeoutSeconds),
-        [&] { return done; });
+    std::unique_lock<std::mutex> lock(state->mutex);
+    const bool ok = state->cv.wait_for(lock, std::chrono::seconds(timeoutSeconds),
+        [&] { return state->done; });
     if (ok) {
         lock.unlock();
         worker.join();


### PR DESCRIPTION
Ten small, independent fixes:

- Wheel zoom no longer fires on zero-vertical-delta (horizontal trackpad) scrolls, which had spuriously zoomed in (ImageView, IsoWidget).
- Drop the dead "Level 0 only" menu item for single-level datasets.
- 3-D animation export uses the frozen export scale so PNG dimensions stay constant across frames instead of changing on a refit (broke MP4 assembly).
- Frame-load failure during animation export shows one dialog, not two.
- ensureDesktopEntry is Linux-only and skips rewriting already-installed icons (was writing .desktop/icons and spawning sh on macOS/Windows).
- Correct the stale ImageView header comment on middle/right-click behavior.
- Close the line-plot window on sequence frame switch so its curves and title do not go stale.
- Strip the line-plot guide and cell-highlight overlays from exported PNGs.
- Vector-glyph spacing uses floating-point division so small planes no longer silently draw zero glyphs.
- line_repro watchdog heap-allocates its sync state, fixing a detached- thread use-after-scope in the timeout path.