### PR TITLE
Make validateMetadata total over malformed input

### DIFF
--- a/src/core/Metadata.cpp
+++ b/src/core/Metadata.cpp
@@ -121,6 +121,18 @@ std::vector<MetadataIssue> validateMetadata(const DatasetMetadata& metadata)
         }
     }
 
+    // The per-axis checks below index the fixed-size (3-element) geometry
+    // arrays with metadata.dimension. A malformed dimension is exactly the
+    // input this validator exists to catch, so it must not drive those reads
+    // out of bounds: clamp the axis count to the array bounds. An
+    // out-of-range dimension is already reported above; when it is invalid we
+    // skip the per-axis geometry checks entirely (they have no meaningful
+    // "active direction" to check) rather than emit a cascade of derived
+    // issues.
+    const int axisCount = metadata.dimension >= 1 && metadata.dimension <= 3
+        ? metadata.dimension
+        : 0;
+
     for (std::size_t levelIndex = 0; levelIndex < metadata.levels.size(); ++levelIndex) {
         const auto& level = metadata.levels[levelIndex];
         const auto path = "levels[" + std::to_string(levelIndex) + "]";
@@ -130,7 +142,7 @@ std::vector<MetadataIssue> validateMetadata(const DatasetMetadata& metadata)
         if (!level.domain.valid(metadata.dimension)) {
             add(path + ".domain", "must be a valid index-space box");
         }
-        for (int axis = 0; axis < metadata.dimension; ++axis) {
+        for (int axis = 0; axis < axisCount; ++axis) {
             const auto i = static_cast<std::size_t>(axis);
             if (level.domain.centering[i] != 0
                 && level.domain.centering[i] != 1) {
@@ -161,7 +173,7 @@ std::vector<MetadataIssue> validateMetadata(const DatasetMetadata& metadata)
                 add(boxPath, "must be a valid index-space box");
                 continue;
             }
-            for (int axis = 0; axis < metadata.dimension; ++axis) {
+            for (int axis = 0; axis < axisCount; ++axis) {
                 const auto i = static_cast<std::size_t>(axis);
                 if (box.lower[i] < level.domain.lower[i]
                     || box.upper[i] > level.domain.upper[i]) {
@@ -180,7 +192,11 @@ std::vector<MetadataIssue> validateMetadata(const DatasetMetadata& metadata)
         for (std::size_t blockIndex = 0; blockIndex < level.blocks.size(); ++blockIndex) {
             const auto& block = level.blocks[blockIndex];
             const auto blockPath = path + ".blocks[" + std::to_string(blockIndex) + "]";
-            if (!(block.box == level.boxes[blockIndex])) {
+            // Guard against a blocks/boxes size mismatch (already reported
+            // above): a block with no corresponding box cannot be compared,
+            // and indexing past level.boxes would be undefined behavior.
+            if (blockIndex < level.boxes.size()
+                && !(block.box == level.boxes[blockIndex])) {
                 add(blockPath + ".box", "must match the corresponding level box");
             }
             if (block.filePath.empty()) {

--- a/tests/unit/test_core_metadata.cpp
+++ b/tests/unit/test_core_metadata.cpp
@@ -16,6 +16,17 @@ void require(bool condition, const char* message)
     }
 }
 
+bool hasIssue(const std::vector<amrvis::MetadataIssue>& issues,
+    const char* pathPrefix)
+{
+    for (const auto& issue : issues) {
+        if (issue.path.rfind(pathPrefix, 0) == 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
 } // namespace
 
 int main()
@@ -93,6 +104,53 @@ int main()
     slice.visibleRegion = {{{0.0, 0.0, 0.0}}, {{1.0, 1.0, 0.0}}};
     slice.outputSize = {640, 480};
     require(amrvis::validateSliceRequest(slice, 2).empty(), "valid slice request was rejected");
+
+    // Negative path: a dimension outside [1,3] must be reported without the
+    // per-axis geometry checks reading past the fixed-size (3-element)
+    // arrays. Pre-fix this loops axis up to dimension-1 over Int3/Real3 and
+    // reads out of bounds; running it to completion (especially under the
+    // sanitizer build) is the real regression assertion.
+    {
+        amrvis::DatasetMetadata bad;
+        bad.dimension = 5;
+        bad.finestLevel = 0;
+        bad.physicalDomain = {{{0.0, 0.0, 0.0}}, {{1.0, 1.0, 1.0}}};
+        bad.fields.push_back({"phi", 1, amrvis::Centering::Cell, {"phi"}});
+        amrvis::LevelMetadata badLevel;
+        badLevel.domain = {{{0, 0, 0}}, {{3, 3, 3}}, {{0, 0, 0}}};
+        badLevel.cellSize = {{0.25, 0.25, 0.25}};
+        badLevel.storedComponents = 1;
+        badLevel.boxes.push_back(badLevel.domain);
+        badLevel.blocks.push_back({badLevel.domain, "Cell_D_00000", 0,
+            amrvis::BlockStatistics{{0.0}, {1.0}}});
+        bad.levels.push_back(std::move(badLevel));
+        require(hasIssue(amrvis::validateMetadata(bad), "dimension"),
+            "an out-of-range dimension was not reported");
+    }
+
+    // Negative path: more blocks than boxes must be reported without indexing
+    // past the level box array. Pre-fix the block loop reads level.boxes[1]
+    // when there is only one box.
+    {
+        amrvis::DatasetMetadata bad;
+        bad.dimension = 2;
+        bad.finestLevel = 0;
+        bad.physicalDomain = {{{0.0, 0.0, 0.0}}, {{1.0, 1.0, 0.0}}};
+        bad.fields.push_back({"phi", 1, amrvis::Centering::Cell, {"phi"}});
+        amrvis::LevelMetadata badLevel;
+        badLevel.domain = {{{0, 0, 0}}, {{3, 3, 0}}, {{0, 0, 0}}};
+        badLevel.cellSize = {{0.25, 0.25, 1.0}};
+        badLevel.storedComponents = 1;
+        badLevel.boxes.push_back(badLevel.domain);
+        badLevel.blocks.push_back({badLevel.domain, "Cell_D_00000", 0,
+            amrvis::BlockStatistics{{0.0}, {1.0}}});
+        // One more block than boxes: blockIndex 1 has no boxes[1].
+        badLevel.blocks.push_back({badLevel.domain, "Cell_D_00001", 4096,
+            amrvis::BlockStatistics{{0.0}, {1.0}}});
+        bad.levels.push_back(std::move(badLevel));
+        require(hasIssue(amrvis::validateMetadata(bad), "levels[0].blocks"),
+            "a blocks/boxes size mismatch was not reported");
+    }
 
     return 0;
 }


### PR DESCRIPTION
The validator recorded an out-of-range dimension and a blocks/boxes size mismatch but kept going, then read past the fixed-size (3-element) geometry arrays (dimension > 3) and past the level box array (more blocks than boxes) — undefined behavior on exactly the malformed input it exists to report.

Clamp the per-axis loops to an axis count of 0 when the dimension is outside [1,3], and guard the block/box comparison with blockIndex < boxes.size(). Both mismatches are still reported. Add negative-path tests; each reaches the pre-fix OOB, verified by reverting the fix under the sanitizer build where the buggy code aborts on the array bounds assertion.