### PR TITLE
Add smoke tests for quitting during in-flight and failing loads

### DIFF
--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -79,13 +79,13 @@
 
 #include <algorithm>
 #include <array>
+#include <atomic>
 #include <cmath>
 #include <exception>
 #include <filesystem>
 #include <fstream>
 #include <limits>
 #include <map>
-#include <atomic>
 #include <memory>
 #include <optional>
 #include <stdexcept>

--- a/src/qt/main.cpp
+++ b/src/qt/main.cpp
@@ -476,6 +476,22 @@ int main(int argc, char* argv[])
         QTimer::singleShot(0, &window, [&window, first, second] {
             window.openSequence({first, second});
         });
+    } else if (argc == 3
+        && std::string_view(argv[1]) == "--quit-smoke-test") {
+        // Open a dataset, then quit through the main window once the initial
+        // slice resolves (success or failure) and also mid-load. Passes if the
+        // process exits promptly; a regression that blocks quit (an uncanceled
+        // worker pinning the global pool, or a modal failure dialog) keeps it
+        // alive until the watchdog fails the test.
+        const std::filesystem::path path(argv[2]);
+        QObject::connect(&window, &amrvis::qt::MainWindow::initialSliceFinished,
+            &application, [&window](bool) {
+                QTimer::singleShot(0, &window, [&window] { window.close(); });
+            });
+        QTimer::singleShot(300, &window, [&window] { window.close(); });
+        QTimer::singleShot(15000, &application,
+            [&application] { application.exit(1); });
+        QTimer::singleShot(0, &window, [&window, path] { window.openDataset(path); });
     } else if (argc >= 2 && !std::string_view(argv[1]).starts_with("--")) {
         // One or more plotfile paths: a single path opens a dataset, two or
         // more open a plotfile sequence (matching the GUI's Open Plotfile

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -193,6 +193,28 @@ if(TARGET amrexplorer_qt)
     )
     set_tests_properties(qt_slice_smoke_3d PROPERTIES TIMEOUT 30)
     add_test(
+        NAME qt_quit_smoke_3d
+        COMMAND "${CMAKE_COMMAND}"
+            "-DMATERIALIZER=$<TARGET_FILE:fixture_materializer>"
+            "-DAMREXPLORER_QT=$<TARGET_FILE:amrexplorer_qt>"
+            "-DSOURCE=${CMAKE_CURRENT_SOURCE_DIR}/data/plotfile_3d"
+            "-DWORK=${CMAKE_CURRENT_BINARY_DIR}/fixtures_quit_3d"
+            -DMODE=quit
+            -P "${CMAKE_CURRENT_SOURCE_DIR}/qt_smoke_driver.cmake"
+    )
+    set_tests_properties(qt_quit_smoke_3d PROPERTIES TIMEOUT 30)
+    add_test(
+        NAME qt_quit_on_failure_smoke_3d
+        COMMAND "${CMAKE_COMMAND}"
+            "-DMATERIALIZER=$<TARGET_FILE:fixture_materializer>"
+            "-DAMREXPLORER_QT=$<TARGET_FILE:amrexplorer_qt>"
+            "-DSOURCE=${CMAKE_CURRENT_SOURCE_DIR}/data/plotfile_3d"
+            "-DWORK=${CMAKE_CURRENT_BINARY_DIR}/fixtures_quit_on_failure_3d"
+            -DMODE=quit-on-failure
+            -P "${CMAKE_CURRENT_SOURCE_DIR}/qt_smoke_driver.cmake"
+    )
+    set_tests_properties(qt_quit_on_failure_smoke_3d PROPERTIES TIMEOUT 30)
+    add_test(
         NAME qt_multifab_missing_range
         COMMAND "${CMAKE_COMMAND}"
             "-DMATERIALIZER=$<TARGET_FILE:fixture_materializer>"

--- a/tests/qt_smoke_driver.cmake
+++ b/tests/qt_smoke_driver.cmake
@@ -6,7 +6,7 @@
 #   SOURCE        fixture source directory (e.g. tests/data/plotfile_2d)
 #   WORK          directory the materialized copies are written into
 #   MODE          slice | sequence | missing-range | non-finite | raw-fab |
-#                 multifab-fab
+#                 multifab-fab | quit | quit-on-failure
 foreach(argument MATERIALIZER AMREXPLORER_QT SOURCE WORK MODE)
     if(NOT DEFINED ${argument})
         message(FATAL_ERROR "qt_smoke_driver.cmake requires -D${argument}=...")
@@ -51,6 +51,18 @@ elseif(MODE STREQUAL "multifab-fab")
     run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt")
     run_or_die("${AMREXPLORER_QT}" --multifab-fab-smoke-test
         "${WORK}/plt/Level_0/Cell")
+elseif(MODE STREQUAL "quit")
+    run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt")
+    run_or_die("${AMREXPLORER_QT}" --quit-smoke-test "${WORK}/plt")
+elseif(MODE STREQUAL "quit-on-failure")
+    run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt")
+    # Drop the FAB payloads so the slice read fails while metadata stays valid
+    # (a non-modal background failure), then quit.
+    file(GLOB fabPayloads "${WORK}/plt/Level_*/*_D_*")
+    foreach(payload ${fabPayloads})
+        file(REMOVE "${payload}")
+    endforeach()
+    run_or_die("${AMREXPLORER_QT}" --quit-smoke-test "${WORK}/plt")
 else()
     message(FATAL_ERROR "qt_smoke_driver.cmake: unknown MODE '${MODE}'")
 endif()


### PR DESCRIPTION
Open a dataset offscreen and quit through the main window once the initial
slice resolves (and mid-load), with an in-app watchdog and a ctest timeout
that fail if the process stays alive. Covers a valid load and a failing one
-- the FAB payloads are removed after materialization so the slice fails
while metadata stays valid (a non-modal background failure). Guards the
quit-path hardening against regressions that would hang shutdown.