### PR TITLE
Restore the FAB round-trip zoom into view state

### DIFF
--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -2033,6 +2033,16 @@ bool MainWindow::activeViewRasterMatchesDisplayRangeForTest()
     return displayImageFor(reference) == state.view->image();
 }
 
+void MainWindow::viewFabForTest(std::size_t index)
+{
+    viewFab(index);
+}
+
+bool MainWindow::activeViewIsZoomedForTest() const
+{
+    return m_activeView != nullptr && m_activeView->visibleRegion.has_value();
+}
+
 void MainWindow::showNumberFormatDialog()
 {
     if (m_numberFormatDialog != nullptr) {
@@ -4104,6 +4114,24 @@ void MainWindow::requestInitialSlice(
                             != viewGenerations[index]) {
                             continue;
                         }
+                        // A FAB round-trip preserved the zoom in restoredSpec and
+                        // executeFrameLoad rendered the slice against it, but
+                        // openDatasetImpl reset the view states. Restore the zoom
+                        // from the region that actually produced this plane (so it
+                        // stays in step with the slice cache key), gated on
+                        // whether the spec recorded a zoom for this view — a
+                        // full-domain view stays nullopt, without float-comparing
+                        // regions. See fab-round-trip-loses-visible-region.
+                        if (restoredSpec) {
+                            const bool wasZoomed =
+                                index < restoredSpec->visibleRegions.size()
+                                && restoredSpec->visibleRegions[index]
+                                    .has_value();
+                            views[index]->visibleRegion = wasZoomed
+                                ? std::optional<RealBox>{
+                                    result.displays[index].request.visibleRegion}
+                                : std::optional<RealBox>{};
+                        }
                         showSlice(*views[index], result.displays[index]);
                     }
                     const auto cache = m_dataset->cacheMetrics();
@@ -5370,7 +5398,6 @@ FrameSliceSpec MainWindow::buildFrameSpec()
     spec.slicePositions = m_slicePosition3d;
     const auto views = currentViews();
     spec.visibleRegions.reserve(views.size());
-    spec.outputSizes.reserve(views.size());
     for (const auto* state : views) {
         spec.visibleRegions.push_back(state->visibleRegion);
     }

--- a/src/qt/MainWindow.hpp
+++ b/src/qt/MainWindow.hpp
@@ -121,7 +121,7 @@ struct InitialSliceResult {
 // sequence path builds this from the current UI state so frame switches keep
 // the user's field/level/range/log/palette/visible-region settings; empty or
 // default entries mean "fall back to the new dataset's defaults" (midpoint
-// slice positions, whole domain, 640x640 output).
+// slice positions, whole domain, finest-native output size).
 struct FrameSliceSpec {
     DisplayMode displayMode = DisplayMode::Raster;
     std::uint32_t field = 0;
@@ -137,7 +137,6 @@ struct FrameSliceSpec {
     bool defaultPositions = true;
     std::array<double, 3> slicePositions{0.0, 0.0, 0.0};
     std::vector<std::optional<RealBox>> visibleRegions;  // per view, normal order
-    std::vector<std::array<int, 2>> outputSizes;         // per view, normal order
 };
 
 class MainWindow final : public QMainWindow {
@@ -198,6 +197,14 @@ public:
     // i.e. the raster and color bar agree. See
     // raster-colorbar-mismatch-on-2d-visible-zoom.
     [[nodiscard]] bool activeViewRasterMatchesDisplayRangeForTest();
+
+    // Test-only: drill into the FAB catalog entry at index (the same path the
+    // dock's viewRequested signal drives). Used by the FAB round-trip zoom test.
+    void viewFabForTest(std::size_t index);
+
+    // Test-only: true when the active view holds a zoom (visibleRegion set).
+    // See fab-round-trip-loses-visible-region.
+    [[nodiscard]] bool activeViewIsZoomedForTest() const;
 
 signals:
     void datasetOpenFinished(bool success);

--- a/src/qt/main.cpp
+++ b/src/qt/main.cpp
@@ -630,6 +630,48 @@ int main(int argc, char* argv[])
             });
         QTimer::singleShot(0, &window,
             [&window, path] { window.openDataset(path); });
+    } else if (argc == 3
+        && std::string_view(argv[1]) == "--fab-zoom-smoke-test") {
+        // Regression for fab-round-trip-loses-visible-region: zoom the MultiFab
+        // slice, drill into a FAB, go back, and confirm the restored MultiFab
+        // view still holds the zoom. Without the fix the round-trip resets it to
+        // full domain. initialSliceFinished fires on each open (MultiFab, FAB,
+        // restored MultiFab); interactiveSlicesSettled fires once for the zoom.
+        // A shared phase sequences the two signals across this branch's scope.
+        const std::filesystem::path path(argv[2]);
+        auto phase = std::make_shared<int>(0);
+        QObject::connect(&window, &amrvis::qt::MainWindow::initialSliceFinished,
+            &application, [&window, &application, phase](bool success) {
+                if (!success) {
+                    application.exit(1);
+                    return;
+                }
+                if (*phase == 0) {
+                    *phase = 1;
+                    window.zoomActiveViewForTest();       // zoom the MultiFab
+                } else if (*phase == 2) {
+                    *phase = 3;
+                    auto* back = window.findChild<QPushButton*>(
+                        QStringLiteral("fabBackButton"));
+                    if (back == nullptr) {
+                        application.exit(1);
+                        return;
+                    }
+                    QTimer::singleShot(0, back, &QPushButton::click);  // go back
+                } else if (*phase == 3) {
+                    application.exit(
+                        window.activeViewIsZoomedForTest() ? 0 : 1);
+                }
+            });
+        QObject::connect(&window,
+            &amrvis::qt::MainWindow::interactiveSlicesSettled,
+            &application, [&window, phase] {
+                if (*phase == 1) {
+                    *phase = 2;
+                    window.viewFabForTest(0);             // drill into FAB 0
+                }
+            });
+        QTimer::singleShot(0, &window, [&window, path] { window.openDataset(path); });
     } else if (argc == 4
         && std::string_view(argv[1]) == "--sequence-smoke-test") {
         // Opens the two-frame sequence, waits for the first frame to display,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -316,6 +316,20 @@ if(TARGET amrexplorer_qt)
             -P "${CMAKE_CURRENT_SOURCE_DIR}/qt_smoke_driver.cmake"
     )
     set_tests_properties(qt_multifab_fab_mode PROPERTIES TIMEOUT 30)
+    # Regression test for fab-round-trip-loses-visible-region: zooming a MultiFab
+    # slice, drilling into a FAB, and going back must leave the restored view
+    # still zoomed (visibleRegion written back into the view state).
+    add_test(
+        NAME qt_fab_zoom_smoke_2d
+        COMMAND "${CMAKE_COMMAND}"
+            "-DMATERIALIZER=$<TARGET_FILE:fixture_materializer>"
+            "-DAMREXPLORER_QT=$<TARGET_FILE:amrexplorer_qt>"
+            "-DSOURCE=${CMAKE_CURRENT_SOURCE_DIR}/data/plotfile_2d"
+            "-DWORK=${CMAKE_CURRENT_BINARY_DIR}/fixtures_fab_zoom"
+            -DMODE=fab-zoom
+            -P "${CMAKE_CURRENT_SOURCE_DIR}/qt_smoke_driver.cmake"
+    )
+    set_tests_properties(qt_fab_zoom_smoke_2d PROPERTIES TIMEOUT 30)
     add_test(
         NAME qt_sequence_smoke
         COMMAND "${CMAKE_COMMAND}"

--- a/tests/qt_smoke_driver.cmake
+++ b/tests/qt_smoke_driver.cmake
@@ -7,7 +7,7 @@
 #   WORK          directory the materialized copies are written into
 #   MODE          slice | sequence | missing-range | non-finite | raw-fab |
 #                 multifab-fab | quit | quit-on-failure | export-quit |
-#                 contour-sync | raster-zoom | range-cache
+#                 contour-sync | raster-zoom | range-cache | fab-zoom
 foreach(argument MATERIALIZER AMREXPLORER_QT SOURCE WORK MODE)
     if(NOT DEFINED ${argument})
         message(FATAL_ERROR "qt_smoke_driver.cmake requires -D${argument}=...")
@@ -64,6 +64,10 @@ elseif(MODE STREQUAL "raw-fab")
 elseif(MODE STREQUAL "multifab-fab")
     run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt")
     run_or_die("${AMREXPLORER_QT}" --multifab-fab-smoke-test
+        "${WORK}/plt/Level_0/Cell")
+elseif(MODE STREQUAL "fab-zoom")
+    run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt")
+    run_or_die("${AMREXPLORER_QT}" --fab-zoom-smoke-test
         "${WORK}/plt/Level_0/Cell")
 elseif(MODE STREQUAL "quit")
     run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt")


### PR DESCRIPTION
viewFab/backToMultiFab pass a FrameSliceSpec with visibleRegions into openDatasetImpl, and executeFrameLoad renders the restored slices zoomed, but openDatasetImpl reset each view's visibleRegion to nullopt and nothing wrote the regions back. The view then showed zoomed data while believing it was unzoomed, so the next cosmetic change built a full-domain request, missed sameSliceSpec, and silently re-queried the whole domain — losing the zoom.

In requestInitialSlice's restoredSpec path, write each view's visibleRegion back from the region that actually produced the plane (a full-domain region stays nullopt). Adopting the rendered region keeps state.visibleRegion in step with the slice cache key, so cosmetic changes hit the cache. Covers both round-trip directions.

Also remove the dead FrameSliceSpec::outputSizes (only ever reserved, never filled or read) and fix the stale "640x640 output" comment.

Cover it with qt_fab_zoom_smoke_2d: zoom a MultiFab slice, drill into a FAB, go back, and confirm the restored view is still zoomed.