### PR TITLE
Close the remaining CI coverage gaps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install --yes cmake ninja-build qt6-base-dev ${{ matrix.package }}
+          sudo apt-get install --yes cmake desktop-file-utils ninja-build qt6-base-dev ${{ matrix.package }}
 
       - name: Configure
         run: cmake --preset default -DAMREXPLORER_WARNINGS_AS_ERRORS=ON
@@ -51,6 +51,13 @@ jobs:
 
       - name: Test
         run: ctest --preset default --parallel 4
+
+      - name: Install check
+        run: |
+          cmake --install build --prefix "${RUNNER_TEMP}/install-test"
+          test -x "${RUNNER_TEMP}/install-test/bin/amrexplorer"
+          desktop-file-validate \
+            "${RUNNER_TEMP}/install-test/share/applications/amrexplorer.desktop"
 
   macos:
     name: macOS / AppleClang
@@ -72,6 +79,11 @@ jobs:
       - name: Test
         run: ctest --preset default --parallel 4
 
+      - name: Install check
+        run: |
+          cmake --install build --prefix "${RUNNER_TEMP}/install-test"
+          test -x "${RUNNER_TEMP}/install-test/amrexplorer.app/Contents/MacOS/amrexplorer"
+
   windows:
     name: Windows / MSVC
     runs-on: windows-2022
@@ -88,21 +100,13 @@ jobs:
           cache: true
 
       - name: Configure
-        run: |
-          cmake -S . -B build-windows `
-            -G "Visual Studio 17 2022" -A x64 `
-            -DCMAKE_PREFIX_PATH="$env:QT_ROOT_DIR" `
-            -DAMREXPLORER_ENABLE_QT=ON `
-            -DAMREXPLORER_ENABLE_VTK=OFF `
-            -DAMREXPLORER_ENABLE_MPI=OFF `
-            -DAMREXPLORER_BUILD_TESTS=ON `
-            -DAMREXPLORER_WARNINGS_AS_ERRORS=ON
+        run: cmake --preset windows -DAMREXPLORER_WARNINGS_AS_ERRORS=ON
 
       - name: Build
-        run: cmake --build build-windows --config Release --parallel 4
+        run: cmake --build --preset windows --parallel 4
 
       - name: Test
-        run: ctest --test-dir build-windows --build-config Release --parallel 4 --output-on-failure
+        run: ctest --preset windows --parallel 4
 
   sanitizers:
     name: Linux / ASan + UBSan
@@ -125,6 +129,28 @@ jobs:
 
       - name: Test
         run: ctest --preset sanitizers --parallel 4
+
+  qt-sanitizers:
+    name: Linux / Qt + ASan + UBSan
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - name: Check out source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes cmake g++ ninja-build qt6-base-dev
+
+      - name: Configure
+        run: cmake --preset qt-sanitizers -DAMREXPLORER_WARNINGS_AS_ERRORS=ON
+
+      - name: Build
+        run: cmake --build --preset qt-sanitizers --parallel 4
+
+      - name: Test
+        run: ctest --preset qt-sanitizers --parallel 4
 
   tsan:
     name: Linux / TSan

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install codespell
         run: |

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -14,13 +14,13 @@ jobs:
   tabs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Tabs
         run: .github/workflows/style/check_tabs.sh
 
   trailing_whitespaces:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Trailing Whitespaces
         run: .github/workflows/style/check_trailing_whitespaces.sh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,6 @@ project(
 
 option(AMREXPLORER_ENABLE_QT "Build the Qt 6 desktop application" ON)
 option(AMREXPLORER_ENABLE_VTK "Build the optional VTK volume module" OFF)
-option(AMREXPLORER_ENABLE_MPI "Enable MPI-aware backends" OFF)
 option(AMREXPLORER_BUILD_TESTS "Build unit and integration tests" ON)
 option(AMREXPLORER_BUILD_MACOS_APP_BUNDLE
     "Build the Qt application as a macOS .app bundle" ${APPLE})
@@ -65,10 +64,6 @@ endif()
 if(AMREXPLORER_ENABLE_TSAN)
     include(amrexplorer_sanitizers)
     amrexplorer_enable_tsan()
-endif()
-
-if(AMREXPLORER_ENABLE_MPI)
-    find_package(MPI REQUIRED COMPONENTS CXX)
 endif()
 
 add_subdirectory(src/core)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -15,7 +15,6 @@
         "CMAKE_BUILD_TYPE": "Release",
         "AMREXPLORER_ENABLE_QT": "ON",
         "AMREXPLORER_ENABLE_VTK": "OFF",
-        "AMREXPLORER_ENABLE_MPI": "OFF",
         "AMREXPLORER_BUILD_TESTS": "ON"
       }
     },
@@ -39,7 +38,6 @@
         "CMAKE_BUILD_TYPE": "Debug",
         "AMREXPLORER_ENABLE_QT": "ON",
         "AMREXPLORER_ENABLE_VTK": "OFF",
-        "AMREXPLORER_ENABLE_MPI": "OFF",
         "AMREXPLORER_BUILD_TESTS": "ON"
       }
     },
@@ -69,6 +67,33 @@
       "cacheVariables": {
         "AMREXPLORER_ENABLE_TSAN": "ON"
       }
+    },
+    {
+      "name": "qt-sanitizers",
+      "inherits": "debug",
+      "displayName": "Qt + ASan and UBSan build (offscreen smoke tests)",
+      "binaryDir": "${sourceDir}/build-qt-sanitizers",
+      "cacheVariables": {
+        "AMREXPLORER_ENABLE_SANITIZERS": "ON"
+      }
+    },
+    {
+      "name": "windows",
+      "displayName": "Windows MSVC build (mirrors the CI job)",
+      "generator": "Visual Studio 17 2022",
+      "architecture": { "value": "x64" },
+      "binaryDir": "${sourceDir}/build-windows",
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Windows"
+      },
+      "cacheVariables": {
+        "CMAKE_PREFIX_PATH": "$env{QT_ROOT_DIR}",
+        "AMREXPLORER_ENABLE_QT": "ON",
+        "AMREXPLORER_ENABLE_VTK": "OFF",
+        "AMREXPLORER_BUILD_TESTS": "ON"
+      }
     }
   ],
   "buildPresets": [
@@ -95,6 +120,15 @@
     {
       "name": "tsan",
       "configurePreset": "tsan"
+    },
+    {
+      "name": "qt-sanitizers",
+      "configurePreset": "qt-sanitizers"
+    },
+    {
+      "name": "windows",
+      "configurePreset": "windows",
+      "configuration": "Release"
     }
   ],
   "testPresets": [
@@ -143,6 +177,25 @@
       "environment": {
         "TSAN_OPTIONS": "halt_on_error=1 second_deadlock_stack=1"
       },
+      "output": {
+        "outputOnFailure": true
+      }
+    },
+    {
+      "name": "qt-sanitizers",
+      "configurePreset": "qt-sanitizers",
+      "environment": {
+        "ASAN_OPTIONS": "detect_leaks=1:halt_on_error=1",
+        "UBSAN_OPTIONS": "halt_on_error=1:print_stacktrace=1"
+      },
+      "output": {
+        "outputOnFailure": true
+      }
+    },
+    {
+      "name": "windows",
+      "configurePreset": "windows",
+      "configuration": "Release",
       "output": {
         "outputOnFailure": true
       }

--- a/docs/building.md
+++ b/docs/building.md
@@ -31,11 +31,18 @@ ctest --preset sanitizers
 cmake --preset tsan        # Headless + ThreadSanitizer → build-tsan/
 cmake --build --preset tsan
 ctest --preset tsan
+
+cmake --preset qt-sanitizers  # Qt + ASan + UBSan → build-qt-sanitizers/
+cmake --build --preset qt-sanitizers
+ctest --preset qt-sanitizers
 ```
 
 The sanitizer preset enables AddressSanitizer and UndefinedBehaviorSanitizer.
 The tsan preset enables ThreadSanitizer (mutually exclusive with the ASan
 build), covering the concurrent block-read, cache, and stop-token paths.
+The qt-sanitizers preset runs the full suite — including the offscreen Qt
+smoke tests — under ASan/UBSan with leak detection. A `windows` preset
+(usable only on Windows hosts) mirrors the CI MSVC job.
 
 The clang preset mirrors the CI clang job (which builds with
 `-DAMREXPLORER_WARNINGS_AS_ERRORS=ON`): run it before pushing to catch

--- a/src/qt/main.cpp
+++ b/src/qt/main.cpp
@@ -751,20 +751,24 @@ int main(int argc, char* argv[])
     } else if (argc == 3
         && std::string_view(argv[1]) == "--raw-fab-smoke-test") {
         const std::filesystem::path path(argv[2]);
-        int phase = 0;
+        // Shared, not a block-scoped local captured by reference: the
+        // connection outlives this else-if block, and a by-reference phase
+        // is a stack-use-after-scope once main moves on (caught by the
+        // Qt-enabled ASan build).
+        auto phase = std::make_shared<int>(0);
         QObject::connect(&window, &amrvis::qt::MainWindow::initialSliceFinished,
-            &application, [&window, &application, &phase](bool success) {
+            &application, [&window, &application, phase](bool success) {
                 auto* selector =
                     window.findChild<amrvis::qt::FabSelectorDock*>();
                 const auto valid = success && selector != nullptr
                     && selector->isVisible() && selector->entries().size() >= 2
                     && fabSelectorIsAscending(*selector)
                     && fabSelectorColumnsMatch(*selector, false)
-                    && fabSelectorPointFilterMatches(*selector, phase == 0)
+                    && fabSelectorPointFilterMatches(*selector, *phase == 0)
                     && fabRangeSelectorMatches(window);
                 if (!valid) {
                     application.exit(1);
-                } else if (phase++ == 0) {
+                } else if ((*phase)++ == 0) {
                     // The unique point match starts the FAB load.
                 } else {
                     application.exit(
@@ -776,9 +780,10 @@ int main(int argc, char* argv[])
     } else if (argc == 3
         && std::string_view(argv[1]) == "--multifab-fab-smoke-test") {
         const std::filesystem::path path(argv[2]);
-        int phase = 0;
+        // Shared for the same lifetime reason as the raw-fab branch above.
+        auto phase = std::make_shared<int>(0);
         QObject::connect(&window, &amrvis::qt::MainWindow::initialSliceFinished,
-            &application, [&window, &application, &phase](bool success) {
+            &application, [&window, &application, phase](bool success) {
                 auto* selector =
                     window.findChild<amrvis::qt::FabSelectorDock*>();
                 if (!success || selector == nullptr
@@ -786,13 +791,13 @@ int main(int argc, char* argv[])
                     || !fabSelectorIsAscending(*selector)
                     || !fabSelectorColumnsMatch(*selector, true)
                     || !fabSelectorPointFilterMatches(
-                        *selector, phase == 0)) {
+                        *selector, *phase == 0)) {
                     application.exit(1);
                     return;
                 }
-                if (phase == 0) {
-                    ++phase;
-                } else if (phase == 1) {
+                if (*phase == 0) {
+                    ++*phase;
+                } else if (*phase == 1) {
                     auto* back = selector->findChild<QPushButton*>(
                         QStringLiteral("fabBackButton"));
                     if (back == nullptr || !back->isVisible()
@@ -801,7 +806,7 @@ int main(int argc, char* argv[])
                         application.exit(1);
                         return;
                     }
-                    ++phase;
+                    ++*phase;
                     QTimer::singleShot(0, back, &QPushButton::click);
                 } else {
                     const auto* back = selector->findChild<QPushButton*>(


### PR DESCRIPTION
- Add a qt-sanitizers preset and CI job: the full suite including the offscreen Qt smokes runs under ASan/UBSan with leak detection (no suppressions needed). This immediately caught both FAB smoke harnesses capturing a block-scoped phase counter by reference in connections that outlive the block (stack-use-after-scope); switch them to the shared_ptr pattern the neighboring branches already use.
- Add install checks: cmake --install plus desktop-file-validate on Linux, bundle layout on macOS.
- Remove the dead AMREXPLORER_ENABLE_MPI option and its failing-configure path.
- Drive the Windows job from a committed, host-conditioned preset instead of hand-duplicated flags.
- Pin actions/checkout by SHA in codespell.yml and style.yml.