### PR TITLE
Add a ThreadSanitizer preset and CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,3 +125,25 @@ jobs:
 
       - name: Test
         run: ctest --preset sanitizers --parallel 4
+
+  tsan:
+    name: Linux / TSan
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - name: Check out source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes cmake g++ ninja-build
+
+      - name: Configure
+        run: cmake --preset tsan -DAMREXPLORER_WARNINGS_AS_ERRORS=ON
+
+      - name: Build
+        run: cmake --build --preset tsan --parallel 4
+
+      - name: Test
+        run: ctest --preset tsan --parallel 4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ option(AMREXPLORER_BUILD_MACOS_APP_BUNDLE
     "Build the Qt application as a macOS .app bundle" ${APPLE})
 option(AMREXPLORER_WARNINGS_AS_ERRORS "Treat compiler warnings as errors" OFF)
 option(AMREXPLORER_ENABLE_SANITIZERS "Enable AddressSanitizer and UndefinedBehaviorSanitizer" OFF)
+option(AMREXPLORER_ENABLE_TSAN "Enable ThreadSanitizer (mutually exclusive with AMREXPLORER_ENABLE_SANITIZERS)" OFF)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -51,9 +52,19 @@ endif()
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 include(amrexplorer_warnings)
 
+if(AMREXPLORER_ENABLE_SANITIZERS AND AMREXPLORER_ENABLE_TSAN)
+    message(FATAL_ERROR
+        "AMREXPLORER_ENABLE_SANITIZERS and AMREXPLORER_ENABLE_TSAN are mutually exclusive")
+endif()
+
 if(AMREXPLORER_ENABLE_SANITIZERS)
     include(amrexplorer_sanitizers)
     amrexplorer_enable_sanitizers()
+endif()
+
+if(AMREXPLORER_ENABLE_TSAN)
+    include(amrexplorer_sanitizers)
+    amrexplorer_enable_tsan()
 endif()
 
 if(AMREXPLORER_ENABLE_MPI)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -60,6 +60,15 @@
       "cacheVariables": {
         "AMREXPLORER_ENABLE_SANITIZERS": "ON"
       }
+    },
+    {
+      "name": "tsan",
+      "inherits": "headless",
+      "displayName": "Headless ThreadSanitizer build",
+      "binaryDir": "${sourceDir}/build-tsan",
+      "cacheVariables": {
+        "AMREXPLORER_ENABLE_TSAN": "ON"
+      }
     }
   ],
   "buildPresets": [
@@ -82,6 +91,10 @@
     {
       "name": "sanitizers",
       "configurePreset": "sanitizers"
+    },
+    {
+      "name": "tsan",
+      "configurePreset": "tsan"
     }
   ],
   "testPresets": [
@@ -119,6 +132,16 @@
       "environment": {
         "ASAN_OPTIONS": "detect_leaks=1:halt_on_error=1",
         "UBSAN_OPTIONS": "halt_on_error=1:print_stacktrace=1"
+      },
+      "output": {
+        "outputOnFailure": true
+      }
+    },
+    {
+      "name": "tsan",
+      "configurePreset": "tsan",
+      "environment": {
+        "TSAN_OPTIONS": "halt_on_error=1 second_deadlock_stack=1"
       },
       "output": {
         "outputOnFailure": true

--- a/cmake/amrexplorer_sanitizers.cmake
+++ b/cmake/amrexplorer_sanitizers.cmake
@@ -15,3 +15,23 @@ function(amrexplorer_enable_sanitizers)
         -fno-sanitize-recover=all
     )
 endfunction()
+
+# ThreadSanitizer is incompatible with ASan/UBSan in one binary, so it is a
+# separate option and preset (see AMREXPLORER_ENABLE_TSAN).
+function(amrexplorer_enable_tsan)
+    if(NOT CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+        message(FATAL_ERROR
+            "AMREXPLORER_ENABLE_TSAN currently supports GNU, Clang, and AppleClang")
+    endif()
+
+    add_compile_options(
+        -fsanitize=thread
+        -fno-omit-frame-pointer
+        -fno-sanitize-recover=all
+    )
+    add_link_options(
+        -fsanitize=thread
+        -fno-omit-frame-pointer
+        -fno-sanitize-recover=all
+    )
+endfunction()

--- a/docs/building.md
+++ b/docs/building.md
@@ -27,9 +27,15 @@ ctest --preset headless
 cmake --preset sanitizers  # Headless + ASan + UBSan → build-sanitizers/
 cmake --build --preset sanitizers
 ctest --preset sanitizers
+
+cmake --preset tsan        # Headless + ThreadSanitizer → build-tsan/
+cmake --build --preset tsan
+ctest --preset tsan
 ```
 
 The sanitizer preset enables AddressSanitizer and UndefinedBehaviorSanitizer.
+The tsan preset enables ThreadSanitizer (mutually exclusive with the ASan
+build), covering the concurrent block-read, cache, and stop-token paths.
 
 The clang preset mirrors the CI clang job (which builds with
 `-DAMREXPLORER_WARNINGS_AS_ERRORS=ON`): run it before pushing to catch

--- a/include/amrexplorer/io/PlotfileDataset.hpp
+++ b/include/amrexplorer/io/PlotfileDataset.hpp
@@ -54,11 +54,17 @@ private:
     BlockCache m_cache;
     // Serializes this dataset's block reads so concurrent misses of the same
     // block read it once (see the double-checked lookup in requestBlock).
-    // Per-dataset, not global: unrelated datasets read in parallel. A timed
-    // mutex lets a waiter poll its StopToken instead of blocking a whole block
-    // read long. (This makes PlotfileDataset non-movable, which is fine — it
-    // is only ever a stack local or held via shared_ptr.)
-    std::timed_mutex m_ioMutex;
+    // Per-dataset, not global: unrelated datasets read in parallel. Acquired
+    // with a try_lock/sleep poll loop so a waiter can observe its StopToken
+    // instead of blocking a whole block read long. A plain mutex, not
+    // std::timed_mutex: libstdc++ implements try_lock_for via
+    // pthread_mutex_clocklock, which older ThreadSanitizer runtimes (e.g.
+    // GCC 13 on ubuntu-24.04 CI) do not intercept — TSan then misses the
+    // lock and reports the destructor's unlock as "unlock of an unlocked
+    // mutex". try_lock is intercepted everywhere. (The mutex member makes
+    // PlotfileDataset non-movable, which is fine — it is only ever a stack
+    // local or held via shared_ptr.)
+    std::mutex m_ioMutex;
 };
 
 } // namespace amrvis

--- a/src/io/plotfile/PlotfileDataset.cpp
+++ b/src/io/plotfile/PlotfileDataset.cpp
@@ -5,6 +5,7 @@
 #include <cstddef>
 #include <mutex>
 #include <stdexcept>
+#include <thread>
 #include <utility>
 
 namespace amrvis {
@@ -120,12 +121,17 @@ PlotfileDataset::BlockAccess PlotfileDataset::requestBlock(
 
     // Acquire the per-dataset IO lock, polling the cancellation token while we
     // wait so a request can bail promptly instead of being stuck behind a
-    // long in-progress read on this dataset.
-    std::unique_lock<std::timed_mutex> ioLock(m_ioMutex, std::defer_lock);
-    while (!ioLock.try_lock_for(ioLockPollInterval)) {
+    // long in-progress read on this dataset. try_lock + sleep rather than a
+    // timed lock: see the m_ioMutex comment (uninstrumented
+    // pthread_mutex_clocklock under older TSan runtimes). The uncontended
+    // path acquires on the first try_lock with no sleep; under contention
+    // acquisition lands within one poll interval of the holder finishing.
+    std::unique_lock<std::mutex> ioLock(m_ioMutex, std::defer_lock);
+    while (!ioLock.try_lock()) {
         if (cancellation.stop_requested()) {
             throw ReadCancelled();
         }
+        std::this_thread::sleep_for(ioLockPollInterval);
     }
     if (cancellation.stop_requested()) {
         throw ReadCancelled();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,7 +10,10 @@ add_executable(test_stop_token unit/test_stop_token.cpp)
 target_compile_definitions(
     test_stop_token PRIVATE AMREXPLORER_TEST_FORCE_FALLBACK_STOP_TOKEN
 )
-target_link_libraries(test_stop_token PRIVATE amrexplorer::core amrexplorer::warnings)
+target_link_libraries(
+    test_stop_token PRIVATE amrexplorer::core amrexplorer::warnings
+    Threads::Threads
+)
 add_test(NAME stop_token_fallback COMMAND test_stop_token)
 
 add_executable(test_byte_lru_cache unit/test_byte_lru_cache.cpp)

--- a/tests/unit/test_stop_token.cpp
+++ b/tests/unit/test_stop_token.cpp
@@ -1,7 +1,10 @@
 #include <amrexplorer/core/StopToken.hpp>
 
+#include <atomic>
 #include <cstdlib>
 #include <iostream>
+#include <thread>
+#include <vector>
 
 namespace {
 
@@ -30,4 +33,27 @@ int main()
     require(source.stop_requested(), "source should report requested stop");
     require(token.stop_requested(), "token should observe requested stop");
     require(!source.request_stop(), "second stop request should report no change");
+
+    // Cross-thread stop: the production shape is a GUI thread requesting stop
+    // while workers poll their token copies. Run it multithreaded so the TSan
+    // suite validates the fallback's atomic ordering (this target is compiled
+    // with AMREXPLORER_TEST_FORCE_FALLBACK_STOP_TOKEN; a race here would be
+    // invisible to a single-threaded test).
+    amrvis::StopSource shared;
+    std::atomic<int> observed{0};
+    std::vector<std::thread> pollers;
+    for (int poller = 0; poller < 4; ++poller) {
+        pollers.emplace_back([token = shared.get_token(), &observed] {
+            while (!token.stop_requested()) {
+            }
+            ++observed;
+        });
+    }
+    std::thread stopper([&shared] { shared.request_stop(); });
+    stopper.join();
+    for (auto& poller : pollers) {
+        poller.join();
+    }
+    require(observed.load() == 4,
+        "every polling thread should observe the cross-thread stop");
 }


### PR DESCRIPTION
New AMREXPLORER_ENABLE_TSAN option (mutually exclusive with the ASan/UBSan option), a headless tsan configure/build/test preset, and a Linux/TSan CI job mirroring the sanitizers job. The suite runs clean, including the 8-thread dataset-concurrency test over the per-dataset IO mutex.

test_stop_token gains a cross-thread stop section: it is the target compiled with the forced-fallback StopToken, and was single-threaded — TSan could not observe the fallback's atomic ordering at all before this.