### PR TITLE
Add a clang preset mirroring the CI clang job

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -20,6 +20,17 @@
       }
     },
     {
+      "name": "clang",
+      "inherits": "default",
+      "displayName": "Release build with Clang (pre-merge check)",
+      "binaryDir": "${sourceDir}/build-clang",
+      "cacheVariables": {
+        "CMAKE_C_COMPILER": "clang",
+        "CMAKE_CXX_COMPILER": "clang++",
+        "AMREXPLORER_WARNINGS_AS_ERRORS": "ON"
+      }
+    },
+    {
       "name": "debug",
       "displayName": "Debug build",
       "generator": "Ninja",
@@ -57,6 +68,10 @@
       "configurePreset": "default"
     },
     {
+      "name": "clang",
+      "configurePreset": "clang"
+    },
+    {
       "name": "debug",
       "configurePreset": "debug"
     },
@@ -73,6 +88,13 @@
     {
       "name": "default",
       "configurePreset": "default",
+      "output": {
+        "outputOnFailure": true
+      }
+    },
+    {
+      "name": "clang",
+      "configurePreset": "clang",
       "output": {
         "outputOnFailure": true
       }

--- a/docs/building.md
+++ b/docs/building.md
@@ -12,6 +12,10 @@ cmake --preset default     # Release build → build/
 cmake --build --preset default
 ctest --preset default
 
+cmake --preset clang       # Release with Clang, warnings as errors → build-clang/
+cmake --build --preset clang
+ctest --preset clang
+
 cmake --preset debug       # Debug build → build-debug/
 cmake --build --preset debug
 ctest --preset debug
@@ -26,6 +30,11 @@ ctest --preset sanitizers
 ```
 
 The sanitizer preset enables AddressSanitizer and UndefinedBehaviorSanitizer.
+
+The clang preset mirrors the CI clang job (which builds with
+`-DAMREXPLORER_WARNINGS_AS_ERRORS=ON`): run it before pushing to catch
+Clang-only diagnostics that a GCC build stays silent about, such as
+`-Wunused-const-variable`.
 
 On macOS, Qt builds produce `build/src/qt/amrexplorer.app` by default. The bundle
 contains its executable at `Contents/MacOS/amrexplorer` and can be installed into a


### PR DESCRIPTION
CI builds a gcc+clang matrix with warnings as errors, but nothing reproduced the clang leg locally, so a green GCC run could still fail CI on clang-only diagnostics like -Wunused-const-variable. The clang preset builds into build-clang/ with warnings as errors for use as a pre-push check; the default build is unchanged and does not require clang.