### PR TITLE
Extract the animation-export state machine into AnimationExporter

### DIFF
--- a/src/qt/AnimationExporter.cpp
+++ b/src/qt/AnimationExporter.cpp
@@ -1,0 +1,288 @@
+#include "AnimationExporter.hpp"
+
+#include <QDir>
+#include <QFileInfo>
+#include <QFutureWatcher>
+#include <QPair>
+#include <QProcess>
+#include <QProgressDialog>
+#include <QStringList>
+#include <QtConcurrent>
+
+#include <algorithm>
+
+namespace amrvis::qt {
+
+AnimationExporter::AnimationExporter(
+    FrameRenderer renderFrames, AdvanceFrame advanceFrame, QObject* parent)
+    : QObject(parent)
+    , m_renderFrames(std::move(renderFrames))
+    , m_advanceFrame(std::move(advanceFrame))
+{
+}
+
+bool AnimationExporter::begin(const QString& path, bool includeColorBar,
+    int totalFrames, int restoreIndex, qreal scale,
+    std::vector<QString> panelSuffixes, QWidget* dialogParent)
+{
+    if (m_active || totalFrames <= 0 || panelSuffixes.empty()) {
+        return false;
+    }
+    const QFileInfo info(path);
+    m_active = true;
+    m_canceled = false;
+    m_framesDone = false;
+    m_includeColorBar = includeColorBar;
+    m_hasFfmpeg = probeFfmpeg();
+    m_scale = scale;
+    m_totalFrames = totalFrames;
+    m_restoreIndex = restoreIndex;
+    m_digitWidth = std::max(5,
+        static_cast<int>(QString::number(totalFrames - 1).length()));
+    m_directory = info.absolutePath();
+    m_stem = info.completeBaseName();
+    m_panelSuffixes = std::move(panelSuffixes);
+    m_encoderCancel.reset();
+    m_encodersRemaining = 0;
+    m_encodeFailed = false;
+    m_encodeFailureLog.clear();
+
+    m_progress = new QProgressDialog(
+        tr("Rendering frame 1 of %1...").arg(totalFrames), tr("Cancel"),
+        0, totalFrames, dialogParent);
+    m_progress->setWindowTitle(tr("Export Animation"));
+    m_progress->setWindowModality(Qt::WindowModal);
+    m_progress->setMinimumDuration(0);
+    m_progress->setValue(0);
+    connect(m_progress, &QProgressDialog::canceled, this, [this] {
+        m_canceled = true;
+        if (m_encoderCancel) {
+            m_encoderCancel->store(true);
+        }
+    });
+    return true;
+}
+
+void AnimationExporter::cancelForShutdown()
+{
+    if (m_progress != nullptr) {
+        m_canceled = true;
+        if (m_encoderCancel) {
+            m_encoderCancel->store(true);
+        }
+        m_progress->cancel();
+    }
+}
+
+void AnimationExporter::onFrameDisplayed(int index)
+{
+    if (!m_active || m_framesDone) {
+        return;
+    }
+    if (m_canceled) {
+        endExport(false, tr("Animation export cancelled."));
+        return;
+    }
+
+    const QString padded
+        = QString("%1").arg(index, m_digitWidth, 10, QChar('0'));
+    for (const auto& [suffix, frame] : m_renderFrames(m_includeColorBar,
+             m_scale)) {
+        if (frame.isNull()) {
+            endExport(false, tr("A frame could not be rendered."));
+            return;
+        }
+        const QString filePath = QDir(m_directory).absoluteFilePath(
+            m_stem + suffix + "_" + padded + ".png");
+        if (!frame.save(filePath, "PNG")) {
+            endExport(false, tr("Could not write %1.").arg(filePath));
+            return;
+        }
+    }
+
+    m_progress->setValue(index + 1);
+    m_progress->setLabelText(tr("Rendering frame %1 of %2...")
+        .arg(index + 2).arg(m_totalFrames));
+
+    if (index + 1 < m_totalFrames) {
+        m_advanceFrame(index + 1);
+    } else {
+        finalizeEncoding();
+    }
+}
+
+void AnimationExporter::onFrameFailed()
+{
+    if (!m_active) {
+        return;
+    }
+    endExport(false, tr("A frame failed to load; animation export aborted."));
+}
+
+void AnimationExporter::finalizeEncoding()
+{
+    m_framesDone = true;
+
+    if (!m_hasFfmpeg) {
+        endExport(true, tr("Exported %1 PNG frames "
+            "(FFmpeg not found; skipped MP4).").arg(m_totalFrames));
+        return;
+    }
+
+    m_progress->setLabelText(tr("Encoding MP4..."));
+    m_progress->setRange(0, 0);
+    // Cancellation flag shared with the encoder workers (captured by value,
+    // so it outlives this object). Set by the progress Cancel and by
+    // cancelForShutdown.
+    m_encoderCancel = std::make_shared<std::atomic<bool>>(false);
+    emit encodingStarted();
+
+    const auto encode = [this](const QString& stem) {
+        const QString inputPattern = m_directory + "/"
+            + stem + "_%0" + QString::number(m_digitWidth) + "d.png";
+        const QString outputPath
+            = QDir(m_directory).absoluteFilePath(stem + ".mp4");
+        const QStringList args{
+            "-y", "-framerate", "24", "-i", inputPattern,
+            "-vf", "scale=trunc(iw/2)*2:trunc(ih/2)*2",
+            "-pix_fmt", "yuv420p", "-crf", "14", outputPath,
+        };
+        return QtConcurrent::run(
+            [args, cancel = m_encoderCancel]() -> QPair<int, QString> {
+            QProcess proc;
+            proc.setProcessChannelMode(QProcess::MergedChannels);
+            proc.start("ffmpeg", args);
+            if (!proc.waitForStarted(3000)) {
+                return { -2,
+                    QString::fromLocal8Bit(proc.readAllStandardOutput()) };
+            }
+            // Bounded wait: poll so Cancel/close can interrupt instead of
+            // blocking the global pool forever. This worker owns proc, so it
+            // terminates -- and kills, if needed -- the encoder itself.
+            while (proc.state() != QProcess::NotRunning) {
+                if (proc.waitForFinished(200)) {
+                    break;
+                }
+                if (cancel && cancel->load()) {
+                    proc.terminate();
+                    if (!proc.waitForFinished(3000)) {
+                        proc.kill();
+                        proc.waitForFinished(1000);
+                    }
+                    break;
+                }
+            }
+            const int code = proc.exitStatus() == QProcess::NormalExit
+                ? proc.exitCode() : -1;
+            QString log = QString::fromLocal8Bit(
+                proc.readAllStandardOutput());
+            if (log.length() > 800) {
+                log = QStringLiteral("...") + log.right(800);
+            }
+            return { code, log.trimmed() };
+        });
+    };
+
+    if (m_panelSuffixes.size() > 1) {
+        QStringList stems;
+        for (const auto& suffix : m_panelSuffixes) {
+            stems.append(m_stem + suffix);
+        }
+        m_encodersRemaining = static_cast<int>(stems.size());
+        m_encodeFailed = false;
+        m_encodeFailureLog.clear();
+        for (const auto& stem : stems) {
+            auto* watcher = new QFutureWatcher<QPair<int, QString>>(this);
+            connect(watcher, &QFutureWatcher<QPair<int, QString>>::finished,
+                this, [this, watcher, stems] {
+                    const auto result = watcher->result();
+                    watcher->deleteLater();
+                    if (result.first != 0) {
+                        m_encodeFailed = true;
+                        m_encodeFailureLog = result.second;
+                    }
+                    if (--m_encodersRemaining == 0) {
+                        if (m_canceled) {
+                            endExport(false, tr("Export cancelled."));
+                        } else if (m_encodeFailed) {
+                            endExport(false,
+                                tr("FFmpeg failed. PNG frames were "
+                                "still written.\n\n%1")
+                                .arg(m_encodeFailureLog));
+                        } else {
+                            QStringList names;
+                            for (const auto& encoded : stems) {
+                                names.append(encoded + ".mp4");
+                            }
+                            endExport(true,
+                                tr("Exported %1 frames and %2.")
+                                .arg(m_totalFrames)
+                                .arg(names.join(QStringLiteral(", "))));
+                        }
+                    }
+                });
+            watcher->setFuture(encode(stem));
+        }
+    } else {
+        const QString stem = m_stem + m_panelSuffixes.front();
+        auto* watcher = new QFutureWatcher<QPair<int, QString>>(this);
+        connect(watcher, &QFutureWatcher<QPair<int, QString>>::finished,
+            this, [this, watcher, stem] {
+                const auto result = watcher->result();
+                watcher->deleteLater();
+                if (m_canceled) {
+                    endExport(false, tr("Export cancelled."));
+                    return;
+                }
+                const QString outputPath
+                    = QDir(m_directory).absoluteFilePath(stem + ".mp4");
+                if (result.first == 0) {
+                    endExport(true, tr("Exported %1 frames and %2.")
+                        .arg(m_totalFrames).arg(outputPath));
+                } else {
+                    endExport(false,
+                        tr("FFmpeg failed (exit %1). "
+                        "PNG frames were still written.\n\n%2")
+                        .arg(result.first).arg(result.second));
+                }
+            });
+        watcher->setFuture(encode(stem));
+    }
+}
+
+void AnimationExporter::endExport(bool success, const QString& message)
+{
+    if (!m_active) {
+        return;
+    }
+    const int restoreIndex = m_restoreIndex;
+
+    if (m_progress != nullptr) {
+        m_progress->hide();
+        m_progress->deleteLater();
+        m_progress = nullptr;
+    }
+    m_active = false;
+    m_canceled = false;
+    m_framesDone = false;
+    m_encoderCancel.reset();
+    m_encodersRemaining = 0;
+    m_encodeFailed = false;
+    m_encodeFailureLog.clear();
+    m_panelSuffixes.clear();
+    m_restoreIndex = -1;
+
+    emit finished(success, message, restoreIndex);
+}
+
+bool AnimationExporter::probeFfmpeg()
+{
+    QProcess proc;
+    proc.start("ffmpeg", {"-version"});
+    if (!proc.waitForStarted(2000) || !proc.waitForFinished(2000)) {
+        return false;
+    }
+    return proc.exitStatus() == QProcess::NormalExit && proc.exitCode() == 0;
+}
+
+} // namespace amrvis::qt

--- a/src/qt/AnimationExporter.hpp
+++ b/src/qt/AnimationExporter.hpp
@@ -1,0 +1,106 @@
+#pragma once
+
+#include <QImage>
+#include <QObject>
+#include <QString>
+
+#include <atomic>
+#include <functional>
+#include <memory>
+#include <utility>
+#include <vector>
+
+class QProgressDialog;
+class QWidget;
+
+namespace amrvis::qt {
+
+// Drives the signal-driven animation-export loop extracted from MainWindow:
+// advances the open sequence one frame at a time as each renders, saves the
+// rendered frame(s) as PNGs, then encodes MP4s with FFmpeg on worker
+// threads with bounded, cancellable waits. Owns every piece of export state
+// (progress dialog, cancellation flags, encoder bookkeeping — previously
+// raw-new'd shared counters that leaked on early teardown). The host window
+// supplies frame rendering and sequence navigation as callbacks, forwards
+// sequenceFrameDisplayed/Failed here, and reacts to finished() by restoring
+// its UI; it never reaches into the exporter's state.
+class AnimationExporter final : public QObject {
+    Q_OBJECT
+
+public:
+    // Renders the current frame for export: one (fileSuffix, image) pair per
+    // panel ("" for the single 2-D view, "_yz"/"_xz"/"_xy" in 3-D). A null
+    // image aborts the export; an absent panel is simply skipped.
+    using FrameRenderer = std::function<
+        std::vector<std::pair<QString, QImage>>(bool includeColorBar,
+            qreal scale)>;
+    // Navigates the sequence to the given frame (the host's
+    // goToSequenceFrame); the next sequenceFrameDisplayed continues the loop.
+    using AdvanceFrame = std::function<void(int index)>;
+
+    AnimationExporter(FrameRenderer renderFrames, AdvanceFrame advanceFrame,
+        QObject* parent = nullptr);
+
+    // Starts an export writing <stem><suffix>_<index>.png next to `path`
+    // (whose directory and basename become the output location and stem) and
+    // one <stem><suffix>.mp4 per panel suffix. panelSuffixes is frozen for
+    // the whole export. Returns false when an export is already running or
+    // there is nothing to export. The caller is expected to navigate to
+    // frame 0 afterwards (mirroring the pre-extraction flow).
+    [[nodiscard]] bool begin(const QString& path, bool includeColorBar,
+        int totalFrames, int restoreIndex, qreal scale,
+        std::vector<QString> panelSuffixes, QWidget* dialogParent);
+
+    [[nodiscard]] bool active() const noexcept { return m_active; }
+
+    // Application shutdown: dismiss the progress dialog and signal the
+    // encoder workers to terminate their FFmpeg processes.
+    void cancelForShutdown();
+
+    // Forwarded sequence events: a rendered frame continues the loop; a
+    // failed frame aborts the export (the host suppresses its own error
+    // dialog while an export is active — endExport reports instead).
+    void onFrameDisplayed(int index);
+    void onFrameFailed();
+
+signals:
+    // Frames are written; the FFmpeg workers are about to run. The
+    // export-quit smoke test quits here to exercise bounded encoder
+    // cancellation.
+    void encodingStarted();
+    // Emitted exactly once per begin(): the export state is already reset;
+    // restoreIndex is the frame the user was viewing before the export.
+    void finished(bool success, const QString& message, int restoreIndex);
+
+private:
+    void endExport(bool success, const QString& message);
+    void finalizeEncoding();
+    [[nodiscard]] static bool probeFfmpeg();
+
+    FrameRenderer m_renderFrames;
+    AdvanceFrame m_advanceFrame;
+
+    bool m_active = false;
+    bool m_canceled = false;
+    bool m_framesDone = false;
+    bool m_includeColorBar = false;
+    bool m_hasFfmpeg = false;
+    qreal m_scale = 1.0;   // frozen export zoom so every frame matches
+    int m_totalFrames = 0;
+    int m_restoreIndex = -1;
+    int m_digitWidth = 5;
+    QString m_directory;
+    QString m_stem;
+    std::vector<QString> m_panelSuffixes;
+    QProgressDialog* m_progress = nullptr;
+    // Shared with the encoder workers (captured by value, so it outlives
+    // this object). Set by the progress Cancel and by cancelForShutdown.
+    std::shared_ptr<std::atomic<bool>> m_encoderCancel;
+    // Multi-panel encoder bookkeeping — plain members instead of the former
+    // raw-new'd shared counters, so nothing leaks on early teardown.
+    int m_encodersRemaining = 0;
+    bool m_encodeFailed = false;
+    QString m_encodeFailureLog;
+};
+
+} // namespace amrvis::qt

--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -1,4 +1,6 @@
 add_executable(amrexplorer_qt
+    AnimationExporter.cpp
+    AnimationExporter.hpp
     AnimationPanel.cpp
     AnimationPanel.hpp
     CacheConfig.hpp

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -1,4 +1,5 @@
 #include "MainWindow.hpp"
+#include "AnimationExporter.hpp"
 #include "AnimationPanel.hpp"
 #include "CacheConfig.hpp"
 #include "ColorBarWidget.hpp"
@@ -616,11 +617,56 @@ MainWindow::MainWindow(QWidget* parent)
     // stops the other (see setPlaybackMode).
     m_playbackTimer = new QTimer(this);
     connect(m_playbackTimer, &QTimer::timeout, this, [this] { playbackTick(); });
-    // Animation export advances one frame at a time as each renders.
+    // Animation export advances one frame at a time as each renders. The
+    // exporter owns the whole export state machine; this window supplies
+    // frame rendering and navigation, and restores its UI on finished().
+    m_animationExporter = new AnimationExporter(
+        [this](bool includeColorBar, qreal scale) {
+            std::vector<std::pair<QString, QImage>> frames;
+            if (m_viewDimension == 3) {
+                constexpr std::array<const char*, 3> suffixes{
+                    "_yz", "_xz", "_xy"};
+                for (int normal = 0; normal < 3; ++normal) {
+                    const auto idx = static_cast<std::size_t>(normal);
+                    auto* panelView = m_planeViews[idx].view;
+                    if (panelView == nullptr || !panelView->hasImage()) {
+                        continue;
+                    }
+                    frames.emplace_back(QString::fromLatin1(suffixes[idx]),
+                        composeExportFrame(panelView, includeColorBar, scale));
+                }
+            } else {
+                frames.emplace_back(QString(), composeExportFrame(
+                    m_activeView != nullptr ? m_activeView->view : nullptr,
+                    includeColorBar, scale));
+            }
+            return frames;
+        },
+        [this](int index) { goToSequenceFrame(index); },
+        this);
+    connect(m_animationExporter, &AnimationExporter::encodingStarted,
+        this, &MainWindow::exportEncodingStarted);
+    connect(m_animationExporter, &AnimationExporter::finished, this,
+        [this](bool success, const QString& message, int restoreIndex) {
+            // Return the user to the frame they were viewing (unless we are
+            // closing, which would launch a new frame load mid-shutdown).
+            if (!m_closing && !m_sequenceFrames.empty()) {
+                goToSequenceFrame(restoreIndex < 0 ? 0 : restoreIndex);
+            }
+            m_exportAnimationAction->setEnabled(!m_sequenceFrames.empty());
+            if (!m_closing) {
+                if (success) {
+                    QMessageBox::information(
+                        this, tr("Export Animation"), message);
+                } else {
+                    reportBackgroundError(message);
+                }
+            }
+        });
     connect(this, &MainWindow::sequenceFrameDisplayed,
-        this, [this](int index) { onExportFrameDisplayed(index); });
+        m_animationExporter, &AnimationExporter::onFrameDisplayed);
     connect(this, &MainWindow::sequenceFrameFailed,
-        this, [this] { onExportFrameFailed(); });
+        m_animationExporter, &AnimationExporter::onFrameFailed);
     applySpeed();
     connect(m_animationPanel, &AnimationPanel::sweepStepRequested, this,
         [this](int direction) { stepSweep(direction); });
@@ -2330,15 +2376,9 @@ void MainWindow::closeEvent(QCloseEvent* event)
         m_userGuideDialog = nullptr;
         dialog->close();
     }
-    if (m_exportAnim.progress != nullptr) {
-        // Dismiss the export progress dialog and signal the encoder workers to
-        // terminate their FFmpeg processes (see finalizeExportAnimation).
-        m_exportAnim.canceled = true;
-        if (m_exportAnim.encoderCancel) {
-            m_exportAnim.encoderCancel->store(true);
-        }
-        m_exportAnim.progress->cancel();
-    }
+    // Dismiss any export progress dialog and signal the encoder workers to
+    // terminate their FFmpeg processes (see AnimationExporter).
+    m_animationExporter->cancelForShutdown();
     saveSettings();
     auto settings = makeSettings();
     settings.setValue(QStringLiteral("geometry"), saveGeometry());
@@ -2775,19 +2815,9 @@ QImage MainWindow::composeExportFrame(const ImageView* view,
     return composite;
 }
 
-bool MainWindow::probeFfmpeg() const
-{
-    QProcess proc;
-    proc.start("ffmpeg", {"-version"});
-    if (!proc.waitForStarted(2000) || !proc.waitForFinished(2000)) {
-        return false;
-    }
-    return proc.exitStatus() == QProcess::NormalExit && proc.exitCode() == 0;
-}
-
 void MainWindow::exportAnimation()
 {
-    if (m_exportAnim.active) {
+    if (m_animationExporter->active()) {
         return;
     }
     if (m_sequenceFrames.empty()) {
@@ -2833,7 +2863,7 @@ void MainWindow::exportAnimation()
 void MainWindow::startAnimationExportForTest(const QString& path,
     bool includeColorBar)
 {
-    if (m_exportAnim.active) {
+    if (m_animationExporter->active()) {
         return;
     }
     beginAnimationExport(path, includeColorBar);
@@ -2845,283 +2875,30 @@ void MainWindow::beginAnimationExport(const QString& path, bool includeColorBar)
     if (view == nullptr || !view->hasImage() || m_sequenceFrames.empty()) {
         return;
     }
-    const QFileInfo info(path);
-    const auto total = static_cast<int>(m_sequenceFrames.size());
-    const int digits =
-        std::max(5, static_cast<int>(QString::number(total - 1).length()));
-
-    m_exportAnim = ExportAnimationState{};
-    m_exportAnim.active = true;
-    m_exportAnim.includeColorBar = includeColorBar;
     // Freeze the export zoom from the current view so every frame renders at the
     // same dimensions even if a frame's image size changes and refits the view.
     // In 3-D this single scale is shared by all three panels, so a panel whose
     // fitted zoom differs from the active view exports at the active view's
     // scale -- constant across frames, which is the goal.
-    m_exportAnim.scale = std::max(1.0, view->transform().m11());
-    m_exportAnim.hasFfmpeg = probeFfmpeg();
-    m_exportAnim.totalFrames = total;
-    m_exportAnim.restoreIndex = m_sequenceIndex;
-    m_exportAnim.digitWidth = digits;
-    m_exportAnim.directory = info.absolutePath();
-    m_exportAnim.stem = info.completeBaseName();
-
-    m_exportAnim.progress = new QProgressDialog(
-        tr("Rendering frame 1 of %1...").arg(total), tr("Cancel"), 0, total, this);
-    m_exportAnim.progress->setWindowTitle(tr("Export Animation"));
-    m_exportAnim.progress->setWindowModality(Qt::WindowModal);
-    m_exportAnim.progress->setMinimumDuration(0);
-    m_exportAnim.progress->setValue(0);
-    connect(m_exportAnim.progress, &QProgressDialog::canceled,
-        this, [this] {
-            m_exportAnim.canceled = true;
-            if (m_exportAnim.encoderCancel) {
-                m_exportAnim.encoderCancel->store(true);
-            }
-        });
+    const auto scale = std::max(1.0, view->transform().m11());
+    std::vector<QString> suffixes;
+    if (m_viewDimension == 3) {
+        suffixes = {QStringLiteral("_yz"), QStringLiteral("_xz"),
+            QStringLiteral("_xy")};
+    } else {
+        suffixes = {QString()};
+    }
+    if (!m_animationExporter->begin(path, includeColorBar,
+            static_cast<int>(m_sequenceFrames.size()), m_sequenceIndex, scale,
+            std::move(suffixes), this)) {
+        return;
+    }
 
     // Freeze the action and stop playback while exporting.
     m_exportAnimationAction->setEnabled(false);
     setPlaybackMode(PlaybackMode::None);
 
     goToSequenceFrame(0);
-}
-
-void MainWindow::onExportFrameDisplayed(int index)
-{
-    if (!m_exportAnim.active || m_exportAnim.framesDone) {
-        return;
-    }
-    if (m_exportAnim.canceled) {
-        endExportAnimation(false, tr("Animation export cancelled."));
-        return;
-    }
-
-    const QString padded = QString("%1").arg(index,
-        m_exportAnim.digitWidth, 10, QChar('0'));
-
-    if (m_viewDimension == 3) {
-        constexpr std::array<const char*, 3> suffixes{"_yz", "_xz", "_xy"};
-        for (int normal = 0; normal < 3; ++normal) {
-            const auto idx = static_cast<std::size_t>(normal);
-            auto* panelView = m_planeViews[idx].view;
-            if (panelView == nullptr || !panelView->hasImage()) {
-                continue;
-            }
-            const QImage frame = composeExportFrame(
-                panelView, m_exportAnim.includeColorBar, m_exportAnim.scale);
-            if (frame.isNull()) {
-                endExportAnimation(false,
-                    tr("A frame could not be rendered."));
-                return;
-            }
-            const QString filePath = QDir(m_exportAnim.directory)
-                .absoluteFilePath(m_exportAnim.stem
-                    + QString::fromLatin1(suffixes[idx])
-                    + "_" + padded + ".png");
-            if (!frame.save(filePath, "PNG")) {
-                endExportAnimation(false,
-                    tr("Could not write %1.").arg(filePath));
-                return;
-            }
-        }
-    } else {
-        const QImage frame = composeExportFrame(
-            m_activeView != nullptr ? m_activeView->view : nullptr,
-            m_exportAnim.includeColorBar, m_exportAnim.scale);
-        if (frame.isNull()) {
-            endExportAnimation(false,
-                tr("A frame could not be rendered."));
-            return;
-        }
-        const QString filePath = QDir(m_exportAnim.directory)
-            .absoluteFilePath(m_exportAnim.stem + "_" + padded + ".png");
-        if (!frame.save(filePath, "PNG")) {
-            endExportAnimation(false,
-                tr("Could not write %1.").arg(filePath));
-            return;
-        }
-    }
-
-    m_exportAnim.progress->setValue(index + 1);
-    m_exportAnim.progress->setLabelText(tr("Rendering frame %1 of %2...")
-        .arg(index + 2).arg(m_exportAnim.totalFrames));
-
-    if (index + 1 < m_exportAnim.totalFrames) {
-        goToSequenceFrame(index + 1);
-    } else {
-        finalizeExportAnimation();
-    }
-}
-
-void MainWindow::onExportFrameFailed()
-{
-    if (!m_exportAnim.active) {
-        return;
-    }
-    endExportAnimation(false, tr("A frame failed to load; animation export aborted."));
-}
-
-void MainWindow::finalizeExportAnimation()
-{
-    m_exportAnim.framesDone = true;
-
-    if (!m_exportAnim.hasFfmpeg) {
-        endExportAnimation(true, tr("Exported %1 PNG frames "
-            "(FFmpeg not found; skipped MP4).").arg(m_exportAnim.totalFrames));
-        return;
-    }
-
-    m_exportAnim.progress->setLabelText(tr("Encoding MP4..."));
-    m_exportAnim.progress->setRange(0, 0);
-    // Cancellation flag shared with the encoder workers (captured by value, so
-    // it outlives this window). Set by the progress Cancel and by closeEvent.
-    m_exportAnim.encoderCancel = std::make_shared<std::atomic<bool>>(false);
-    // Frames are written; the FFmpeg workers are about to run. The export-quit
-    // smoke test quits here to exercise bounded encoder cancellation.
-    emit exportEncodingStarted();
-
-    auto encode = [this](const QString& stem) {
-        const QString inputPattern = m_exportAnim.directory + "/"
-            + stem + "_%0" + QString::number(m_exportAnim.digitWidth)
-            + "d.png";
-        const QString outputPath = QDir(m_exportAnim.directory)
-            .absoluteFilePath(stem + ".mp4");
-        const QStringList args{
-            "-y", "-framerate", "24", "-i", inputPattern,
-            "-vf", "scale=trunc(iw/2)*2:trunc(ih/2)*2",
-            "-pix_fmt", "yuv420p", "-crf", "14", outputPath,
-        };
-        return QtConcurrent::run([args, cancel = m_exportAnim.encoderCancel]() -> QPair<int, QString> {
-            QProcess proc;
-            proc.setProcessChannelMode(QProcess::MergedChannels);
-            proc.start("ffmpeg", args);
-            if (!proc.waitForStarted(3000)) {
-                return { -2,
-                    QString::fromLocal8Bit(proc.readAllStandardOutput()) };
-            }
-            // Bounded wait: poll so Cancel/close can interrupt instead of
-            // blocking the global pool forever. This worker owns proc, so it
-            // terminates -- and kills, if needed -- the encoder itself.
-            while (proc.state() != QProcess::NotRunning) {
-                if (proc.waitForFinished(200)) {
-                    break;
-                }
-                if (cancel && cancel->load()) {
-                    proc.terminate();
-                    if (!proc.waitForFinished(3000)) {
-                        proc.kill();
-                        proc.waitForFinished(1000);
-                    }
-                    break;
-                }
-            }
-            const int code = proc.exitStatus() == QProcess::NormalExit
-                ? proc.exitCode() : -1;
-            QString log = QString::fromLocal8Bit(
-                proc.readAllStandardOutput());
-            if (log.length() > 800) {
-                log = QStringLiteral("...") + log.right(800);
-            }
-            return { code, log.trimmed() };
-        });
-    };
-
-    if (m_viewDimension == 3) {
-        const QStringList stems{
-            m_exportAnim.stem + "_yz",
-            m_exportAnim.stem + "_xz",
-            m_exportAnim.stem + "_xy",
-        };
-        int* remaining = new int(3);
-        bool* failed = new bool(false);
-        QString* failMsg = new QString();
-        for (const auto& stem : stems) {
-            auto* watcher = new QFutureWatcher<QPair<int, QString>>(this);
-            connect(watcher,
-                &QFutureWatcher<QPair<int, QString>>::finished,
-                this, [this, watcher, remaining, failed, failMsg, stems] {
-                    const auto result = watcher->result();
-                    watcher->deleteLater();
-                    if (result.first != 0) {
-                        *failed = true;
-                        *failMsg = result.second;
-                    }
-                    if (--(*remaining) == 0) {
-                        delete remaining;
-                        if (m_exportAnim.canceled) {
-                            endExportAnimation(false, tr("Export cancelled."));
-                        } else if (*failed) {
-                            endExportAnimation(false,
-                                tr("FFmpeg failed. PNG frames were "
-                                "still written.\n\n%1").arg(*failMsg));
-                        } else {
-                            endExportAnimation(true,
-                                tr("Exported %1 frames and %2, %3, %4.")
-                                .arg(m_exportAnim.totalFrames)
-                                .arg(stems[0] + ".mp4")
-                                .arg(stems[1] + ".mp4")
-                                .arg(stems[2] + ".mp4"));
-                        }
-                        delete failed;
-                        delete failMsg;
-                    }
-                });
-            watcher->setFuture(encode(stem));
-        }
-    } else {
-        const QString stem = m_exportAnim.stem;
-        auto* watcher = new QFutureWatcher<QPair<int, QString>>(this);
-        connect(watcher, &QFutureWatcher<QPair<int, QString>>::finished,
-            this, [this, watcher, stem] {
-                const auto result = watcher->result();
-                watcher->deleteLater();
-                if (m_exportAnim.canceled) {
-                    endExportAnimation(false, tr("Export cancelled."));
-                    return;
-                }
-                const QString outputPath = QDir(m_exportAnim.directory)
-                    .absoluteFilePath(stem + ".mp4");
-                if (result.first == 0) {
-                    endExportAnimation(true,
-                        tr("Exported %1 frames and %2.")
-                        .arg(m_exportAnim.totalFrames).arg(outputPath));
-                } else {
-                    endExportAnimation(false,
-                        tr("FFmpeg failed (exit %1). "
-                        "PNG frames were still written.\n\n%2")
-                        .arg(result.first).arg(result.second));
-                }
-            });
-        watcher->setFuture(encode(stem));
-    }
-}
-
-void MainWindow::endExportAnimation(bool success, const QString& message)
-{
-    const bool wasActive = m_exportAnim.active;
-    const int restoreIndex = m_exportAnim.restoreIndex;
-
-    if (m_exportAnim.progress != nullptr) {
-        m_exportAnim.progress->hide();
-        m_exportAnim.progress->deleteLater();
-    }
-    m_exportAnim = ExportAnimationState{};
-
-    // Return the user to the frame they were viewing (unless we are closing,
-    // which would launch a new frame load mid-shutdown).
-    if (wasActive && !m_closing && !m_sequenceFrames.empty()) {
-        goToSequenceFrame(restoreIndex < 0 ? 0 : restoreIndex);
-    }
-    m_exportAnimationAction->setEnabled(!m_sequenceFrames.empty());
-
-    if (wasActive && !m_closing) {
-        if (success) {
-            QMessageBox::information(this, tr("Export Animation"), message);
-        } else {
-            reportBackgroundError(message);
-        }
-    }
 }
 
 std::optional<DatasetRequest> MainWindow::buildDatasetRequest() const
@@ -4544,7 +4321,7 @@ void MainWindow::startFrameLoad(int index, std::uint64_t generation)
                     statusBar()->showMessage(tr("Frame load failed"));
                     // During animation export the failure is reported by the
                     // export handler (endExportAnimation); avoid a second dialog.
-                    const bool wasExporting = m_exportAnim.active;
+                    const bool wasExporting = m_animationExporter->active();
                     emit sequenceFrameFailed();
                     if (!wasExporting) {
                         reportBackgroundError(
@@ -4573,7 +4350,7 @@ void MainWindow::finishFrameLoad(InitialSliceResult result, bool defaultPosition
         statusBar()->showMessage(tr("Frame load failed"));
         // During animation export the failure is reported by the export
         // handler (endExportAnimation); avoid a second dialog.
-        const bool wasExporting = m_exportAnim.active;
+        const bool wasExporting = m_animationExporter->active();
         emit sequenceFrameFailed();
         if (!wasExporting) {
             reportBackgroundError(

--- a/src/qt/MainWindow.hpp
+++ b/src/qt/MainWindow.hpp
@@ -62,6 +62,7 @@ enum class CompositionPolicy : std::uint8_t;
 
 namespace amrvis::qt {
 
+class AnimationExporter;
 class AnimationPanel;
 class ColorBarWidget;
 class DatasetWindow;
@@ -264,20 +265,12 @@ private:
     void exportImage();
     void exportAnimation();
     // Shared body of exportAnimation once the output path and color-bar choice
-    // are known (from the dialogs, or from the test hook): configures the export
-    // state, progress dialog, and kicks off frame 0.
+    // are known (from the dialogs, or from the test hook): freezes the export
+    // zoom, starts the AnimationExporter (which owns the export state machine),
+    // and kicks off frame 0.
     void beginAnimationExport(const QString& path, bool includeColorBar);
-    // Animation export is signal-driven (frame rendering is async): exportAnimation
-    // kicks off frame 0; onExportFrameDisplayed saves each rendered frame and
-    // advances; finalizeExportAnimation encodes the MP4; endExportAnimation is the
-    // shared cleanup/restore/report path.
-    void onExportFrameDisplayed(int index);
-    void onExportFrameFailed();
-    void finalizeExportAnimation();
-    void endExportAnimation(bool success, const QString& message);
     [[nodiscard]] QImage composeExportFrame(const ImageView* view,
         bool includeColorBar, qreal scaleFactor) const;
-    [[nodiscard]] bool probeFfmpeg() const;
     void createMenus();
     void rebuildLevelMenu();
     void rebuildVariableMenu();
@@ -500,24 +493,10 @@ private:
     QAction* m_datasetAction = nullptr;
     QAction* m_exportAnimationAction = nullptr;
 
-    // Drives File -> Export Animation... Active only while an export is running;
-    // sequenceFrameDisplayed advances it one frame at a time.
-    struct ExportAnimationState {
-        bool active = false;
-        bool canceled = false;
-        std::shared_ptr<std::atomic<bool>> encoderCancel;
-        bool framesDone = false;
-        bool includeColorBar = false;
-        bool hasFfmpeg = false;
-        qreal scale = 1.0;  // frozen export zoom factor so every frame matches
-        int totalFrames = 0;
-        int restoreIndex = -1;
-        int digitWidth = 5;
-        QString directory;
-        QString stem;
-        QProgressDialog* progress = nullptr;
-    };
-    ExportAnimationState m_exportAnim;
+    // Drives File -> Export Animation...: owns the whole export state machine
+    // (progress, cancellation, FFmpeg encoding). This window supplies frame
+    // rendering and sequence navigation, and restores its UI on finished().
+    AnimationExporter* m_animationExporter = nullptr;
     std::shared_ptr<PlotfileDataset> m_dataset;
     std::shared_ptr<const DatasetMetadata> m_openMetadata;
     std::string m_fileVersion;


### PR DESCRIPTION
Step 5a of the MainWindow extraction. The exporter owns the whole signal-driven export loop — progress dialog, cancellation, per-frame PNG writing, and FFmpeg encoding with bounded cancellable waits — with MainWindow supplying frame rendering and sequence navigation as callbacks, forwarding sequence signals, and restoring its UI on finished(). closeEvent routes through cancelForShutdown, and exportEncodingStarted forwards unchanged for the export-quit smoke test.

This removes the raw-new'd shared encoder counters that leaked on early teardown; they are plain members of the single-export object now. The 3-panel success message is assembled by joining stem names (identical text), and panel suffixes are frozen at begin().

MainWindow.cpp shrinks 5,654 to 4,836 lines. No behavior change; full suite green including the export-quit and quit smokes.