### PR TITLE
Read FAB components straight into their typed buffer

### DIFF
--- a/src/io/plotfile/PlotfileBlockReader.cpp
+++ b/src/io/plotfile/PlotfileBlockReader.cpp
@@ -200,30 +200,6 @@ std::uint64_t pointCount(const IntBox& box, int dimension)
     return result;
 }
 
-double decodeReal(const unsigned char* source, const RealEncoding& encoding)
-{
-    const bool nativeLittle = std::endian::native == std::endian::little;
-    if (encoding.bytes == sizeof(double)) {
-        std::array<unsigned char, sizeof(double)> bytes{};
-        std::copy_n(source, bytes.size(), bytes.begin());
-        if (nativeLittle != encoding.littleEndian) {
-            std::reverse(bytes.begin(), bytes.end());
-        }
-        double value = 0.0;
-        std::memcpy(&value, bytes.data(), sizeof(value));
-        return value;
-    }
-
-    std::array<unsigned char, sizeof(float)> bytes{};
-    std::copy_n(source, bytes.size(), bytes.begin());
-    if (nativeLittle != encoding.littleEndian) {
-        std::reverse(bytes.begin(), bytes.end());
-    }
-    float value = 0.0F;
-    std::memcpy(&value, bytes.data(), sizeof(value));
-    return static_cast<double>(value);
-}
-
 } // namespace
 
 FabValues::FabValues(std::vector<float> values) noexcept
@@ -360,41 +336,53 @@ BlockReadResult PlotfileBlockReader::readBlock(
         throw BlockReadError("FAB component extends past the end of the data file");
     }
 
-    std::vector<unsigned char> encoded(static_cast<std::size_t>(componentBytes));
-    constexpr std::size_t cancellationChunkBytes = 1024U * 1024U;
-    std::size_t bytesCompleted = 0;
-    while (bytesCompleted < encoded.size()) {
-        if (cancellation.stop_requested()) {
-            throw ReadCancelled();
+    // Read the component straight into its typed value buffer instead of
+    // staging raw bytes and decoding into a second, equally large vector: this
+    // halves peak memory. IEEE-32/64 data always matches the target type's
+    // size (see parseRealDescriptor), so on a native-endian file (the common
+    // case) the read is the whole decode; a cross-endian file only needs an
+    // in-place per-value byte swap afterward.
+    const bool nativeEndian = (std::endian::native == std::endian::little)
+        == header.encoding.littleEndian;
+    const auto readComponent = [&]<typename Value>() {
+        std::vector<Value> values(static_cast<std::size_t>(valuesPerComponent));
+        constexpr std::size_t cancellationChunkBytes = 1024U * 1024U;
+        auto* const storage = reinterpret_cast<char*>(values.data());
+        std::size_t bytesCompleted = 0;
+        const auto total = static_cast<std::size_t>(componentBytes);
+        while (bytesCompleted < total) {
+            if (cancellation.stop_requested()) {
+                throw ReadCancelled();
+            }
+            const auto chunk = std::min(
+                cancellationChunkBytes, total - bytesCompleted);
+            input.read(storage + bytesCompleted,
+                static_cast<std::streamsize>(chunk));
+            if (input.gcount() != static_cast<std::streamsize>(chunk)) {
+                throw BlockReadError("FAB component payload is truncated");
+            }
+            bytesCompleted += chunk;
         }
-        const auto chunk = std::min(
-            cancellationChunkBytes, encoded.size() - bytesCompleted);
-        input.read(reinterpret_cast<char*>(encoded.data() + bytesCompleted),
-            static_cast<std::streamsize>(chunk));
-        if (input.gcount() != static_cast<std::streamsize>(chunk)) {
-            throw BlockReadError("FAB component payload is truncated");
+        if (!nativeEndian) {
+            auto* const raw = reinterpret_cast<unsigned char*>(values.data());
+            for (std::size_t value = 0; value < values.size(); ++value) {
+                if ((value & 4095U) == 0U && cancellation.stop_requested()) {
+                    throw ReadCancelled();
+                }
+                std::reverse(raw + value * sizeof(Value),
+                    raw + (value + 1) * sizeof(Value));
+            }
         }
-        bytesCompleted += chunk;
-    }
+        return FabValues{std::move(values)};
+    };
 
     auto block = std::make_shared<FabBlock>();
     block->box = header.box;
     block->field = request.field;
     block->component = 0;
-    const auto decodeValues = [&]<typename Value>() {
-        std::vector<Value> values(static_cast<std::size_t>(valuesPerComponent));
-        for (std::size_t value = 0; value < values.size(); ++value) {
-            if ((value & 4095U) == 0U && cancellation.stop_requested()) {
-                throw ReadCancelled();
-            }
-            values[value] = static_cast<Value>(decodeReal(
-                encoded.data() + value * header.encoding.bytes, header.encoding));
-        }
-        return FabValues{std::move(values)};
-    };
     block->values = header.encoding.bytes == sizeof(float)
-        ? decodeValues.template operator()<float>()
-        : decodeValues.template operator()<double>();
+        ? readComponent.template operator()<float>()
+        : readComponent.template operator()<double>();
 
     return {
         std::shared_ptr<const FabBlock>(std::move(block)),

--- a/tests/integration/test_selective_block_read.cpp
+++ b/tests/integration/test_selective_block_read.cpp
@@ -3,12 +3,16 @@
 #include <amrexplorer/io/PlotfileMetadataReader.hpp>
 #include <amrexplorer/io/StandaloneMetadataReader.hpp>
 
+#include <algorithm>
 #include <array>
+#include <bit>
 #include <chrono>
 #include <cstdlib>
+#include <cstring>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
+#include <span>
 #include <string>
 
 namespace {
@@ -47,6 +51,62 @@ std::string minimalHeader(const std::string& dataPath,
         "0 1 0.0\n0\n"
         "0.0 1.0\n0.0 1.0\n"
         + dataPath + "\n";
+}
+
+// Writes each value in big-endian (MSB-first) byte order, portably: on a
+// little-endian host the native bytes are reversed, on a big-endian host they
+// are already MSB-first.
+void writeBigEndianDoubles(std::ofstream& out, std::span<const double> values)
+{
+    for (const double value : values) {
+        std::array<unsigned char, sizeof(double)> bytes{};
+        std::memcpy(bytes.data(), &value, sizeof(double));
+        if constexpr (std::endian::native == std::endian::little) {
+            std::reverse(bytes.begin(), bytes.end());
+        }
+        out.write(reinterpret_cast<const char*>(bytes.data()),
+            static_cast<std::streamsize>(bytes.size()));
+    }
+}
+
+// A cross-endian (big-endian) FAB must decode to the same values a native-
+// endian one does: exercises the byte-swap path of the block decoder, which
+// every little-endian test fixture otherwise skips.
+void testBigEndianDecode(const std::filesystem::path& base)
+{
+    const auto root = base / "big_endian";
+    std::filesystem::create_directories(root / "Level_0");
+    writeText(root / "Header", minimalHeader("Level_0/Cell"));
+    // Version-1 _H: one 2x2 box, one component; the FAB header in the data
+    // file carries the (big-endian) RealDescriptor read by readFabHeader.
+    writeText(root / "Level_0" / "Cell_H",
+        "1\n1\n1\n0\n"
+        "(1 0\n((0,0) (1,1) (0,0))\n)\n"
+        "1\nFabOnDisk: Cell_D_00000 0\n\n"
+        "1,1\n1.0,\n\n1,1\n4.0,\n");
+    const std::array<double, 4> values{1.0, 2.0, 3.0, 4.0};
+    {
+        std::ofstream data(root / "Level_0" / "Cell_D_00000", std::ios::binary);
+        require(static_cast<bool>(data), "could not create big-endian payload");
+        // Ascending byte order (1 2 3 4 5 6 7 8) => big-endian in AMReX's
+        // descriptor; parseRealDescriptor maps it to littleEndian == false.
+        data << "FAB ((8, (64 11 52 0 1 12 0 1023)),"
+                "(8, (1 2 3 4 5 6 7 8)))((0,0) (1,1) (0,0)) 1\n";
+        writeBigEndianDoubles(data, values);
+    }
+
+    const auto metadata = amrvis::PlotfileMetadataReader{}.read(root);
+    amrvis::PlotfileBlockReader reader(root, metadata.metadata);
+    amrvis::BlockRequest request;
+    request.dataset.value = 1;
+    request.field.value = 0;
+    const auto result = reader.readBlock(request);
+    require(result.block->values.size() == values.size(),
+        "big-endian block value count mismatch");
+    for (std::size_t i = 0; i < values.size(); ++i) {
+        require(result.block->values[i] == values[i],
+            "big-endian FAB value decoded incorrectly");
+    }
 }
 
 // A path that walks above the plotfile directory must be rejected at metadata
@@ -216,6 +276,7 @@ int main()
     require(multiFabAccess.handle->values[2] == 30.0,
         "standalone MultiFab selective read value mismatch");
 
+    testBigEndianDecode(root);
     testRejectsEscapingDataPath(root);
     testRejectsOversizedBox(root);
 


### PR DESCRIPTION
readBlock staged the whole component as raw bytes and decoded into a second, equally large vector, so peak memory was 2x the block and decodeReal retested endianness per value. Read directly into the std::vector<float>/<double> instead: IEEE-32/64 data matches the target type's size, so a native-endian file (the common case) needs no decode at all and a cross-endian file only an in-place per-value byte swap. Halves peak read memory; deletes decodeReal.

The typed vector is allocator-aligned for its element type and only written through char*/unsigned char*, so there is no alignment or aliasing UB (clean under ASan/UBSan). Add a host-agnostic big-endian FAB test covering the byte-swap path, which the little-endian fixtures otherwise never reach.