### PR TITLE
Harden the plotfile/FAB readers against malformed files

### DIFF
--- a/src/io/plotfile/PlotfileBlockReader.cpp
+++ b/src/io/plotfile/PlotfileBlockReader.cpp
@@ -5,10 +5,12 @@
 #include <bit>
 #include <cstddef>
 #include <cstring>
+#include <filesystem>
 #include <fstream>
 #include <limits>
 #include <sstream>
 #include <string>
+#include <system_error>
 #include <type_traits>
 #include <utility>
 
@@ -302,6 +304,15 @@ BlockReadResult PlotfileBlockReader::readBlock(
     if (!input) {
         throw BlockReadError("cannot open FAB data file '" + dataPath.string() + "'");
     }
+    // Stat the file up front so a crafted box extent (which sizes the buffer
+    // below) cannot force a huge transient allocation or bad_alloc: the
+    // requested component must actually fit within the data file.
+    std::error_code sizeError;
+    const auto fileSize = std::filesystem::file_size(dataPath, sizeError);
+    if (sizeError) {
+        throw BlockReadError("cannot stat FAB data file '" + dataPath.string()
+            + "': " + sizeError.message());
+    }
 
     FabHeader header;
     if (level.visMfHeaderVersion == 1) {
@@ -341,6 +352,12 @@ BlockReadResult PlotfileBlockReader::readBlock(
         || componentBytes
             > static_cast<std::uint64_t>(std::numeric_limits<std::streamsize>::max())) {
         throw BlockReadError("FAB component exceeds addressable memory");
+    }
+    // Bound the allocation by the actual file (staged to avoid overflow in
+    // offset + bytes): a truncated file or an oversized claimed box is caught
+    // here, before the buffer is sized, rather than after a failed read.
+    if (componentOffset > fileSize || componentBytes > fileSize - componentOffset) {
+        throw BlockReadError("FAB component extends past the end of the data file");
     }
 
     std::vector<unsigned char> encoded(static_cast<std::size_t>(componentBytes));

--- a/src/io/plotfile/PlotfileMetadataReader.cpp
+++ b/src/io/plotfile/PlotfileMetadataReader.cpp
@@ -106,8 +106,36 @@ std::vector<int> parseIntegers(const std::string& line)
     return values;
 }
 
+// Rejects a metadata-derived path that could redirect reads outside the
+// plotfile directory when joined to the plotfile root: an absolute path
+// replaces the root entirely, and a '..' component walks above it. AMReX only
+// ever writes relative names within the tree, so anything else is malformed
+// or crafted.
+void requireContainedPath(const std::string& value, std::string_view what)
+{
+    const std::filesystem::path path(value);
+    if (value.empty() || path.is_absolute()) {
+        throw MetadataReadError(std::string(what)
+            + " must be a relative path inside the plotfile: '" + value + "'");
+    }
+    for (const auto& component : path) {
+        if (component == "..") {
+            throw MetadataReadError(std::string(what)
+                + " must not contain a parent-directory component: '"
+                + value + "'");
+        }
+    }
+}
+
+// Reads a comma-separated VisMF real matrix. AMReX always writes exactly
+// expectedRows x expectedColumns (one row per box, one column per component),
+// so the claimed dimensions are checked against that before any allocation:
+// a crafted header cannot request a huge matrix and OOM the process (the
+// dimensions were previously capped only independently, then allocated in
+// full before the count was cross-checked).
 std::vector<std::vector<double>> readRealMatrix(
-    std::istream& input, std::string_view description)
+    std::istream& input, std::string_view description,
+    std::uint64_t expectedRows, std::uint64_t expectedColumns)
 {
     const auto rows = readRequired<std::uint64_t>(input, description);
     char comma = '\0';
@@ -115,9 +143,9 @@ std::vector<std::vector<double>> readRealMatrix(
         throw MetadataReadError("malformed VisMF matrix dimensions");
     }
     const auto columns = readRequired<std::uint64_t>(input, description);
-    if (rows > static_cast<std::uint64_t>(maximumGridsPerLevel)
-        || columns > static_cast<std::uint64_t>(maximumComponents)) {
-        throw MetadataReadError("VisMF matrix dimensions are outside supported bounds");
+    if (rows != expectedRows || columns != expectedColumns) {
+        throw MetadataReadError("VisMF matrix dimensions do not match the "
+            "BoxArray size and component count");
     }
 
     std::vector<std::vector<double>> matrix(
@@ -209,12 +237,17 @@ detail::VisMfIndex detail::readVisMfIndex(
             throw MetadataReadError("malformed FabOnDisk record");
         }
         index.fileNames.push_back(readRequired<std::string>(input, "FAB data filename"));
+        requireContainedPath(index.fileNames.back(), "FAB data filename");
         index.fileOffsets.push_back(readRequired<std::uint64_t>(input, "FAB data offset"));
     }
 
     if (index.version == 1 || index.version == 3) {
-        index.minimum = readRealMatrix(input, "per-block minima");
-        index.maximum = readRealMatrix(input, "per-block maxima");
+        index.minimum = readRealMatrix(input, "per-block minima",
+            static_cast<std::uint64_t>(boxCount),
+            static_cast<std::uint64_t>(index.components));
+        index.maximum = readRealMatrix(input, "per-block maxima",
+            static_cast<std::uint64_t>(boxCount),
+            static_cast<std::uint64_t>(index.components));
         index.hasPerBlockStatistics = true;
         if (index.minimum.size() != boxCount || index.maximum.size() != boxCount) {
             throw MetadataReadError("VisMF statistics do not match BoxArray size");
@@ -424,6 +457,7 @@ PlotfileMetadataResult PlotfileMetadataReader::read(
                 level.domain.lower, level.domain.centering, metadata->dimension));
         }
         level.dataPath = readRequired<std::string>(input, "level data path");
+        requireContainedPath(level.dataPath, "plotfile level data path");
     }
 
     const auto issues = validateMetadata(*metadata);

--- a/src/io/plotfile/PlotfileMetadataReader.cpp
+++ b/src/io/plotfile/PlotfileMetadataReader.cpp
@@ -114,7 +114,11 @@ std::vector<int> parseIntegers(const std::string& line)
 void requireContainedPath(const std::string& value, std::string_view what)
 {
     const std::filesystem::path path(value);
-    if (value.empty() || path.is_absolute()) {
+    // Reject anything with a root: a root-name (drive/UNC) or a root-directory
+    // (leading separator). is_absolute() is not enough — it is platform
+    // specific, so a POSIX-style "/etc/..." reads as relative on Windows yet
+    // still escapes to the drive root when joined to the plotfile path.
+    if (value.empty() || path.has_root_name() || path.has_root_directory()) {
         throw MetadataReadError(std::string(what)
             + " must be a relative path inside the plotfile: '" + value + "'");
     }

--- a/tests/integration/test_selective_block_read.cpp
+++ b/tests/integration/test_selective_block_read.cpp
@@ -28,6 +28,84 @@ void writeText(const std::filesystem::path& path, const std::string& text)
     output << text;
 }
 
+// A minimal 2-D single-component plotfile Header with one small grid. The
+// level data path is supplied so a crafted (escaping) path can be exercised;
+// the index-space domain box is supplied so a large domain (that can contain
+// an oversized _H box) can be exercised. The domain box is a raw index box,
+// independent of the grid's physical-bounds -> cell mapping, so the grid stays
+// small and valid regardless.
+std::string minimalHeader(const std::string& dataPath,
+    const std::string& domainBox = "((0,0) (1,1) (0,0))")
+{
+    return
+        "HyperCLaw-V1.1\n"
+        "1\nphi\n"
+        "2\n0.0\n0\n"
+        "0.0 0.0\n1.0 1.0\n\n"
+        + domainBox + "\n"
+        "0\n0.5 0.5\n0\n0\n"
+        "0 1 0.0\n0\n"
+        "0.0 1.0\n0.0 1.0\n"
+        + dataPath + "\n";
+}
+
+// A path that walks above the plotfile directory must be rejected at metadata
+// read, not silently followed.
+void testRejectsEscapingDataPath(const std::filesystem::path& base)
+{
+    const auto root = base / "escaping_datapath";
+    std::filesystem::create_directories(root);
+    writeText(root / "Header", minimalHeader("../escape/Cell"));
+    bool threw = false;
+    try {
+        (void)amrvis::PlotfileMetadataReader{}.read(root);
+    } catch (const amrvis::MetadataReadError& error) {
+        // Pin the rejection to the path guard (not an incidental "cannot open
+        // the _H at that location" failure, which would also throw).
+        threw = std::string(error.what()).find("parent-directory")
+            != std::string::npos;
+    }
+    require(threw, "an escaping level data path was not rejected by the path guard");
+}
+
+// A box extent larger than the FAB data file must be caught before the read
+// buffer is sized, as a clean BlockReadError rather than std::bad_alloc from
+// a multi-gigabyte allocation.
+void testRejectsOversizedBox(const std::filesystem::path& base)
+{
+    const auto root = base / "oversized_box";
+    std::filesystem::create_directories(root / "Level_0");
+    // The index-space domain is large enough to contain the oversized box so
+    // the metadata itself validates; only the box-vs-file check should fire.
+    writeText(root / "Header",
+        minimalHeader("Level_0/Cell", "((0,0) (80000,80000) (0,0))"));
+    // Version-2 (NoFabHeader) _H: the box claims 80001 x 80001 cells (~51 GB
+    // of doubles), while the data file below holds 16 bytes.
+    writeText(root / "Level_0" / "Cell_H",
+        "2\n1\n1\n0\n"
+        "(1 0\n((0,0) (80000,80000) (0,0))\n)\n"
+        "1\nFabOnDisk: Cell_D_00000 0\n\n"
+        "((8, (64 11 52 0 1 12 0 1023)),(8, (8 7 6 5 4 3 2 1)))\n");
+    writeText(root / "Level_0" / "Cell_D_00000", std::string(16, '\0'));
+
+    const auto metadata = amrvis::PlotfileMetadataReader{}.read(root);
+    amrvis::PlotfileBlockReader reader(root, metadata.metadata);
+    amrvis::BlockRequest request;
+    request.dataset.value = 1;
+    request.field.value = 0;
+    bool threw = false;
+    try {
+        (void)reader.readBlock(request);
+    } catch (const amrvis::BlockReadError& error) {
+        // Pin to the up-front size guard's message: the post-read gcount
+        // "truncated" check would only fire after the (multi-GB) allocation,
+        // so requiring this message proves the allocation was never attempted.
+        threw = std::string(error.what()).find("past the end of the data file")
+            != std::string::npos;
+    }
+    require(threw, "an oversized FAB box was not rejected before allocation");
+}
+
 } // namespace
 
 int main()
@@ -131,6 +209,9 @@ int main()
     const auto multiFabAccess = multiFabDataset.requestBlock(request);
     require(multiFabAccess.handle->values[2] == 30.0,
         "standalone MultiFab selective read value mismatch");
+
+    testRejectsEscapingDataPath(root);
+    testRejectsOversizedBox(root);
 
     std::filesystem::remove_all(root);
     return 0;

--- a/tests/unit/test_vismf_index.cpp
+++ b/tests/unit/test_vismf_index.cpp
@@ -4,6 +4,7 @@
 // min/max matrix). The reader must skip those blanks and still find the
 // descriptor; otherwise v2/v3 plotfiles are unopenable.
 #include <amrexplorer/io/detail/VisMfIndex.hpp>
+#include <amrexplorer/io/PlotfileMetadataReader.hpp>
 #include <amrexplorer/io/StandaloneMetadataReader.hpp>
 
 #include <cstdlib>
@@ -146,6 +147,106 @@ void testVersion3(const std::filesystem::path& path)
         "v3 per-block statistics count mismatch");
 }
 
+// A crafted header must be rejected with MetadataReadError specifically (not
+// std::bad_alloc from over-allocating, and not some other exception). When
+// expectedMessage is set, the error text must contain it — this pins the
+// rejection to the intended check rather than an incidental parse failure
+// (e.g. a truncated body or a missing file).
+void expectRejected(const std::filesystem::path& path, const std::string& body,
+    int dimension, const char* what, const char* expectedMessage = nullptr)
+{
+    writeHeader(path, body);
+    bool threw = false;
+    try {
+        (void)amrvis::detail::readVisMfIndex(path, dimension);
+    } catch (const amrvis::MetadataReadError& error) {
+        threw = true;
+        if (expectedMessage != nullptr
+            && std::string(error.what()).find(expectedMessage) == std::string::npos) {
+            std::cerr << "FAILED: " << what
+                      << " was rejected for the wrong reason: " << error.what()
+                      << '\n';
+            ++g_failures;
+            return;
+        }
+    } catch (const std::exception& other) {
+        std::cerr << "FAILED: " << what << " threw the wrong exception: "
+                  << other.what() << '\n';
+        ++g_failures;
+        return;
+    }
+    require(threw, what);
+}
+
+// A well-formed version-1 header prefix (through the FabOnDisk list) with a
+// two-box, two-component BoxArray, so only the crafted tail below varies.
+constexpr const char* kV1Prefix =
+    "1\n1\n2\n0\n"
+    "(2 0\n"
+    "((0,0) (1,3) (0,0))\n"
+    "((2,0) (3,3) (0,0))\n"
+    ")\n"
+    "2\n"
+    "FabOnDisk: Cell_D_00000 0\n"
+    "FabOnDisk: Cell_D_00000 4096\n"
+    "\n";
+
+void testRejectsOversizedMatrix(const std::filesystem::path& path)
+{
+    // The per-block minima matrix claims 10^12 entries. The dimensions must
+    // be checked against the BoxArray/component count (2 x 2) before the
+    // matrix is allocated, so this is a clean MetadataReadError rather than
+    // an OOM kill.
+    expectRejected(path, std::string(kV1Prefix) + "10000000,100000\n", 2,
+        "oversized VisMF statistics matrix was not rejected",
+        "do not match");
+}
+
+void testRejectsMatrixShapeMismatch(const std::filesystem::path& path)
+{
+    // A merely wrong (but small) shape is still rejected: AMReX always writes
+    // exactly boxCount x components.
+    expectRejected(path, std::string(kV1Prefix) + "2,1\n0.0,\n2.0,\n", 2,
+        "mismatched VisMF statistics shape was not rejected",
+        "do not match");
+}
+
+// A well-formed version-2 (NoFabHeader, no statistics matrix) body, whose only
+// defect is the crafted first FAB filename: without the path guard it parses
+// cleanly, so these tests fail loudly if the guard is removed rather than
+// passing on an incidental parse error.
+std::string version2Body(const std::string& firstFabName)
+{
+    return
+        "2\n1\n2\n0\n"
+        "(2 0\n"
+        "((0,0) (1,3) (0,0))\n"
+        "((2,0) (3,3) (0,0))\n"
+        ")\n"
+        "2\n"
+        "FabOnDisk: " + firstFabName + " 0\n"
+        "FabOnDisk: Cell_D_00000 4096\n"
+        "\n"
+        "((8, (64 11 52 0 1 12 0 1023)),(8, (8 7 6 5 4 3 2 1)))\n";
+}
+
+void testRejectsRelativeTraversal(const std::filesystem::path& path)
+{
+    // A FabOnDisk name that walks above the plotfile directory is rejected at
+    // parse time (an otherwise-valid v2 header).
+    expectRejected(path, version2Body("../escape"), 2,
+        "a parent-directory FAB name was not rejected",
+        "parent-directory");
+}
+
+void testRejectsAbsolutePath(const std::filesystem::path& path)
+{
+    // An absolute FabOnDisk name would replace the plotfile root entirely.
+    expectRejected(path, version2Body("/etc/passwd"), 2,
+        "an absolute FAB name was not rejected",
+        "relative path");
+}
+
 } // namespace
 
 int main()
@@ -157,6 +258,10 @@ int main()
     testVersion1(scratch / "v1_H");
     testVersion2(scratch / "v2_H");
     testVersion3(scratch / "v3_H");
+    testRejectsOversizedMatrix(scratch / "bad_matrix_H");
+    testRejectsMatrixShapeMismatch(scratch / "bad_shape_H");
+    testRejectsRelativeTraversal(scratch / "traversal_H");
+    testRejectsAbsolutePath(scratch / "absolute_H");
 
     std::error_code removeError;
     std::filesystem::remove_all(scratch, removeError);


### PR DESCRIPTION
Three reader paths trusted header-claimed sizes and paths. Now:

- readRealMatrix checks the declared VisMF matrix shape against the expected boxCount x components before allocating, instead of independent 10M/100k caps that let a 10^12-entry request reach an OOM-kill.
- readBlock stats the FAB data file and rejects a component whose offset+bytes exceed it before sizing the buffer, turning a crafted-box bad_alloc and a truncated file into a clean BlockReadError.
- FabOnDisk names and level data paths are rejected at metadata-read time if empty, absolute, or containing a '..' component, so a crafted header cannot redirect reads outside the plotfile tree.

Each guard has a negative test pinned to its own error message and verified to fail when the guard is removed. Default, clang, and ASan/UBSan suites green.