### PR TITLE
Re-render the 2-D raster when the full-domain range is reused

### DIFF
--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -123,6 +123,20 @@ QImage verticallyFlippedCopy(const QImage& image)
 #endif
 }
 
+// The single conversion from a rendered ImageBuffer to the QImage the views
+// display: ARGB32 over the buffer's rgba, mirrored vertically because plane
+// row 0 is the bottom row. Returns a detached copy (verticallyFlippedCopy
+// copies), so it outlives the buffer. Every setImage caller goes through here
+// so the transform has one definition (see showSlice, syncVisibleRanges, and
+// activeViewRasterMatchesDisplayRangeForTest).
+QImage displayImageFor(const ImageBuffer& image)
+{
+    const QImage wrapped(
+        reinterpret_cast<const uchar*>(image.rgba.data()),
+        image.width, image.height, image.strideBytes, QImage::Format_ARGB32);
+    return verticallyFlippedCopy(wrapped);
+}
+
 // Marks the active row in the palette dropdown with a bullet. The bullet lives
 // in a reserved left column that every row's sizeHint accounts for, so names
 // align and the indented text is never clipped. Installed only on the combo's
@@ -1959,6 +1973,64 @@ MainWindow::contourViewProbesForTest()
         probes.push_back(std::move(probe));
     }
     return probes;
+}
+
+void MainWindow::enableVisibleRasterForTest()
+{
+    if (!m_dataset) {
+        return;
+    }
+    {
+        const QSignalBlocker rangeBlocker(m_rangeMode);
+        const auto index = m_rangeMode->findData(
+            static_cast<int>(RangeMode::Visible));
+        if (index >= 0) {
+            m_rangeMode->setCurrentIndex(index);
+        }
+    }
+    m_displayMode = DisplayMode::Raster;
+    scheduleSliceRequest(false);
+}
+
+void MainWindow::zoomActiveViewForTest()
+{
+    if (!m_dataset || m_activeView == nullptr) {
+        return;
+    }
+    const auto bounds = datasetSampleBounds(m_dataset->metadata());
+    auto subregion = bounds;
+    const auto axes = displayAxes(m_activeView->normal);
+    for (std::size_t k = 0; k < 2; ++k) {
+        const auto axis = static_cast<std::size_t>(axes[k]);
+        subregion.lower[axis] = 0.5 * (bounds.lower[axis] + bounds.upper[axis]);
+        subregion.upper[axis] = bounds.upper[axis];
+    }
+    m_activeView->visibleRegion = subregion;
+    scheduleSliceRequest(*m_activeView, true);
+}
+
+bool MainWindow::activeViewRasterMatchesDisplayRangeForTest()
+{
+    if (m_activeView == nullptr) {
+        return false;
+    }
+    const auto& state = *m_activeView;
+    if (state.plane.width <= 0 || state.plane.height <= 0
+        || !state.view->hasImage()) {
+        return false;
+    }
+    const auto reference = renderScalarPlane(state.plane, ScalarRenderSettings{
+        .minimum = state.displayMinimum,
+        .maximum = state.displayMaximum,
+        .logarithmic = state.displayLogarithmic,
+        .palette = &m_palette
+    });
+    if (!reference.valid()) {
+        return false;
+    }
+    // Same buffer->view transform showSlice uses, so this stays in lockstep
+    // with however the raster is actually displayed.
+    return displayImageFor(reference) == state.view->image();
 }
 
 void MainWindow::showNumberFormatDialog()
@@ -4387,12 +4459,26 @@ void MainWindow::requestSlice(PlaneViewState& state, bool rasterDirty)
                             == result.request.composition) {
                         result.minimum = m_fullDomainRange->first;
                         result.maximum = m_fullDomainRange->second;
-                        // The polylines were extracted from the subregion's
-                        // own range; re-extract them against the reused
-                        // full-domain range so they match the colorbar. In
-                        // 3-D syncVisibleRanges re-extracts again below, but
-                        // in 2-D this is the only place it happens.
-                        recomputeContourPolylines(result);
+                        // executeSlice/refreshCachedSlice produced the raster
+                        // and contours against the subregion's own range;
+                        // realign both to the reused full-domain range so they
+                        // match the colorbar. In 3-D syncVisibleRanges realigns
+                        // every panel below (m_viewDimension == 3), so only 2-D,
+                        // which it skips, needs it here — and doing it only here
+                        // avoids re-rendering each 3-D panel's raster twice.
+                        if (m_viewDimension != 3) {
+                            if (!result.rasterUnchanged) {
+                                result.image = renderScalarPlane(
+                                    result.slice.plane,
+                                    ScalarRenderSettings{
+                                        .minimum = result.minimum,
+                                        .maximum = result.maximum,
+                                        .logarithmic = result.logarithmic,
+                                        .palette = &m_palette
+                                    });
+                            }
+                            recomputeContourPolylines(result);
+                        }
                     }
                     showSlice(state, result);
                     syncVisibleRanges();
@@ -4616,12 +4702,7 @@ void MainWindow::showSlice(PlaneViewState& state, const SliceDisplayResult& disp
         if (!display.image.valid()) {
             throw std::runtime_error("renderer produced an invalid image");
         }
-        const QImage wrapped(
-            reinterpret_cast<const uchar*>(display.image.rgba.data()),
-            display.image.width, display.image.height, display.image.strideBytes,
-            QImage::Format_ARGB32);
-        const auto displayImage = verticallyFlippedCopy(wrapped);
-        state.view->setImage(displayImage);
+        state.view->setImage(displayImageFor(display.image));
     }
     state.plane = display.slice.plane;
     state.contourPlane = display.contourPlane;
@@ -4756,11 +4837,7 @@ void MainWindow::syncVisibleRanges()
         if (!image.valid()) {
             continue;
         }
-        const QImage wrapped(
-            reinterpret_cast<const uchar*>(image.rgba.data()),
-            image.width, image.height, image.strideBytes,
-            QImage::Format_ARGB32);
-        state->view->setImage(verticallyFlippedCopy(wrapped));
+        state->view->setImage(displayImageFor(image));
     }
     // setImage clears grid boxes and vector/contour overlays; restore them.
     for (auto* state : views) {

--- a/src/qt/MainWindow.hpp
+++ b/src/qt/MainWindow.hpp
@@ -181,6 +181,24 @@ public:
     };
     [[nodiscard]] std::vector<ContourViewProbe> contourViewProbesForTest();
 
+    // Test-only: select Visible range + Raster display and re-slice the full
+    // domain, so the full-domain range is cached. Pair with zoomActiveViewForTest
+    // to drive the 2-D range-reuse raster path. interactiveSlicesSettled fires
+    // when the re-slice completes.
+    void enableVisibleRasterForTest();
+
+    // Test-only: zoom the active view to the upper-value quadrant — a strict
+    // subregion whose local range differs from the full domain — and re-slice.
+    // With Visible mode active and the full-domain range cached, this exercises
+    // the reuse path that must re-render the raster to match the color bar.
+    void zoomActiveViewForTest();
+
+    // Test-only: true when the active view's displayed raster is byte-identical
+    // to its plane re-rendered against the current display (color-bar) range —
+    // i.e. the raster and color bar agree. See
+    // raster-colorbar-mismatch-on-2d-visible-zoom.
+    [[nodiscard]] bool activeViewRasterMatchesDisplayRangeForTest();
+
 signals:
     void datasetOpenFinished(bool success);
     void initialSliceFinished(bool success);

--- a/src/qt/main.cpp
+++ b/src/qt/main.cpp
@@ -25,6 +25,7 @@
 #include <array>
 #include <cmath>
 #include <filesystem>
+#include <memory>
 #include <string_view>
 #include <vector>
 
@@ -485,6 +486,38 @@ int main(int argc, char* argv[])
                 // local ranges [3/9,1], [2/9,8/9], [1/9,7/9] -> shared [1/9,1].
                 window.configureContourSyncForTest(
                     3, true, {0.875, 0.625, 0.375});
+            });
+        QTimer::singleShot(0, &window, [&window, path] { window.openDataset(path); });
+    } else if (argc == 3
+        && std::string_view(argv[1]) == "--raster-zoom-smoke-test") {
+        // 2-D Visible-range raster/color-bar consistency: after a full-domain
+        // Visible slice caches the range, a zoom must re-render the raster
+        // against that reused range (not the subregion's local range) so it
+        // matches the color bar. See raster-colorbar-mismatch-on-2d-visible-zoom.
+        // interactiveSlicesSettled fires twice: after the full-domain slice
+        // (phase 0 -> zoom) and after the zoom (phase 1 -> verify). phase is a
+        // shared_ptr so it outlives this branch's scope through exec().
+        const std::filesystem::path path(argv[2]);
+        auto phase = std::make_shared<int>(0);
+        QObject::connect(&window, &amrvis::qt::MainWindow::initialSliceFinished,
+            &application, [&window, &application](bool success) {
+                if (!success) {
+                    application.exit(1);
+                    return;
+                }
+                window.enableVisibleRasterForTest();
+            });
+        QObject::connect(&window,
+            &amrvis::qt::MainWindow::interactiveSlicesSettled,
+            &application, [&window, &application, phase] {
+                if (*phase == 0) {
+                    *phase = 1;
+                    window.zoomActiveViewForTest();
+                } else {
+                    application.exit(
+                        window.activeViewRasterMatchesDisplayRangeForTest()
+                            ? 0 : 1);
+                }
             });
         QTimer::singleShot(0, &window, [&window, path] { window.openDataset(path); });
     } else if (argc == 3

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -181,6 +181,20 @@ if(TARGET amrexplorer_qt)
             -P "${CMAKE_CURRENT_SOURCE_DIR}/qt_smoke_driver.cmake"
     )
     set_tests_properties(qt_slice_smoke_2d PROPERTIES TIMEOUT 30)
+    # Regression test for raster-colorbar-mismatch-on-2d-visible-zoom: after a
+    # full-domain Visible slice caches the range, zooming a 2-D view must
+    # re-render the raster against that reused range so it matches the color bar.
+    add_test(
+        NAME qt_raster_zoom_smoke_2d
+        COMMAND "${CMAKE_COMMAND}"
+            "-DMATERIALIZER=$<TARGET_FILE:fixture_materializer>"
+            "-DAMREXPLORER_QT=$<TARGET_FILE:amrexplorer_qt>"
+            "-DSOURCE=${CMAKE_CURRENT_SOURCE_DIR}/data/plotfile_2d"
+            "-DWORK=${CMAKE_CURRENT_BINARY_DIR}/fixtures_raster_zoom_2d"
+            -DMODE=raster-zoom
+            -P "${CMAKE_CURRENT_SOURCE_DIR}/qt_smoke_driver.cmake"
+    )
+    set_tests_properties(qt_raster_zoom_smoke_2d PROPERTIES TIMEOUT 30)
     add_test(
         NAME qt_slice_smoke_3d
         COMMAND "${CMAKE_COMMAND}"

--- a/tests/qt_smoke_driver.cmake
+++ b/tests/qt_smoke_driver.cmake
@@ -7,7 +7,7 @@
 #   WORK          directory the materialized copies are written into
 #   MODE          slice | sequence | missing-range | non-finite | raw-fab |
 #                 multifab-fab | quit | quit-on-failure | export-quit |
-#                 contour-sync
+#                 contour-sync | raster-zoom
 foreach(argument MATERIALIZER AMREXPLORER_QT SOURCE WORK MODE)
     if(NOT DEFINED ${argument})
         message(FATAL_ERROR "qt_smoke_driver.cmake requires -D${argument}=...")
@@ -47,6 +47,9 @@ elseif(MODE STREQUAL "non-finite")
 elseif(MODE STREQUAL "contour-sync")
     run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt")
     run_or_die("${AMREXPLORER_QT}" --contour-sync-smoke-test "${WORK}/plt")
+elseif(MODE STREQUAL "raster-zoom")
+    run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt")
+    run_or_die("${AMREXPLORER_QT}" --raster-zoom-smoke-test "${WORK}/plt")
 elseif(MODE STREQUAL "raw-fab")
     run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt")
     run_or_die("${AMREXPLORER_QT}" --raw-fab-smoke-test


### PR DESCRIPTION
In Visible mode, requestSlice reuses the cached full-domain range for a zoomed subregion so the color bar stays stable, but only overwrote the color-bar range — the raster kept the subregion-local normalization from executeSlice, so its colors no longer matched the color-bar labels (syncVisibleRanges re-renders for 3-D but early-returns for 2-D).

Re-render the raster against the reused range in the completion handler, guarded by m_viewDimension != 3 to complement syncVisibleRanges and avoid rendering 3-D panels twice; skip it when the raster was not otherwise touched. This also folds the contour re-extract under the same guard, dropping the redundant 3-D re-extract.

Cover it with qt_raster_zoom_smoke_2d: after a full-domain Visible slice, a zoom must leave the displayed raster byte-identical to the plane re-rendered against the color-bar range.