### PR TITLE
Reject non-finite scalar render/contour ranges

### DIFF
--- a/src/render2d/Contours.cpp
+++ b/src/render2d/Contours.cpp
@@ -23,6 +23,11 @@ std::vector<double> contourValues(
     if (!(minimum < maximum)) {
         throw std::invalid_argument("contour range must have positive extent");
     }
+    if (!std::isfinite(minimum) || !std::isfinite(maximum)
+        || !std::isfinite(maximum - minimum)) {
+        throw std::invalid_argument(
+            "contour range must be finite with a finite span");
+    }
     if (logarithmic && !(minimum > 0.0)) {
         throw std::invalid_argument("logarithmic contour range must be positive");
     }

--- a/src/render2d/ScalarRenderer.cpp
+++ b/src/render2d/ScalarRenderer.cpp
@@ -58,6 +58,11 @@ ImageBuffer renderScalarPlane(
     if (!(settings.minimum < settings.maximum)) {
         throw std::invalid_argument("scalar render range must have positive extent");
     }
+    if (!std::isfinite(settings.minimum) || !std::isfinite(settings.maximum)
+        || !std::isfinite(settings.maximum - settings.minimum)) {
+        throw std::invalid_argument(
+            "scalar render range must be finite with a finite span");
+    }
     if (settings.logarithmic && !(settings.minimum > 0.0)) {
         throw std::invalid_argument("logarithmic scalar range must be positive");
     }

--- a/tests/unit/test_contours.cpp
+++ b/tests/unit/test_contours.cpp
@@ -5,6 +5,7 @@
 #include <cmath>
 #include <cstdlib>
 #include <iostream>
+#include <limits>
 #include <stdexcept>
 #include <vector>
 
@@ -155,6 +156,32 @@ int main()
         threw = true;
     }
     require(threw, "contourValues accepted a non-positive logarithmic range");
+    threw = false;
+    try {
+        (void)amrvis::contourValues(
+            -std::numeric_limits<double>::max(),
+            std::numeric_limits<double>::max(), 4, false);
+    } catch (const std::invalid_argument&) {
+        threw = true;
+    }
+    require(threw, "contourValues accepted a range whose span overflows to infinity");
+    threw = false;
+    try {
+        (void)amrvis::contourValues(
+            -std::numeric_limits<double>::infinity(),
+            std::numeric_limits<double>::infinity(), 4, false);
+    } catch (const std::invalid_argument&) {
+        threw = true;
+    }
+    require(threw, "contourValues accepted an infinite range");
+    threw = false;
+    try {
+        (void)amrvis::contourValues(
+            std::numeric_limits<double>::quiet_NaN(), 1.0, 4, false);
+    } catch (const std::invalid_argument&) {
+        threw = true;
+    }
+    require(threw, "contourValues accepted a NaN range endpoint");
 
     // Cells whose value range brackets 2.5: (0,0), (1,0), (2,0), (0,1).
     const auto plane = makePlane();

--- a/tests/unit/test_scalar_renderer.cpp
+++ b/tests/unit/test_scalar_renderer.cpp
@@ -75,5 +75,39 @@ int main()
         threw = true;
     }
     require(threw, "renderer accepted an unrepresentable row stride");
+
+    // An extreme but finite range (±DBL_MAX) overflows the span to infinity;
+    // the renderer must reject it instead of normalizing every value to zero.
+    settings.minimum = -std::numeric_limits<double>::max();
+    settings.maximum = std::numeric_limits<double>::max();
+    threw = false;
+    try {
+        (void)amrvis::renderScalarPlane(plane, settings);
+    } catch (const std::invalid_argument&) {
+        threw = true;
+    }
+    require(threw, "renderer accepted a range whose span overflows to infinity");
+
+    // Non-finite endpoints are also rejected: ±inf where the ordering still
+    // holds fails the span check, and NaN fails the ordering check outright.
+    settings.minimum = -std::numeric_limits<double>::infinity();
+    settings.maximum = std::numeric_limits<double>::infinity();
+    threw = false;
+    try {
+        (void)amrvis::renderScalarPlane(plane, settings);
+    } catch (const std::invalid_argument&) {
+        threw = true;
+    }
+    require(threw, "renderer accepted an infinite range");
+
+    settings.minimum = std::numeric_limits<double>::quiet_NaN();
+    settings.maximum = 1.0;
+    threw = false;
+    try {
+        (void)amrvis::renderScalarPlane(plane, settings);
+    } catch (const std::invalid_argument&) {
+        threw = true;
+    }
+    require(threw, "renderer accepted a NaN range endpoint");
     return 0;
 }


### PR DESCRIPTION
renderScalarPlane and contourValues only checked minimum < maximum, so a range of ±DBL_MAX (reachable from the UI spinboxes) overflowed the span to +inf: the renderer normalized every value to zero (a flat image) and contour levels became inf and were silently filtered out, with no error.  Validate that the endpoints and span are finite.