### PR TITLE
Make LineQuery end epsilon cell-relative

### DIFF
--- a/src/query/LineQuery.cpp
+++ b/src/query/LineQuery.cpp
@@ -236,7 +236,11 @@ LineQueryResult LineQuery::execute(
     // points. Uncovered stretches (ExactLevel outside coverage, or out of
     // domain) become invalid samples so the polyline breaks there.
     auto x = physicalStart;
-    constexpr double endEpsilon = 1e-9;
+    // Relative to the cell size (matching cellStepNudge below): an absolute
+    // 1e-9 epsilon truncates domains whose physical extent is near that scale
+    // (micro/nano-scale SI-unit geometries), dropping the tail samples or
+    // yielding an empty line with no error.
+    const double endEpsilon = 1e-9 * finestCellSize;
     while (x < physicalEnd - endEpsilon) {
         if ((result.line.positions.size() & 31U) == 0U
             && cancellation.stop_requested()) {

--- a/tests/integration/test_line_query.cpp
+++ b/tests/integration/test_line_query.cpp
@@ -458,6 +458,85 @@ void testOffsetGeometry(const std::filesystem::path& source, const std::filesyst
         "offset line query hung (regression: cell-boundary round-trip stall)");
 }
 
+// Regression for the absolute end epsilon: the walk's endEpsilon used to be an
+// absolute 1e-9 in physical units, so a domain at or below that scale
+// (micro/nano-scale SI-unit geometries) was truncated -- an extent of 4e-10
+// produced an empty line. With the cell-relative epsilon the full domain is
+// sampled. Geometry: prob_lo 0, cell size 1e-10, extent 4e-10 (4 cells).
+void testTinyDomain(const std::filesystem::path& source, const std::filesystem::path& work)
+{
+    const auto root = materializeFixture(source, work / "plotfile_3d_tiny");
+    writeFab(root / "Level_0" / "Cell_D_00000", 0,
+        "((0,0,0) (3,3,3) (0,0,0))", 1, field3d());
+    {
+        std::ofstream header(root / "Header", std::ios::binary | std::ios::trunc);
+        require(static_cast<bool>(header), "could not open tiny Header for writing");
+        header <<
+            "HyperCLaw-V1.1\n"
+            "1\n"
+            "q\n"
+            "3\n"
+            "0.0\n"
+            "0\n"
+            "0.0 0.0 0.0\n"
+            "4e-10 4e-10 4e-10\n"
+            "\n"
+            "((0,0,0) (3,3,3) (0,0,0))\n"
+            "0\n"
+            "1e-10 1e-10 1e-10\n"
+            "0\n"
+            "0\n"
+            "0 1 0.0\n"
+            "0\n"
+            "0.0 4e-10\n"
+            "0.0 4e-10\n"
+            "0.0 4e-10\n"
+            "Level_0/Cell\n";
+    }
+
+    amrvis::PlotfileDataset dataset(root, amrvis::DatasetId{22}, 1024 * 1024);
+    amrvis::LineQuery lines(dataset);
+    const auto& metadata = dataset.metadata();
+    require(metadata.dimension == 3 && metadata.finestLevel == 0,
+        "tiny fixture parsed unexpected dimension or level count");
+
+    amrvis::LineRequest request;
+    request.dataset.value = 22;
+    request.field.value = 0;
+    request.axis = 0;
+    const double center = 0.5 * (metadata.physicalDomain.lower[1]
+        + metadata.physicalDomain.upper[1]);
+    request.fixedCoordinates = {center, center, center};
+    request.maximumLevel = 0;
+    request.region = amrvis::RealBox{metadata.physicalDomain.lower,
+        metadata.physicalDomain.upper};
+    const auto lineAxisIndex = static_cast<std::size_t>(request.axis);
+    const auto lineCellSize = metadata.levels[0].cellSize[lineAxisIndex];
+    const auto lineOrigin = metadata.physicalDomain.lower[lineAxisIndex];
+
+    auto ranToCompletion = runWithTimeout(
+        [&] {
+            const auto result = lines.execute(request);
+            require(result.line.positions.size() == 4,
+                "tiny-domain line query was truncated (expected one sample per cell)");
+            for (std::size_t sample = 0; sample < 4; ++sample) {
+                require(result.line.valid[sample] == 1
+                        && result.line.sourceLevel[sample] == 0,
+                    "tiny-domain line query left a hole or reported a wrong level");
+                // Cell centers: origin + (i + 0.5) * cellSize. Pins the walk's
+                // calibration, not just completeness (a half-cell or origin
+                // offset would miss by far more than 1e-6 of a cell).
+                const double expected = lineOrigin
+                    + (static_cast<double>(sample) + 0.5) * lineCellSize;
+                require(std::fabs(result.line.positions[sample] - expected)
+                        <= 1e-6 * lineCellSize,
+                    "tiny-domain sample is not at its cell center");
+            }
+        },
+        10);
+    require(ranToCompletion, "tiny-domain line query hung");
+}
+
 } // namespace
 
 int main(int argc, char* argv[])
@@ -478,6 +557,7 @@ int main(int argc, char* argv[])
     test2d(plotfile2d, work);
     test3d(plotfile3d, work);
     testOffsetGeometry(plotfile3d, work);
+    testTinyDomain(plotfile3d, work);
 
     std::filesystem::remove_all(work);
     return 0;


### PR DESCRIPTION
The line walk used an absolute 1e-9 endEpsilon against physical coords, so domains at or below that scale (micro/nano-scale SI-unit geometries) were truncated -- an extent of 1e-8 lost its last ~10% of samples and an extent <= 1e-9 produced an empty line with no error. Scale it by the cell size, matching the existing relative cellStepNudge, and add a tiny-domain test.