### PR TITLE
Make the metadata read cooperatively cancellable

### DIFF
--- a/include/amrexplorer/io/PlotfileMetadataReader.hpp
+++ b/include/amrexplorer/io/PlotfileMetadataReader.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <amrexplorer/core/Metadata.hpp>
+#include <amrexplorer/core/StopToken.hpp>
 
 #include <cstdint>
 #include <filesystem>
@@ -30,7 +31,7 @@ public:
 
 class PlotfileMetadataReader {
 public:
-    [[nodiscard]] PlotfileMetadataResult read(const std::filesystem::path& plotfile) const;
+    [[nodiscard]] PlotfileMetadataResult read(const std::filesystem::path& plotfile, StopToken cancellation = {}) const;
 };
 
 } // namespace amrvis

--- a/include/amrexplorer/io/StandaloneMetadataReader.hpp
+++ b/include/amrexplorer/io/StandaloneMetadataReader.hpp
@@ -13,9 +13,9 @@ class StandaloneMetadataReader {
 public:
     [[nodiscard]] PlotfileMetadataResult readFab(
         const std::filesystem::path& fabPath,
-        std::uint64_t offset = 0) const;
+        std::uint64_t offset = 0, StopToken cancellation = {}) const;
     [[nodiscard]] PlotfileMetadataResult readMultiFab(
-        const std::filesystem::path& prefixOrHeader) const;
+        const std::filesystem::path& prefixOrHeader, StopToken cancellation = {}) const;
 };
 
 [[nodiscard]] PlotfileMetadataResult makeSelectedFabMetadata(

--- a/include/amrexplorer/io/StandaloneMetadataReader.hpp
+++ b/include/amrexplorer/io/StandaloneMetadataReader.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <amrexplorer/io/PlotfileMetadataReader.hpp>
+#include <amrexplorer/core/StopToken.hpp>
 
 #include <cstddef>
 #include <cstdint>
@@ -23,6 +24,6 @@ public:
 
 // Inspect a plotfile directory, standalone FAB, or serialized MultiFab prefix/header.
 [[nodiscard]] PlotfileMetadataResult readDatasetMetadata(
-    const std::filesystem::path& path);
+    const std::filesystem::path& path, StopToken cancellation = {});
 
 } // namespace amrvis

--- a/include/amrexplorer/io/detail/VisMfIndex.hpp
+++ b/include/amrexplorer/io/detail/VisMfIndex.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <amrexplorer/core/Geometry.hpp>
+#include <amrexplorer/core/StopToken.hpp>
 
 #include <cstdint>
 #include <filesystem>
@@ -24,6 +25,7 @@ struct VisMfIndex {
 };
 
 [[nodiscard]] VisMfIndex readVisMfIndex(
-    const std::filesystem::path& headerPath, int dimension);
+    const std::filesystem::path& headerPath, int dimension,
+    StopToken cancellation = {});
 
 } // namespace amrvis::detail

--- a/src/io/plotfile/PlotfileMetadataReader.cpp
+++ b/src/io/plotfile/PlotfileMetadataReader.cpp
@@ -137,7 +137,8 @@ std::vector<std::vector<double>> readRealMatrix(
 } // namespace
 
 detail::VisMfIndex detail::readVisMfIndex(
-    const std::filesystem::path& headerPath, int dimension)
+    const std::filesystem::path& headerPath, int dimension,
+    StopToken cancellation)
 {
     std::error_code sizeError;
     const auto headerSize = std::filesystem::file_size(headerPath, sizeError);
@@ -184,6 +185,9 @@ detail::VisMfIndex detail::readVisMfIndex(
     const auto boxCount = static_cast<std::size_t>(boxArrayHeader.front());
     index.boxes.reserve(boxCount);
     for (std::size_t box = 0; box < boxCount; ++box) {
+        if (cancellation.stop_requested()) {
+            throw ReadCancelled();
+        }
         index.boxes.push_back(readAmrexBox(input, dimension, "VisMF BoxArray entry"));
     }
     if (readNonEmptyLine(input, "VisMF BoxArray terminator") != ")") {
@@ -197,6 +201,9 @@ detail::VisMfIndex detail::readVisMfIndex(
     index.fileNames.reserve(boxCount);
     index.fileOffsets.reserve(boxCount);
     for (std::size_t block = 0; block < boxCount; ++block) {
+        if (cancellation.stop_requested()) {
+            throw ReadCancelled();
+        }
         const auto prefix = readRequired<std::string>(input, "FabOnDisk prefix");
         if (prefix != "FabOnDisk:") {
             throw MetadataReadError("malformed FabOnDisk record");
@@ -432,7 +439,7 @@ PlotfileMetadataResult PlotfileMetadataReader::read(
         }
         const auto dataPrefix = plotfile / level.dataPath;
         const auto indexPath = std::filesystem::path(dataPrefix.string() + "_H");
-        const auto visMf = detail::readVisMfIndex(indexPath, metadata->dimension);
+        const auto visMf = detail::readVisMfIndex(indexPath, metadata->dimension, cancellation);
         ++metrics.filesRead;
         metrics.bytesRead += visMf.bytesRead;
         if (visMf.components != componentCount) {

--- a/src/io/plotfile/PlotfileMetadataReader.cpp
+++ b/src/io/plotfile/PlotfileMetadataReader.cpp
@@ -1,4 +1,5 @@
 #include <amrexplorer/io/PlotfileMetadataReader.hpp>
+#include <amrexplorer/io/PlotfileBlockReader.hpp>
 #include <amrexplorer/io/detail/VisMfIndex.hpp>
 
 #include <algorithm>
@@ -281,7 +282,7 @@ IntBox physicalBoundsToCellBox(
 } // namespace
 
 PlotfileMetadataResult PlotfileMetadataReader::read(
-    const std::filesystem::path& plotfile) const
+    const std::filesystem::path& plotfile, StopToken cancellation) const
 {
     const auto headerPath = plotfile / "Header";
     std::error_code sizeError;
@@ -294,6 +295,9 @@ PlotfileMetadataResult PlotfileMetadataReader::read(
     std::ifstream input(headerPath, std::ios::binary);
     if (!input) {
         throw MetadataReadError("cannot open plotfile Header '" + headerPath.string() + "'");
+    }
+    if (cancellation.stop_requested()) {
+        throw ReadCancelled();
     }
 
     auto metadata = std::make_shared<DatasetMetadata>();
@@ -398,6 +402,9 @@ PlotfileMetadataResult PlotfileMetadataReader::read(
         level.step = headerStep;
         level.boxes.reserve(static_cast<std::size_t>(gridCount));
         for (int grid = 0; grid < gridCount; ++grid) {
+            if (cancellation.stop_requested()) {
+                throw ReadCancelled();
+            }
             Real3 lower;
             Real3 upper;
             for (int axis = 0; axis < metadata->dimension; ++axis) {
@@ -420,6 +427,9 @@ PlotfileMetadataResult PlotfileMetadataReader::read(
 
     MetadataReadMetrics metrics{1, headerSize, 0, 0};
     for (auto& level : metadata->levels) {
+        if (cancellation.stop_requested()) {
+            throw ReadCancelled();
+        }
         const auto dataPrefix = plotfile / level.dataPath;
         const auto indexPath = std::filesystem::path(dataPrefix.string() + "_H");
         const auto visMf = detail::readVisMfIndex(indexPath, metadata->dimension);

--- a/src/io/plotfile/StandaloneMetadataReader.cpp
+++ b/src/io/plotfile/StandaloneMetadataReader.cpp
@@ -1,5 +1,6 @@
 #include <amrexplorer/io/StandaloneMetadataReader.hpp>
 #include <amrexplorer/io/FabCatalog.hpp>
+#include <amrexplorer/io/PlotfileBlockReader.hpp>
 #include <amrexplorer/io/detail/VisMfIndex.hpp>
 
 #include <algorithm>
@@ -233,11 +234,15 @@ PlotfileMetadataResult StandaloneMetadataReader::readMultiFab(
     };
 }
 
-PlotfileMetadataResult readDatasetMetadata(const std::filesystem::path& path)
+PlotfileMetadataResult readDatasetMetadata(const std::filesystem::path& path,
+    StopToken cancellation)
 {
     if (std::filesystem::is_directory(path)
         && std::filesystem::is_regular_file(path / "Header")) {
-        return PlotfileMetadataReader{}.read(path);
+        return PlotfileMetadataReader{}.read(path, cancellation);
+    }
+    if (cancellation.stop_requested()) {
+        throw ReadCancelled();
     }
     if (path.string().ends_with("_H")
         || std::filesystem::is_regular_file(

--- a/src/io/plotfile/StandaloneMetadataReader.cpp
+++ b/src/io/plotfile/StandaloneMetadataReader.cpp
@@ -100,8 +100,12 @@ void validateStandalone(const DatasetMetadata& metadata)
 } // namespace
 
 PlotfileMetadataResult StandaloneMetadataReader::readFab(
-    const std::filesystem::path& fabPath, std::uint64_t offset) const
+    const std::filesystem::path& fabPath, std::uint64_t offset,
+    StopToken cancellation) const
 {
+    if (cancellation.stop_requested()) {
+        throw ReadCancelled();
+    }
     const auto record = inspectFabRecord(fabPath, offset);
 
     auto metadata = makeSingleLevelMetadata(
@@ -180,8 +184,11 @@ PlotfileMetadataResult makeSelectedFabMetadata(
 }
 
 PlotfileMetadataResult StandaloneMetadataReader::readMultiFab(
-    const std::filesystem::path& prefixOrHeader) const
+    const std::filesystem::path& prefixOrHeader, StopToken cancellation) const
 {
+    if (cancellation.stop_requested()) {
+        throw ReadCancelled();
+    }
     auto prefix = prefixOrHeader;
     if (prefix.string().ends_with("_H")) {
         auto value = prefix.string();
@@ -190,7 +197,7 @@ PlotfileMetadataResult StandaloneMetadataReader::readMultiFab(
     }
     const auto headerPath = std::filesystem::path(prefix.string() + "_H");
     const auto dimension = inferMultiFabDimension(headerPath);
-    const auto index = detail::readVisMfIndex(headerPath, dimension);
+    const auto index = detail::readVisMfIndex(headerPath, dimension, cancellation);
     if (index.boxes.empty() || index.components <= 0) {
         throw MetadataReadError("standalone MultiFab is empty");
     }
@@ -241,15 +248,12 @@ PlotfileMetadataResult readDatasetMetadata(const std::filesystem::path& path,
         && std::filesystem::is_regular_file(path / "Header")) {
         return PlotfileMetadataReader{}.read(path, cancellation);
     }
-    if (cancellation.stop_requested()) {
-        throw ReadCancelled();
-    }
     if (path.string().ends_with("_H")
         || std::filesystem::is_regular_file(
             std::filesystem::path(path.string() + "_H"))) {
-        return StandaloneMetadataReader{}.readMultiFab(path);
+        return StandaloneMetadataReader{}.readMultiFab(path, cancellation);
     }
-    return StandaloneMetadataReader{}.readFab(path);
+    return StandaloneMetadataReader{}.readFab(path, 0, cancellation);
 }
 
 } // namespace amrvis

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -2773,6 +2773,7 @@ void MainWindow::cancelInFlight()
         m_playbackTimer->stop();
     }
     m_initialStopSource.request_stop();
+    m_metadataStopSource.request_stop();
     m_prefetchStopSource.request_stop();
     m_linePlotStopSource.request_stop();
     m_view2d.stopSource.request_stop();
@@ -3734,6 +3735,8 @@ void MainWindow::openDatasetImpl(const std::filesystem::path& path,
     m_probeLabel->clear();
     m_colorBar->clearRange();
     const auto generation = ++m_generation;
+    m_metadataStopSource = StopSource{};
+    const auto metadataCancellation = m_metadataStopSource.get_token();
     ++m_activeRequests;
     statusBar()->showMessage(tr("Reading metadata for %1...").arg(
         QString::fromStdString(path.string())));
@@ -3786,11 +3789,12 @@ void MainWindow::openDatasetImpl(const std::filesystem::path& path,
             watcher->deleteLater();
         });
     watcher->setFuture(QtConcurrent::run(
-        [path, preparedMetadata = std::move(preparedMetadata)]() mutable {
+        [path, preparedMetadata = std::move(preparedMetadata),
+            cancellation = metadataCancellation]() mutable {
         if (preparedMetadata) {
             return std::move(*preparedMetadata);
         }
-        return readDatasetMetadata(path);
+        return readDatasetMetadata(path, cancellation);
     }));
 }
 

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -3735,6 +3735,7 @@ void MainWindow::openDatasetImpl(const std::filesystem::path& path,
     m_probeLabel->clear();
     m_colorBar->clearRange();
     const auto generation = ++m_generation;
+    m_metadataStopSource.request_stop();
     m_metadataStopSource = StopSource{};
     const auto metadataCancellation = m_metadataStopSource.get_token();
     ++m_activeRequests;

--- a/src/qt/MainWindow.hpp
+++ b/src/qt/MainWindow.hpp
@@ -482,6 +482,7 @@ private:
     // OR of the rasterDirty flags of the coalesced pending requests.
     bool m_pendingRasterDirty = false;
     StopSource m_initialStopSource;
+    StopSource m_metadataStopSource;
     DisplayMode m_displayMode = DisplayMode::Raster;
     int m_contourCount = 15;
     int m_contourColor = contourColorBlack;


### PR DESCRIPTION
The async metadata read had no cancellation token, so a slow read could keep the global pool (and thus shutdown) waiting. Thread a StopToken (default {}) through readDatasetMetadata and PlotfileMetadataReader::read, check it at the read loop boundaries, and drive it from a new m_metadataStopSource that cancelInFlight stops. Existing callers are unaffected via the default argument.