### PR TITLE
Close remaining issue #16 gaps: last modals and an encoder test

### DIFF
--- a/src/qt/DatasetWindow.cpp
+++ b/src/qt/DatasetWindow.cpp
@@ -10,7 +10,6 @@
 #include <QFutureWatcher>
 #include <QHBoxLayout>
 #include <QLabel>
-#include <QMessageBox>
 #include <QPushButton>
 #include <QStringList>
 #include <QTabWidget>
@@ -144,12 +143,12 @@ void DatasetWindow::startLoad()
                 populateTabs();
                 m_status->setText(tr("Field: %1").arg(m_request.fieldName));
             } catch (const std::exception& error) {
-                // One message for a real failure, then the window closes; a
-                // cancelled read (close/refresh) stays silent.
+                // Report a real failure non-modally through the owner, then
+                // close; a cancelled read (close/refresh) stays silent. A modal
+                // dialog here would disable the whole app and block quitting.
                 if (!m_stopSource.stop_requested()) {
-                    QMessageBox::critical(this,
-                        tr("Cannot load dataset values"),
-                        exceptionMessage(error));
+                    emit extractionFailed(tr("Cannot load dataset values: %1")
+                        .arg(exceptionMessage(error)));
                     close();
                 }
             }

--- a/src/qt/DatasetWindow.hpp
+++ b/src/qt/DatasetWindow.hpp
@@ -61,6 +61,9 @@ signals:
     void cellActivated(const amrvis::RealBox& physicalCell);
     // The Refresh button; the owner rebuilds the request from app state.
     void refreshRequested();
+    // A real (non-cancelled) extraction failure; the owner reports it through
+    // its non-modal background-error channel instead of a blocking dialog.
+    void extractionFailed(const QString& message);
 
 protected:
     void closeEvent(QCloseEvent* event) override;

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -3227,6 +3227,24 @@ void MainWindow::exportAnimation()
     if (path.isEmpty()) {
         return;
     }
+    beginAnimationExport(path, includeColorBar);
+}
+
+void MainWindow::startAnimationExportForTest(const QString& path,
+    bool includeColorBar)
+{
+    if (m_exportAnim.active) {
+        return;
+    }
+    beginAnimationExport(path, includeColorBar);
+}
+
+void MainWindow::beginAnimationExport(const QString& path, bool includeColorBar)
+{
+    auto* view = m_activeView != nullptr ? m_activeView->view : nullptr;
+    if (view == nullptr || !view->hasImage() || m_sequenceFrames.empty()) {
+        return;
+    }
     const QFileInfo info(path);
     const auto total = static_cast<int>(m_sequenceFrames.size());
     const int digits =
@@ -3359,6 +3377,9 @@ void MainWindow::finalizeExportAnimation()
     // Cancellation flag shared with the encoder workers (captured by value, so
     // it outlives this window). Set by the progress Cancel and by closeEvent.
     m_exportAnim.encoderCancel = std::make_shared<std::atomic<bool>>(false);
+    // Frames are written; the FFmpeg workers are about to run. The export-quit
+    // smoke test quits here to exercise bounded encoder cancellation.
+    emit exportEncodingStarted();
 
     auto encode = [this](const QString& stem) {
         const QString inputPattern = m_exportAnim.directory + "/"
@@ -3547,6 +3568,8 @@ void MainWindow::showDatasetWindow()
             state->view->setCellHighlight(std::nullopt);
         }
     });
+    connect(window, &DatasetWindow::extractionFailed, this,
+        &MainWindow::reportBackgroundError);
     connect(window, &DatasetWindow::cellActivated, this,
         [this](const RealBox& physicalCell) {
             datasetCellActivated(physicalCell);
@@ -3777,9 +3800,8 @@ void MainWindow::openDatasetImpl(const std::filesystem::path& path,
                 }
             } catch (const std::exception& error) {
                 if (generation == m_generation) {
-                    statusBar()->showMessage(tr("Dataset open failed"));
-                    QMessageBox::critical(this, tr("Cannot open dataset"),
-                        exceptionMessage(error));
+                    reportBackgroundError(
+                        tr("Cannot open dataset: %1").arg(exceptionMessage(error)));
                     emit datasetOpenFinished(false);
                 } else {
                     ++m_staleResults;
@@ -3928,8 +3950,9 @@ void MainWindow::requestInitialSlice(
                     m_cachePinnedBytes = cache.pinnedBytes;
                     m_cacheEvictions = cache.evictions;
                     if (result.cacheFallbackToLevel >= 0) {
-                        QMessageBox::warning(this, tr("Reduced level detail"),
-                            cacheFallbackMessage(result));
+                        // Non-modal: an informational cache-fallback notice must
+                        // not pop a modal dialog that would block the quit path.
+                        statusBar()->showMessage(cacheFallbackMessage(result));
                     }
                     emit initialSliceFinished(true);
                 } else {

--- a/src/qt/MainWindow.hpp
+++ b/src/qt/MainWindow.hpp
@@ -19,9 +19,9 @@
 #include <QStringList>
 
 #include <array>
+#include <atomic>
 #include <cstdint>
 #include <filesystem>
-#include <atomic>
 #include <memory>
 #include <optional>
 #include <string>
@@ -154,6 +154,10 @@ public:
     // Steps the open sequence by direction frames, wrapping at the ends; the
     // same slot the sequence step buttons and the smoke test hook use.
     void stepSequence(int direction);
+    // Starts an animation export without the interactive color-bar/save
+    // dialogs, writing frames and MP4s under path's directory. Test-only entry
+    // used by the export-quit smoke test to reach the encoder deterministically.
+    void startAnimationExportForTest(const QString& path, bool includeColorBar);
 
 signals:
     void datasetOpenFinished(bool success);
@@ -162,6 +166,10 @@ signals:
     // smoke test drives frame stepping off it.
     void sequenceFrameDisplayed(int index);
     void sequenceFrameFailed();
+    // Emitted when the FFmpeg encoding phase begins (frames rendered, encoder
+    // workers about to run); the export-quit smoke test quits on it to exercise
+    // bounded encoder cancellation.
+    void exportEncodingStarted();
 
 protected:
     void closeEvent(QCloseEvent* event) override;
@@ -233,6 +241,10 @@ private:
     MainWindow* createNewWindow();
     void exportImage();
     void exportAnimation();
+    // Shared body of exportAnimation once the output path and color-bar choice
+    // are known (from the dialogs, or from the test hook): configures the export
+    // state, progress dialog, and kicks off frame 0.
+    void beginAnimationExport(const QString& path, bool includeColorBar);
     // Animation export is signal-driven (frame rendering is async): exportAnimation
     // kicks off frame 0; onExportFrameDisplayed saves each rendered frame and
     // advances; finalizeExportAnimation encodes the MP4; endExportAnimation is the

--- a/src/qt/main.cpp
+++ b/src/qt/main.cpp
@@ -492,6 +492,35 @@ int main(int argc, char* argv[])
         QTimer::singleShot(15000, &application,
             [&application] { application.exit(1); });
         QTimer::singleShot(0, &window, [&window, path] { window.openDataset(path); });
+    } else if (argc == 4
+        && std::string_view(argv[1]) == "--export-quit-smoke-test") {
+        // Open a two-frame sequence, start an animation export (bypassing the
+        // interactive color-bar/save dialogs), and quit the instant FFmpeg
+        // encoding begins. With a hung stand-in ffmpeg on PATH the encoder
+        // workers block, so shutdown stays alive unless they are cancelled and
+        // their process terminated on close; the ctest timeout fails the test
+        // if the process never exits.
+        const std::filesystem::path first(argv[2]);
+        const std::filesystem::path second(argv[3]);
+        const QString outputPath = QString::fromStdString(
+            (first.parent_path() / "anim.png").string());
+        QObject::connect(&window, &amrvis::qt::MainWindow::sequenceFrameDisplayed,
+            &application, [&window, outputPath](int index) {
+                if (index == 0) {
+                    window.startAnimationExportForTest(outputPath, false);
+                }
+            });
+        QObject::connect(&window, &amrvis::qt::MainWindow::exportEncodingStarted,
+            &application, [&window] {
+                QTimer::singleShot(0, &window, [&window] { window.close(); });
+            });
+        QObject::connect(&window, &amrvis::qt::MainWindow::sequenceFrameFailed,
+            &application, [&application] { application.exit(1); });
+        QTimer::singleShot(20000, &application,
+            [&application] { application.exit(1); });
+        QTimer::singleShot(0, &window, [&window, first, second] {
+            window.openSequence({first, second});
+        });
     } else if (argc >= 2 && !std::string_view(argv[1]).starts_with("--")) {
         // One or more plotfile paths: a single path opens a dataset, two or
         // more open a plotfile sequence (matching the GUI's Open Plotfile

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -214,6 +214,21 @@ if(TARGET amrexplorer_qt)
             -P "${CMAKE_CURRENT_SOURCE_DIR}/qt_smoke_driver.cmake"
     )
     set_tests_properties(qt_quit_on_failure_smoke_3d PROPERTIES TIMEOUT 30)
+    if(NOT WIN32)
+        # Uses a POSIX shell stand-in for ffmpeg (see the driver's export-quit
+        # MODE); skipped on Windows.
+        add_test(
+            NAME qt_export_quit_smoke_3d
+            COMMAND "${CMAKE_COMMAND}"
+                "-DMATERIALIZER=$<TARGET_FILE:fixture_materializer>"
+                "-DAMREXPLORER_QT=$<TARGET_FILE:amrexplorer_qt>"
+                "-DSOURCE=${CMAKE_CURRENT_SOURCE_DIR}/data/plotfile_3d"
+                "-DWORK=${CMAKE_CURRENT_BINARY_DIR}/fixtures_export_quit_3d"
+                -DMODE=export-quit
+                -P "${CMAKE_CURRENT_SOURCE_DIR}/qt_smoke_driver.cmake"
+        )
+        set_tests_properties(qt_export_quit_smoke_3d PROPERTIES TIMEOUT 30)
+    endif()
     add_test(
         NAME qt_multifab_missing_range
         COMMAND "${CMAKE_COMMAND}"

--- a/tests/qt_smoke_driver.cmake
+++ b/tests/qt_smoke_driver.cmake
@@ -72,13 +72,16 @@ elseif(MODE STREQUAL "export-quit")
     # the ctest TIMEOUT fails the test.
     set(fakeBin "${WORK}/bin")
     file(MAKE_DIRECTORY "${fakeBin}")
+    # exec so the tracked child IS the sleep, not a /bin/sh (dash) wrapper that
+    # dies on SIGTERM and orphans its sleep child for the full hour. This makes
+    # the stand-in a single process that terminate() actually kills.
     file(WRITE "${fakeBin}/ffmpeg"
 "#!/bin/sh
 if [ \"$1\" = \"-version\" ]; then
   echo 'ffmpeg version 0.0-fake'
   exit 0
 fi
-sleep 3600
+exec sleep 3600
 ")
     execute_process(COMMAND chmod 755 "${fakeBin}/ffmpeg")
     set(ENV{PATH} "${fakeBin}:$ENV{PATH}")

--- a/tests/qt_smoke_driver.cmake
+++ b/tests/qt_smoke_driver.cmake
@@ -6,7 +6,7 @@
 #   SOURCE        fixture source directory (e.g. tests/data/plotfile_2d)
 #   WORK          directory the materialized copies are written into
 #   MODE          slice | sequence | missing-range | non-finite | raw-fab |
-#                 multifab-fab | quit | quit-on-failure
+#                 multifab-fab | quit | quit-on-failure | export-quit
 foreach(argument MATERIALIZER AMREXPLORER_QT SOURCE WORK MODE)
     if(NOT DEFINED ${argument})
         message(FATAL_ERROR "qt_smoke_driver.cmake requires -D${argument}=...")
@@ -63,6 +63,27 @@ elseif(MODE STREQUAL "quit-on-failure")
         file(REMOVE "${payload}")
     endforeach()
     run_or_die("${AMREXPLORER_QT}" --quit-smoke-test "${WORK}/plt")
+elseif(MODE STREQUAL "export-quit")
+    run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt00000")
+    run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt00010" "2.5")
+    # Stand-in ffmpeg: answers -version so the app enables encoding, then blocks
+    # on the encode call. A quit while it is "encoding" must cancel and
+    # terminate it; if the encoder is not bounded the process never exits and
+    # the ctest TIMEOUT fails the test.
+    set(fakeBin "${WORK}/bin")
+    file(MAKE_DIRECTORY "${fakeBin}")
+    file(WRITE "${fakeBin}/ffmpeg"
+"#!/bin/sh
+if [ \"$1\" = \"-version\" ]; then
+  echo 'ffmpeg version 0.0-fake'
+  exit 0
+fi
+sleep 3600
+")
+    execute_process(COMMAND chmod 755 "${fakeBin}/ffmpeg")
+    set(ENV{PATH} "${fakeBin}:$ENV{PATH}")
+    run_or_die("${AMREXPLORER_QT}" --export-quit-smoke-test
+        "${WORK}/plt00000" "${WORK}/plt00010")
 else()
     message(FATAL_ERROR "qt_smoke_driver.cmake: unknown MODE '${MODE}'")
 endif()


### PR DESCRIPTION
Convert the three async failure handlers that still popped a quit-blocking modal to the non-modal background-error channel: dataset-open failure and the Dataset-window extraction failure (via a new
DatasetWindow::extractionFailed signal) now report through reportBackgroundError, and the "reduced level detail" cache-fallback notice becomes a status-bar message.

Add an automated encoder-cancellation test: split beginAnimationExport out of exportAnimation, expose a test-only start hook and an exportEncodingStarted signal, and add an --export-quit-smoke-test mode plus an export-quit driver that plants a hung stand-in ffmpeg on PATH. The ctest timeout fails the test if a quit during encoding never terminates the encoder.

Also move <atomic> into alphabetical order in MainWindow.hpp.