### PR TITLE
Extract the sequence/prefetch state machine into SequenceController

### DIFF
--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -24,6 +24,8 @@ add_executable(amrexplorer_qt
     NumberFormat.hpp
     ScientificDoubleSpinBox.cpp
     ScientificDoubleSpinBox.hpp
+    SequenceController.cpp
+    SequenceController.hpp
     SetContoursDialog.cpp
     SetContoursDialog.hpp
     Theme.hpp

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -1,5 +1,6 @@
 #include "MainWindow.hpp"
 #include "AnimationExporter.hpp"
+#include "SequenceController.hpp"
 #include "AnimationPanel.hpp"
 #include "CacheConfig.hpp"
 #include "ColorBarWidget.hpp"
@@ -103,10 +104,6 @@
 
 namespace amrvis::qt {
 namespace {
-
-// Sequence frame loads and prefetches get dataset ids from a dedicated range
-// so they never collide with the ids openDataset derives from m_generation.
-constexpr std::uint64_t sequenceDatasetIdBase = 0x4000000000000000ULL;
 
 constexpr std::array<BuiltinPalette, 7> builtinPalettes{
     BuiltinPalette::Rainbow, BuiltinPalette::Turbo, BuiltinPalette::Viridis,
@@ -617,6 +614,89 @@ MainWindow::MainWindow(QWidget* parent)
     // stops the other (see setPlaybackMode).
     m_playbackTimer = new QTimer(this);
     connect(m_playbackTimer, &QTimer::timeout, this, [this] { playbackTick(); });
+    // The sequence controller owns the frame/prefetch state machine; this
+    // window supplies the GUI-coupled hooks (spec snapshot, frame display,
+    // shutdown flag) and reacts to its signals below.
+    m_sequenceController = new SequenceController(
+        SequenceController::Hooks{
+            [this] { return buildFrameSpec(); },
+            [this](InitialSliceResult& result, bool defaultPositions) {
+                displayFrameResult(result, defaultPositions);
+            },
+            [this] { return m_closing; },
+        },
+        this);
+    connect(m_sequenceController, &SequenceController::frameSwitchStarted,
+        this, [this](int index) {
+            // Cancel the current dataset's in-flight work, exactly like
+            // opening a fresh dataset does, but keep the view state (field,
+            // level, range, log, palette, zoom, slice positions) for the
+            // next frame.
+            const std::array<PlaneViewState*, 4> states{&m_view2d,
+                &m_planeViews[0], &m_planeViews[1], &m_planeViews[2]};
+            for (auto* state : states) {
+                state->stopSource.request_stop();
+                ++state->sliceGeneration;
+            }
+            m_initialStopSource.request_stop();
+            m_linePlotStopSource.request_stop();
+            m_pendingAllViews = false;
+            m_pendingViews.clear();
+            m_sliceDebounce->stop();
+            // The dataset window shows the previous frame's raw values;
+            // drop it, and the line plot window whose curves are snapshots
+            // of this dataset, so neither goes stale across the switch.
+            closeDatasetWindow();
+            auto* linePlotWindow = m_linePlotWindow;
+            m_linePlotWindow = nullptr;
+            if (linePlotWindow != nullptr) {
+                linePlotWindow->close();
+            }
+            ++m_generation;
+            m_datasetPath = m_sequenceController->framePath(index);
+            m_animationPanel->setSequenceFrame(index);
+        });
+    connect(m_sequenceController, &SequenceController::loadActivityChanged,
+        this, [this](int delta) {
+            if (delta > 0) {
+                m_activeRequests += static_cast<std::uint64_t>(delta);
+            } else {
+                m_activeRequests -= static_cast<std::uint64_t>(-delta);
+            }
+            updateDiagnostics();
+        });
+    connect(m_sequenceController, &SequenceController::staleResultDropped,
+        this, [this] {
+            ++m_staleResults;
+            updateDiagnostics();
+        });
+    connect(m_sequenceController, &SequenceController::statusMessage,
+        this, [this](const QString& message) {
+            statusBar()->showMessage(message);
+        });
+    connect(m_sequenceController, &SequenceController::frameDisplayed,
+        this, [this](int index) {
+            m_animationPanel->setSequenceFrame(index);
+            m_animationPanel->setSequenceInfo(
+                QString::fromStdString(m_datasetPath.filename().string()),
+                m_openMetadata->time);
+            updateDiagnostics();
+            emit sequenceFrameDisplayed(index);
+        });
+    connect(m_sequenceController, &SequenceController::frameLoadFailed,
+        this, [this](const QString& message) {
+            statusBar()->showMessage(tr("Frame load failed"));
+            // During animation export the failure is reported by the export
+            // handler; avoid a second dialog.
+            const bool wasExporting = m_animationExporter->active();
+            emit sequenceFrameFailed();
+            if (!wasExporting) {
+                reportBackgroundError(
+                    tr("Cannot load frame: %1").arg(message));
+            }
+            updateDiagnostics();
+        });
+
     // Animation export advances one frame at a time as each renders. The
     // exporter owns the whole export state machine; this window supplies
     // frame rendering and navigation, and restores its UI on finished().
@@ -650,10 +730,11 @@ MainWindow::MainWindow(QWidget* parent)
         [this](bool success, const QString& message, int restoreIndex) {
             // Return the user to the frame they were viewing (unless we are
             // closing, which would launch a new frame load mid-shutdown).
-            if (!m_closing && !m_sequenceFrames.empty()) {
+            if (!m_closing && m_sequenceController->hasSequence()) {
                 goToSequenceFrame(restoreIndex < 0 ? 0 : restoreIndex);
             }
-            m_exportAnimationAction->setEnabled(!m_sequenceFrames.empty());
+            m_exportAnimationAction->setEnabled(
+                m_sequenceController->hasSequence());
             if (!m_closing) {
                 if (success) {
                     QMessageBox::information(
@@ -2406,7 +2487,7 @@ void MainWindow::cancelInFlight()
     }
     m_initialStopSource.request_stop();
     m_metadataStopSource.request_stop();
-    m_prefetchStopSource.request_stop();
+    m_sequenceController->cancelActiveWork();
     m_linePlotStopSource.request_stop();
     m_view2d.stopSource.request_stop();
     for (auto& state : m_planeViews) {
@@ -2820,7 +2901,7 @@ void MainWindow::exportAnimation()
     if (m_animationExporter->active()) {
         return;
     }
-    if (m_sequenceFrames.empty()) {
+    if (!m_sequenceController->hasSequence()) {
         QMessageBox::information(this, tr("No animation"),
             tr("Open a plotfile sequence before exporting an animation."));
         return;
@@ -2872,7 +2953,8 @@ void MainWindow::startAnimationExportForTest(const QString& path,
 void MainWindow::beginAnimationExport(const QString& path, bool includeColorBar)
 {
     auto* view = m_activeView != nullptr ? m_activeView->view : nullptr;
-    if (view == nullptr || !view->hasImage() || m_sequenceFrames.empty()) {
+    if (view == nullptr || !view->hasImage()
+        || !m_sequenceController->hasSequence()) {
         return;
     }
     // Freeze the export zoom from the current view so every frame renders at the
@@ -2889,7 +2971,8 @@ void MainWindow::beginAnimationExport(const QString& path, bool includeColorBar)
         suffixes = {QString()};
     }
     if (!m_animationExporter->begin(path, includeColorBar,
-            static_cast<int>(m_sequenceFrames.size()), m_sequenceIndex, scale,
+            m_sequenceController->frameCount(),
+            m_sequenceController->currentIndex(), scale,
             std::move(suffixes), this)) {
         return;
     }
@@ -3513,8 +3596,7 @@ void MainWindow::scheduleSliceRequest(bool rasterDirty)
     if (m_controlsReady && m_dataset) {
         // Any slice-affecting UI change funnels through here; a prefetched
         // frame rendered against the old spec is obsolete.
-        ++m_specGeneration;
-        discardPrefetch();
+        m_sequenceController->invalidatePrefetch();
         m_pendingRasterDirty = m_pendingRasterDirty || rasterDirty;
         m_pendingAllViews = true;
         m_sliceDebounce->start();
@@ -3524,8 +3606,7 @@ void MainWindow::scheduleSliceRequest(bool rasterDirty)
 void MainWindow::scheduleSliceRequest(PlaneViewState& state, bool rasterDirty)
 {
     if (m_controlsReady && m_dataset) {
-        ++m_specGeneration;
-        discardPrefetch();
+        m_sequenceController->invalidatePrefetch();
         m_pendingRasterDirty = m_pendingRasterDirty || rasterDirty;
         if (std::find(m_pendingViews.begin(), m_pendingViews.end(), &state)
             == m_pendingViews.end()) {
@@ -4185,9 +4266,7 @@ void MainWindow::openSequence(const std::vector<std::filesystem::path>& frames)
         return;
     }
 
-    m_sequenceFrames = std::move(sorted);
-    m_animationPanel->setSequenceFrameCount(
-        static_cast<int>(m_sequenceFrames.size()));
+    m_animationPanel->setSequenceFrameCount(static_cast<int>(sorted.size()));
     m_animationPanel->setSequenceVisible(true);
     updateAnimationDockVisibility();
     // Line plot curves are snapshots of the previous dataset; drop the window.
@@ -4196,7 +4275,7 @@ void MainWindow::openSequence(const std::vector<std::filesystem::path>& frames)
     if (linePlotWindow != nullptr) {
         linePlotWindow->close();
     }
-    goToSequenceFrame(0);
+    m_sequenceController->open(std::move(sorted));
 }
 
 void MainWindow::closeSequence()
@@ -4204,10 +4283,7 @@ void MainWindow::closeSequence()
     if (m_playbackMode == PlaybackMode::Sequence) {
         setPlaybackMode(PlaybackMode::None);
     }
-    discardPrefetch();
-    m_sequenceFrames.clear();
-    m_sequenceIndex = -1;
-    m_sequenceInFlight = false;
+    m_sequenceController->close();
     m_animationPanel->setSequenceVisible(false);
     updateAnimationDockVisibility();
 }
@@ -4217,7 +4293,7 @@ void MainWindow::updateAnimationDockVisibility()
     // The Animation panel hosts the 3-D slice-sweep controls and the
     // plotfile-sequence controls. Keep it visible only when one of those
     // applies; otherwise it is dead space.
-    const auto sequenceActive = !m_sequenceFrames.empty();
+    const auto sequenceActive = m_sequenceController->hasSequence();
     const auto threeD = m_dataset != nullptr
         && m_dataset->metadata().dimension == 3;
     m_animationDock->setVisible(sequenceActive || threeD);
@@ -4225,160 +4301,12 @@ void MainWindow::updateAnimationDockVisibility()
 
 void MainWindow::stepSequence(int direction)
 {
-    if (m_sequenceFrames.empty()) {
-        return;
-    }
-    goToSequenceFrame(m_sequenceIndex + direction);
+    m_sequenceController->step(direction);
 }
 
 void MainWindow::goToSequenceFrame(int index)
 {
-    if (m_sequenceFrames.empty()) {
-        return;
-    }
-    const auto count = static_cast<int>(m_sequenceFrames.size());
-    // Both steps and playback wrap around the ends of the sequence.
-    index = ((index % count) + count) % count;
-    if (m_sequenceInFlight && index == m_sequenceIndex) {
-        return;
-    }
-    // Cancel the current dataset's in-flight work, exactly like opening a
-    // fresh dataset does, but keep the view state (field, level, range,
-    // log, palette, zoom, slice positions) for the next frame.
-    const std::array<PlaneViewState*, 4> states{
-        &m_view2d, &m_planeViews[0], &m_planeViews[1], &m_planeViews[2]};
-    for (auto* state : states) {
-        state->stopSource.request_stop();
-        ++state->sliceGeneration;
-    }
-    m_initialStopSource.request_stop();
-    m_linePlotStopSource.request_stop();
-    m_pendingAllViews = false;
-    m_pendingViews.clear();
-    m_sliceDebounce->stop();
-    // The dataset window shows the previous frame's raw values; drop it.
-    closeDatasetWindow();
-    // Line plot curves are snapshots of this dataset; drop the window so its
-    // title and curves do not go stale across the frame switch.
-    auto* linePlotWindow = m_linePlotWindow;
-    m_linePlotWindow = nullptr;
-    if (linePlotWindow != nullptr) {
-        linePlotWindow->close();
-    }
-    const auto generation = ++m_generation;
-    m_sequenceIndex = index;
-    m_sequenceInFlight = true;
-    m_frameTimer.start();
-    m_datasetPath = m_sequenceFrames[static_cast<std::size_t>(index)];
-    m_animationPanel->setSequenceFrame(index);
-
-    // A still-valid prefetch of this frame is consumed instead of loading
-    // again; anything else in the slot is cancelled and dropped.
-    if (m_prefetched && m_prefetched->frameIndex == index
-        && m_prefetched->specGeneration == m_specGeneration) {
-        auto prefetched = std::move(*m_prefetched);
-        m_prefetched.reset();
-        discardPrefetch();
-        finishFrameLoad(std::move(prefetched.result), prefetched.defaultPositions);
-        return;
-    }
-    discardPrefetch();
-    startFrameLoad(index, generation);
-}
-
-void MainWindow::startFrameLoad(int index, std::uint64_t generation)
-{
-    auto spec = buildFrameSpec();
-    const auto defaultPositions = spec.defaultPositions;
-    const auto path = m_sequenceFrames[static_cast<std::size_t>(index)];
-    const auto datasetId = DatasetId{
-        sequenceDatasetIdBase + ++m_sequenceDatasetCounter};
-    m_initialStopSource = StopSource{};
-    const auto cancellation = m_initialStopSource.get_token();
-    ++m_activeRequests;
-    statusBar()->showMessage(tr("Loading frame %1...").arg(
-        QString::fromStdString(path.filename().string())));
-    updateDiagnostics();
-
-    auto* watcher = new QFutureWatcher<InitialSliceResult>(this);
-    connect(watcher, &QFutureWatcher<InitialSliceResult>::finished, this,
-        [this, watcher, generation, index, defaultPositions] {
-            --m_activeRequests;
-            if (m_closing) {
-                watcher->deleteLater();
-                return;
-            }
-            try {
-                auto result = watcher->result();
-                if (generation == m_generation && index == m_sequenceIndex) {
-                    finishFrameLoad(std::move(result), defaultPositions);
-                } else {
-                    ++m_staleResults;
-                }
-            } catch (const std::exception& error) {
-                if (generation == m_generation && index == m_sequenceIndex) {
-                    m_sequenceInFlight = false;
-                    statusBar()->showMessage(tr("Frame load failed"));
-                    // During animation export the failure is reported by the
-                    // export handler (endExportAnimation); avoid a second dialog.
-                    const bool wasExporting = m_animationExporter->active();
-                    emit sequenceFrameFailed();
-                    if (!wasExporting) {
-                        reportBackgroundError(
-                            tr("Cannot load frame: %1").arg(exceptionMessage(error)));
-                    }
-                } else {
-                    ++m_staleResults;
-                }
-            }
-            updateDiagnostics();
-            watcher->deleteLater();
-        });
-    watcher->setFuture(QtConcurrent::run(
-        [path, datasetId, spec = std::move(spec), cancellation] {
-        return executeFrameLoad(path, datasetId, spec, initialCacheBudget(),
-            cancellation);
-    }));
-}
-
-void MainWindow::finishFrameLoad(InitialSliceResult result, bool defaultPositions)
-{
-    try {
-        displayFrameResult(result, defaultPositions);
-    } catch (const std::exception& error) {
-        m_sequenceInFlight = false;
-        statusBar()->showMessage(tr("Frame load failed"));
-        // During animation export the failure is reported by the export
-        // handler (endExportAnimation); avoid a second dialog.
-        const bool wasExporting = m_animationExporter->active();
-        emit sequenceFrameFailed();
-        if (!wasExporting) {
-            reportBackgroundError(
-                tr("Cannot load frame: %1").arg(exceptionMessage(error)));
-        }
-        updateDiagnostics();
-        return;
-    }
-    m_sequenceInFlight = false;
-    m_lastFrameSwitchMs = m_frameTimer.elapsed();
-    m_animationPanel->setSequenceFrame(m_sequenceIndex);
-    m_animationPanel->setSequenceInfo(
-        QString::fromStdString(m_datasetPath.filename().string()),
-        m_openMetadata->time);
-    updateDiagnostics();
-    emit sequenceFrameDisplayed(m_sequenceIndex);
-    // Bounded low-priority prefetch of the next frame: queued behind the
-    // display update, and re-validated when it runs so a frame jump in the
-    // meantime does not start obsolete I/O.
-    const auto displayedIndex = m_sequenceIndex;
-    QTimer::singleShot(0, this, [this, displayedIndex] {
-        if (m_sequenceFrames.empty() || m_sequenceInFlight
-            || m_sequenceIndex != displayedIndex) {
-            return;
-        }
-        const auto count = static_cast<int>(m_sequenceFrames.size());
-        startPrefetch((displayedIndex + 1) % count);
-    });
+    m_sequenceController->goToFrame(index);
 }
 
 void MainWindow::displayFrameResult(InitialSliceResult& result,
@@ -4637,60 +4565,6 @@ FrameSliceSpec MainWindow::buildFrameSpec()
     return spec;
 }
 
-void MainWindow::startPrefetch(int frameIndex)
-{
-    // Single bounded slot: cancel and drop whatever prefetch came before.
-    discardPrefetch();
-    auto spec = buildFrameSpec();
-    const auto defaultPositions = spec.defaultPositions;
-    const auto specGeneration = m_specGeneration;
-    const auto generation = m_prefetchGeneration;
-    const auto path = m_sequenceFrames[static_cast<std::size_t>(frameIndex)];
-    const auto datasetId = DatasetId{
-        sequenceDatasetIdBase + ++m_sequenceDatasetCounter};
-    m_prefetchStopSource = StopSource{};
-    const auto cancellation = m_prefetchStopSource.get_token();
-    ++m_activeRequests;
-    updateDiagnostics();
-
-    auto* watcher = new QFutureWatcher<InitialSliceResult>(this);
-    connect(watcher, &QFutureWatcher<InitialSliceResult>::finished, this,
-        [this, watcher, generation, frameIndex, specGeneration,
-            defaultPositions] {
-            --m_activeRequests;
-            try {
-                auto result = watcher->result();
-                if (generation == m_prefetchGeneration
-                    && !m_sequenceFrames.empty()) {
-                    m_prefetched = PrefetchedFrame{frameIndex, specGeneration,
-                        defaultPositions, std::move(result)};
-                } else {
-                    ++m_staleResults;
-                }
-            } catch (const std::exception&) {
-                // Prefetch failures stay silent: reaching the frame loads it
-                // through the normal path and reports any error then.
-                if (generation != m_prefetchGeneration) {
-                    ++m_staleResults;
-                }
-            }
-            updateDiagnostics();
-            watcher->deleteLater();
-        });
-    watcher->setFuture(QtConcurrent::run(
-        [path, datasetId, spec = std::move(spec), cancellation] {
-        return executeFrameLoad(path, datasetId, spec, initialCacheBudget(),
-            cancellation);
-    }));
-}
-
-void MainWindow::discardPrefetch()
-{
-    m_prefetchStopSource.request_stop();
-    ++m_prefetchGeneration;
-    m_prefetched.reset();
-}
-
 void MainWindow::stepSweep(int direction)
 {
     if (!m_dataset || m_dataset->metadata().dimension != 3) {
@@ -4727,7 +4601,7 @@ void MainWindow::toggleSequencePlayback()
         setPlaybackMode(PlaybackMode::None);
         return;
     }
-    if (m_sequenceFrames.size() < 2) {
+    if (m_sequenceController->frameCount() < 2) {
         return;
     }
     setPlaybackMode(PlaybackMode::Sequence);
@@ -4765,15 +4639,15 @@ void MainWindow::playbackTick()
         return;
     }
     if (m_playbackMode == PlaybackMode::Sequence) {
-        if (m_sequenceFrames.size() < 2) {
+        if (m_sequenceController->frameCount() < 2) {
             setPlaybackMode(PlaybackMode::None);
             return;
         }
         // Skip the tick while the previous frame is still loading.
-        if (m_sequenceInFlight) {
+        if (m_sequenceController->inFlight()) {
             return;
         }
-        goToSequenceFrame(m_sequenceIndex + 1);
+        m_sequenceController->step(1);
     }
 }
 
@@ -4821,7 +4695,7 @@ void MainWindow::updateDiagnostics()
             .arg(m_cacheResidentBytes)
             .arg(m_cachePinnedBytes)
             .arg(m_cacheEvictions)
-            .arg(m_lastFrameSwitchMs);
+            .arg(m_sequenceController->lastFrameSwitchMs());
     for (const auto& line : m_probeLines) {
         text += QLatin1Char('\n');
         text += line;

--- a/src/qt/MainWindow.hpp
+++ b/src/qt/MainWindow.hpp
@@ -71,6 +71,7 @@ class ImageView;
 class IsoWidget;
 class LinePlotWindow;
 class ScientificDoubleSpinBox;
+class SequenceController;
 class UserGuideDialog;
 
 // These now live in the Qt-free pipeline layer (SlicePipeline.hpp); re-export
@@ -240,15 +241,6 @@ private:
         int pendingRequests = 0;
     };
 
-    // One prefetched sequence frame: the dataset plus its rendered slice(s),
-    // consumable only while the slice spec that produced it is unchanged.
-    struct PrefetchedFrame {
-        int frameIndex = -1;
-        std::uint64_t specGeneration = 0;
-        bool defaultPositions = false;
-        InitialSliceResult result;
-    };
-
     void chooseDataset();
     void chooseStandaloneDataset(const QString& caption, bool rawFab);
     void openDatasetImpl(const std::filesystem::path& path, bool metadataOnly,
@@ -409,16 +401,11 @@ private:
     void playbackTick();
     void applySpeed();
 
-    // Sequence frame switching. At most one sync frame load and one
-    // prefetch are alive; everything superseded is cancelled via stop
-    // sources and discarded via generation counters.
-    void startFrameLoad(int index, std::uint64_t generation);
-    void finishFrameLoad(InitialSliceResult result, bool defaultPositions);
+    // Sequence frame switching lives in the SequenceController; this window
+    // supplies the GUI-coupled pieces below as its hooks.
     void displayFrameResult(InitialSliceResult& result, bool defaultPositions);
     void configureSequenceControls(bool defaultPositions);
     [[nodiscard]] FrameSliceSpec buildFrameSpec();
-    void startPrefetch(int frameIndex);
-    void discardPrefetch();
     // Stop timers, request stop on every async task this window can launch,
     // and clear queued thread-pool work. Wired to aboutToQuit so the process
     // exits promptly instead of blocking QThreadPool teardown on an in-flight
@@ -551,24 +538,13 @@ private:
     std::uint64_t m_cachePinnedBytes = 0;
     std::uint64_t m_cacheEvictions = 0;
 
-    // Animation state.
+    // Animation state. The sequence frames/index/in-flight/prefetch state
+    // machine lives in the SequenceController; this window keeps only the
+    // playback timer and mode.
     AnimationPanel* m_animationPanel = nullptr;
     QTimer* m_playbackTimer = nullptr;
     PlaybackMode m_playbackMode = PlaybackMode::None;
-    std::vector<std::filesystem::path> m_sequenceFrames;
-    int m_sequenceIndex = -1;
-    bool m_sequenceInFlight = false;
-    // Bumped by every slice-affecting UI change; prefetched frames store the
-    // value they were built against and are discarded once it moves on.
-    std::uint64_t m_specGeneration = 0;
-    // Bumped whenever the prefetch slot is cancelled/invalidated, so a late
-    // prefetch watcher knows to drop its result.
-    std::uint64_t m_prefetchGeneration = 0;
-    std::uint64_t m_sequenceDatasetCounter = 0;
-    StopSource m_prefetchStopSource;
-    std::optional<PrefetchedFrame> m_prefetched;
-    QElapsedTimer m_frameTimer;
-    qint64 m_lastFrameSwitchMs = 0;
+    SequenceController* m_sequenceController = nullptr;
 };
 
 } // namespace amrvis::qt

--- a/src/qt/SequenceController.cpp
+++ b/src/qt/SequenceController.cpp
@@ -1,0 +1,221 @@
+#include "SequenceController.hpp"
+
+#include "CacheConfig.hpp"
+
+#include <QFutureWatcher>
+#include <QTimer>
+#include <QtConcurrent>
+
+#include <utility>
+
+namespace amrvis::qt {
+
+namespace {
+
+// Sequence frames get synthetic dataset ids well above interactive ones so a
+// stale cross-dataset cache entry can never alias a frame's blocks.
+constexpr std::uint64_t sequenceDatasetIdBase = 0x4000000000000000ULL;
+
+} // namespace
+
+SequenceController::SequenceController(Hooks hooks, QObject* parent)
+    : QObject(parent)
+    , m_hooks(std::move(hooks))
+{
+}
+
+void SequenceController::open(std::vector<std::filesystem::path> frames)
+{
+    m_frames = std::move(frames);
+    goToFrame(0);
+}
+
+void SequenceController::close()
+{
+    discardPrefetch();
+    m_loadStopSource.request_stop();
+    ++m_loadGeneration;
+    m_frames.clear();
+    m_index = -1;
+    m_inFlight = false;
+}
+
+void SequenceController::step(int direction)
+{
+    if (m_frames.empty()) {
+        return;
+    }
+    goToFrame(m_index + direction);
+}
+
+void SequenceController::goToFrame(int index)
+{
+    if (m_frames.empty()) {
+        return;
+    }
+    const auto count = static_cast<int>(m_frames.size());
+    // Both steps and playback wrap around the ends of the sequence.
+    index = ((index % count) + count) % count;
+    if (m_inFlight && index == m_index) {
+        return;
+    }
+    // The host cancels the previous frame's in-flight work and closes its
+    // per-dataset windows (synchronously — direct connection).
+    emit frameSwitchStarted(index);
+
+    const auto generation = ++m_loadGeneration;
+    m_index = index;
+    m_inFlight = true;
+    m_frameTimer.start();
+
+    // A still-valid prefetch of this frame is consumed instead of loading
+    // again; anything else in the slot is cancelled and dropped.
+    if (m_prefetched && m_prefetched->frameIndex == index
+        && m_prefetched->specGeneration == m_specGeneration) {
+        auto prefetched = std::move(*m_prefetched);
+        m_prefetched.reset();
+        discardPrefetch();
+        finishLoad(std::move(prefetched.result), prefetched.defaultPositions);
+        return;
+    }
+    discardPrefetch();
+    startLoad(index, generation);
+}
+
+void SequenceController::invalidatePrefetch()
+{
+    ++m_specGeneration;
+    discardPrefetch();
+}
+
+void SequenceController::cancelActiveWork()
+{
+    m_loadStopSource.request_stop();
+    m_prefetchStopSource.request_stop();
+}
+
+void SequenceController::startLoad(int index, std::uint64_t generation)
+{
+    auto spec = m_hooks.buildSpec();
+    const auto defaultPositions = spec.defaultPositions;
+    const auto path = m_frames[static_cast<std::size_t>(index)];
+    const auto datasetId = DatasetId{
+        sequenceDatasetIdBase + ++m_datasetCounter};
+    m_loadStopSource = StopSource{};
+    const auto cancellation = m_loadStopSource.get_token();
+    emit loadActivityChanged(+1);
+    emit statusMessage(tr("Loading frame %1...").arg(
+        QString::fromStdString(path.filename().string())));
+
+    auto* watcher = new QFutureWatcher<InitialSliceResult>(this);
+    connect(watcher, &QFutureWatcher<InitialSliceResult>::finished, this,
+        [this, watcher, generation, index, defaultPositions] {
+            emit loadActivityChanged(-1);
+            if (m_hooks.isShuttingDown()) {
+                watcher->deleteLater();
+                return;
+            }
+            try {
+                auto result = watcher->result();
+                if (generation == m_loadGeneration && index == m_index) {
+                    finishLoad(std::move(result), defaultPositions);
+                } else {
+                    emit staleResultDropped();
+                }
+            } catch (const std::exception& error) {
+                if (generation == m_loadGeneration && index == m_index) {
+                    m_inFlight = false;
+                    emit frameLoadFailed(
+                        QString::fromUtf8(error.what()));
+                } else {
+                    emit staleResultDropped();
+                }
+            }
+            watcher->deleteLater();
+        });
+    watcher->setFuture(QtConcurrent::run(
+        [path, datasetId, spec = std::move(spec), cancellation] {
+        return executeFrameLoad(path, datasetId, spec, initialCacheBudget(),
+            cancellation);
+    }));
+}
+
+void SequenceController::finishLoad(
+    InitialSliceResult result, bool defaultPositions)
+{
+    try {
+        m_hooks.displayFrame(result, defaultPositions);
+    } catch (const std::exception& error) {
+        m_inFlight = false;
+        emit frameLoadFailed(QString::fromUtf8(error.what()));
+        return;
+    }
+    m_inFlight = false;
+    m_lastFrameSwitchMs = m_frameTimer.elapsed();
+    emit frameDisplayed(m_index);
+    // Bounded low-priority prefetch of the next frame: queued behind the
+    // display update, and re-validated when it runs so a frame jump in the
+    // meantime does not start obsolete I/O.
+    const auto displayedIndex = m_index;
+    QTimer::singleShot(0, this, [this, displayedIndex] {
+        if (m_frames.empty() || m_inFlight || m_index != displayedIndex) {
+            return;
+        }
+        const auto count = static_cast<int>(m_frames.size());
+        startPrefetch((displayedIndex + 1) % count);
+    });
+}
+
+void SequenceController::startPrefetch(int frameIndex)
+{
+    // Single bounded slot: cancel and drop whatever prefetch came before.
+    discardPrefetch();
+    auto spec = m_hooks.buildSpec();
+    const auto defaultPositions = spec.defaultPositions;
+    const auto specGeneration = m_specGeneration;
+    const auto generation = m_prefetchGeneration;
+    const auto path = m_frames[static_cast<std::size_t>(frameIndex)];
+    const auto datasetId = DatasetId{
+        sequenceDatasetIdBase + ++m_datasetCounter};
+    m_prefetchStopSource = StopSource{};
+    const auto cancellation = m_prefetchStopSource.get_token();
+    emit loadActivityChanged(+1);
+
+    auto* watcher = new QFutureWatcher<InitialSliceResult>(this);
+    connect(watcher, &QFutureWatcher<InitialSliceResult>::finished, this,
+        [this, watcher, generation, frameIndex, specGeneration,
+            defaultPositions] {
+            emit loadActivityChanged(-1);
+            try {
+                auto result = watcher->result();
+                if (generation == m_prefetchGeneration && !m_frames.empty()) {
+                    m_prefetched = PrefetchedFrame{frameIndex, specGeneration,
+                        defaultPositions, std::move(result)};
+                } else {
+                    emit staleResultDropped();
+                }
+            } catch (const std::exception&) {
+                // Prefetch failures stay silent: reaching the frame loads it
+                // through the normal path and reports any error then. A
+                // superseded failure still counts as a stale drop.
+                if (generation != m_prefetchGeneration) {
+                    emit staleResultDropped();
+                }
+            }
+            watcher->deleteLater();
+        });
+    watcher->setFuture(QtConcurrent::run(
+        [path, datasetId, spec = std::move(spec), cancellation] {
+        return executeFrameLoad(path, datasetId, spec, initialCacheBudget(),
+            cancellation);
+    }));
+}
+
+void SequenceController::discardPrefetch()
+{
+    m_prefetchStopSource.request_stop();
+    ++m_prefetchGeneration;
+    m_prefetched.reset();
+}
+
+} // namespace amrvis::qt

--- a/src/qt/SequenceController.hpp
+++ b/src/qt/SequenceController.hpp
@@ -1,0 +1,133 @@
+#pragma once
+
+#include <amrexplorer/core/StopToken.hpp>
+#include <amrexplorer/pipeline/SlicePipeline.hpp>
+
+#include <QObject>
+#include <QElapsedTimer>
+#include <QString>
+
+#include <cstdint>
+#include <filesystem>
+#include <functional>
+#include <optional>
+#include <vector>
+
+namespace amrvis::qt {
+
+// The plotfile-sequence state machine extracted from MainWindow: owns the
+// frame list, the current index, the in-flight flag, the single-slot
+// prefetch with its spec/stop generations, the per-sequence dataset-id
+// counter, and the frame-switch timing. It runs the frame-load and prefetch
+// workers (executeFrameLoad on the global pool) and their watchers; the host
+// window supplies the GUI-coupled pieces through Hooks, reacts to the
+// signals below, and keeps its public openSequence/stepSequence surface as
+// thin wrappers over this controller.
+class SequenceController final : public QObject {
+    Q_OBJECT
+
+public:
+    struct Hooks {
+        // Snapshot of the current UI state for a frame load (the host's
+        // buildFrameSpec).
+        std::function<FrameSliceSpec()> buildSpec;
+        // Displays a loaded frame in the views; throws to report a failure
+        // (the host's displayFrameResult).
+        std::function<void(InitialSliceResult&, bool defaultPositions)>
+            displayFrame;
+        // True once application shutdown began; late watcher results are
+        // dropped without touching the GUI.
+        std::function<bool()> isShuttingDown;
+    };
+
+    SequenceController(Hooks hooks, QObject* parent = nullptr);
+
+    // Takes ownership of a validated, sorted, deduplicated frame list and
+    // navigates to frame 0. The host performs validation and its own UI
+    // setup before calling.
+    void open(std::vector<std::filesystem::path> frames);
+    // Drops the sequence and cancels the in-flight load and prefetch. The
+    // host hides its sequence UI itself.
+    void close();
+    void step(int direction);
+    void goToFrame(int index);
+
+    // A slice-affecting UI change invalidates any prefetched frame rendered
+    // against the old spec.
+    void invalidatePrefetch();
+    // Application shutdown: cooperative stop for the load/prefetch workers.
+    void cancelActiveWork();
+
+    [[nodiscard]] bool hasSequence() const noexcept
+    {
+        return !m_frames.empty();
+    }
+    [[nodiscard]] int frameCount() const noexcept
+    {
+        return static_cast<int>(m_frames.size());
+    }
+    [[nodiscard]] int currentIndex() const noexcept { return m_index; }
+    [[nodiscard]] bool inFlight() const noexcept { return m_inFlight; }
+    [[nodiscard]] qint64 lastFrameSwitchMs() const noexcept
+    {
+        return m_lastFrameSwitchMs;
+    }
+    [[nodiscard]] const std::filesystem::path& framePath(int index) const
+    {
+        return m_frames[static_cast<std::size_t>(index)];
+    }
+
+signals:
+    // Emitted synchronously at the start of every frame switch, before the
+    // load begins: the host cancels the previous frame's in-flight work and
+    // closes per-dataset windows, exactly like opening a fresh dataset, but
+    // keeps the view state for the next frame.
+    void frameSwitchStarted(int index);
+    // Background-load bookkeeping for the host's diagnostics (+1 when a
+    // load or prefetch worker starts, -1 when its watcher fires).
+    void loadActivityChanged(int delta);
+    void statusMessage(const QString& message);
+    // A frame is on screen (displayFrame returned): the host updates its
+    // panel/diagnostics and forwards its public sequenceFrameDisplayed.
+    void frameDisplayed(int index);
+    // Loading or displaying the current frame failed; the host reports it
+    // (suppressing its own dialog while an export is active) and forwards
+    // its public sequenceFrameFailed.
+    void frameLoadFailed(const QString& message);
+    // A load or prefetch result arrived after being superseded and was
+    // dropped; the host counts these in its diagnostics.
+    void staleResultDropped();
+
+private:
+    // One prefetched sequence frame: the dataset plus its rendered slice(s),
+    // consumable only while the slice spec that produced it is unchanged.
+    struct PrefetchedFrame {
+        int frameIndex = -1;
+        std::uint64_t specGeneration = 0;
+        bool defaultPositions = false;
+        InitialSliceResult result;
+    };
+
+    void startLoad(int index, std::uint64_t generation);
+    void finishLoad(InitialSliceResult result, bool defaultPositions);
+    void startPrefetch(int frameIndex);
+    void discardPrefetch();
+
+    Hooks m_hooks;
+    std::vector<std::filesystem::path> m_frames;
+    int m_index = -1;
+    bool m_inFlight = false;
+    // Invalidates in-flight loads across frame switches and close(); the
+    // watcher also re-checks the index so a stale result never displays.
+    std::uint64_t m_loadGeneration = 0;
+    std::uint64_t m_specGeneration = 0;
+    std::uint64_t m_prefetchGeneration = 0;
+    std::uint64_t m_datasetCounter = 0;
+    std::optional<PrefetchedFrame> m_prefetched;
+    StopSource m_loadStopSource;
+    StopSource m_prefetchStopSource;
+    QElapsedTimer m_frameTimer;
+    qint64 m_lastFrameSwitchMs = 0;
+};
+
+} // namespace amrvis::qt


### PR DESCRIPTION
Step 5b, completing the MainWindow extraction plan. The controller owns the frame list, index, in-flight flag, single-slot prefetch with its spec/stop generations, dataset-id counter, and frame timing, and runs the load and prefetch workers and watchers, with staleness guarded by an internal load generation. MainWindow supplies buildFrameSpec, displayFrameResult, and the shutdown flag as hooks; reacts to frameSwitchStarted (its cancel-and-close cleanup), load activity, status, displayed/failed, and stale-drop signals; and keeps its public sequence methods as thin wrappers so the smoke-test and exporter APIs are unchanged. The quit path routes through cancelActiveWork.

No behavior change; full suite green including the sequence, range-cache, export-quit, and quit smokes.