### PR TITLE
Bound Palette::load to one read of at most 1025 bytes

### DIFF
--- a/src/render2d/Palette.cpp
+++ b/src/render2d/Palette.cpp
@@ -3,10 +3,8 @@
 #include <algorithm>
 #include <cstddef>
 #include <fstream>
-#include <iterator>
 #include <stdexcept>
 #include <string>
-#include <vector>
 
 namespace amrvis {
 
@@ -66,19 +64,27 @@ Palette Palette::load(const std::filesystem::path& path)
     if (!stream) {
         throw std::runtime_error("cannot open palette file: " + path.string());
     }
-    const std::vector<char> bytes(
-        (std::istreambuf_iterator<char>(stream)), std::istreambuf_iterator<char>());
+    // Bound the read so an accidentally-selected huge file cannot block the GUI
+    // thread or exhaust memory. Read at most one byte more than the largest
+    // valid size: gcount is 768 or 1024 only for an exactly-sized file, while
+    // anything larger yields 1025 (the cap) and is rejected.
     constexpr std::size_t channelBytes = slotCount;
-    if (bytes.size() != 3 * channelBytes && bytes.size() != 4 * channelBytes) {
+    constexpr std::size_t maxBytes = 4 * channelBytes + 1;
+    std::array<char, maxBytes> buffer{};
+    stream.read(buffer.data(), static_cast<std::streamsize>(maxBytes));
+    const auto byteCount = static_cast<std::size_t>(stream.gcount());
+    if (byteCount != 3 * channelBytes && byteCount != 4 * channelBytes) {
         throw std::runtime_error("palette file " + path.string()
             + " is not a legacy sequential palette (expected 768 or 1024 bytes, got "
-            + std::to_string(bytes.size()) + ")");
+            + (byteCount == maxBytes ? std::string("more than 1024")
+                                     : std::to_string(byteCount))
+            + ")");
     }
     std::array<Rgb, slotCount> slots{};
     for (std::size_t index = 0; index < channelBytes; ++index) {
-        slots[index].red = static_cast<std::uint8_t>(bytes[index]);
-        slots[index].green = static_cast<std::uint8_t>(bytes[channelBytes + index]);
-        slots[index].blue = static_cast<std::uint8_t>(bytes[2 * channelBytes + index]);
+        slots[index].red = static_cast<std::uint8_t>(buffer[index]);
+        slots[index].green = static_cast<std::uint8_t>(buffer[channelBytes + index]);
+        slots[index].blue = static_cast<std::uint8_t>(buffer[2 * channelBytes + index]);
     }
     return Palette(slots);
 }

--- a/tests/unit/test_palette.cpp
+++ b/tests/unit/test_palette.cpp
@@ -8,6 +8,7 @@
 #include <iostream>
 #include <iterator>
 #include <stdexcept>
+#include <string>
 #include <vector>
 
 namespace {
@@ -82,6 +83,45 @@ int main(int argc, char** argv)
         threw = true;
     }
     require(threw, "Palette::load accepted a missing palette file");
+
+    // load() accepts a 768-byte (3-channel) palette: the rainbow bytes minus
+    // the unused fourth channel round-trip to the same colors.
+    const auto palette768Path = std::filesystem::temp_directory_path()
+        / "amrexplorer_test_palette_768.pal";
+    {
+        std::ofstream stream(palette768Path, std::ios::binary);
+        stream.write(fileBytes.data(), 3 * amrvis::Palette::slotCount);
+    }
+    const auto loaded768 = amrvis::Palette::load(palette768Path);
+    bool roundTrip768 = true;
+    for (int index = 0; index < amrvis::Palette::slotCount; ++index) {
+        roundTrip768 = roundTrip768
+            && loaded768.slotArgb(index) == rainbow.slotArgb(index);
+    }
+    require(roundTrip768, "Palette::load did not round-trip a 768-byte palette");
+    std::filesystem::remove(palette768Path);
+
+    // load() rejects a file larger than 1024 bytes (the bounded read caps it).
+    const auto oversizedPath = std::filesystem::temp_directory_path()
+        / "amrexplorer_test_palette_oversized.pal";
+    {
+        const std::vector<char> bytesOver(static_cast<std::size_t>(2000), 0);
+        std::ofstream stream(oversizedPath, std::ios::binary);
+        stream.write(bytesOver.data(),
+            static_cast<std::streamsize>(bytesOver.size()));
+    }
+    threw = false;
+    std::string overMessage;
+    try {
+        (void)amrvis::Palette::load(oversizedPath);
+    } catch (const std::runtime_error& error) {
+        threw = true;
+        overMessage = error.what();
+    }
+    std::filesystem::remove(oversizedPath);
+    require(threw, "Palette::load accepted an oversized palette file");
+    require(overMessage.find("more than 1024") != std::string::npos,
+        "oversized palette rejection did not report the size");
 
     // The normalized endpoints map to distinct colors and out-of-range t clamps.
     require(rainbow.argb(0.0) != rainbow.argb(1.0),


### PR DESCRIPTION
The loader previously slurped the entire selected file before checking its size, so loading a multi-GB file blocked the GUI thread and risked an oversized allocation. Read at most one byte past the largest valid size and validate the count, so only exactly 768/1024-byte files are accepted.