### PR TITLE
Key the full-domain range cache by dataset so it drops across frames

### DIFF
--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -4451,6 +4451,7 @@ void MainWindow::requestSlice(PlaneViewState& state, bool rasterDirty)
                     if (!isFullDomain
                         && rangeMode == RangeMode::Visible
                         && m_fullDomainRange.has_value()
+                        && m_fullDomainRangeDataset == result.request.dataset
                         && m_fullDomainRangeField.value
                             == result.request.field.value
                         && m_fullDomainRangeMaxLevel
@@ -4488,6 +4489,7 @@ void MainWindow::requestSlice(PlaneViewState& state, bool rasterDirty)
                         && state.plane.width > 0) {
                         m_fullDomainRange = std::make_pair(
                             state.displayMinimum, state.displayMaximum);
+                        m_fullDomainRangeDataset = result.request.dataset;
                         m_fullDomainRangeField = result.request.field;
                         m_fullDomainRangeMaxLevel
                             = result.request.maximumLevel;
@@ -4776,6 +4778,7 @@ void MainWindow::syncVisibleRanges()
     double globalMin = std::numeric_limits<double>::infinity();
     double globalMax = -std::numeric_limits<double>::infinity();
     const bool useCachedRange = m_fullDomainRange.has_value()
+        && m_fullDomainRangeDataset == m_dataset->id()
         && m_fullDomainRangeField.value == currentField.value
         && m_fullDomainRangeMaxLevel == maximumLevel
         && m_fullDomainRangeComposition == composition;
@@ -5270,6 +5273,7 @@ void MainWindow::resetRangeState()
     m_fieldRanges.clear();
     m_trackedField = 0;
     m_fullDomainRange.reset();
+    m_fullDomainRangeDataset = {};
     m_fullDomainRangeField = {};
     m_fullDomainRangeMaxLevel = -1;
     const QSignalBlocker modeBlocker(m_rangeMode);

--- a/src/qt/MainWindow.hpp
+++ b/src/qt/MainWindow.hpp
@@ -483,6 +483,11 @@ private:
     // completes, and reused for RangeMode::Visible during zoom/pan so the
     // color bar stays stable instead of tracking the subregion extrema.
     std::optional<std::pair<double, double>> m_fullDomainRange;
+    // The dataset the cached range belongs to. Sequence frames each load a
+    // fresh dataset (a new DatasetId), so keying on it invalidates the cache
+    // across frames — without it a zoomed Visible color bar would keep an
+    // earlier frame's range (see sequence-frame-range-cache-goes-stale).
+    DatasetId m_fullDomainRangeDataset{};
     FieldId m_fullDomainRangeField{};
     int m_fullDomainRangeMaxLevel = -1;
     CompositionPolicy m_fullDomainRangeComposition{};

--- a/src/qt/main.cpp
+++ b/src/qt/main.cpp
@@ -520,6 +520,52 @@ int main(int argc, char* argv[])
                 }
             });
         QTimer::singleShot(0, &window, [&window, path] { window.openDataset(path); });
+    } else if (argc == 4
+        && std::string_view(argv[1]) == "--range-cache-smoke-test") {
+        // Regression for sequence-frame-range-cache-goes-stale: cache the
+        // full-domain Visible range on frame 0, step to frame 1 (whose field is
+        // 10x-scaled), zoom, and confirm the color bar tracks frame 1 instead
+        // of reusing frame 0's cached range. Two signals interleave, sequenced
+        // by a phase held in a shared_ptr so it outlives this branch scope.
+        const std::filesystem::path first(argv[2]);
+        const std::filesystem::path second(argv[3]);
+        struct RangeCacheState { int phase = 0; double frame0Max = 0.0; };
+        auto state = std::make_shared<RangeCacheState>();
+        QObject::connect(&window,
+            &amrvis::qt::MainWindow::sequenceFrameDisplayed,
+            &application, [&window](int index) {
+                if (index == 0) {
+                    window.enableVisibleRasterForTest();  // cache frame 0 range
+                } else {
+                    window.zoomActiveViewForTest();        // re-slice frame 1
+                }
+            });
+        QObject::connect(&window, &amrvis::qt::MainWindow::sequenceFrameFailed,
+            &application, [&application] { application.exit(1); });
+        QObject::connect(&window,
+            &amrvis::qt::MainWindow::interactiveSlicesSettled,
+            &application, [&window, &application, state] {
+                const auto probes = window.contourViewProbesForTest();
+                if (probes.empty()) {
+                    application.exit(1);
+                    return;
+                }
+                const auto displayMax = probes.front().displayMaximum;
+                if (state->phase == 0) {
+                    state->frame0Max = displayMax;   // frame 0 full-domain max
+                    state->phase = 1;
+                    window.stepSequence(1);
+                } else {
+                    // Frame 1 is scaled 10x, so its zoomed max must far exceed
+                    // frame 0's cached max. Reusing the stale cache (the bug)
+                    // would instead leave them equal.
+                    application.exit(
+                        displayMax > 2.0 * state->frame0Max ? 0 : 1);
+                }
+            });
+        QTimer::singleShot(0, &window, [&window, first, second] {
+            window.openSequence({first, second});
+        });
     } else if (argc == 3
         && std::string_view(argv[1]) == "--raw-fab-smoke-test") {
         const std::filesystem::path path(argv[2]);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -195,6 +195,21 @@ if(TARGET amrexplorer_qt)
             -P "${CMAKE_CURRENT_SOURCE_DIR}/qt_smoke_driver.cmake"
     )
     set_tests_properties(qt_raster_zoom_smoke_2d PROPERTIES TIMEOUT 30)
+    # Regression test for sequence-frame-range-cache-goes-stale: across sequence
+    # frames the full-domain range cache must invalidate (its key includes the
+    # dataset), so a zoomed Visible color bar tracks the current frame instead
+    # of reusing an earlier frame's range. Frame 1's field is scaled 10x.
+    add_test(
+        NAME qt_range_cache_smoke_2d
+        COMMAND "${CMAKE_COMMAND}"
+            "-DMATERIALIZER=$<TARGET_FILE:fixture_materializer>"
+            "-DAMREXPLORER_QT=$<TARGET_FILE:amrexplorer_qt>"
+            "-DSOURCE=${CMAKE_CURRENT_SOURCE_DIR}/data/plotfile_2d"
+            "-DWORK=${CMAKE_CURRENT_BINARY_DIR}/fixtures_range_cache_2d"
+            -DMODE=range-cache
+            -P "${CMAKE_CURRENT_SOURCE_DIR}/qt_smoke_driver.cmake"
+    )
+    set_tests_properties(qt_range_cache_smoke_2d PROPERTIES TIMEOUT 30)
     add_test(
         NAME qt_slice_smoke_3d
         COMMAND "${CMAKE_COMMAND}"

--- a/tests/fixture_materializer/main.cpp
+++ b/tests/fixture_materializer/main.cpp
@@ -142,7 +142,7 @@ std::vector<BlockRecord> readCellHeader(
 // the level storing the grid.
 std::vector<double> blockValues(
     const BlockRecord& block, int dimension, int fieldCount,
-    bool nonFiniteValues)
+    bool nonFiniteValues, double scale)
 {
     const auto lower = [&block](int axis) {
         return block.indices[static_cast<std::size_t>(axis)];
@@ -176,7 +176,7 @@ std::vector<double> blockValues(
                         }
                     } else {
                         values.push_back(
-                            component == 0 ? base : 100.0 + base);
+                            scale * (component == 0 ? base : 100.0 + base));
                     }
                 }
             }
@@ -189,7 +189,7 @@ std::vector<double> blockValues(
 // test_line_query.cpp's writeFab: an ASCII header line followed by
 // little-endian doubles.
 void writeFab(const std::filesystem::path& path, BlockRecord& block,
-    int dimension, int fieldCount, bool nonFiniteValues)
+    int dimension, int fieldCount, bool nonFiniteValues, double scale)
 {
     if (block.offset == 0) {
         std::ofstream create(path, std::ios::binary | std::ios::trunc);
@@ -203,7 +203,7 @@ void writeFab(const std::filesystem::path& path, BlockRecord& block,
     output << header;
     block.payloadOffset = block.offset + header.size();
     const auto values = blockValues(
-        block, dimension, fieldCount, nonFiniteValues);
+        block, dimension, fieldCount, nonFiniteValues, scale);
     output.write(reinterpret_cast<const char*>(values.data()),
         static_cast<std::streamsize>(values.size() * sizeof(double)));
     require(static_cast<bool>(output), "could not write a fixture FAB payload");
@@ -234,14 +234,17 @@ void writeHeaderWithoutStatistics(const std::filesystem::path& path,
 
 int main(int argc, char* argv[])
 {
-    require(argc >= 3 && argc <= 6,
+    require(argc >= 3 && argc <= 8,
         "usage: fixture_materializer <sourceFixtureDir> <destDir> "
-        "[newTime] [--no-statistics] [--non-finite]");
+        "[newTime] [--no-statistics] [--non-finite] [--scale <factor>]");
     const std::filesystem::path source(argv[1]);
     const std::filesystem::path destination(argv[2]);
     std::optional<std::string> newTime;
     bool omitStatistics = false;
     bool nonFiniteValues = false;
+    // Multiplies the synthesized field values so successive frames of a
+    // sequence can carry different ranges (used by the range-cache test).
+    double scale = 1.0;
     for (int argument = 3; argument < argc; ++argument) {
         const std::string value(argv[argument]);
         if (value == "--no-statistics") {
@@ -252,6 +255,14 @@ int main(int argc, char* argv[])
             require(!nonFiniteValues,
                 "--non-finite was specified more than once");
             nonFiniteValues = true;
+        } else if (value == "--scale") {
+            require(argument + 1 < argc, "--scale requires a factor argument");
+            const std::string factor(argv[++argument]);
+            try {
+                scale = std::stod(factor);
+            } catch (const std::exception&) {
+                require(false, "--scale factor is not a number");
+            }
         } else {
             require(!newTime.has_value(), "more than one new time was specified");
             newTime = value;
@@ -291,7 +302,7 @@ int main(int argc, char* argv[])
         auto blocks = readCellHeader(levelDir / "Cell_H", header.dimension);
         for (auto& block : blocks) {
             writeFab(levelDir / block.fileName, block,
-                header.dimension, header.fieldCount, nonFiniteValues);
+                header.dimension, header.fieldCount, nonFiniteValues, scale);
         }
         if (omitStatistics) {
             writeHeaderWithoutStatistics(

--- a/tests/qt_smoke_driver.cmake
+++ b/tests/qt_smoke_driver.cmake
@@ -7,7 +7,7 @@
 #   WORK          directory the materialized copies are written into
 #   MODE          slice | sequence | missing-range | non-finite | raw-fab |
 #                 multifab-fab | quit | quit-on-failure | export-quit |
-#                 contour-sync | raster-zoom
+#                 contour-sync | raster-zoom | range-cache
 foreach(argument MATERIALIZER AMREXPLORER_QT SOURCE WORK MODE)
     if(NOT DEFINED ${argument})
         message(FATAL_ERROR "qt_smoke_driver.cmake requires -D${argument}=...")
@@ -50,6 +50,13 @@ elseif(MODE STREQUAL "contour-sync")
 elseif(MODE STREQUAL "raster-zoom")
     run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt")
     run_or_die("${AMREXPLORER_QT}" --raster-zoom-smoke-test "${WORK}/plt")
+elseif(MODE STREQUAL "range-cache")
+    # Two frames of the same fixture; frame 1's field is scaled 10x so its
+    # range differs, making a stale range-cache reuse observable.
+    run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt00000")
+    run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt00010" "--scale" "10")
+    run_or_die("${AMREXPLORER_QT}" --range-cache-smoke-test
+        "${WORK}/plt00000" "${WORK}/plt00010")
 elseif(MODE STREQUAL "raw-fab")
     run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt")
     run_or_die("${AMREXPLORER_QT}" --raw-fab-smoke-test


### PR DESCRIPTION
m_fullDomainRange is reused for zoomed Visible slices to keep the color bar stable during pan/zoom, but its key was (field, maxLevel, composition) with no frame identity, and goToSequenceFrame preserves view state without resetting it. So after switching sequence frames while zoomed, the first interactive re-slice reused an earlier frame's range for the color bar (the frame-load path itself recomputes per frame, so plain stepping looked fine).

Add the dataset id to the key: each frame loads a fresh dataset with a unique DatasetId, so the reuse in the requestSlice completion handler and the useCachedRange branch of syncVisibleRanges now require a dataset match, and the cache records the id when set. Within a single dataset the id is stable, so the stable-color-bar-during-zoom behavior is unchanged.

Cover it with qt_range_cache_smoke_2d: a two-frame sequence whose second frame is scaled 10x (new fixture_materializer --scale). It caches the full-domain range on frame 0, steps to frame 1, zooms, and asserts the display max tracks frame 1 rather than reusing frame 0's cached range.