### PR TITLE
Docs: fix default number format and macOS Qt setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,9 +63,6 @@ jobs:
       - name: Install dependencies
         run: brew install cmake ninja qt
 
-      - name: Configure Qt
-        run: echo "CMAKE_PREFIX_PATH=$(brew --prefix qt)" >> "$GITHUB_ENV"
-
       - name: Configure
         run: cmake --preset default -DAMREXPLORER_WARNINGS_AS_ERRORS=ON
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -29,7 +29,14 @@ cmake --build --preset default
 Install the dependencies with [Homebrew][]:
 
 ```bash
-brew install cmake ninja qt6
+brew install cmake ninja qt
+```
+
+Homebrew's Qt is keg-only, so CMake cannot locate it without a prefix hint.
+Export this before configuring (or add it to your shell profile):
+
+```bash
+export CMAKE_PREFIX_PATH="$(brew --prefix qt)"
 ```
 
 [Homebrew]: https://brew.sh

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -32,13 +32,6 @@ Install the dependencies with [Homebrew][]:
 brew install cmake ninja qt
 ```
 
-Homebrew's Qt is keg-only, so CMake cannot locate it without a prefix hint.
-Export this before configuring (or add it to your shell profile):
-
-```bash
-export CMAKE_PREFIX_PATH="$(brew --prefix qt)"
-```
-
 [Homebrew]: https://brew.sh
 
 **Optional:** `ffmpeg` is needed to encode animation exports (MP4).

--- a/docs/building.md
+++ b/docs/building.md
@@ -1,7 +1,10 @@
 # Building AMReXplorer
 
 AMReXplorer requires a C++20 compiler, CMake 3.25 or newer, and Ninja for the
-provided presets. Qt 6.4 or newer is required only by the desktop target.
+provided presets. Qt 6.4 or newer is required only by the desktop target. On
+macOS, Homebrew's Qt is keg-only, so export
+`CMAKE_PREFIX_PATH="$(brew --prefix qt)"` before configuring or CMake cannot
+find it.
 There is no build-time dataset dimension: one executable reads 2-D and 3-D
 data, and the same runtime metadata representation accepts 1-D data.
 

--- a/docs/building.md
+++ b/docs/building.md
@@ -1,10 +1,7 @@
 # Building AMReXplorer
 
 AMReXplorer requires a C++20 compiler, CMake 3.25 or newer, and Ninja for the
-provided presets. Qt 6.4 or newer is required only by the desktop target. On
-macOS, Homebrew's Qt is keg-only, so export
-`CMAKE_PREFIX_PATH="$(brew --prefix qt)"` before configuring or CMake cannot
-find it.
+provided presets. Qt 6.4 or newer is required only by the desktop target.
 There is no build-time dataset dimension: one executable reads 2-D and 3-D
 data, and the same runtime metadata representation accepts 1-D data.
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -122,7 +122,7 @@ the visible physical region. Values are grouped by AMR level. Clicking a
 value highlights the corresponding sample in the main view.
 
 Choose **View > Number Format...** to set the `printf`-style format used for
-numeric readouts. The default is `%7.5f`.
+numeric readouts. The default is `%g`.
 
 ## Working with 3-D data
 


### PR DESCRIPTION
- User guide default is %g, not %7.5f (matches NumberFormat.cpp); the guide is also embedded in-app via user-guide.qrc.
- Document that Homebrew Qt is keg-only and requires CMAKE_PREFIX_PATH=$(brew --prefix qt); align the package name to qt.