### PR TITLE
Make cache metrics accurate

### DIFF
--- a/include/amrexplorer/cache/ByteLruCache.hpp
+++ b/include/amrexplorer/cache/ByteLruCache.hpp
@@ -4,6 +4,7 @@
 
 #include <cstdint>
 #include <functional>
+#include <iterator>
 #include <list>
 #include <memory>
 #include <mutex>
@@ -123,6 +124,23 @@ public:
         return Handle(m_state, key, found->second.value, found->second.bytes);
     }
 
+    // Like findAndPin but records no hit or miss. Used for the double-checked
+    // second lookup a caller performs after taking a heavier lock: the logical
+    // lookup was already counted by the first findAndPin, so counting again
+    // would double-count the miss (and record a spurious miss+hit for a
+    // key a racing thread inserted in between).
+    [[nodiscard]] Handle peekAndPin(const Key& key)
+    {
+        std::scoped_lock lock(m_state->mutex);
+        const auto found = m_state->entries.find(key);
+        if (found == m_state->entries.end()) {
+            return {};
+        }
+        touch(*m_state, found->second);
+        pin(*m_state, found->second);
+        return Handle(m_state, key, found->second.value, found->second.bytes);
+    }
+
     [[nodiscard]] Handle insertAndPin(
         Key key, std::shared_ptr<const Value> value, std::uint64_t bytes)
     {
@@ -168,6 +186,7 @@ public:
             return false;
         }
         eraseEntry(*m_state, found);
+        ++m_state->metrics.clears;
         return true;
     }
 
@@ -187,6 +206,7 @@ public:
             if (current->second.pinCount == 0) {
                 const auto doomed = current++;
                 eraseEntry(*m_state, doomed);
+                ++m_state->metrics.clears;
             } else {
                 ++current;
             }
@@ -235,30 +255,36 @@ private:
         ++entry.pinCount;
     }
 
+    // Removes an entry's storage and accounting. The caller records the
+    // reason (capacity eviction vs. explicit clear) in the matching counter.
     static void eraseEntry(State& state, typename EntryMap::iterator entry)
     {
         state.metrics.residentBytes -= entry->second.bytes;
         state.lru.erase(entry->second.lruPosition);
         state.entries.erase(entry);
-        ++state.metrics.evictions;
     }
 
+    // Single tail-to-head sweep of the LRU list, evicting unpinned entries
+    // until the incoming bytes fit or the list is exhausted. Each list node is
+    // examined at most once (O(n)); the previous version restarted from the
+    // tail after every eviction, making it O(k*n) with a pinned-heavy tail.
     static void evictFor(State& state, std::uint64_t incomingBytes)
     {
-        while (state.metrics.residentBytes + incomingBytes > state.metrics.budgetBytes) {
-            bool evicted = false;
-            auto candidate = state.lru.rbegin();
-            while (candidate != state.lru.rend()) {
-                const auto found = state.entries.find(*candidate);
-                if (found != state.entries.end() && found->second.pinCount == 0) {
-                    eraseEntry(state, found);
-                    evicted = true;
-                    break;
-                }
-                ++candidate;
-            }
-            if (!evicted) {
-                break;
+        auto it = state.lru.end();
+        while (it != state.lru.begin()
+            && state.metrics.residentBytes + incomingBytes
+                > state.metrics.budgetBytes) {
+            const auto candidate = std::prev(it);
+            const auto found = state.entries.find(*candidate);
+            if (found != state.entries.end() && found->second.pinCount == 0) {
+                // eraseEntry removes *candidate from the list (invalidating
+                // `candidate`); `it` points past it and stays valid, so the
+                // next std::prev(it) is the node that preceded the erased one.
+                eraseEntry(state, found);
+                ++state.metrics.evictions;
+            } else {
+                // Keep a pinned (or already-gone) entry and move toward head.
+                it = candidate;
             }
         }
     }

--- a/include/amrexplorer/cache/CacheMetrics.hpp
+++ b/include/amrexplorer/cache/CacheMetrics.hpp
@@ -10,7 +10,12 @@ struct CacheMetrics {
     std::uint64_t pinnedBytes = 0;
     std::uint64_t hits = 0;
     std::uint64_t misses = 0;
+    // Capacity-driven evictions only (an entry dropped to make room). Entries
+    // removed by an explicit erase()/clearUnpinned() are counted in `clears`
+    // instead, so the eviction diagnostic is not inflated by a user-initiated
+    // cache clear (e.g. the cache-pressure fallback).
     std::uint64_t evictions = 0;
+    std::uint64_t clears = 0;
 
     [[nodiscard]] double hitRate() const noexcept;
     [[nodiscard]] bool withinBudget() const noexcept;

--- a/src/io/plotfile/PlotfileDataset.cpp
+++ b/src/io/plotfile/PlotfileDataset.cpp
@@ -122,7 +122,10 @@ PlotfileDataset::BlockAccess PlotfileDataset::requestBlock(
     if (cancellation.stop_requested()) {
         throw ReadCancelled();
     }
-    if (auto cached = m_cache.findAndPin(key)) {
+    // The logical lookup's miss was already recorded by the findAndPin above;
+    // this second, in-lock check only catches a block a racing thread inserted
+    // while we waited for the IO lock, so it must not count again.
+    if (auto cached = m_cache.peekAndPin(key)) {
         return {std::move(cached), true, {}};
     }
 

--- a/tests/integration/test_selective_block_read.cpp
+++ b/tests/integration/test_selective_block_read.cpp
@@ -195,6 +195,12 @@ int main()
         "second dataset access did not reuse the cached block");
     require(secondAccess.handle->values[2] == 30.0, "cached block value mismatch");
     require(dataset.cacheMetrics().residentBytes > 0, "dataset cache did not account bytes");
+    // One cold read is one logical lookup: exactly one miss (the in-lock
+    // re-check must not double-count it), and the warm read is exactly one hit.
+    require(dataset.cacheMetrics().misses == 1,
+        "a cold block read recorded more than one cache miss");
+    require(dataset.cacheMetrics().hits == 1,
+        "a warm block read did not record exactly one cache hit");
 
     amrvis::PlotfileDataset fabDataset(
         root / "Level_0" / "Cell_D_00000", amrvis::DatasetId{8}, 1024 * 1024);

--- a/tests/unit/test_byte_lru_cache.cpp
+++ b/tests/unit/test_byte_lru_cache.cpp
@@ -65,6 +65,70 @@ int main()
     }
     require(oversizeFailure, "oversize entry was accepted");
     require(cache.metrics().withinBudget(), "cache ended outside its byte budget");
+
+    const auto make = [](const char* text) {
+        return std::make_shared<const std::string>(text);
+    };
+
+    // --- hit/miss accounting: peekAndPin records neither ------------------
+    amrvis::ByteLruCache<int, std::string> metrics(100);
+    require(!metrics.peekAndPin(1), "peek on an absent key returned a value");
+    require(metrics.metrics().misses == 0 && metrics.metrics().hits == 0,
+        "peekAndPin recorded a hit or miss");
+    require(!metrics.findAndPin(1), "find on an absent key returned a value");
+    require(metrics.metrics().misses == 1, "a single miss was not counted once");
+
+    auto pinned = metrics.insertAndPin(1, make("a"), 40);
+    if (auto peeked = metrics.peekAndPin(1)) {
+        require(metrics.metrics().hits == 0, "peekAndPin recorded a hit");
+    } else {
+        require(false, "peekAndPin missed a present key");
+    }
+    if (auto hit = metrics.findAndPin(1)) {
+        require(metrics.metrics().hits == 1, "findAndPin hit was not counted");
+    } else {
+        require(false, "findAndPin missed a present key");
+    }
+    require(metrics.metrics().misses == 1, "a hit inflated the miss count");
+
+    // --- clearUnpinned counts clears, not evictions ----------------------
+    auto other = metrics.insertAndPin(2, make("b"), 40);
+    pinned = {};
+    other = {};
+    const auto beforeClear = metrics.metrics();
+    metrics.clearUnpinned();
+    const auto afterClear = metrics.metrics();
+    require(afterClear.residentBytes == 0, "clearUnpinned left entries resident");
+    require(afterClear.clears == beforeClear.clears + 2,
+        "clearUnpinned did not count two clears");
+    require(afterClear.evictions == beforeClear.evictions,
+        "clearUnpinned inflated the eviction count");
+
+    // --- a capacity eviction counts an eviction, not a clear -------------
+    auto resident = metrics.insertAndPin(3, make("c"), 60);
+    resident = {};
+    const auto beforeEvict = metrics.metrics();
+    auto incoming = metrics.insertAndPin(4, make("d"), 60);
+    require(metrics.metrics().evictions == beforeEvict.evictions + 1,
+        "a capacity eviction was not counted");
+    require(metrics.metrics().clears == beforeEvict.clears,
+        "a capacity eviction inflated the clear count");
+    incoming = {};
+
+    // --- evictFor sweeps past a pinned LRU tail --------------------------
+    // Entry 1 is the least-recently-used (list tail) but pinned; the single
+    // rbegin->rend sweep must skip it and evict the newer unpinned entry 2.
+    amrvis::ByteLruCache<int, std::string> sweep(100);
+    auto pinnedTail = sweep.insertAndPin(1, make("pinned"), 40);
+    auto evictable = sweep.insertAndPin(2, make("evictable"), 40);
+    evictable = {};
+    auto big = sweep.insertAndPin(3, make("big"), 40);
+    require(!sweep.findAndPin(2), "the unpinned entry was not evicted");
+    if (auto survivor = sweep.findAndPin(1)) {
+        require(*survivor == "pinned", "wrong entry survived the sweep");
+    } else {
+        require(false, "the pinned tail entry was wrongly evicted");
+    }
     return 0;
 }
 


### PR DESCRIPTION
Three inaccuracies in ByteLruCache/PlotfileDataset diagnostics:

- Every cold requestBlock counted two misses, because the double-checked lookup inside the IO lock called the counting findAndPin again. Add a non-counting peekAndPin for that re-check so each logical lookup records one outcome; hitRate() is now meaningful.
- evictions conflated capacity evictions with erase()/clearUnpinned(), so the cache-pressure fallback inflated the eviction diagnostic by the whole cleared working set. Split explicit removals into a new clears counter; evictions now counts capacity evictions only.
- evictFor restarted from the LRU tail after every eviction (O(k*n) with a pinned-heavy tail); rewrite it as a single O(n) tail-to-head sweep.

Extend the cache unit test (peek non-counting, clears vs evictions, pinned-tail sweep) and assert one-miss/one-hit accounting in the selective-read test.