### PR TITLE
Remove the production-dead contour-supersampling path

### DIFF
--- a/include/amrexplorer/render2d/Contours.hpp
+++ b/include/amrexplorer/render2d/Contours.hpp
@@ -28,31 +28,6 @@ struct ContourPolyline {
 [[nodiscard]] std::vector<double> contourValues(
     double minimum, double maximum, int count, bool logarithmic = false);
 
-// Refines a scalar plane by bilinear interpolation so contour extraction on
-// the result produces genuinely smooth iso-lines instead of cell-scale
-// staircases. The fine grid has dimensions ((width - 1) * factor + 1) x
-// ((height - 1) * factor + 1), so fine sample (i * factor + k, j * factor + l)
-// sits at continuous coordinate (i + k / factor, j + l / factor) and every
-// original sample lands exactly on a fine sample. physicalRegion is copied
-// unchanged; sourceLevel holds the nearest original sample's level (left
-// empty when the input plane has no per-sample levels).
-//
-// A fine sample takes the bilinear interpolation of the four surrounding
-// original samples when all four are valid (valid != 0) and finite; otherwise
-// it copies the value and validity of the nearest original sample. The
-// nearest-sample fallback preserves plateaus and keeps NaN and invalid
-// samples from bleeding across mask boundaries: a fine sample is valid if and
-// only if its nearest original sample is valid and finite. Non-finite
-// original samples count as invalid for this purpose and are never
-// propagated; a fine sample that would copy a non-finite value is marked
-// invalid and stores 0 instead.
-//
-// Throws std::invalid_argument when factor < 1. factor == 1 returns a copy
-// of the plane. With factor > 1, throws std::invalid_argument when width or
-// height is less than 1 or when the plane storage does not match its
-// dimensions.
-[[nodiscard]] ScalarPlane supersamplePlane(const ScalarPlane& plane, int factor);
-
 // Marching squares over the plane's corner samples. A cell is the quad formed
 // by samples (i, j), (i + 1, j), (i, j + 1), (i + 1, j + 1), so segment
 // coordinates are plane pixel coordinates (x = column, y = row) spanning
@@ -83,31 +58,15 @@ struct ContourPolyline {
 // bounding box. This smoothing is a visual enhancement beyond legacy Amrvis
 // behavior, which drew the raw segments. smoothIterations <= 0 returns the
 // chained but unsmoothed polylines.
-//
-// Supersampling: with supersampleFactor > 1 the plane is first refined with
-// supersamplePlane, segments are chained and smoothed on the fine grid, and
-// every output coordinate is finally scaled back by 1 / supersampleFactor, so
-// polylines are always returned in the original plane pixel space. This
-// removes the cell-scale staircase that Chaikin smoothing alone cannot fix.
-// Throws std::invalid_argument when supersampleFactor < 1.
 [[nodiscard]] std::vector<ContourPolyline> generateContourPolylines(
     const ScalarPlane& plane, const std::vector<double>& values,
-    int smoothIterations = 2, int supersampleFactor = 1);
+    int smoothIterations = 2);
 
-// Chooses the bilinear refinement factor for contour extraction on a
-// data-resolution plane: ceil(display samples per contour-plane sample / 2)
-// (the coarser axis wins), clamped to [1, 16], with a minimum fine-grid
-// target of 256 on the shorter axis, then reduced while the fine grid would
-// exceed 1024 samples on either axis. One fine cell then spans at most a
-// couple of display pixels, so marching squares on the refined plane
-// resolves the bilinear interpolant's iso-curve far below the visible scale.
-[[nodiscard]] int contourUpsampleFactor(
-    int contourWidth, int contourHeight, int displayWidth, int displayHeight);
-
-// Marching squares + chaining + one Chaikin corner-cutting pass on an already
-// refined plane (see supersamplePlane), with the output mapped from
-// fine-plane pixel space into display-plane pixel space. fineFactor is the
-// factor the plane was refined with, so fine coordinate f corresponds to
+// Marching squares + chaining + one Chaikin corner-cutting pass on a contour
+// plane, with the output mapped from contour-plane pixel space into
+// display-plane pixel space. fineFactor is the refinement factor the plane
+// was produced with (1 when the plane is already at contour resolution, which
+// is what the slice pipeline produces): fine coordinate f corresponds to
 // original sample coordinate f / fineFactor, and original sample center j
 // maps to display pixel ((j + 0.5) * display / original) - 0.5 (cell-center
 // to cell-center; display-plane sample i sits at scene coordinate i).

--- a/src/pipeline/SlicePipeline.cpp
+++ b/src/pipeline/SlicePipeline.cpp
@@ -233,22 +233,16 @@ SliceDisplayResult executeSliceWithFallback(
     }
 }
 
-// Contour overlays are extracted from a piecewise-constant slice at DATA
-// resolution: one sample per cell of the finest participating level covering
-// the visible region, capped at 1024 samples per axis (for coarse data this
-// plane is tiny — 4x4 on the test fixture). When the data is finer than the
-// display on both axes the display plane doubles as the contour plane,
-// because the cell-scale staircase is sub-pixel there. The contour plane is
-// then bilinearly refined so one fine cell spans at most a few display
-// pixels; marching squares on the refinement converges to the exact
-// iso-curve of the bilinear interpolant (no new extrema, no ringing), and a
-// single Chaikin pass finishes the polyline. This replaces the old second
-// SliceQuery with linear sampling at display resolution, which cost about as
-// much as the display query itself. Extraction runs on the slice worker,
-// with the output mapped to display-plane pixel space; the GUI thread only
-// converts the polylines to painter paths. The planes and the refinement are
-// cached by the GUI, so range and contour-count changes re-run only this
-// cheap extraction (see refreshCachedSlice).
+// Contour overlays are extracted from a dedicated linearly-sampled slice
+// queried at a resolution fine enough that the cell-scale staircase is
+// invisible: at least 512 samples on the shorter axis, capped at 1024 (see
+// contourRequest below). Because this plane already carries the smooth
+// interpolant, contour extraction runs on it directly with no further
+// refinement, and two Chaikin passes finish the polylines. Extraction runs
+// on the slice worker, with the output mapped to display-plane pixel space;
+// the GUI thread only converts the polylines to painter paths. The contour
+// plane is cached by the GUI, so range and contour-count changes re-run only
+// this cheap extraction (see refreshCachedSlice).
 void appendContours(const std::shared_ptr<PlotfileDataset>& dataset,
     const SliceRequest& request, int contourCount, double minimum, double maximum,
     bool logarithmic, StopToken cancellation, SliceDisplayResult& result)

--- a/src/render2d/Contours.cpp
+++ b/src/render2d/Contours.cpp
@@ -44,98 +44,6 @@ std::vector<double> contourValues(
     return values;
 }
 
-ScalarPlane supersamplePlane(const ScalarPlane& plane, int factor)
-{
-    if (factor < 1) {
-        throw std::invalid_argument("supersample factor must be at least 1");
-    }
-    if (factor == 1) {
-        return plane;
-    }
-    if (plane.width < 1 || plane.height < 1) {
-        throw std::invalid_argument("scalar plane dimensions must be positive");
-    }
-    const auto pixelCount = static_cast<std::size_t>(plane.width)
-        * static_cast<std::size_t>(plane.height);
-    if (plane.values.size() != pixelCount || plane.valid.size() != pixelCount) {
-        throw std::invalid_argument("scalar plane storage does not match its dimensions");
-    }
-
-    // Fine sample (i * factor + k, j * factor + l) sits at continuous
-    // coordinate (i + k / factor, j + l / factor), so original samples land
-    // exactly on the fine grid.
-    ScalarPlane fine;
-    fine.width = (plane.width - 1) * factor + 1;
-    fine.height = (plane.height - 1) * factor + 1;
-    fine.physicalRegion = plane.physicalRegion;
-    const auto fineCount = static_cast<std::size_t>(fine.width)
-        * static_cast<std::size_t>(fine.height);
-    fine.values.resize(fineCount);
-    fine.valid.resize(fineCount);
-    if (plane.sourceLevel.size() == pixelCount) {
-        fine.sourceLevel.resize(fineCount);
-    }
-
-    const auto width = static_cast<std::size_t>(plane.width);
-    const auto sampleAt = [&](int i, int j) {
-        return static_cast<std::size_t>(i) + static_cast<std::size_t>(j) * width;
-    };
-    const auto usable = [&](std::size_t index) {
-        return plane.valid[index] != 0 && std::isfinite(plane.values[index]);
-    };
-    // Nearest original sample to continuous coordinate (x, y), rounding
-    // halves up, clamped to the plane. Computed in integer arithmetic on the
-    // fine indices so the result is exact for every factor.
-    const auto nearest = [&](int fineIndex, int extent) {
-        const int base = fineIndex / factor;
-        const int rem = fineIndex % factor;
-        int index = base + (2 * rem >= factor ? 1 : 0);
-        return index < extent ? index : extent - 1;
-    };
-
-    for (int j = 0; j < fine.height; ++j) {
-        const int j0 = j / factor;
-        const int j1 = j0 + 1 < plane.height ? j0 + 1 : plane.height - 1;
-        const double ty = static_cast<double>(j % factor) / factor;
-        const int nj = nearest(j, plane.height);
-        for (int i = 0; i < fine.width; ++i) {
-            const int i0 = i / factor;
-            const int i1 = i0 + 1 < plane.width ? i0 + 1 : plane.width - 1;
-            const double tx = static_cast<double>(i % factor) / factor;
-            const auto fineIndex = static_cast<std::size_t>(i)
-                + static_cast<std::size_t>(j) * static_cast<std::size_t>(fine.width);
-
-            const auto bl = sampleAt(i0, j0);
-            const auto br = sampleAt(i1, j0);
-            const auto tl = sampleAt(i0, j1);
-            const auto tr = sampleAt(i1, j1);
-            if (usable(bl) && usable(br) && usable(tl) && usable(tr)) {
-                const double bottom = static_cast<double>(plane.values[bl])
-                    + tx * (static_cast<double>(plane.values[br])
-                        - static_cast<double>(plane.values[bl]));
-                const double top = static_cast<double>(plane.values[tl])
-                    + tx * (static_cast<double>(plane.values[tr])
-                        - static_cast<double>(plane.values[tl]));
-                fine.values[fineIndex] =
-                    static_cast<float>(bottom + ty * (top - bottom));
-                fine.valid[fineIndex] = 1;
-            } else {
-                // Nearest-sample fallback: preserves plateaus and keeps NaN
-                // and invalid samples from bleeding across mask boundaries.
-                const auto near = sampleAt(nearest(i, plane.width), nj);
-                fine.values[fineIndex] = std::isfinite(plane.values[near])
-                    ? plane.values[near] : 0.0F;
-                fine.valid[fineIndex] = usable(near) ? 1 : 0;
-            }
-            if (!fine.sourceLevel.empty()) {
-                const auto near = sampleAt(nearest(i, plane.width), nj);
-                fine.sourceLevel[fineIndex] = plane.sourceLevel[near];
-            }
-        }
-    }
-    return fine;
-}
-
 std::vector<ContourSegment> generateContours(
     const ScalarPlane& plane, const std::vector<double>& values)
 {
@@ -426,21 +334,9 @@ void chaikinPass(ContourPolyline& polyline)
 
 std::vector<ContourPolyline> generateContourPolylines(
     const ScalarPlane& plane, const std::vector<double>& values,
-    int smoothIterations, int supersampleFactor)
+    int smoothIterations)
 {
-    if (supersampleFactor < 1) {
-        throw std::invalid_argument("supersample factor must be at least 1");
-    }
-    // With supersampling, chaining and smoothing run on the fine grid and the
-    // coordinates are scaled back at the end, so the output always uses the
-    // original plane pixel space.
-    ScalarPlane fineStorage;
-    const ScalarPlane* grid = &plane;
-    if (supersampleFactor > 1) {
-        fineStorage = supersamplePlane(plane, supersampleFactor);
-        grid = &fineStorage;
-    }
-    const auto segments = generateContours(*grid, values);
+    const auto segments = generateContours(plane, values);
     std::vector<ContourPolyline> polylines;
     // generateContours emits segments grouped by value in `values` order;
     // chain each group separately so different levels never join.
@@ -462,45 +358,7 @@ std::vector<ContourPolyline> generateContourPolylines(
             chaikinPass(polyline);
         }
     }
-    if (supersampleFactor > 1) {
-        const auto scale = 1.0F / static_cast<float>(supersampleFactor);
-        for (auto& polyline : polylines) {
-            for (auto& point : polyline.points) {
-                point[0] *= scale;
-                point[1] *= scale;
-            }
-        }
-    }
     return polylines;
-}
-
-int contourUpsampleFactor(
-    int contourWidth, int contourHeight, int displayWidth, int displayHeight)
-{
-    if (contourWidth < 1 || contourHeight < 1
-        || displayWidth < 1 || displayHeight < 1) {
-        return 1;
-    }
-    const auto displayRatio = std::max(
-        static_cast<double>(displayWidth) / static_cast<double>(contourWidth),
-        static_cast<double>(displayHeight) / static_cast<double>(contourHeight));
-    // Choose factor so that one fine cell spans at most two display pixels,
-    // then enforce a minimum fine-grid size of 256 on the shorter axis so
-    // contours stay smooth when the display is resized (contour extraction
-    // only sees the SliceQuery output size, not the widget dimensions).
-    const auto minAxis = static_cast<double>(
-        std::min(contourWidth, contourHeight));
-    const auto minFactor = static_cast<int>(
-        std::ceil((256.0 - 1.0) / (minAxis - 1.0)));
-    auto factor = std::clamp(static_cast<int>(std::ceil(displayRatio / 2.0)),
-        1, 16);
-    factor = std::max(factor, std::min(minFactor, 16));
-    while (factor > 1
-        && (static_cast<std::int64_t>(contourWidth - 1) * factor + 1 > 1024
-            || static_cast<std::int64_t>(contourHeight - 1) * factor + 1 > 1024)) {
-        --factor;
-    }
-    return factor;
 }
 
 std::vector<ContourPolyline> contourPolylinesForDisplay(
@@ -510,16 +368,16 @@ std::vector<ContourPolyline> contourPolylinesForDisplay(
     if (fineFactor < 1) {
         throw std::invalid_argument("fine factor must be at least 1");
     }
-    // The fine plane is already refined, so extraction runs without further
-    // supersampling; one Chaikin pass softens the cell-scale corners.
-    auto polylines = generateContourPolylines(finePlane, values, 1, 1);
+    // The contour plane is already at contour resolution; one Chaikin pass
+    // softens the cell-scale corners.
+    auto polylines = generateContourPolylines(finePlane, values, 1);
     if (finePlane.width < 1 || finePlane.height < 1) {
         return polylines;
     }
-    // Recover the original (pre-refinement) dimensions supersamplePlane
-    // produced this fine plane from, then map fine coordinates into display
-    // pixel space: fine coordinate f is original sample coordinate
-    // f / fineFactor, and original sample center j maps to display pixel
+    // Recover the original (pre-refinement) dimensions the fine plane was
+    // produced from, then map fine coordinates into display pixel space: fine
+    // coordinate f is original sample coordinate f / fineFactor, and original
+    // sample center j maps to display pixel
     // ((j + 0.5) * display / original) - 0.5, cell-center to cell-center.
     const auto originalWidth = (finePlane.width - 1) / fineFactor + 1;
     const auto originalHeight = (finePlane.height - 1) / fineFactor + 1;

--- a/tests/unit/test_contours.cpp
+++ b/tests/unit/test_contours.cpp
@@ -86,16 +86,6 @@ bool matchesSegmentEndpoint(const std::vector<amrvis::ContourSegment>& segments,
     return false;
 }
 
-// Nearest original sample index for a fine coordinate, rounding halves up;
-// mirrors supersamplePlane's nearest-sample selection.
-int nearestIndex(int fineIndex, int factor, int extent)
-{
-    const int base = fineIndex / factor;
-    const int rem = fineIndex % factor;
-    const int index = base + (2 * rem >= factor ? 1 : 0);
-    return index < extent ? index : extent - 1;
-}
-
 // True when the segment list contains a segment between the two points, in
 // either direction.
 bool hasSegment(const std::vector<amrvis::ContourSegment>& segments,
@@ -336,201 +326,6 @@ int main()
     const auto none = amrvis::generateContourPolylines(plane, {100.0});
     require(none.empty(), "out-of-range contour produced polylines");
 
-    // (g) supersamplePlane: factor validation, the dimension formula, exact
-    // reproduction of the original samples at multiples of factor, and
-    // bilinear interpolation in between.
-    threw = false;
-    try {
-        (void)amrvis::supersamplePlane(plane, 0);
-    } catch (const std::invalid_argument&) {
-        threw = true;
-    }
-    require(threw, "supersamplePlane accepted a zero factor");
-
-    const auto copy = amrvis::supersamplePlane(plane, 1);
-    require(copy.width == plane.width && copy.height == plane.height
-        && copy.values == plane.values && copy.valid == plane.valid,
-        "factor 1 did not return a copy of the plane");
-
-    constexpr int factor = 4;
-    const auto fine = amrvis::supersamplePlane(plane, factor);
-    require(fine.width == (plane.width - 1) * factor + 1
-        && fine.height == (plane.height - 1) * factor + 1,
-        "supersampled dimensions do not match the formula");
-    require(fine.values.size()
-        == static_cast<std::size_t>(fine.width) * static_cast<std::size_t>(fine.height),
-        "supersampled storage does not match its dimensions");
-    for (int y = 0; y < plane.height; ++y) {
-        for (int x = 0; x < plane.width; ++x) {
-            const auto coarseIndex = static_cast<std::size_t>(x + y * plane.width);
-            const auto fineIndex = static_cast<std::size_t>(x * factor)
-                + static_cast<std::size_t>(y * factor) * static_cast<std::size_t>(fine.width);
-            require(fine.values[fineIndex] == plane.values[coarseIndex],
-                "original sample not reproduced exactly on the fine grid");
-            require(fine.valid[fineIndex] == plane.valid[coarseIndex],
-                "original validity not reproduced on the fine grid");
-            require(fine.sourceLevel[fineIndex] == plane.sourceLevel[coarseIndex],
-                "source level does not track the nearest original sample");
-        }
-    }
-    // Fine index (2, 2) is continuous coordinate (0.5, 0.5); the bilinear
-    // interpolation of v = x + 2y there is exactly 1.5.
-    require(nearlyEqual(fine.values[static_cast<std::size_t>(2 + 2 * fine.width)], 1.5),
-        "bilinear interpolation mismatch");
-
-    // (h) Supersampled contour of the linear field v = x + 2y at 2.3 follows
-    // the analytic straight line with no staircase. 2.3 is not a multiple of
-    // 1 / factor, so no fine sample hits the contour exactly.
-    const auto fineLine = amrvis::generateContourPolylines(plane, {2.3}, 2, factor);
-    require(fineLine.size() == 1, "supersampled linear contour split into pieces");
-    require(!fineLine.front().closed, "supersampled linear contour should stay open");
-    require(fineLine.front().points.size() > 4 * openRaw.front().points.size(),
-        "supersampling did not densify the polyline");
-    for (const auto& point : fineLine.front().points) {
-        require(std::isfinite(point[0]) && std::isfinite(point[1]),
-            "supersampled contour produced a non-finite point");
-        require(point[0] >= 0.0F && point[0] <= 3.0F
-            && point[1] >= 0.0F && point[1] <= 3.0F,
-            "supersampled point escaped the original plane bounds");
-        require(nearlyEqual(point[0] + 2.0 * point[1], 2.3, 1.0e-3),
-            "supersampled linear contour deviates from the analytic line");
-    }
-    // The contour still enters at the bottom edge (2.3, 0) and leaves at the
-    // left edge (0, 1.15), in either chaining direction.
-    const auto& fineFirst = fineLine.front().points.front();
-    const auto& fineLast = fineLine.front().points.back();
-    const bool bottomFirst = nearlyEqual(fineFirst[0], 2.3, 1.0e-3)
-        && nearlyEqual(fineFirst[1], 0.0, 1.0e-3);
-    const bool leftLast = nearlyEqual(fineLast[0], 0.0, 1.0e-3)
-        && nearlyEqual(fineLast[1], 1.15, 1.0e-3);
-    const bool leftFirst = nearlyEqual(fineFirst[0], 0.0, 1.0e-3)
-        && nearlyEqual(fineFirst[1], 1.15, 1.0e-3);
-    const bool bottomLast = nearlyEqual(fineLast[0], 2.3, 1.0e-3)
-        && nearlyEqual(fineLast[1], 0.0, 1.0e-3);
-    require((bottomFirst && leftLast) || (leftFirst && bottomLast),
-        "supersampled linear contour has the wrong boundary crossings");
-
-    // (i) Mask behavior with corner (1, 1) invalidated: a fine sample is
-    // valid if and only if its nearest original sample (rounding halves up)
-    // is valid and finite. The invalid corner neither bleeds into the
-    // bilinear interior nor shrinks the valid plateau region.
-    const auto maskedFine = amrvis::supersamplePlane(masked, factor);
-    for (int y = 0; y < maskedFine.height; ++y) {
-        for (int x = 0; x < maskedFine.width; ++x) {
-            const auto fineIndex = static_cast<std::size_t>(x)
-                + static_cast<std::size_t>(y) * static_cast<std::size_t>(maskedFine.width);
-            const auto nearIndex = static_cast<std::size_t>(
-                nearestIndex(x, factor, masked.width)
-                + nearestIndex(y, factor, masked.height) * masked.width);
-            const bool expectValid = masked.valid[nearIndex] != 0
-                && std::isfinite(masked.values[nearIndex]);
-            require((maskedFine.valid[fineIndex] != 0) == expectValid,
-                "fine validity does not track the nearest original sample");
-            require(!expectValid || std::isfinite(maskedFine.values[fineIndex]),
-                "valid fine sample holds a non-finite value");
-        }
-    }
-    // The supersampled contour at 2.5 must not enter the union of skipped
-    // fine cells, the open box (0.25, 1.5) x (0.25, 1.5) around corner
-    // (1, 1), and where the bilinear stencil stays fully valid (x >= 2) it
-    // still follows the analytic line.
-    const auto maskedContour = amrvis::generateContourPolylines(masked, {2.5}, 0, factor);
-    require(!maskedContour.empty(), "supersampled contour vanished with one invalid corner");
-    bool farPoint = false;
-    for (const auto& polyline : maskedContour) {
-        for (const auto& point : polyline.points) {
-            require(std::isfinite(point[0]) && std::isfinite(point[1]),
-                "masked supersampled contour produced a non-finite point");
-            require(!(point[0] > 0.25F && point[0] < 1.5F
-                && point[1] > 0.25F && point[1] < 1.5F),
-                "supersampled contour entered the fully-invalid region");
-            if (point[0] >= 2.0F) {
-                farPoint = true;
-                require(nearlyEqual(point[0] + 2.0 * point[1], 2.5, 1.0e-3),
-                    "valid-region supersampled contour deviates from the analytic line");
-            }
-        }
-    }
-    require(farPoint, "supersampled contour lost the fully-valid region");
-
-    // (j) NaN corner: NaN counts as an invalid contributor. No supersampled
-    // value is non-finite, validity tracks the nearest finite original
-    // sample, and samples whose bilinear stencil avoids the NaN corner keep
-    // the exact interpolated (linear) values.
-    const auto nanFine = amrvis::supersamplePlane(withNaN, factor);
-    for (int y = 0; y < nanFine.height; ++y) {
-        for (int x = 0; x < nanFine.width; ++x) {
-            const auto fineIndex = static_cast<std::size_t>(x)
-                + static_cast<std::size_t>(y) * static_cast<std::size_t>(nanFine.width);
-            require(std::isfinite(nanFine.values[fineIndex]),
-                "NaN bled into a supersampled value");
-            const auto nearIndex = static_cast<std::size_t>(
-                nearestIndex(x, factor, withNaN.width)
-                + nearestIndex(y, factor, withNaN.height) * withNaN.width);
-            const bool expectValid = withNaN.valid[nearIndex] != 0
-                && std::isfinite(withNaN.values[nearIndex]);
-            require((nanFine.valid[fineIndex] != 0) == expectValid,
-                "NaN corner did not count as an invalid contributor");
-            const int i0 = x / factor;
-            const int i1 = i0 + 1 < withNaN.width ? i0 + 1 : withNaN.width - 1;
-            const int j0 = y / factor;
-            const int j1 = j0 + 1 < withNaN.height ? j0 + 1 : withNaN.height - 1;
-            const bool stencilHasNaN = i0 <= 2 && 2 <= i1 && j0 <= 2 && 2 <= j1;
-            if (!stencilHasNaN) {
-                const double exact = static_cast<double>(x) / factor
-                    + 2.0 * static_cast<double>(y) / factor;
-                require(nearlyEqual(nanFine.values[fineIndex], exact, 1.0e-4),
-                    "bilinear interpolation mismatch away from the NaN corner");
-            }
-        }
-    }
-    const auto nanContour = amrvis::generateContourPolylines(withNaN, {7.5}, 2, factor);
-    for (const auto& polyline : nanContour) {
-        for (const auto& point : polyline.points) {
-            require(std::isfinite(point[0]) && std::isfinite(point[1]),
-                "supersampled NaN-plane contour produced a non-finite point");
-        }
-    }
-
-    // (k) Supersampled radial contour: still a single closed loop, hugging
-    // the analytic circle and staying inside the original plane pixel bounds;
-    // factor 1 reproduces the two-argument behavior exactly. The contour
-    // value 100.37 is not a multiple of 1 / 16: on this field every
-    // supersampled value is an exact multiple of 1 / factor^2 (quadratic
-    // field, exact bilinear interpolation), and a contour value that hits a
-    // fine sample exactly would split chains into pieces, just like exact
-    // corner hits do on the coarse grid.
-    const auto fineLoop = amrvis::generateContourPolylines(radial, {100.37}, 2, factor);
-    require(fineLoop.size() == 1, "supersampled radial contour split into pieces");
-    require(fineLoop.front().closed, "supersampled radial contour is not closed");
-    require(nearlyEqual(fineLoop.front().value, 100.37), "supersampled value mismatch");
-    for (const auto& point : fineLoop.front().points) {
-        require(point[0] >= 0.0F && point[0] <= 31.0F
-            && point[1] >= 0.0F && point[1] <= 31.0F,
-            "supersampled point escaped the original plane bounds");
-        const double dx = point[0] - 15.5;
-        const double dy = point[1] - 15.5;
-        require(nearlyEqual(std::sqrt(dx * dx + dy * dy), std::sqrt(100.37), 0.15),
-            "supersampled radial contour deviates from the analytic circle");
-    }
-    const auto defaultFactor = amrvis::generateContourPolylines(radial, {100.0}, 2);
-    const auto explicitOne = amrvis::generateContourPolylines(radial, {100.0}, 2, 1);
-    require(explicitOne.size() == defaultFactor.size(),
-        "factor 1 changed the polyline count");
-    for (std::size_t p = 0; p < explicitOne.size(); ++p) {
-        require(explicitOne[p].points == defaultFactor[p].points
-            && explicitOne[p].closed == defaultFactor[p].closed
-            && explicitOne[p].value == defaultFactor[p].value,
-            "factor 1 output differs from the two-argument behavior");
-    }
-    threw = false;
-    try {
-        (void)amrvis::generateContourPolylines(radial, {100.0}, 2, 0);
-    } catch (const std::invalid_argument&) {
-        threw = true;
-    }
-    require(threw, "generateContourPolylines accepted a zero supersample factor");
-
     // (l) Saddle cells resolve with the asymptotic decider: the contour
     // value is compared against the mean of the four corner values (the
     // bilinear interpolant's cell-center value). With the main diagonal
@@ -560,22 +355,7 @@ int main()
             && hasSegment(saddleMean, 0.5, 1.0, 1.0, 0.5),
         "saddle at the mean did not follow the center rule");
 
-    // (m) contourUpsampleFactor: targets ~2 display pixels per fine cell
-    // with a minimum fine-grid size of 256 on the shorter axis.
-    require(amrvis::contourUpsampleFactor(4, 4, 640, 640) == 16,
-        "coarse data did not get the maximum factor");
-    require(amrvis::contourUpsampleFactor(640, 640, 640, 640) == 1,
-        "data at display resolution should not be refined");
-    require(amrvis::contourUpsampleFactor(100, 100, 640, 640) == 4,
-        "factor does not reach the 256 minimum fine-grid size");
-    require(amrvis::contourUpsampleFactor(500, 500, 9000, 9000) == 2,
-        "fine grid was not reduced to the 1024 cap");
-    require(amrvis::contourUpsampleFactor(900, 900, 7000, 7000) == 1,
-        "fine grid cap did not lower the factor to one");
-    require(amrvis::contourUpsampleFactor(0, 0, 640, 640) == 1,
-        "degenerate dimensions should fall back to one");
-
-    // (n) contourPolylinesForDisplay on the 4x4 data plane v = (i + j) / 2:
+    // (m) contourPolylinesForDisplay on the 4x4 data plane v = (i + j) / 2:
     // the 2.3 iso-line (i + j = 4.6 in sample coordinates) stays straight,
     // and the known edge crossings at sample coordinates (3, 1.6) and
     // (1.6, 3) land at display pixels (559.5, 335.5) and (335.5, 559.5)
@@ -591,10 +371,10 @@ int main()
                 = 0.5F * static_cast<float>(i + j);
         }
     }
-    const auto dataFactor = amrvis::contourUpsampleFactor(4, 4, 640, 640);
-    const auto dataFine = amrvis::supersamplePlane(data, dataFactor);
+    // The slice pipeline always supplies a contour plane already at contour
+    // resolution (fineFactor 1), so exercise that mapping directly.
     const auto displayLines = amrvis::contourPolylinesForDisplay(
-        dataFine, dataFactor, {2.3}, 640, 640);
+        data, 1, {2.3}, 640, 640);
     require(displayLines.size() == 1, "display contour split into pieces");
     require(!displayLines.front().closed, "display contour should stay open");
     for (const auto& point : displayLines.front().points) {


### PR DESCRIPTION
supersamplePlane and contourUpsampleFactor were reachable only from tests: the slice pipeline queries a fine linear contour plane directly (fineFactor 1), having deliberately replaced upsampling of coarse samples with sampling real data. That dead path held two UB sites — signed overflow in the fine-grid dimension/`2*rem` for large factors, and static_cast<int>(ceil(inf)) when a contour axis is length 1.

Delete both functions and the now-unused supersampleFactor parameter of generateContourPolylines; keep contourPolylinesForDisplay and its fineFactor param (always 1; draining that plumbing tracked in #16). Rewrite the stale appendContours comment to match the actual design, drop the supersampling unit tests and the nearestIndex helper, and retarget the display-mapping test at the production fineFactor==1 path.

Net -409 lines. Verified on the default, clang, and ASan/UBSan suites.