### PR TITLE
Probe ffmpeg off the GUI thread

### DIFF
--- a/src/qt/AnimationExporter.cpp
+++ b/src/qt/AnimationExporter.cpp
@@ -33,7 +33,10 @@ bool AnimationExporter::begin(const QString& path, bool includeColorBar,
     m_canceled = false;
     m_framesDone = false;
     m_includeColorBar = includeColorBar;
-    m_hasFfmpeg = probeFfmpeg();
+    // Probe ffmpeg off the GUI thread (waitForStarted/Finished can block up to
+    // ~4 s); the result is only needed at finalize, after every frame renders.
+    m_hasFfmpeg = false;
+    m_ffmpegProbe = QtConcurrent::run([] { return probeFfmpeg(); });
     m_scale = scale;
     m_totalFrames = totalFrames;
     m_restoreIndex = restoreIndex;
@@ -122,7 +125,27 @@ void AnimationExporter::onFrameFailed()
 void AnimationExporter::finalizeEncoding()
 {
     m_framesDone = true;
+    // Continue once the probe launched at begin() resolves. Rendering has
+    // usually already let it finish, so the watcher typically fires
+    // immediately; either way the GUI thread never blocks on it.
+    auto* watcher = new QFutureWatcher<bool>(this);
+    connect(watcher, &QFutureWatcher<bool>::finished, this, [this, watcher] {
+        m_hasFfmpeg = watcher->result();
+        watcher->deleteLater();
+        finalizeEncodingWithProbe();
+    });
+    watcher->setFuture(m_ffmpegProbe);
+}
 
+void AnimationExporter::finalizeEncodingWithProbe()
+{
+    if (!m_active) {
+        return;
+    }
+    if (m_canceled) {
+        endExport(false, tr("Animation export cancelled."));
+        return;
+    }
     if (!m_hasFfmpeg) {
         endExport(true, tr("Exported %1 PNG frames "
             "(FFmpeg not found; skipped MP4).").arg(m_totalFrames));

--- a/src/qt/AnimationExporter.hpp
+++ b/src/qt/AnimationExporter.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <QFuture>
 #include <QImage>
 #include <QObject>
 #include <QString>
@@ -74,7 +75,11 @@ signals:
 
 private:
     void endExport(bool success, const QString& message);
+    // finalizeEncoding waits for the (already-running) ffmpeg probe off the
+    // GUI thread, then finalizeEncodingWithProbe does the PNG-only vs. MP4
+    // decision and launches the encoders.
     void finalizeEncoding();
+    void finalizeEncodingWithProbe();
     [[nodiscard]] static bool probeFfmpeg();
 
     FrameRenderer m_renderFrames;
@@ -85,6 +90,10 @@ private:
     bool m_framesDone = false;
     bool m_includeColorBar = false;
     bool m_hasFfmpeg = false;
+    // Launched off the GUI thread at begin() (probing ffmpeg can block up to
+    // ~4 s); consumed at finalize, by which point rendering has usually
+    // already let it finish.
+    QFuture<bool> m_ffmpegProbe;
     qreal m_scale = 1.0;   // frozen export zoom so every frame matches
     int m_totalFrames = 0;
     int m_restoreIndex = -1;


### PR DESCRIPTION
AnimationExporter::begin() called probeFfmpeg() (up to ~4 s of waitForStarted/waitForFinished) directly on the GUI thread. Launch it via QtConcurrent::run at begin() and consume the result at finalize through a QFutureWatcher (finalizeEncoding -> finalizeEncodingWithProbe); by finalize time frame rendering has usually let it finish, so the watcher typically fires immediately and the event loop never blocks. The continuation guards teardown/cancel and still emits encodingStarted at the same point, so the export-quit smoke contract is unchanged.