### PR TITLE
Move the display-sync computation onto the DisplayCoordinator

### DIFF
--- a/include/amrexplorer/pipeline/DisplayCoordinator.hpp
+++ b/include/amrexplorer/pipeline/DisplayCoordinator.hpp
@@ -3,10 +3,13 @@
 #include <amrexplorer/core/Request.hpp>
 #include <amrexplorer/core/Result.hpp>
 #include <amrexplorer/pipeline/ImageTransformPolicy.hpp>
+#include <amrexplorer/pipeline/SlicePipeline.hpp>
 
+#include <array>
 #include <optional>
 #include <span>
 #include <utility>
+#include <vector>
 
 // Owns derived display state that the GUI's slice paths must keep mutually
 // consistent across transitions, and the pure decisions that were previously
@@ -64,6 +67,58 @@ public:
     [[nodiscard]] static ImageTransformPolicy rasterTransformPolicy(
         bool hasCachedRequest, const SliceRequest& cached,
         const SliceRequest& incoming, bool zoomed);
+
+    // Realigns an arrived result to a replacement display range (the reused
+    // full-domain range): overwrites minimum/maximum and, when
+    // realignRasterAndContours is set, re-renders the raster against it
+    // (unless the raster was intentionally left untouched) and re-extracts
+    // the contour polylines. The 3-D shared-range sync realigns every panel
+    // afterwards, so its caller passes false there to avoid rendering each
+    // panel twice; 2-D has no later sync and passes true.
+    static void realignArrivalToRange(SliceDisplayResult& result,
+        std::pair<double, double> range, const Palette& palette,
+        bool realignRasterAndContours);
+
+    // One panel's inputs to / outputs of the shared-range sync below.
+    struct PanelSyncInput {
+        const ScalarPlane* plane = nullptr;            // display plane
+        const ScalarPlane* contourFinePlane = nullptr; // contour modes only
+        int contourFineFactor = 1;
+        bool logarithmic = false;      // the panel's effective log mapping
+        std::array<int, 2> outputSize{0, 0};  // display size for contours
+    };
+    struct PanelSyncUpdate {
+        bool applies = false;          // false: empty plane, leave untouched
+        ImageBuffer image;             // rendered against the shared range
+        bool contoursRecomputed = false;
+        std::vector<ContourPolyline> contourPolylines;
+    };
+    struct SharedRangeSync {
+        std::pair<double, double> range;
+        std::vector<PanelSyncUpdate> panels;  // parallel to the input span
+    };
+
+    // The 3-D Visible-range synchronization: resolve the shared range (the
+    // cached full-domain range for `key` when current, else the union of the
+    // panels' finite extrema) and produce, per panel, the raster re-rendered
+    // against it and — in contour mode — the polylines re-extracted against
+    // it, so every panel matches the one shared color bar. Returns nullopt
+    // when there is neither a cached range nor any finite sample, in which
+    // case the caller leaves the panels untouched.
+    [[nodiscard]] std::optional<SharedRangeSync> syncPanelsToSharedRange(
+        const RangeKey& key, std::span<const PanelSyncInput> panels,
+        bool logarithmic, bool contourMode, int contourCount,
+        const Palette& palette) const;
+
+    // True when the two planes map pixels to physical units at different
+    // densities on the given in-plane axes — the condition under which
+    // preserving a scene transform would misframe the replacement raster
+    // (a capped full-domain raster replaced by a finer subregion crop, see
+    // issue #45). Degenerate planes or extents compare as not-different, so
+    // callers fall back to the plain Preserve behavior.
+    [[nodiscard]] static bool planeDensitiesDiffer(
+        const ScalarPlane& before, const ScalarPlane& after,
+        std::array<int, 2> axes);
 
 private:
     std::optional<RangeKey> m_rangeKey;

--- a/src/pipeline/DisplayCoordinator.cpp
+++ b/src/pipeline/DisplayCoordinator.cpp
@@ -1,5 +1,7 @@
 #include <amrexplorer/pipeline/DisplayCoordinator.hpp>
 
+#include <amrexplorer/render2d/ScalarRenderer.hpp>
+
 #include <algorithm>
 #include <cmath>
 #include <limits>
@@ -86,6 +88,105 @@ ImageTransformPolicy DisplayCoordinator::rasterTransformPolicy(
         return ImageTransformPolicy::Preserve;
     }
     return ImageTransformPolicy::GeometryAware;
+}
+
+void DisplayCoordinator::realignArrivalToRange(SliceDisplayResult& result,
+    std::pair<double, double> range, const Palette& palette,
+    bool realignRasterAndContours)
+{
+    result.minimum = range.first;
+    result.maximum = range.second;
+    if (!realignRasterAndContours) {
+        return;
+    }
+    if (!result.rasterUnchanged) {
+        result.image = renderScalarPlane(result.slice.plane,
+            ScalarRenderSettings{
+                .minimum = result.minimum,
+                .maximum = result.maximum,
+                .logarithmic = result.logarithmic,
+                .palette = &palette
+            });
+    }
+    recomputeContourPolylines(result);
+}
+
+std::optional<DisplayCoordinator::SharedRangeSync>
+DisplayCoordinator::syncPanelsToSharedRange(
+    const RangeKey& key, std::span<const PanelSyncInput> panels,
+    bool logarithmic, bool contourMode, int contourCount,
+    const Palette& palette) const
+{
+    auto shared = cachedFullDomainRange(key);
+    if (!shared) {
+        std::vector<const ScalarPlane*> planes;
+        planes.reserve(panels.size());
+        for (const auto& panel : panels) {
+            planes.push_back(panel.plane);
+        }
+        shared = sharedVisibleRange(planes, logarithmic);
+    }
+    if (!shared) {
+        return std::nullopt;
+    }
+    SharedRangeSync sync;
+    sync.range = *shared;
+    sync.panels.resize(panels.size());
+    for (std::size_t index = 0; index < panels.size(); ++index) {
+        const auto& panel = panels[index];
+        auto& update = sync.panels[index];
+        if (panel.plane == nullptr || panel.plane->width <= 0
+            || panel.plane->height <= 0) {
+            continue;
+        }
+        update.applies = true;
+        // Contours before the raster, mirroring the original inline order.
+        if (contourMode && panel.contourFinePlane != nullptr
+            && panel.contourFinePlane->width > 0) {
+            update.contourPolylines = recomputeContourPolylines(
+                *panel.contourFinePlane, panel.contourFineFactor,
+                sync.range.first, sync.range.second, panel.logarithmic,
+                contourCount, panel.outputSize[0], panel.outputSize[1]);
+            update.contoursRecomputed = true;
+        }
+        update.image = renderScalarPlane(*panel.plane, ScalarRenderSettings{
+            .minimum = sync.range.first,
+            .maximum = sync.range.second,
+            .logarithmic = panel.logarithmic,
+            .palette = &palette
+        });
+    }
+    return sync;
+}
+
+bool DisplayCoordinator::planeDensitiesDiffer(
+    const ScalarPlane& before, const ScalarPlane& after,
+    std::array<int, 2> axes)
+{
+    if (before.width <= 0 || before.height <= 0
+        || after.width <= 0 || after.height <= 0) {
+        return false;
+    }
+    const auto xAxis = static_cast<std::size_t>(axes[0]);
+    const auto yAxis = static_cast<std::size_t>(axes[1]);
+    const auto beforeExtentX
+        = before.physicalRegion.upper[xAxis] - before.physicalRegion.lower[xAxis];
+    const auto beforeExtentY
+        = before.physicalRegion.upper[yAxis] - before.physicalRegion.lower[yAxis];
+    const auto afterExtentX
+        = after.physicalRegion.upper[xAxis] - after.physicalRegion.lower[xAxis];
+    const auto afterExtentY
+        = after.physicalRegion.upper[yAxis] - after.physicalRegion.lower[yAxis];
+    if (!(beforeExtentX > 0.0) || !(beforeExtentY > 0.0)
+        || !(afterExtentX > 0.0) || !(afterExtentY > 0.0)) {
+        return false;
+    }
+    const auto matches = [](double a, double b) {
+        return std::abs(a - b) <= 1.0e-9 * std::max(std::abs(a), std::abs(b));
+    };
+    return !matches(before.width / beforeExtentX, after.width / afterExtentX)
+        || !matches(before.height / beforeExtentY,
+            after.height / afterExtentY);
 }
 
 } // namespace amrvis

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -3957,28 +3957,14 @@ void MainWindow::requestSlice(PlaneViewState& state, bool rasterDirty)
                                 rangeKey)
                             : std::nullopt;
                     if (cachedRange) {
-                        result.minimum = cachedRange->first;
-                        result.maximum = cachedRange->second;
-                        // executeSlice/refreshCachedSlice produced the raster
-                        // and contours against the subregion's own range;
-                        // realign both to the reused full-domain range so they
-                        // match the colorbar. In 3-D syncVisibleRanges realigns
-                        // every panel below (m_viewDimension == 3), so only 2-D,
-                        // which it skips, needs it here — and doing it only here
-                        // avoids re-rendering each 3-D panel's raster twice.
-                        if (m_viewDimension != 3) {
-                            if (!result.rasterUnchanged) {
-                                result.image = renderScalarPlane(
-                                    result.slice.plane,
-                                    ScalarRenderSettings{
-                                        .minimum = result.minimum,
-                                        .maximum = result.maximum,
-                                        .logarithmic = result.logarithmic,
-                                        .palette = &m_palette
-                                    });
-                            }
-                            recomputeContourPolylines(result);
-                        }
+                        // The subregion result was produced against its own
+                        // range; realign it to the reused full-domain range
+                        // so it matches the colorbar. In 3-D the shared-range
+                        // sync below realigns every panel, so only 2-D (which
+                        // it skips) realigns the raster and contours here —
+                        // that also avoids rendering each 3-D panel twice.
+                        DisplayCoordinator::realignArrivalToRange(result,
+                            *cachedRange, m_palette, m_viewDimension != 3);
                     }
                     showSlice(state, result);
                     syncVisibleRanges();
@@ -4210,11 +4196,13 @@ std::optional<QRectF> MainWindow::preservedDataWindow(
     const PlaneViewState& state, const ScalarPlane& incoming) const
 {
     const auto& cached = state.plane;
-    if (cached.width <= 0 || cached.height <= 0
-        || incoming.width <= 0 || incoming.height <= 0) {
+    const auto axes = displayAxes(state.normal);
+    // Equal densities (or degenerate geometry) mean the preserved scene
+    // transform already preserves the on-screen data, so leave it alone; the
+    // coordinator owns that decision.
+    if (!DisplayCoordinator::planeDensitiesDiffer(cached, incoming, axes)) {
         return std::nullopt;
     }
-    const auto axes = displayAxes(state.normal);
     const auto xAxis = static_cast<std::size_t>(axes[0]);
     const auto yAxis = static_cast<std::size_t>(axes[1]);
     const auto& oldRegion = cached.physicalRegion;
@@ -4223,23 +4211,6 @@ std::optional<QRectF> MainWindow::preservedDataWindow(
     const auto oldExtentY = oldRegion.upper[yAxis] - oldRegion.lower[yAxis];
     const auto newExtentX = newRegion.upper[xAxis] - newRegion.lower[xAxis];
     const auto newExtentY = newRegion.upper[yAxis] - newRegion.lower[yAxis];
-    if (!(oldExtentX > 0.0) || !(oldExtentY > 0.0)
-        || !(newExtentX > 0.0) || !(newExtentY > 0.0)) {
-        return std::nullopt;
-    }
-    // Pixels per physical unit; equal densities mean the preserved scene
-    // transform already preserves the on-screen data, so leave it alone.
-    const auto oldDensityX = cached.width / oldExtentX;
-    const auto oldDensityY = cached.height / oldExtentY;
-    const auto newDensityX = incoming.width / newExtentX;
-    const auto newDensityY = incoming.height / newExtentY;
-    const auto matches = [](double a, double b) {
-        return std::abs(a - b) <= 1.0e-9 * std::max(std::abs(a), std::abs(b));
-    };
-    if (matches(oldDensityX, newDensityX)
-        && matches(oldDensityY, newDensityY)) {
-        return std::nullopt;
-    }
     // Viewport -> old scene -> physical -> new scene. Scene y runs opposite
     // to physical y: plane row 0 is the bottom row and the displayed raster
     // is mirrored vertically (see displayImageFor), for both planes alike.
@@ -4363,52 +4334,43 @@ void MainWindow::syncVisibleRanges()
         &m_planeViews[0], &m_planeViews[1], &m_planeViews[2]};
     const bool logarithmic = m_logarithmic->isChecked();
 
-    // Use the cached full-domain range when it is current, so the shared
-    // color bar stays stable during zoom and pan instead of tracking the
-    // subregion extrema of whichever panel just finished rendering; fall
-    // back to the union of finite extrema across the three panels.
+    // The coordinator resolves the shared range (the cached full-domain
+    // range when current, so the color bar stays stable during zoom and pan;
+    // else the union of the panels' finite extrema) and produces every
+    // panel's raster and contours realigned to it. This method only blits
+    // the updates into the views.
     const FieldId currentField{m_fieldSelector->currentData().toUInt()};
     const auto rawLevel = m_levelSelector->currentData().toInt();
     const auto [composition, maximumLevel] = decodeLevelData(
         rawLevel, m_dataset->metadata().finestLevel);
-    auto shared = m_displayCoordinator.cachedFullDomainRange(
-        {m_dataset->id(), currentField, maximumLevel, composition});
-    if (!shared) {
-        const std::array<const ScalarPlane*, 3> planes{
-            &views[0]->plane, &views[1]->plane, &views[2]->plane};
-        shared = DisplayCoordinator::sharedVisibleRange(planes, logarithmic);
+    std::array<DisplayCoordinator::PanelSyncInput, 3> inputs;
+    for (std::size_t index = 0; index < views.size(); ++index) {
+        const auto* state = views[index];
+        inputs[index] = {&state->plane, &state->contourFinePlane,
+            state->contourFineFactor, state->displayLogarithmic,
+            state->cachedRequest.outputSize};
     }
-    if (!shared) {
+    auto sync = m_displayCoordinator.syncPanelsToSharedRange(
+        {m_dataset->id(), currentField, maximumLevel, composition}, inputs,
+        logarithmic, isContourMode(m_displayMode), m_contourCount, m_palette);
+    if (!sync) {
         return;
     }
-    const auto [globalMin, globalMax] = *shared;
-    for (auto* state : views) {
-        if (state->plane.width <= 0 || state->plane.height <= 0) {
+    const auto [globalMin, globalMax] = sync->range;
+    for (std::size_t index = 0; index < views.size(); ++index) {
+        auto* state = views[index];
+        auto& update = sync->panels[index];
+        if (!update.applies) {
             continue;
         }
         state->displayMinimum = globalMin;
         state->displayMaximum = globalMax;
-        // The contour polylines were extracted against this view's own range;
-        // re-extract them against the shared range so their levels match the
-        // shared colorbar. updateOverlay below repaints from these polylines
-        // (see contours-stale-after-visible-range-sync).
-        if (isContourMode(m_displayMode) && state->contourFinePlane.width > 0) {
-            state->contourPolylines = recomputeContourPolylines(
-                state->contourFinePlane, state->contourFineFactor,
-                globalMin, globalMax, state->displayLogarithmic, m_contourCount,
-                state->cachedRequest.outputSize[0],
-                state->cachedRequest.outputSize[1]);
+        if (update.contoursRecomputed) {
+            state->contourPolylines = std::move(update.contourPolylines);
         }
-        auto image = renderScalarPlane(state->plane, ScalarRenderSettings{
-            .minimum = globalMin,
-            .maximum = globalMax,
-            .logarithmic = state->displayLogarithmic,
-            .palette = &m_palette
-        });
-        if (!image.valid()) {
-            continue;
+        if (update.image.valid()) {
+            state->view->setImage(displayImageFor(update.image));
         }
-        state->view->setImage(displayImageFor(image));
     }
     // setImage clears grid boxes and vector/contour overlays; restore them.
     for (auto* state : views) {

--- a/tests/unit/test_display_coordinator.cpp
+++ b/tests/unit/test_display_coordinator.cpp
@@ -145,6 +145,133 @@ int main()
             "a constant plane was not ratio-padded in logarithmic mode");
     }
 
+    // --- realignArrivalToRange ----------------------------------------------
+    {
+        amrvis::SliceDisplayResult result;
+        result.slice.plane = makePlane({1.0F, 3.0F});
+        result.minimum = 1.0;
+        result.maximum = 3.0;
+        result.mode = amrvis::DisplayMode::RasterContours;
+        result.contourCount = 2;
+        result.contourFinePlane = makePlane({1.0F, 3.0F});
+        result.request.outputSize = {2, 1};
+        const amrvis::Palette palette;
+
+        // Realigning replaces the range, re-renders the raster, and
+        // re-extracts the contours against the new range.
+        DisplayCoordinator::realignArrivalToRange(
+            result, {0.0, 10.0}, palette, true);
+        require(nearlyEqual(result.minimum, 0.0)
+                && nearlyEqual(result.maximum, 10.0),
+            "realign did not replace the range");
+        require(result.image.valid() && result.image.width > 0,
+            "realign did not render the raster");
+
+        // rasterUnchanged suppresses the raster render but not the range.
+        amrvis::SliceDisplayResult untouched;
+        untouched.slice.plane = makePlane({1.0F, 3.0F});
+        untouched.rasterUnchanged = true;
+        DisplayCoordinator::realignArrivalToRange(
+            untouched, {0.0, 10.0}, palette, true);
+        // A default (empty) ImageBuffer counts as valid, so probe emptiness.
+        require(untouched.image.width == 0,
+            "realign rendered a raster it promised to leave untouched");
+        require(nearlyEqual(untouched.maximum, 10.0),
+            "realign skipped the range on an unchanged raster");
+
+        // realignRasterAndContours=false (the 3-D case, where the shared
+        // sync realigns afterwards) only replaces the range.
+        amrvis::SliceDisplayResult rangeOnly;
+        rangeOnly.slice.plane = makePlane({1.0F, 3.0F});
+        DisplayCoordinator::realignArrivalToRange(
+            rangeOnly, {0.0, 10.0}, palette, false);
+        require(rangeOnly.image.width == 0 && nearlyEqual(rangeOnly.maximum, 10.0),
+            "range-only realign touched the raster");
+    }
+
+    // --- syncPanelsToSharedRange --------------------------------------------
+    {
+        DisplayCoordinator coordinator;
+        const Key key{amrvis::DatasetId{1}, amrvis::FieldId{0}, 0,
+            amrvis::CompositionPolicy::FinestAvailable};
+        const amrvis::Palette palette;
+
+        const auto a = makePlane({2.0F, 6.0F});
+        const auto b = makePlane({-4.0F, 1.0F});
+        const auto fine = makePlane({2.0F, 6.0F});
+        const amrvis::ScalarPlane empty;
+        const std::array<DisplayCoordinator::PanelSyncInput, 3> inputs{{
+            {&a, &fine, 1, false, {2, 1}},
+            {&b, nullptr, 1, false, {2, 1}},
+            {&empty, nullptr, 1, false, {0, 0}},
+        }};
+
+        // No cached range: the union across panels drives every update.
+        auto sync = coordinator.syncPanelsToSharedRange(
+            key, inputs, false, true, 3, palette);
+        require(sync.has_value(), "panel sync found no shared range");
+        require(nearlyEqual(sync->range.first, -4.0)
+                && nearlyEqual(sync->range.second, 6.0),
+            "panel sync range is not the union");
+        require(sync->panels[0].applies && sync->panels[1].applies
+                && !sync->panels[2].applies,
+            "panel sync applied to the wrong panels");
+        require(sync->panels[0].image.width > 0
+                && sync->panels[1].image.width > 0,
+            "panel sync did not render the panel rasters");
+        require(sync->panels[0].contoursRecomputed
+                && !sync->panels[1].contoursRecomputed,
+            "contours were not recomputed exactly where a fine plane exists");
+
+        // A stored full-domain range takes precedence over the union.
+        coordinator.storeFullDomainRange(key, {-100.0, 100.0});
+        sync = coordinator.syncPanelsToSharedRange(
+            key, inputs, false, false, 3, palette);
+        require(sync && nearlyEqual(sync->range.first, -100.0)
+                && nearlyEqual(sync->range.second, 100.0),
+            "the cached full-domain range did not take precedence");
+
+        // Neither cache nor finite samples: nothing to synchronize to.
+        coordinator.invalidateRangeCache();
+        const std::array<DisplayCoordinator::PanelSyncInput, 1> emptyOnly{{
+            {&empty, nullptr, 1, false, {0, 0}}}};
+        require(!coordinator.syncPanelsToSharedRange(
+                key, emptyOnly, false, false, 3, palette).has_value(),
+            "an empty panel set produced a sync");
+    }
+
+    // --- planeDensitiesDiffer -----------------------------------------------
+    {
+        const std::array<int, 2> axes{0, 1};
+        const auto plane = [](int width, double x0, double x1) {
+            amrvis::ScalarPlane p;
+            p.width = width;
+            p.height = 1;
+            p.values.assign(static_cast<std::size_t>(width), 1.0F);
+            p.valid.assign(static_cast<std::size_t>(width), 1);
+            p.physicalRegion.lower = {{x0, 0.0, 0.0}};
+            p.physicalRegion.upper = {{x1, 1.0, 1.0}};
+            return p;
+        };
+
+        // Same density: full domain vs a pan of the same-size window.
+        require(!DisplayCoordinator::planeDensitiesDiffer(
+                plane(4, 0.0, 4.0), plane(4, 4.0, 8.0), axes),
+            "a same-density pan was flagged as a density change");
+        // The issue-#45 shape: a capped full-domain raster (density 1/2)
+        // replaced by a native-resolution crop (density 1).
+        require(DisplayCoordinator::planeDensitiesDiffer(
+                plane(4, 0.0, 8.0), plane(4, 0.0, 4.0), axes),
+            "the capped-to-native density change was not detected");
+        // Degenerate planes and extents compare as not-different.
+        require(!DisplayCoordinator::planeDensitiesDiffer(
+                amrvis::ScalarPlane{}, plane(4, 0.0, 4.0), axes),
+            "an empty plane was flagged as a density change");
+        require(!DisplayCoordinator::planeDensitiesDiffer(
+                plane(4, 2.0, 2.0), plane(4, 0.0, 4.0), axes),
+            "a zero-extent region was flagged as a density change");
+    }
+
     // --- rasterTransformPolicy ----------------------------------------------
     {
         const auto cached = makeRequest(1, 1, 0.0);


### PR DESCRIPTION
Step 3 of the MainWindow extraction. syncPanelsToSharedRange owns the whole 3-D Visible synchronization (shared-range resolution plus per-panel raster and contour realignment); realignArrivalToRange owns the arrival-time realign to a reused full-domain range; planeDensitiesDiffer owns the capped-to-native density decision from preservedDataWindow. MainWindow's paths now only build inputs, sequence the calls, and blit the results; renderScalarPlane no longer appears there outside the test hook.

Unit tests cover the realign variants, cache-vs-union precedence, per-panel application, and the density matrix. No behavior change; full suite green.