### PR TITLE
Introduce DisplayCoordinator owning the shared display-range state

### DIFF
--- a/include/amrexplorer/pipeline/DisplayCoordinator.hpp
+++ b/include/amrexplorer/pipeline/DisplayCoordinator.hpp
@@ -1,0 +1,73 @@
+#pragma once
+
+#include <amrexplorer/core/Request.hpp>
+#include <amrexplorer/core/Result.hpp>
+#include <amrexplorer/pipeline/ImageTransformPolicy.hpp>
+
+#include <optional>
+#include <span>
+#include <utility>
+
+// Owns derived display state that the GUI's slice paths must keep mutually
+// consistent across transitions, and the pure decisions that were previously
+// re-implemented inline at each call site. Step 2 of the MainWindow
+// extraction (see agent-notes/issues/mainwindow-needs-extraction.md): today
+// this holds the full-domain range cache, the shared-Visible-range union,
+// and the raster transform-policy decision; the per-panel reconcile step
+// grows onto it next.
+
+namespace amrvis {
+
+class DisplayCoordinator {
+public:
+    // What the cached full-domain range is valid for. Sequence frames load
+    // fresh datasets with new ids, so keying on the dataset invalidates the
+    // cache across frames (see sequence-frame-range-cache-goes-stale).
+    struct RangeKey {
+        DatasetId dataset;
+        FieldId field;
+        int maximumLevel = -1;
+        CompositionPolicy composition = CompositionPolicy::FinestAvailable;
+
+        friend bool operator==(const RangeKey&, const RangeKey&) = default;
+    };
+
+    // The cached full-domain Visible range, if it was stored for exactly
+    // this key; reused for zoomed (subregion) slices so the color bar stays
+    // stable during pan and zoom.
+    [[nodiscard]] std::optional<std::pair<double, double>>
+    cachedFullDomainRange(const RangeKey& key) const;
+
+    void storeFullDomainRange(
+        const RangeKey& key, std::pair<double, double> range);
+
+    // Drops the cached range (dataset change, slice-position move, range
+    // state reset).
+    void invalidateRangeCache();
+
+    // The shared Visible range across panels: the union of finite valid
+    // samples, padded to positive extent (ratio-padded when logarithmic over
+    // a positive value, additively otherwise). Empty planes are skipped;
+    // nullopt when no panel has a finite sample. One definition for the two
+    // previously drift-prone copies (executeFrameLoad's shared-range block
+    // and syncVisibleRanges).
+    [[nodiscard]] static std::optional<std::pair<double, double>>
+    sharedVisibleRange(
+        std::span<const ScalarPlane* const> planes, bool logarithmic);
+
+    // How the view should treat its transform when `incoming` replaces the
+    // raster produced by `cached`. A zoomed panel-local refresh (same
+    // dataset and orientation) preserves; a replacement whose region or
+    // orientation differs refits even if the dimensions coincide; everything
+    // else refits only on a dimension change. Moved verbatim from the GUI's
+    // showSlice (see the raster-colorbar and rubber-band issues).
+    [[nodiscard]] static ImageTransformPolicy rasterTransformPolicy(
+        bool hasCachedRequest, const SliceRequest& cached,
+        const SliceRequest& incoming, bool zoomed);
+
+private:
+    std::optional<RangeKey> m_rangeKey;
+    std::pair<double, double> m_range{0.0, 0.0};
+};
+
+} // namespace amrvis

--- a/include/amrexplorer/pipeline/ImageTransformPolicy.hpp
+++ b/include/amrexplorer/pipeline/ImageTransformPolicy.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+namespace amrvis {
+
+// How the view treats its existing transform when a replacement raster
+// arrives. Preserve keeps the current panel-local transform (rubber-band zoom
+// or pan refresh). GeometryAware refits only when the raster dimensions
+// change. Refit discards the transform even for equal-size rasters whose
+// data regions are incompatible. Lives in the Qt-free pipeline layer so the
+// DisplayCoordinator can decide it from pure request data; ImageView
+// re-exports it for the GUI.
+enum class ImageTransformPolicy {
+    GeometryAware,
+    Preserve,
+    Refit
+};
+
+} // namespace amrvis

--- a/src/pipeline/CMakeLists.txt
+++ b/src/pipeline/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_library(amrexplorer_pipeline
+    DisplayCoordinator.cpp
     SlicePipeline.cpp
     SliceRangeResolver.cpp
 )

--- a/src/pipeline/DisplayCoordinator.cpp
+++ b/src/pipeline/DisplayCoordinator.cpp
@@ -1,0 +1,91 @@
+#include <amrexplorer/pipeline/DisplayCoordinator.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+
+namespace amrvis {
+
+std::optional<std::pair<double, double>>
+DisplayCoordinator::cachedFullDomainRange(const RangeKey& key) const
+{
+    if (m_rangeKey && *m_rangeKey == key) {
+        return m_range;
+    }
+    return std::nullopt;
+}
+
+void DisplayCoordinator::storeFullDomainRange(
+    const RangeKey& key, std::pair<double, double> range)
+{
+    m_rangeKey = key;
+    m_range = range;
+}
+
+void DisplayCoordinator::invalidateRangeCache()
+{
+    m_rangeKey.reset();
+}
+
+std::optional<std::pair<double, double>> DisplayCoordinator::sharedVisibleRange(
+    std::span<const ScalarPlane* const> planes, bool logarithmic)
+{
+    auto minimum = std::numeric_limits<double>::infinity();
+    auto maximum = -std::numeric_limits<double>::infinity();
+    for (const auto* plane : planes) {
+        if (plane == nullptr || plane->width <= 0 || plane->height <= 0) {
+            continue;
+        }
+        for (std::size_t i = 0; i < plane->values.size(); ++i) {
+            if (plane->valid[i] == 0 || !std::isfinite(plane->values[i])) {
+                continue;
+            }
+            const auto value = static_cast<double>(plane->values[i]);
+            minimum = std::min(minimum, value);
+            maximum = std::max(maximum, value);
+        }
+    }
+    if (!std::isfinite(minimum) || !std::isfinite(maximum)) {
+        return std::nullopt;
+    }
+    if (minimum == maximum) {
+        if (logarithmic && minimum > 0.0) {
+            minimum /= 1.0 + 1.0e-6;
+            maximum *= 1.0 + 1.0e-6;
+        } else {
+            const auto pad = std::max(std::abs(minimum), 1.0) * 1.0e-6;
+            minimum -= pad;
+            maximum += pad;
+        }
+    }
+    return std::pair{minimum, maximum};
+}
+
+ImageTransformPolicy DisplayCoordinator::rasterTransformPolicy(
+    bool hasCachedRequest, const SliceRequest& cached,
+    const SliceRequest& incoming, bool zoomed)
+{
+    // A zoomed visibleRegion is physical data state, not evidence that the
+    // old raster transform is compatible with the incoming image. Preserve
+    // the transform only for a panel-local refresh in the same dataset and
+    // orientation (rubber-band zoom or pan). If a dataset replacement
+    // overtakes such a refresh, explicitly refit when the cached and
+    // incoming rasters cover different regions: their dimensions can
+    // coincide even though their pixel-to-data mappings do not.
+    const bool samePanelRenderContext = hasCachedRequest
+        && cached.dataset == incoming.dataset
+        && cached.normalDirection == incoming.normalDirection;
+    const bool incompatibleRasterContext = hasCachedRequest
+        && !samePanelRenderContext
+        && (cached.normalDirection != incoming.normalDirection
+            || cached.visibleRegion != incoming.visibleRegion);
+    if (incompatibleRasterContext) {
+        return ImageTransformPolicy::Refit;
+    }
+    if (zoomed && samePanelRenderContext) {
+        return ImageTransformPolicy::Preserve;
+    }
+    return ImageTransformPolicy::GeometryAware;
+}
+
+} // namespace amrvis

--- a/src/pipeline/SlicePipeline.cpp
+++ b/src/pipeline/SlicePipeline.cpp
@@ -2,6 +2,7 @@
 
 #include <amrexplorer/cache/ByteLruCache.hpp>
 #include <amrexplorer/io/PlotfileDataset.hpp>
+#include <amrexplorer/pipeline/DisplayCoordinator.hpp>
 #include <amrexplorer/render2d/ScalarRenderer.hpp>
 
 #include <algorithm>
@@ -445,35 +446,17 @@ InitialSliceResult executeFrameLoad(const std::filesystem::path& path,
             // maps all three panels consistently. Compute the union of finite extrema
             // across all three planes and re-render each display with the shared range.
             if (result.displays.size() == 3 && rangeMode == RangeMode::Visible) {
-                double globalMin = std::numeric_limits<double>::infinity();
-                double globalMax = -std::numeric_limits<double>::infinity();
-                for (const auto& d : result.displays) {
-                    const auto range = finiteRange(d.slice.plane);
-                    if (range) {
-                        globalMin = std::min(globalMin, range->first);
-                        globalMax = std::max(globalMax, range->second);
-                    }
-                }
-                const auto logarithmic = spec.logarithmic;
-                if (!std::isfinite(globalMin) || !std::isfinite(globalMax)) {
-                    if (logarithmic) {
-                        globalMin = 1.0;
-                        globalMax = 10.0;
-                    } else {
-                        globalMin = 0.0;
-                        globalMax = 1.0;
-                    }
-                }
-                if (globalMin == globalMax) {
-                    if (logarithmic && globalMin > 0.0) {
-                        globalMin /= 1.0 + 1.0e-6;
-                        globalMax *= 1.0 + 1.0e-6;
-                    } else {
-                        const auto pad = std::max(std::abs(globalMin), 1.0) * 1.0e-6;
-                        globalMin -= pad;
-                        globalMax += pad;
-                    }
-                }
+                const std::array<const ScalarPlane*, 3> planes{
+                    &result.displays[0].slice.plane,
+                    &result.displays[1].slice.plane,
+                    &result.displays[2].slice.plane};
+                const auto shared = DisplayCoordinator::sharedVisibleRange(
+                    planes, spec.logarithmic);
+                // No finite samples anywhere: fall back to a neutral range so
+                // the frame still renders.
+                const auto [globalMin, globalMax] = shared.value_or(
+                    spec.logarithmic ? std::pair{1.0, 10.0}
+                                     : std::pair{0.0, 1.0});
                 for (auto& d : result.displays) {
                     d.minimum = globalMin;
                     d.maximum = globalMax;

--- a/src/qt/ImageView.hpp
+++ b/src/qt/ImageView.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <amrexplorer/pipeline/ImageTransformPolicy.hpp>
+
 #include <QGraphicsView>
 #include <QColor>
 #include <QImage>
@@ -38,11 +40,10 @@ struct OverlayPath {
     float width = 1.0F;
 };
 
-enum class ImageTransformPolicy {
-    GeometryAware,
-    Preserve,
-    Refit
-};
+// ImageTransformPolicy lives in the Qt-free pipeline layer (the
+// DisplayCoordinator decides it from pure request data); re-export it here
+// so amrvis::qt::ImageTransformPolicy keeps resolving for the GUI.
+using amrvis::ImageTransformPolicy;
 
 class ImageView final : public QGraphicsView {
     Q_OBJECT

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -3724,7 +3724,7 @@ void MainWindow::setSlicePosition(int axis, double value)
     m_isoWidget->setSlicePositions(m_slicePosition3d[0], m_slicePosition3d[1],
         m_slicePosition3d[2]);
     // The cached full-domain Visible range is now stale.
-    m_fullDomainRange.reset();
+    m_displayCoordinator.invalidateRangeCache();
     // The other two views only need their crosshair guides redrawn; the view
     // normal to the moved axis gets a fresh (debounced) slice.
     updateCrosshairs();
@@ -3947,18 +3947,18 @@ void MainWindow::requestSlice(PlaneViewState& state, bool rasterDirty)
                     // Visible-range slice; reuse it for zoomed (subregion)
                     // slices so the color bar stays stable during pan and zoom.
                     const bool isFullDomain = !state.visibleRegion.has_value();
-                    if (!isFullDomain
+                    const DisplayCoordinator::RangeKey rangeKey{
+                        result.request.dataset, result.request.field,
+                        result.request.maximumLevel,
+                        result.request.composition};
+                    const auto cachedRange = !isFullDomain
                         && rangeMode == RangeMode::Visible
-                        && m_fullDomainRange.has_value()
-                        && m_fullDomainRangeDataset == result.request.dataset
-                        && m_fullDomainRangeField.value
-                            == result.request.field.value
-                        && m_fullDomainRangeMaxLevel
-                            == result.request.maximumLevel
-                        && m_fullDomainRangeComposition
-                            == result.request.composition) {
-                        result.minimum = m_fullDomainRange->first;
-                        result.maximum = m_fullDomainRange->second;
+                            ? m_displayCoordinator.cachedFullDomainRange(
+                                rangeKey)
+                            : std::nullopt;
+                    if (cachedRange) {
+                        result.minimum = cachedRange->first;
+                        result.maximum = cachedRange->second;
                         // executeSlice/refreshCachedSlice produced the raster
                         // and contours against the subregion's own range;
                         // realign both to the reused full-domain range so they
@@ -3986,14 +3986,8 @@ void MainWindow::requestSlice(PlaneViewState& state, bool rasterDirty)
                     // union across all panels is captured.
                     if (isFullDomain && rangeMode == RangeMode::Visible
                         && state.plane.width > 0) {
-                        m_fullDomainRange = std::make_pair(
-                            state.displayMinimum, state.displayMaximum);
-                        m_fullDomainRangeDataset = result.request.dataset;
-                        m_fullDomainRangeField = result.request.field;
-                        m_fullDomainRangeMaxLevel
-                            = result.request.maximumLevel;
-                        m_fullDomainRangeComposition
-                            = result.request.composition;
+                        m_displayCoordinator.storeFullDomainRange(rangeKey,
+                            {state.displayMinimum, state.displayMaximum});
                     }
                     const auto cache = dataset->cacheMetrics();
                     m_cacheBudgetBytes = cache.budgetBytes;
@@ -4280,28 +4274,11 @@ void MainWindow::showSlice(PlaneViewState& state, const SliceDisplayResult& disp
         if (!display.image.valid()) {
             throw std::runtime_error("renderer produced an invalid image");
         }
-        // A visibleRegion is physical data state, not evidence that the old
-        // raster transform is compatible with this image. Preserve the
-        // transform only for a panel-local refresh in the same dataset and
-        // orientation (rubber-band zoom or pan). If a dataset replacement
-        // overtakes such a refresh, explicitly refit when the cached and
-        // incoming rasters cover different regions: their dimensions can
-        // coincide even though their pixel-to-data mappings do not.
-        const bool samePanelRenderContext = state.hasCachedRequest
-            && state.cachedRequest.dataset == display.request.dataset
-            && state.cachedRequest.normalDirection
-                == display.request.normalDirection;
-        const bool incompatibleRasterContext = state.hasCachedRequest
-            && !samePanelRenderContext
-            && (state.cachedRequest.normalDirection
-                    != display.request.normalDirection
-                || state.cachedRequest.visibleRegion
-                    != display.request.visibleRegion);
-        const auto transformPolicy = incompatibleRasterContext
-            ? ImageTransformPolicy::Refit
-            : state.visibleRegion.has_value() && samePanelRenderContext
-            ? ImageTransformPolicy::Preserve
-            : ImageTransformPolicy::GeometryAware;
+        // Preserve/Refit/GeometryAware from the cached-vs-incoming request
+        // pair; the rationale lives with the decision in the coordinator.
+        const auto transformPolicy = DisplayCoordinator::rasterTransformPolicy(
+            state.hasCachedRequest, state.cachedRequest, display.request,
+            state.visibleRegion.has_value());
         // Preserve keeps the scene transform, which is only equivalent to
         // keeping what the user sees while the raster's pixels-per-data
         // density is unchanged. A zoomed re-slice can arrive denser: the
@@ -4388,50 +4365,23 @@ void MainWindow::syncVisibleRanges()
 
     // Use the cached full-domain range when it is current, so the shared
     // color bar stays stable during zoom and pan instead of tracking the
-    // subregion extrema of whichever panel just finished rendering.
+    // subregion extrema of whichever panel just finished rendering; fall
+    // back to the union of finite extrema across the three panels.
     const FieldId currentField{m_fieldSelector->currentData().toUInt()};
     const auto rawLevel = m_levelSelector->currentData().toInt();
     const auto [composition, maximumLevel] = decodeLevelData(
         rawLevel, m_dataset->metadata().finestLevel);
-    double globalMin = std::numeric_limits<double>::infinity();
-    double globalMax = -std::numeric_limits<double>::infinity();
-    const bool useCachedRange = m_fullDomainRange.has_value()
-        && m_fullDomainRangeDataset == m_dataset->id()
-        && m_fullDomainRangeField.value == currentField.value
-        && m_fullDomainRangeMaxLevel == maximumLevel
-        && m_fullDomainRangeComposition == composition;
-    if (useCachedRange) {
-        globalMin = m_fullDomainRange->first;
-        globalMax = m_fullDomainRange->second;
-    } else {
-        for (const auto* state : views) {
-            if (state->plane.width <= 0 || state->plane.height <= 0) {
-                continue;
-            }
-            for (std::size_t i = 0; i < state->plane.values.size(); ++i) {
-                if (state->plane.valid[i] == 0
-                    || !std::isfinite(state->plane.values[i])) {
-                    continue;
-                }
-                const auto v = static_cast<double>(state->plane.values[i]);
-                globalMin = std::min(globalMin, v);
-                globalMax = std::max(globalMax, v);
-            }
-        }
+    auto shared = m_displayCoordinator.cachedFullDomainRange(
+        {m_dataset->id(), currentField, maximumLevel, composition});
+    if (!shared) {
+        const std::array<const ScalarPlane*, 3> planes{
+            &views[0]->plane, &views[1]->plane, &views[2]->plane};
+        shared = DisplayCoordinator::sharedVisibleRange(planes, logarithmic);
     }
-    if (!std::isfinite(globalMin) || !std::isfinite(globalMax)) {
+    if (!shared) {
         return;
     }
-    if (globalMin == globalMax) {
-        if (logarithmic && globalMin > 0.0) {
-            globalMin /= 1.0 + 1.0e-6;
-            globalMax *= 1.0 + 1.0e-6;
-        } else {
-            const auto pad = std::max(std::abs(globalMin), 1.0) * 1.0e-6;
-            globalMin -= pad;
-            globalMax += pad;
-        }
-    }
+    const auto [globalMin, globalMax] = *shared;
     for (auto* state : views) {
         if (state->plane.width <= 0 || state->plane.height <= 0) {
             continue;
@@ -4894,10 +4844,7 @@ void MainWindow::resetRangeState()
 {
     m_fieldRanges.clear();
     m_trackedField = 0;
-    m_fullDomainRange.reset();
-    m_fullDomainRangeDataset = {};
-    m_fullDomainRangeField = {};
-    m_fullDomainRangeMaxLevel = -1;
+    m_displayCoordinator.invalidateRangeCache();
     const QSignalBlocker modeBlocker(m_rangeMode);
     const QSignalBlocker minBlocker(m_rangeMinimum);
     const QSignalBlocker maxBlocker(m_rangeMaximum);

--- a/src/qt/MainWindow.hpp
+++ b/src/qt/MainWindow.hpp
@@ -7,6 +7,7 @@
 #include <amrexplorer/core/Result.hpp>
 #include <amrexplorer/core/StopToken.hpp>
 #include <amrexplorer/io/PlotfileMetadataReader.hpp>
+#include <amrexplorer/pipeline/DisplayCoordinator.hpp>
 #include <amrexplorer/pipeline/SlicePipeline.hpp>
 #include <amrexplorer/pipeline/SliceRangeResolver.hpp>
 #include <amrexplorer/query/SliceQuery.hpp>
@@ -470,18 +471,11 @@ private:
     QPointF m_panSceneDelta;
     QPointF m_panLastScheduledDelta;
     bool m_panDataRefresh = false;
-    // Full-domain range cache — kept current whenever a non-zoomed slice
-    // completes, and reused for RangeMode::Visible during zoom/pan so the
-    // color bar stays stable instead of tracking the subregion extrema.
-    std::optional<std::pair<double, double>> m_fullDomainRange;
-    // The dataset the cached range belongs to. Sequence frames each load a
-    // fresh dataset (a new DatasetId), so keying on it invalidates the cache
-    // across frames — without it a zoomed Visible color bar would keep an
-    // earlier frame's range (see sequence-frame-range-cache-goes-stale).
-    DatasetId m_fullDomainRangeDataset{};
-    FieldId m_fullDomainRangeField{};
-    int m_fullDomainRangeMaxLevel = -1;
-    CompositionPolicy m_fullDomainRangeComposition{};
+    // Owns the full-domain range cache (kept current whenever a non-zoomed
+    // slice completes, reused for RangeMode::Visible during zoom/pan so the
+    // color bar stays stable) plus the shared-range and transform-policy
+    // decisions the slice paths share. See pipeline/DisplayCoordinator.hpp.
+    amrvis::DisplayCoordinator m_displayCoordinator;
     QTreeWidget* m_metadataTree = nullptr;
     QPlainTextEdit* m_diagnostics = nullptr;
     QDockWidget* m_metadataDock = nullptr;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -44,6 +44,13 @@ add_executable(test_vector_glyphs unit/test_vector_glyphs.cpp)
 target_link_libraries(test_vector_glyphs PRIVATE amrexplorer::render2d amrexplorer::warnings)
 add_test(NAME vector_glyphs COMMAND test_vector_glyphs)
 
+add_executable(test_display_coordinator unit/test_display_coordinator.cpp)
+target_link_libraries(
+    test_display_coordinator
+    PRIVATE amrexplorer::pipeline amrexplorer::warnings
+)
+add_test(NAME display_coordinator COMMAND test_display_coordinator)
+
 add_executable(test_slice_range_resolver unit/test_slice_range_resolver.cpp)
 target_link_libraries(
     test_slice_range_resolver

--- a/tests/unit/test_display_coordinator.cpp
+++ b/tests/unit/test_display_coordinator.cpp
@@ -1,0 +1,188 @@
+#include <amrexplorer/pipeline/DisplayCoordinator.hpp>
+
+#include <array>
+#include <cmath>
+#include <cstdlib>
+#include <initializer_list>
+#include <iostream>
+
+namespace {
+
+void require(bool condition, const char* message)
+{
+    if (!condition) {
+        std::cerr << "FAILED: " << message << '\n';
+        std::exit(1);
+    }
+}
+
+bool nearlyEqual(double a, double b, double tolerance = 1.0e-12)
+{
+    return std::fabs(a - b)
+        <= tolerance * std::max({1.0, std::fabs(a), std::fabs(b)});
+}
+
+amrvis::ScalarPlane makePlane(std::initializer_list<float> values)
+{
+    amrvis::ScalarPlane plane;
+    plane.width = static_cast<int>(values.size());
+    plane.height = 1;
+    plane.values.assign(values);
+    plane.valid.assign(values.size(), 1);
+    return plane;
+}
+
+amrvis::SliceRequest makeRequest(
+    std::uint64_t dataset, int normal, double regionLow)
+{
+    amrvis::SliceRequest request;
+    request.dataset = amrvis::DatasetId{dataset};
+    request.normalDirection = normal;
+    request.visibleRegion.lower = {{regionLow, 0.0, 0.0}};
+    request.visibleRegion.upper = {{regionLow + 1.0, 1.0, 1.0}};
+    return request;
+}
+
+} // namespace
+
+int main()
+{
+    using amrvis::DisplayCoordinator;
+    using amrvis::ImageTransformPolicy;
+    using Key = amrvis::DisplayCoordinator::RangeKey;
+
+    // --- full-domain range cache ------------------------------------------
+    {
+        DisplayCoordinator coordinator;
+        const Key key{amrvis::DatasetId{7}, amrvis::FieldId{2}, 3,
+            amrvis::CompositionPolicy::FinestAvailable};
+        require(!coordinator.cachedFullDomainRange(key).has_value(),
+            "an empty cache returned a range");
+
+        coordinator.storeFullDomainRange(key, {1.5, 9.5});
+        const auto hit = coordinator.cachedFullDomainRange(key);
+        require(hit && nearlyEqual(hit->first, 1.5)
+                && nearlyEqual(hit->second, 9.5),
+            "an exact key did not hit the cache");
+
+        // Every key component must participate: a mismatch in any one is a
+        // miss. The dataset component is the sequence-frame invalidation
+        // (see sequence-frame-range-cache-goes-stale).
+        auto other = key;
+        other.dataset = amrvis::DatasetId{8};
+        require(!coordinator.cachedFullDomainRange(other).has_value(),
+            "a different dataset hit the cache");
+        other = key;
+        other.field = amrvis::FieldId{3};
+        require(!coordinator.cachedFullDomainRange(other).has_value(),
+            "a different field hit the cache");
+        other = key;
+        other.maximumLevel = 2;
+        require(!coordinator.cachedFullDomainRange(other).has_value(),
+            "a different maximum level hit the cache");
+        other = key;
+        other.composition = amrvis::CompositionPolicy::ExactLevel;
+        require(!coordinator.cachedFullDomainRange(other).has_value(),
+            "a different composition hit the cache");
+
+        // Storing overwrites; invalidation clears.
+        coordinator.storeFullDomainRange(key, {2.0, 4.0});
+        require(nearlyEqual(coordinator.cachedFullDomainRange(key)->second, 4.0),
+            "a second store did not overwrite the range");
+        coordinator.invalidateRangeCache();
+        require(!coordinator.cachedFullDomainRange(key).has_value(),
+            "invalidation left the cached range behind");
+    }
+
+    // --- sharedVisibleRange -------------------------------------------------
+    {
+        const auto a = makePlane({2.0F, 5.0F});
+        const auto b = makePlane({-1.0F, 3.0F});
+        const std::array<const amrvis::ScalarPlane*, 2> planes{&a, &b};
+        const auto shared = DisplayCoordinator::sharedVisibleRange(
+            planes, false);
+        require(shared && nearlyEqual(shared->first, -1.0)
+                && nearlyEqual(shared->second, 5.0),
+            "shared range is not the union across panels");
+    }
+    {
+        // Masked and non-finite samples are skipped; empty planes and null
+        // entries are tolerated.
+        auto a = makePlane({2.0F, 50.0F});
+        a.valid[1] = 0;
+        auto b = makePlane({7.0F});
+        b.values[0] = std::nanf("");
+        const amrvis::ScalarPlane empty;
+        const std::array<const amrvis::ScalarPlane*, 4> planes{
+            &a, &b, &empty, nullptr};
+        const auto shared = DisplayCoordinator::sharedVisibleRange(
+            planes, false);
+        // Only the 2.0 sample survives, so the degenerate union is padded
+        // around it; the masked 50 and the NaN must not have widened it.
+        require(shared && shared->first < 2.0 && shared->second > 2.0
+                && nearlyEqual(shared->first, 2.0, 1.0e-5)
+                && nearlyEqual(shared->second, 2.0, 1.0e-5),
+            "masked/non-finite samples leaked into the shared range");
+    }
+    {
+        const amrvis::ScalarPlane empty;
+        const std::array<const amrvis::ScalarPlane*, 1> planes{&empty};
+        require(!DisplayCoordinator::sharedVisibleRange(planes, false),
+            "an all-empty panel set produced a range");
+    }
+    {
+        // Degenerate union: additive pad in linear mode, ratio pad (staying
+        // positive) in logarithmic mode.
+        const auto constant = makePlane({5.0F, 5.0F});
+        const std::array<const amrvis::ScalarPlane*, 1> planes{&constant};
+        const auto linear = DisplayCoordinator::sharedVisibleRange(
+            planes, false);
+        require(linear && linear->first < 5.0 && linear->second > 5.0,
+            "a constant plane was not padded in linear mode");
+        const auto log = DisplayCoordinator::sharedVisibleRange(planes, true);
+        require(log && log->first < 5.0 && log->second > 5.0
+                && log->first > 0.0,
+            "a constant plane was not ratio-padded in logarithmic mode");
+    }
+
+    // --- rasterTransformPolicy ----------------------------------------------
+    {
+        const auto cached = makeRequest(1, 1, 0.0);
+
+        require(DisplayCoordinator::rasterTransformPolicy(
+                false, cached, cached, true)
+                == ImageTransformPolicy::GeometryAware,
+            "no cache should be geometry-aware");
+
+        // Zoomed panel-local refresh (same dataset + normal): preserve, even
+        // when the region moved (pan) or shrank (zoom).
+        require(DisplayCoordinator::rasterTransformPolicy(
+                true, cached, makeRequest(1, 1, 0.5), true)
+                == ImageTransformPolicy::Preserve,
+            "a zoomed same-panel refresh should preserve");
+        require(DisplayCoordinator::rasterTransformPolicy(
+                true, cached, cached, false)
+                == ImageTransformPolicy::GeometryAware,
+            "an unzoomed same-panel refresh should be geometry-aware");
+
+        // A different dataset whose region differs must refit even when the
+        // raster dimensions coincide (the equal-size frame-step trap).
+        require(DisplayCoordinator::rasterTransformPolicy(
+                true, cached, makeRequest(2, 1, 0.5), true)
+                == ImageTransformPolicy::Refit,
+            "a cross-dataset region change should refit");
+        // A different normal must refit regardless of dataset.
+        require(DisplayCoordinator::rasterTransformPolicy(
+                true, cached, makeRequest(1, 2, 0.0), true)
+                == ImageTransformPolicy::Refit,
+            "an orientation change should refit");
+        // A different dataset with an identical region and normal keeps the
+        // geometry-aware default (same pixel-to-data mapping).
+        require(DisplayCoordinator::rasterTransformPolicy(
+                true, cached, makeRequest(2, 1, 0.0), true)
+                == ImageTransformPolicy::GeometryAware,
+            "a same-region dataset swap should stay geometry-aware");
+    }
+
+    return 0;
+}


### PR DESCRIPTION
Step 2 of the MainWindow extraction: a Qt-free coordinator that owns the full-domain range cache (a RangeKey-keyed value replacing five MainWindow members; the key equality is the sequence-frame invalidation), the shared Visible-range union (one definition replacing the drift-prone copies in syncVisibleRanges and executeFrameLoad), and the raster transform-policy decision from showSlice (ImageTransformPolicy moves to the pipeline layer, re-exported by ImageView).

Unit tests cover cache keying per component, union masking and padding, and the transform-policy matrix including the equal-size cross-dataset trap.

One deliberate unification: executeFrameLoad previously padded constant planes per-plane before the union; the shared helper pads only the union. Differs only for constant planes at the 1e-6 pad scale.