### PR TITLE
Degrade post-load slices on cache pressure instead of hard-failing

### DIFF
--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -765,27 +765,27 @@ QString cacheBudgetDescription(std::uint64_t bytes)
     return QObject::tr("%1 bytes").arg(bytes);
 }
 
-QString cacheFallbackMessage(const InitialSliceResult& result)
+QString cacheFallbackMessage(
+    const PlotfileDataset& dataset, int fromLevel, int toLevel)
 {
     const auto budget = cacheBudgetDescription(
-        result.dataset->cacheMetrics().budgetBytes);
+        dataset.cacheMetrics().budgetBytes);
     return QObject::tr(
-        "The finest slice exceeded the %1 cache budget. "
-        "The plotfile was opened using levels 0 through %2 instead of "
-        "levels 0 through %3; higher-resolution levels were omitted.")
+        "The finest slice exceeded the %1 cache budget. Showing levels 0 "
+        "through %2 instead of levels 0 through %3; higher-resolution levels "
+        "were omitted.")
         .arg(budget)
-        .arg(result.cacheFallbackToLevel)
-        .arg(result.cacheFallbackFromLevel);
+        .arg(toLevel)
+        .arg(fromLevel);
 }
 
-bool selectCacheFallbackLevel(
-    QComboBox* selector, const InitialSliceResult& result)
+bool selectCacheFallbackLevel(QComboBox* selector, int toLevel)
 {
-    if (result.cacheFallbackToLevel < 0) {
+    if (toLevel < 0) {
         return false;
     }
-    const auto data = result.cacheFallbackToLevel == 0
-        ? 0 : kUpdateToLevelOffset + result.cacheFallbackToLevel;
+    const auto data = toLevel == 0
+        ? 0 : kUpdateToLevelOffset + toLevel;
     const auto index = selector->findData(data);
     if (index < 0) {
         return false;
@@ -1099,6 +1099,7 @@ MainWindow::MainWindow(QWidget* parent)
     sliceToolbar->setMovable(false);
     sliceToolbar->addWidget(new QLabel(tr("Field:"), sliceToolbar));
     m_fieldSelector = new QComboBox(sliceToolbar);
+    m_fieldSelector->setObjectName(QStringLiteral("fieldSelector"));
     m_fieldSelector->setMinimumContentsLength(10);
     m_fieldSelector->view()->setItemDelegate(new CurrentRowBulletDelegate(
         m_fieldSelector, m_fieldSelector->view()));
@@ -1106,6 +1107,7 @@ MainWindow::MainWindow(QWidget* parent)
     sliceToolbar->addSeparator();
     sliceToolbar->addWidget(new QLabel(tr("Level:"), sliceToolbar));
     m_levelSelector = new QComboBox(sliceToolbar);
+    m_levelSelector->setObjectName(QStringLiteral("levelSelector"));
     m_levelSelector->setMinimumContentsLength(8);
     m_levelSelector->view()->setItemDelegate(new CurrentRowBulletDelegate(
         m_levelSelector, m_levelSelector->view()));
@@ -2043,6 +2045,20 @@ bool MainWindow::activeViewIsZoomedForTest() const
     return m_activeView != nullptr && m_activeView->visibleRegion.has_value();
 }
 
+void MainWindow::setCacheBudgetForTest(std::uint64_t bytes)
+{
+    if (m_dataset) {
+        // The return (whether resident already fits) is irrelevant here; the
+        // next non-cache slice re-pins and triggers the fallback.
+        static_cast<void>(m_dataset->setCacheBudget(bytes));
+    }
+}
+
+std::uint64_t MainWindow::cacheResidentBytesForTest() const
+{
+    return m_dataset ? m_dataset->cacheMetrics().residentBytes : 0;
+}
+
 void MainWindow::showNumberFormatDialog()
 {
     if (m_numberFormatDialog != nullptr) {
@@ -2794,6 +2810,20 @@ void MainWindow::linePlotRequested(PlaneViewState& state, int imageX, int imageY
                     m_lastPayloadBytesRead = result.metrics.payloadBytesRead;
                     statusBar()->showMessage(tr("Added line plot curve for %1")
                         .arg(QString::fromStdString(fieldName)));
+                }
+            } catch (const CacheBudgetExceeded&) {
+                // A line plot cannot shed resolution the way a slice can, so
+                // translate the raw pinned-budget error into actionable advice
+                // instead of degrading (see
+                // cache-budget-exceeded-hard-fails-after-load).
+                if (generation == m_generation && !cancellation.stop_requested()) {
+                    reportBackgroundError(tr(
+                        "The line plot cannot fit in the %1 cache. Choose a "
+                        "lower level or increase AMREXPLORER_CACHE_SIZE_MB.")
+                        .arg(cacheBudgetDescription(
+                            dataset->cacheMetrics().budgetBytes)));
+                } else {
+                    ++m_staleResults;
                 }
             } catch (const std::exception& error) {
                 if (generation == m_generation && !cancellation.stop_requested()) {
@@ -4100,7 +4130,8 @@ void MainWindow::requestInitialSlice(
                         configureSlicePositionControls();
                         syncMenuChecks();
                     }
-                    if (selectCacheFallbackLevel(m_levelSelector, result)) {
+                    if (selectCacheFallbackLevel(
+                            m_levelSelector, result.cacheFallbackToLevel)) {
                         configureSlicePositionControls();
                         updateRangeModeAvailability();
                         syncMenuChecks();
@@ -4142,7 +4173,9 @@ void MainWindow::requestInitialSlice(
                     if (result.cacheFallbackToLevel >= 0) {
                         // Non-modal: an informational cache-fallback notice must
                         // not pop a modal dialog that would block the quit path.
-                        statusBar()->showMessage(cacheFallbackMessage(result));
+                        statusBar()->showMessage(cacheFallbackMessage(
+                            *result.dataset, result.cacheFallbackFromLevel,
+                            result.cacheFallbackToLevel));
                     }
                     emit initialSliceFinished(true);
                 } else {
@@ -4439,22 +4472,60 @@ void MainWindow::requestSlice(PlaneViewState& state, bool rasterDirty)
         future = QtConcurrent::run(
             [dataset, request, rangeMode, userRange, logarithmic, palette,
                 cancellation, displayMode, vectorUField, vectorVField,
-                contourCount] {
-            auto result = executeSlice(dataset, request, rangeMode,
-                userRange, logarithmic, palette, cancellation);
-            result.mode = displayMode;
-            result.vectorUField = vectorUField;
-            result.vectorVField = vectorVField;
-            result.contourCount = contourCount;
-            if (isContourMode(displayMode)) {
-                appendContours(dataset, request, contourCount, result.minimum,
-                    result.maximum, result.logarithmic, cancellation, result);
+                contourCount]() mutable {
+            // Graceful degradation on cache pressure, mirroring executeFrameLoad:
+            // a composite (Finest Available) slice whose multi-level working set
+            // overflows the budget is retried at a lower composite maximum
+            // level; an exact level (or level 0) cannot shed resolution and is
+            // reported instead. See cache-budget-exceeded-hard-fails-after-load.
+            int fallbackFrom = -1;
+            int fallbackTo = -1;
+            for (;;) {
+                try {
+                    auto result = executeSlice(dataset, request, rangeMode,
+                        userRange, logarithmic, palette, cancellation);
+                    result.mode = displayMode;
+                    result.vectorUField = vectorUField;
+                    result.vectorVField = vectorVField;
+                    result.contourCount = contourCount;
+                    if (isContourMode(displayMode)) {
+                        appendContours(dataset, request, contourCount,
+                            result.minimum, result.maximum, result.logarithmic,
+                            cancellation, result);
+                    }
+                    if (displayMode == DisplayMode::VelocityVectors) {
+                        appendVectorGlyphs(dataset, request,
+                            FieldId{vectorUField}, FieldId{vectorVField},
+                            contourCount, cancellation, result);
+                    }
+                    result.cacheFallbackFromLevel = fallbackFrom;
+                    result.cacheFallbackToLevel = fallbackTo;
+                    return result;
+                } catch (const CacheBudgetExceeded&) {
+                    const auto budget = cacheBudgetDescription(
+                        dataset->cacheMetrics().budgetBytes);
+                    if (request.composition
+                            != CompositionPolicy::FinestAvailable) {
+                        throw std::runtime_error(QObject::tr(
+                            "The selected slice level cannot fit in the %1 "
+                            "cache. Choose a lower level or increase "
+                            "AMREXPLORER_CACHE_SIZE_MB.").arg(budget)
+                            .toStdString());
+                    }
+                    if (request.maximumLevel == 0) {
+                        throw std::runtime_error(QObject::tr(
+                            "The slice cannot fit in the %1 cache, even at "
+                            "level 0. Try a smaller plotfile or increase "
+                            "AMREXPLORER_CACHE_SIZE_MB.").arg(budget)
+                            .toStdString());
+                    }
+                    dataset->clearUnpinnedCache();
+                    if (fallbackFrom < 0) {
+                        fallbackFrom = request.maximumLevel;
+                    }
+                    fallbackTo = --request.maximumLevel;
+                }
             }
-            if (displayMode == DisplayMode::VelocityVectors) {
-                appendVectorGlyphs(dataset, request, FieldId{vectorUField},
-                    FieldId{vectorVField}, contourCount, cancellation, result);
-            }
-            return result;
         });
     }
 
@@ -4529,6 +4600,21 @@ void MainWindow::requestSlice(PlaneViewState& state, bool rasterDirty)
                     m_cacheResidentBytes = cache.residentBytes;
                     m_cachePinnedBytes = cache.pinnedBytes;
                     m_cacheEvictions = cache.evictions;
+                    // A cache-pressure fallback lowered the composite level;
+                    // reflect it in the level combo (no re-slice) and inform the
+                    // user, matching the initial-load handling.
+                    if (result.cacheFallbackToLevel >= 0) {
+                        if (selectCacheFallbackLevel(
+                                m_levelSelector,
+                                result.cacheFallbackToLevel)) {
+                            configureSlicePositionControls();
+                            updateRangeModeAvailability();
+                            syncMenuChecks();
+                        }
+                        statusBar()->showMessage(cacheFallbackMessage(
+                            *dataset, result.cacheFallbackFromLevel,
+                            result.cacheFallbackToLevel));
+                    }
                 } else {
                     ++m_staleResults;
                 }
@@ -5164,7 +5250,7 @@ void MainWindow::displayFrameResult(InitialSliceResult& result,
     showMetadata(frameMetadata, m_datasetPath);
 
     configureSequenceControls(defaultPositions);
-    if (selectCacheFallbackLevel(m_levelSelector, result)) {
+    if (selectCacheFallbackLevel(m_levelSelector, result.cacheFallbackToLevel)) {
         configureSlicePositionControls();
         updateRangeModeAvailability();
         syncMenuChecks();
@@ -5183,7 +5269,9 @@ void MainWindow::displayFrameResult(InitialSliceResult& result,
     m_cacheEvictions = cache.evictions;
     validateVectorMode();
     if (result.cacheFallbackToLevel >= 0) {
-        statusBar()->showMessage(cacheFallbackMessage(result));
+        statusBar()->showMessage(cacheFallbackMessage(
+            *result.dataset, result.cacheFallbackFromLevel,
+            result.cacheFallbackToLevel));
     }
 }
 

--- a/src/qt/MainWindow.hpp
+++ b/src/qt/MainWindow.hpp
@@ -102,6 +102,11 @@ struct SliceDisplayResult {
     // Set when the image was intentionally not re-rendered (contour-only
     // refresh): showSlice keeps the view's current pixmap.
     bool rasterUnchanged = false;
+    // Set when a composite (Finest Available) slice exceeded the cache budget
+    // and was retried at a lower composite maximum level, mirroring
+    // InitialSliceResult (see cache-budget-exceeded-hard-fails-after-load).
+    int cacheFallbackFromLevel = -1;
+    int cacheFallbackToLevel = -1;
 };
 
 struct InitialSliceResult {
@@ -205,6 +210,12 @@ public:
     // Test-only: true when the active view holds a zoom (visibleRegion set).
     // See fab-round-trip-loses-visible-region.
     [[nodiscard]] bool activeViewIsZoomedForTest() const;
+
+    // Test-only: shrink the open dataset's cache budget to force cache-pressure
+    // fallback on the next non-cache slice, and read the current resident bytes
+    // to size that budget. See cache-budget-exceeded-hard-fails-after-load.
+    void setCacheBudgetForTest(std::uint64_t bytes);
+    [[nodiscard]] std::uint64_t cacheResidentBytesForTest() const;
 
 signals:
     void datasetOpenFinished(bool success);

--- a/src/qt/main.cpp
+++ b/src/qt/main.cpp
@@ -672,6 +672,49 @@ int main(int argc, char* argv[])
                 }
             });
         QTimer::singleShot(0, &window, [&window, path] { window.openDataset(path); });
+    } else if (argc == 3
+        && std::string_view(argv[1]) == "--cache-budget-smoke-test") {
+        // Regression for cache-budget-exceeded-hard-fails-after-load: load a
+        // 2-D dataset at finest, shrink the cache budget just below the finest
+        // working set, then switch field to force a non-cache finest re-slice
+        // that overflows the budget. With the fix the slice degrades to a lower
+        // composite level (the level combo drops from "Finest available", -1);
+        // without it the slice hard-fails and the level is unchanged.
+        const std::filesystem::path path(argv[2]);
+        QObject::connect(&window, &amrvis::qt::MainWindow::initialSliceFinished,
+            &application, [&window, &application](bool success) {
+                if (!success) {
+                    application.exit(1);
+                    return;
+                }
+                auto* levels = window.findChild<QComboBox*>(
+                    QStringLiteral("levelSelector"));
+                auto* fields = window.findChild<QComboBox*>(
+                    QStringLiteral("fieldSelector"));
+                if (levels == nullptr || fields == nullptr
+                    || fields->count() < 2
+                    || levels->currentData().toInt() != -1) {
+                    application.exit(1);  // expected finest (-1) with >=2 fields
+                    return;
+                }
+                const auto resident = window.cacheResidentBytesForTest();
+                if (resident == 0) {
+                    application.exit(1);
+                    return;
+                }
+                window.setCacheBudgetForTest(resident - 1);
+                QObject::connect(&window,
+                    &amrvis::qt::MainWindow::interactiveSlicesSettled,
+                    &application, [&application, levels] {
+                        // With the fix the overflowing finest re-slice fell back
+                        // to a lower composite level, so the combo no longer
+                        // reads "Finest available" (-1).
+                        application.exit(
+                            levels->currentData().toInt() != -1 ? 0 : 1);
+                    });
+                fields->setCurrentIndex(1);  // non-cache finest re-slice
+            });
+        QTimer::singleShot(0, &window, [&window, path] { window.openDataset(path); });
     } else if (argc == 4
         && std::string_view(argv[1]) == "--sequence-smoke-test") {
         // Opens the two-frame sequence, waits for the first frame to display,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -330,6 +330,20 @@ if(TARGET amrexplorer_qt)
             -P "${CMAKE_CURRENT_SOURCE_DIR}/qt_smoke_driver.cmake"
     )
     set_tests_properties(qt_fab_zoom_smoke_2d PROPERTIES TIMEOUT 30)
+    # Regression test for cache-budget-exceeded-hard-fails-after-load: a
+    # post-load slice that overflows the cache budget must degrade to a lower
+    # composite level (like the initial load) rather than hard-fail.
+    add_test(
+        NAME qt_cache_budget_smoke_2d
+        COMMAND "${CMAKE_COMMAND}"
+            "-DMATERIALIZER=$<TARGET_FILE:fixture_materializer>"
+            "-DAMREXPLORER_QT=$<TARGET_FILE:amrexplorer_qt>"
+            "-DSOURCE=${CMAKE_CURRENT_SOURCE_DIR}/data/plotfile_2d"
+            "-DWORK=${CMAKE_CURRENT_BINARY_DIR}/fixtures_cache_budget"
+            -DMODE=cache-budget
+            -P "${CMAKE_CURRENT_SOURCE_DIR}/qt_smoke_driver.cmake"
+    )
+    set_tests_properties(qt_cache_budget_smoke_2d PROPERTIES TIMEOUT 30)
     add_test(
         NAME qt_sequence_smoke
         COMMAND "${CMAKE_COMMAND}"

--- a/tests/qt_smoke_driver.cmake
+++ b/tests/qt_smoke_driver.cmake
@@ -7,7 +7,8 @@
 #   WORK          directory the materialized copies are written into
 #   MODE          slice | sequence | missing-range | non-finite | raw-fab |
 #                 multifab-fab | quit | quit-on-failure | export-quit |
-#                 contour-sync | raster-zoom | range-cache | fab-zoom
+#                 contour-sync | raster-zoom | range-cache | fab-zoom |
+#                 cache-budget
 foreach(argument MATERIALIZER AMREXPLORER_QT SOURCE WORK MODE)
     if(NOT DEFINED ${argument})
         message(FATAL_ERROR "qt_smoke_driver.cmake requires -D${argument}=...")
@@ -69,6 +70,9 @@ elseif(MODE STREQUAL "fab-zoom")
     run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt")
     run_or_die("${AMREXPLORER_QT}" --fab-zoom-smoke-test
         "${WORK}/plt/Level_0/Cell")
+elseif(MODE STREQUAL "cache-budget")
+    run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt")
+    run_or_die("${AMREXPLORER_QT}" --cache-budget-smoke-test "${WORK}/plt")
 elseif(MODE STREQUAL "quit")
     run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt")
     run_or_die("${AMREXPLORER_QT}" --quit-smoke-test "${WORK}/plt")


### PR DESCRIPTION
SliceQuery pins the whole multi-level working set, so an over-budget query throws. executeFrameLoad catches this and retries at a lower composite level, but post-load slice requests (zoom, field/level change) fell through to the generic handler and hard-failed with the raw pinned-budget text.

Wrap requestSlice's non-cache worker in the same level-fallback retry loop: a composite query clears the unpinned cache and retries at a lower maximum level; an exact level or level 0 reports actionable advice. The fallback level rides back on SliceDisplayResult, and the completion handler drops the level combo and shows the fallback message, matching the initial load. Line plots (which cannot shed resolution) get an actionable message rather than degrading. cacheFallbackMessage/selectCacheFallbackLevel now take primitives so both the initial-load and slice paths share them.

Cover it with qt_cache_budget_smoke_2d: load at finest, shrink the budget below the finest working set, force a non-cache finest re-slice, and confirm it degrades to a lower level instead of hard-failing.