### PR TITLE
Re-extract contours when the display range is replaced

### DIFF
--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -675,6 +675,45 @@ SliceDisplayResult refreshCachedSlice(
     return result;
 }
 
+// Re-extract contour polylines from an already-populated fine plane after the
+// display range is replaced downstream of appendContours/refreshCachedSlice —
+// full-domain-range reuse, the 3-D shared Visible range, or syncVisibleRanges.
+// Cheap: the fine plane is cached, so no SliceQuery runs. Returns empty when
+// the range is unusable (non-positive log range, zero extent), matching
+// updateOverlay's guard, so a bad range clears rather than throws. See the
+// contours-stale-after-visible-range-sync issue.
+std::vector<ContourPolyline> recomputeContourPolylines(
+    const ScalarPlane& finePlane, int fineFactor, double minimum,
+    double maximum, bool logarithmic, int contourCount,
+    int displayWidth, int displayHeight)
+{
+    if (finePlane.width <= 0 || finePlane.height <= 0 || contourCount < 1
+        || !(minimum < maximum) || (logarithmic && !(minimum > 0.0))) {
+        return {};
+    }
+    try {
+        const auto values = contourValues(
+            minimum, maximum, contourCount, logarithmic);
+        return contourPolylinesForDisplay(
+            finePlane, fineFactor, values, displayWidth, displayHeight);
+    } catch (const std::exception&) {
+        return {};
+    }
+}
+
+// SliceDisplayResult overload: regenerate the polylines to match the result's
+// current (possibly replaced) minimum/maximum. No-op outside contour modes.
+void recomputeContourPolylines(SliceDisplayResult& result)
+{
+    if (!isContourMode(result.mode)) {
+        return;
+    }
+    result.contourPolylines = recomputeContourPolylines(
+        result.contourFinePlane, result.contourFineFactor, result.minimum,
+        result.maximum, result.logarithmic, result.contourCount,
+        result.request.outputSize[0], result.request.outputSize[1]);
+}
+
 // Combo data sentinel for "Update to Level N" entries, which composite
 // levels 0..N with FinestAvailable. The selected level N is data - 1000.
 constexpr int kUpdateToLevelOffset = 1000;
@@ -953,6 +992,10 @@ InitialSliceResult executeFrameLoad(const std::filesystem::path& path,
                             .logarithmic = d.logarithmic,
                             .palette = &spec.palette
                         });
+                    // Contours were extracted per view before the shared range
+                    // was known; re-extract them so their levels match the
+                    // shared colorbar (see contours-stale-after-visible-range).
+                    recomputeContourPolylines(d);
                 }
             }
             break;
@@ -1869,6 +1912,53 @@ void MainWindow::applyContourSettings(
     } else {
         updateOverlays();
     }
+}
+
+void MainWindow::configureContourSyncForTest(
+    int count, bool logarithmic, std::array<double, 3> slicePositions)
+{
+    if (!m_dataset) {
+        return;
+    }
+    m_slicePosition3d = slicePositions;
+    // Set range/log through the widgets (requestSlice reads them) but block
+    // their signals so only the single scheduleSliceRequest below re-slices.
+    {
+        const QSignalBlocker rangeBlocker(m_rangeMode);
+        const auto index = m_rangeMode->findData(
+            static_cast<int>(RangeMode::Visible));
+        if (index >= 0) {
+            m_rangeMode->setCurrentIndex(index);
+        }
+    }
+    {
+        const QSignalBlocker logBlocker(m_logarithmic);
+        m_logarithmic->setChecked(logarithmic);
+    }
+    m_displayMode = DisplayMode::RasterContours;
+    m_contourCount = count;
+    scheduleSliceRequest(false);
+}
+
+std::vector<MainWindow::ContourViewProbe>
+MainWindow::contourViewProbesForTest()
+{
+    std::vector<ContourViewProbe> probes;
+    for (const auto* state : currentViews()) {
+        ContourViewProbe probe;
+        probe.displayMinimum = state->displayMinimum;
+        probe.displayMaximum = state->displayMaximum;
+        probe.logarithmic = state->displayLogarithmic;
+        for (const auto& polyline : state->contourPolylines) {
+            probe.contourLevels.push_back(polyline.value);
+        }
+        std::sort(probe.contourLevels.begin(), probe.contourLevels.end());
+        probe.contourLevels.erase(
+            std::unique(probe.contourLevels.begin(), probe.contourLevels.end()),
+            probe.contourLevels.end());
+        probes.push_back(std::move(probe));
+    }
+    return probes;
 }
 
 void MainWindow::showNumberFormatDialog()
@@ -4297,6 +4387,12 @@ void MainWindow::requestSlice(PlaneViewState& state, bool rasterDirty)
                             == result.request.composition) {
                         result.minimum = m_fullDomainRange->first;
                         result.maximum = m_fullDomainRange->second;
+                        // The polylines were extracted from the subregion's
+                        // own range; re-extract them against the reused
+                        // full-domain range so they match the colorbar. In
+                        // 3-D syncVisibleRanges re-extracts again below, but
+                        // in 2-D this is the only place it happens.
+                        recomputeContourPolylines(result);
                     }
                     showSlice(state, result);
                     syncVisibleRanges();
@@ -4332,6 +4428,11 @@ void MainWindow::requestSlice(PlaneViewState& state, bool rasterDirty)
             }
             updateDiagnostics();
             watcher->deleteLater();
+            // The interactive re-slice batch has drained once no view has work
+            // in flight; the smoke test waits on this to read settled state.
+            if (m_activeRequests == 0) {
+                emit interactiveSlicesSettled();
+            }
         });
     watcher->setFuture(future);
 }
@@ -4635,6 +4736,17 @@ void MainWindow::syncVisibleRanges()
         }
         state->displayMinimum = globalMin;
         state->displayMaximum = globalMax;
+        // The contour polylines were extracted against this view's own range;
+        // re-extract them against the shared range so their levels match the
+        // shared colorbar. updateOverlay below repaints from these polylines
+        // (see contours-stale-after-visible-range-sync).
+        if (isContourMode(m_displayMode) && state->contourFinePlane.width > 0) {
+            state->contourPolylines = recomputeContourPolylines(
+                state->contourFinePlane, state->contourFineFactor,
+                globalMin, globalMax, state->displayLogarithmic, m_contourCount,
+                state->cachedRequest.outputSize[0],
+                state->cachedRequest.outputSize[1]);
+        }
         auto image = renderScalarPlane(state->plane, ScalarRenderSettings{
             .minimum = globalMin,
             .maximum = globalMax,

--- a/src/qt/MainWindow.hpp
+++ b/src/qt/MainWindow.hpp
@@ -159,9 +159,35 @@ public:
     // used by the export-quit smoke test to reach the encoder deterministically.
     void startAnimationExportForTest(const QString& path, bool includeColorBar);
 
+    // Test-only: move each 3-D plane to slicePositions (per axis, so the three
+    // panels sample different data with different local ranges), switch to
+    // contour display (count levels) with the Visible range mode and optional
+    // logarithmic mapping, then re-slice every view once. This is the exact
+    // shape that exposed the stale-contour bug: three unequal local ranges
+    // reconciled into one shared Visible range. interactiveSlicesSettled fires
+    // when that batch finishes.
+    void configureContourSyncForTest(
+        int count, bool logarithmic, std::array<double, 3> slicePositions);
+
+    // Test-only: for each current view (ordered by normal axis; 2-D has one),
+    // the display range and the distinct contour levels present in its overlay
+    // polylines. The contour-sync smoke test checks these levels are re-derived
+    // from the shared Visible range rather than each view's local range.
+    struct ContourViewProbe {
+        double displayMinimum = 0.0;
+        double displayMaximum = 0.0;
+        bool logarithmic = false;
+        std::vector<double> contourLevels;
+    };
+    [[nodiscard]] std::vector<ContourViewProbe> contourViewProbesForTest();
+
 signals:
     void datasetOpenFinished(bool success);
     void initialSliceFinished(bool success);
+    // Emitted when an interactive re-slice batch (a mode/range/log/field
+    // change, pan, or zoom) finishes with no slice work left in flight. The
+    // contour-sync smoke test waits on it. Not emitted for the initial load.
+    void interactiveSlicesSettled();
     // Emitted once a sequence frame's slice(s) are on screen; the offscreen
     // smoke test drives frame stepping off it.
     void sequenceFrameDisplayed(int index);

--- a/src/qt/main.cpp
+++ b/src/qt/main.cpp
@@ -19,7 +19,11 @@
 #include <QTextStream>
 #include <QTimer>
 
+#include <amrexplorer/render2d/Contours.hpp>
+
+#include <algorithm>
 #include <array>
+#include <cmath>
 #include <filesystem>
 #include <string_view>
 #include <vector>
@@ -336,6 +340,73 @@ bool clearFabSelectorPointFilter(amrvis::qt::FabSelectorDock& selector)
             == static_cast<int>(selector.entries().size());
 }
 
+// Verifies the contour-sync smoke scenario after the re-slice batch settles.
+// The three 3-D panels were sliced at asymmetric positions, so each has its
+// own local range; Visible mode reconciles them into one shared range. The fix
+// requires every panel's contour levels to come from that shared range. We
+// check: all three panels agree on the (positive) shared range, and every
+// contour level shown in any panel is one of contourValues(shared range) --
+// which fails if a panel kept its local-range levels (the bug). A non-vacuous
+// guard ensures contours actually rendered.
+bool contourSyncMatches(amrvis::qt::MainWindow& window)
+{
+    const auto probes = window.contourViewProbesForTest();
+    if (probes.size() != 3) {
+        return false;
+    }
+    const auto within = [](double a, double b) {
+        const auto scale = std::max({1.0, std::fabs(a), std::fabs(b)});
+        return std::fabs(a - b) <= 1.0e-6 * scale;
+    };
+    // Log was requested and every slice is strictly positive, so log must have
+    // applied and all panels must agree on the shared, positive Visible range.
+    const auto& shared = probes.front();
+    for (const auto& probe : probes) {
+        if (!probe.logarithmic || !(probe.displayMinimum > 0.0)
+            || !(probe.displayMinimum < probe.displayMaximum)
+            || !within(probe.displayMinimum, shared.displayMinimum)
+            || !within(probe.displayMaximum, shared.displayMaximum)) {
+            return false;
+        }
+    }
+    std::vector<double> expected;
+    try {
+        expected = amrvis::contourValues(
+            shared.displayMinimum, shared.displayMaximum, 3, true);
+    } catch (const std::exception&) {
+        return false;
+    }
+    // Every level shown in any panel must be one of the shared-range levels;
+    // the bug leaves a panel showing its own local-range levels instead. Track
+    // which shared levels are actually drawn (map each shown level to its
+    // canonical expected index -- a well-defined membership, unlike dedup by an
+    // intransitive tolerance) so the pass is not vacuously met by empty
+    // overlays: require >= 2 shared levels drawn across >= 2 panels.
+    std::vector<bool> drawn(expected.size(), false);
+    std::size_t panelsWithLevels = 0;
+    for (const auto& probe : probes) {
+        for (const auto level : probe.contourLevels) {
+            std::size_t match = expected.size();
+            for (std::size_t i = 0; i < expected.size(); ++i) {
+                if (within(level, expected[i])) {
+                    match = i;
+                    break;
+                }
+            }
+            if (match == expected.size()) {
+                return false;  // a level not derived from the shared range
+            }
+            drawn[match] = true;
+        }
+        if (!probe.contourLevels.empty()) {
+            ++panelsWithLevels;
+        }
+    }
+    const auto sharedLevelsDrawn = static_cast<std::size_t>(
+        std::count(drawn.begin(), drawn.end(), true));
+    return panelsWithLevels >= 2 && sharedLevelsDrawn >= 2;
+}
+
 } // namespace
 
 int main(int argc, char* argv[])
@@ -391,6 +462,30 @@ int main(int argc, char* argv[])
                     && rangeSelectorMatches(window, true);
                 application.exit(valid ? 0 : 1);
         });
+        QTimer::singleShot(0, &window, [&window, path] { window.openDataset(path); });
+    } else if (argc == 3
+        && std::string_view(argv[1]) == "--contour-sync-smoke-test") {
+        // Once the initial load lands, switch to contours in Visible+log mode
+        // with asymmetric per-panel slice positions (so the three panels have
+        // unequal local ranges), then verify their contour levels once the
+        // re-slice batch settles. See contourSyncMatches / the issue note.
+        const std::filesystem::path path(argv[2]);
+        QObject::connect(&window, &amrvis::qt::MainWindow::initialSliceFinished,
+            &application, [&window, &application](bool success) {
+                if (!success) {
+                    application.exit(1);
+                    return;
+                }
+                QObject::connect(&window,
+                    &amrvis::qt::MainWindow::interactiveSlicesSettled,
+                    &application, [&window, &application] {
+                        application.exit(contourSyncMatches(window) ? 0 : 1);
+                    });
+                // YZ(x)@i=3, XZ(y)@j=2, XY(z)@k=1 on the 4^3 cube q=(i+j+k)/9:
+                // local ranges [3/9,1], [2/9,8/9], [1/9,7/9] -> shared [1/9,1].
+                window.configureContourSyncForTest(
+                    3, true, {0.875, 0.625, 0.375});
+            });
         QTimer::singleShot(0, &window, [&window, path] { window.openDataset(path); });
     } else if (argc == 3
         && std::string_view(argv[1]) == "--raw-fab-smoke-test") {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -192,6 +192,20 @@ if(TARGET amrexplorer_qt)
             -P "${CMAKE_CURRENT_SOURCE_DIR}/qt_smoke_driver.cmake"
     )
     set_tests_properties(qt_slice_smoke_3d PROPERTIES TIMEOUT 30)
+    # Regression test for contours-stale-after-visible-range-sync: switching a
+    # 3-D dataset to contours in Visible+log mode must re-derive every panel's
+    # contour levels from the shared range, not each panel's local range.
+    add_test(
+        NAME qt_contour_sync_smoke_3d
+        COMMAND "${CMAKE_COMMAND}"
+            "-DMATERIALIZER=$<TARGET_FILE:fixture_materializer>"
+            "-DAMREXPLORER_QT=$<TARGET_FILE:amrexplorer_qt>"
+            "-DSOURCE=${CMAKE_CURRENT_SOURCE_DIR}/data/plotfile_3d"
+            "-DWORK=${CMAKE_CURRENT_BINARY_DIR}/fixtures_contour_sync_3d"
+            -DMODE=contour-sync
+            -P "${CMAKE_CURRENT_SOURCE_DIR}/qt_smoke_driver.cmake"
+    )
+    set_tests_properties(qt_contour_sync_smoke_3d PROPERTIES TIMEOUT 30)
     add_test(
         NAME qt_quit_smoke_3d
         COMMAND "${CMAKE_COMMAND}"

--- a/tests/qt_smoke_driver.cmake
+++ b/tests/qt_smoke_driver.cmake
@@ -6,7 +6,8 @@
 #   SOURCE        fixture source directory (e.g. tests/data/plotfile_2d)
 #   WORK          directory the materialized copies are written into
 #   MODE          slice | sequence | missing-range | non-finite | raw-fab |
-#                 multifab-fab | quit | quit-on-failure | export-quit
+#                 multifab-fab | quit | quit-on-failure | export-quit |
+#                 contour-sync
 foreach(argument MATERIALIZER AMREXPLORER_QT SOURCE WORK MODE)
     if(NOT DEFINED ${argument})
         message(FATAL_ERROR "qt_smoke_driver.cmake requires -D${argument}=...")
@@ -43,6 +44,9 @@ elseif(MODE STREQUAL "non-finite")
         "--no-statistics" "--non-finite")
     run_or_die("${AMREXPLORER_QT}" --missing-range-smoke-test
         "${WORK}/plt/Level_0/Cell")
+elseif(MODE STREQUAL "contour-sync")
+    run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt")
+    run_or_die("${AMREXPLORER_QT}" --contour-sync-smoke-test "${WORK}/plt")
 elseif(MODE STREQUAL "raw-fab")
     run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt")
     run_or_die("${AMREXPLORER_QT}" --raw-fab-smoke-test


### PR DESCRIPTION
Contour polylines were generated from the range resolved for an individual slice, but that range can be replaced downstream without regenerating them: the requestSlice completion handler reuses the cached full-domain range for a zoomed Visible slice, syncVisibleRanges applies the shared 3-D range, and executeFrameLoad reconciles the three panels to a shared range. The color bar then reflected the final range while the contour lines still sat at the old per-slice levels — most visibly in log mode, where a range change can move a level by whole decades.

Add recomputeContourPolylines, which rebuilds the polylines from the cached fine plane (no new SliceQuery) and clears them for an unusable range, and call it at all three sites so the levels always track the color bar.

Cover it with qt_contour_sync_smoke_3d: it slices the three 3-D panels at asymmetric positions so each has a distinct local range, switches to contours in Visible+log mode, and asserts every panel's contour levels are drawn from the shared range. Supporting test hooks: configureContourSyncForTest, contourViewProbesForTest, and an interactiveSlicesSettled signal.