### PR TITLE
Consolidate duplicated helpers into shared detail headers

### DIFF
--- a/include/amrexplorer/io/detail/FabHeaderParsing.hpp
+++ b/include/amrexplorer/io/detail/FabHeaderParsing.hpp
@@ -1,0 +1,180 @@
+#pragma once
+
+// Shared low-level parsing for AMReX FAB and plotfile headers. These helpers
+// were previously duplicated (with drifting strictness) across the four
+// readers; this is the one strict definition. Each reader reports failures
+// through its own public error type (MetadataReadError, BlockReadError), so
+// every throwing helper is templated on that error type — call sites choose
+// the exception their callers and tests already expect.
+
+#include <amrexplorer/core/Geometry.hpp>
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace amrvis::detail {
+
+// Every integer in the text, in order; any non-numeric characters act as
+// separators. Never throws — callers validate the count/shape themselves.
+[[nodiscard]] inline std::vector<int> parseIntegers(const std::string& text)
+{
+    std::string numbers = text;
+    std::replace_if(numbers.begin(), numbers.end(), [](char character) {
+        return !(character >= '0' && character <= '9')
+            && character != '-' && character != '+';
+    }, ' ');
+    std::istringstream input(numbers);
+    std::vector<int> values;
+    int value = 0;
+    while (input >> value) {
+        values.push_back(value);
+    }
+    return values;
+}
+
+// One past the ')' matching the '(' at start.
+template <typename Error>
+[[nodiscard]] std::size_t balancedExpressionEnd(
+    const std::string& text, std::size_t start)
+{
+    if (start >= text.size() || text[start] != '(') {
+        throw Error("expected a parenthesized FAB header expression");
+    }
+    int depth = 0;
+    for (std::size_t i = start; i < text.size(); ++i) {
+        if (text[i] == '(') {
+            ++depth;
+        } else if (text[i] == ')') {
+            --depth;
+            if (depth == 0) {
+                return i + 1;
+            }
+        }
+    }
+    throw Error("unterminated FAB header expression");
+}
+
+// AMReX Box text "((lo...) (hi...) (type...))" with the dimension known.
+template <typename Error>
+[[nodiscard]] IntBox parseAmrexBox(const std::string& text, int dimension)
+{
+    const auto values = parseIntegers(text);
+    if (values.size() != static_cast<std::size_t>(dimension * 3)) {
+        throw Error("malformed AMReX Box in FAB header");
+    }
+    IntBox box;
+    for (int axis = 0; axis < dimension; ++axis) {
+        const auto i = static_cast<std::size_t>(axis);
+        box.lower[i] = values[i];
+        box.upper[i] = values[static_cast<std::size_t>(dimension + axis)];
+        box.centering[i] = values[static_cast<std::size_t>(2 * dimension + axis)];
+    }
+    return box;
+}
+
+// AMReX Box text with the dimension inferred from the first tuple's length.
+template <typename Error>
+[[nodiscard]] IntBox parseAmrexBoxInferDimension(
+    const std::string& text, int& dimension)
+{
+    const auto firstTuple = text.find('(', 1);
+    const auto firstEnd = text.find(')', firstTuple);
+    if (firstTuple == std::string::npos || firstEnd == std::string::npos) {
+        throw Error("cannot infer FAB dimension");
+    }
+    dimension = static_cast<int>(
+        parseIntegers(text.substr(firstTuple, firstEnd - firstTuple + 1))
+            .size());
+    if (dimension < 1 || dimension > 3) {
+        throw Error("malformed AMReX Box in FAB header");
+    }
+    return parseAmrexBox<Error>(text, dimension);
+}
+
+// Parsed FAB RealDescriptor: IEEE-32 or IEEE-64 with a contiguous byte
+// order. This is the strict parse (format-entry count, the full format
+// tuple, and the byte-order permutation are all validated); the previously
+// separate catalog-side variant skipped the byte-order check, so a
+// descriptor could pass cataloging and fail at the first block read.
+struct ParsedRealDescriptor {
+    std::size_t bytes = 0;
+    bool littleEndian = false;
+};
+
+template <typename Error>
+[[nodiscard]] ParsedRealDescriptor parseRealDescriptor(
+    const std::string& descriptor)
+{
+    const auto values = parseIntegers(descriptor);
+    constexpr std::size_t formatCountIndex = 0;
+    constexpr std::size_t formatStartIndex = 1;
+    constexpr std::size_t formatEntries = 8;
+    constexpr std::size_t orderCountIndex = formatStartIndex + formatEntries;
+    if (values.size() <= orderCountIndex
+        || values[formatCountIndex] != static_cast<int>(formatEntries)) {
+        throw Error("malformed FAB RealDescriptor");
+    }
+
+    constexpr std::array<int, formatEntries> ieee32{
+        32, 8, 23, 0, 1, 9, 0, 127};
+    constexpr std::array<int, formatEntries> ieee64{
+        64, 11, 52, 0, 1, 12, 0, 1023};
+    const auto matchesFormat = [&values](const auto& expected) {
+        return std::equal(expected.begin(), expected.end(),
+            values.begin() + static_cast<std::ptrdiff_t>(formatStartIndex));
+    };
+    const auto bytes = matchesFormat(ieee32) ? 4
+        : matchesFormat(ieee64) ? 8 : 0;
+    if (bytes == 0) {
+        throw Error("only IEEE-32 and IEEE-64 FAB data are supported");
+    }
+
+    if (values[orderCountIndex] != bytes
+        || values.size() < orderCountIndex + 1 + static_cast<std::size_t>(bytes)) {
+        throw Error("malformed FAB byte-order descriptor");
+    }
+
+    bool ascending = true;
+    bool descending = true;
+    for (int byte = 0; byte < bytes; ++byte) {
+        const auto value = values[orderCountIndex + 1 + static_cast<std::size_t>(byte)];
+        ascending = ascending && value == byte + 1;
+        descending = descending && value == bytes - byte;
+    }
+    if (!ascending && !descending) {
+        throw Error("unsupported non-contiguous FAB byte order");
+    }
+    return {static_cast<std::size_t>(bytes), descending};
+}
+
+// The box grown by the ghost width on every active axis, guarded against
+// integer overflow (one previously duplicated copy did this arithmetic in
+// plain int).
+template <typename Error>
+[[nodiscard]] IntBox grownBox(
+    const IntBox& source, const Int3& ghost, int dimension)
+{
+    auto result = source;
+    for (int axis = 0; axis < dimension; ++axis) {
+        const auto i = static_cast<std::size_t>(axis);
+        const auto lower = static_cast<std::int64_t>(source.lower[i]) - ghost[i];
+        const auto upper = static_cast<std::int64_t>(source.upper[i]) + ghost[i];
+        if (lower < std::numeric_limits<int>::min()
+            || lower > std::numeric_limits<int>::max()
+            || upper < std::numeric_limits<int>::min()
+            || upper > std::numeric_limits<int>::max()) {
+            throw Error("ghost-grown FAB box exceeds supported integer range");
+        }
+        result.lower[i] = static_cast<int>(lower);
+        result.upper[i] = static_cast<int>(upper);
+    }
+    return result;
+}
+
+} // namespace amrvis::detail

--- a/include/amrexplorer/query/detail/BlockLookup.hpp
+++ b/include/amrexplorer/query/detail/BlockLookup.hpp
@@ -1,0 +1,110 @@
+#pragma once
+
+// Shared per-point block-lookup helpers for the query layer. These were
+// previously copied verbatim between SliceQuery.cpp and LineQuery.cpp, with a
+// third, unchecked valueOffset variant in the GUI's DatasetExtract — this is
+// the one overflow-checked definition.
+
+#include <amrexplorer/core/Geometry.hpp>
+#include <amrexplorer/core/Metadata.hpp>
+#include <amrexplorer/io/PlotfileDataset.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <stdexcept>
+
+namespace amrvis::detail {
+
+// One cached block pinned for a query: the grid's valid box plus the cache
+// handle that keeps its values resident.
+struct LoadedBlock {
+    IntBox validBox;
+    PlotfileDataset::BlockCache::Handle data;
+};
+
+[[nodiscard]] inline bool intersects(
+    const IntBox& left, const IntBox& right, int dimension)
+{
+    for (int axis = 0; axis < dimension; ++axis) {
+        const auto i = static_cast<std::size_t>(axis);
+        if (left.upper[i] < right.lower[i] || right.upper[i] < left.lower[i]) {
+            return false;
+        }
+    }
+    return true;
+}
+
+[[nodiscard]] inline bool contains(
+    const IntBox& box, const Int3& point, int dimension)
+{
+    for (int axis = 0; axis < dimension; ++axis) {
+        const auto i = static_cast<std::size_t>(axis);
+        if (point[i] < box.lower[i] || point[i] > box.upper[i]) {
+            return false;
+        }
+    }
+    return true;
+}
+
+[[nodiscard]] inline int physicalToIndex(double position,
+    const DatasetMetadata& metadata, const LevelMetadata& level, int axis)
+{
+    (void) metadata;
+    return sampleIndex(level, axis, position);
+}
+
+// Offset of `point` into a FAB's component-major values (first axis
+// fastest), overflow-checked end to end. `point` must lie inside `box`
+// (checked via the relative-coordinate guard).
+[[nodiscard]] inline std::size_t valueOffset(
+    const IntBox& box, const Int3& point, int dimension)
+{
+    const auto extent = [&box](std::size_t axis) {
+        const auto value = static_cast<std::int64_t>(box.upper[axis])
+            - box.lower[axis] + 1;
+        if (value <= 0) {
+            throw std::overflow_error("FAB extent is not positive");
+        }
+        return static_cast<std::uint64_t>(value);
+    };
+    const auto relative = [&box, &point](std::size_t axis) {
+        const auto value = static_cast<std::int64_t>(point[axis]) - box.lower[axis];
+        if (value < 0) {
+            throw std::overflow_error("FAB point precedes its indexed box");
+        }
+        return static_cast<std::uint64_t>(value);
+    };
+    const auto nx = extent(0);
+    const auto x = relative(0);
+    if (dimension == 1) {
+        return static_cast<std::size_t>(x);
+    }
+    const auto ny = extent(1);
+    const auto y = relative(1);
+    if (dimension == 2) {
+        if (y > (std::numeric_limits<std::uint64_t>::max() - x) / nx) {
+            throw std::overflow_error("2-D FAB offset overflows");
+        }
+        const auto offset = x + nx * y;
+        if (offset > std::numeric_limits<std::size_t>::max()) {
+            throw std::overflow_error("2-D FAB offset exceeds addressable memory");
+        }
+        return static_cast<std::size_t>(offset);
+    }
+    const auto z = relative(2);
+    if (z > (std::numeric_limits<std::uint64_t>::max() - y) / ny) {
+        throw std::overflow_error("3-D FAB row offset overflows");
+    }
+    const auto row = y + ny * z;
+    if (row > (std::numeric_limits<std::uint64_t>::max() - x) / nx) {
+        throw std::overflow_error("3-D FAB offset overflows");
+    }
+    const auto offset = x + nx * row;
+    if (offset > std::numeric_limits<std::size_t>::max()) {
+        throw std::overflow_error("3-D FAB offset exceeds addressable memory");
+    }
+    return static_cast<std::size_t>(offset);
+}
+
+} // namespace amrvis::detail

--- a/include/amrexplorer/render2d/detail/PlaneValidation.hpp
+++ b/include/amrexplorer/render2d/detail/PlaneValidation.hpp
@@ -1,0 +1,44 @@
+#pragma once
+
+// The one definition of "this ScalarPlane's storage matches its dimensions",
+// previously reimplemented with drifting strictness by the renderer, the
+// glyph generator, and the contour extractor. Extent policy is explicit:
+// rendering requires a positive extent, while contour extraction legitimately
+// accepts empty planes (and returns no segments).
+
+#include <amrexplorer/core/Result.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <stdexcept>
+
+namespace amrvis::detail {
+
+enum class PlaneExtent : std::uint8_t {
+    RequirePositive,
+    AllowEmpty
+};
+
+inline void validatePlaneStorage(const ScalarPlane& plane, PlaneExtent extent)
+{
+    if (extent == PlaneExtent::RequirePositive) {
+        if (plane.width <= 0 || plane.height <= 0) {
+            throw std::invalid_argument(
+                "scalar plane dimensions must be positive");
+        }
+    } else if (plane.width < 0 || plane.height < 0) {
+        throw std::invalid_argument(
+            "scalar plane dimensions must not be negative");
+    }
+    const auto pixelCount = static_cast<std::uint64_t>(plane.width)
+        * static_cast<std::uint64_t>(plane.height);
+    if (pixelCount > std::numeric_limits<std::size_t>::max()
+        || plane.values.size() != static_cast<std::size_t>(pixelCount)
+        || plane.valid.size() != static_cast<std::size_t>(pixelCount)) {
+        throw std::invalid_argument(
+            "scalar plane storage does not match its dimensions");
+    }
+}
+
+} // namespace amrvis::detail

--- a/src/io/plotfile/FabCatalog.cpp
+++ b/src/io/plotfile/FabCatalog.cpp
@@ -1,4 +1,5 @@
 #include <amrexplorer/io/FabCatalog.hpp>
+#include <amrexplorer/io/detail/FabHeaderParsing.hpp>
 
 #include <amrexplorer/io/PlotfileMetadataReader.hpp>
 #include <amrexplorer/io/StandaloneMetadataReader.hpp>
@@ -16,73 +17,29 @@
 namespace amrvis {
 namespace {
 
-std::vector<int> parseIntegers(const std::string& text)
-{
-    std::string numbers = text;
-    std::replace_if(numbers.begin(), numbers.end(), [](char character) {
-        return !(character >= '0' && character <= '9')
-            && character != '-' && character != '+';
-    }, ' ');
-    std::istringstream input(numbers);
-    std::vector<int> values;
-    int value = 0;
-    while (input >> value) values.push_back(value);
-    return values;
-}
-
 std::size_t balancedEnd(const std::string& text, std::size_t start)
 {
-    if (start >= text.size() || text[start] != '(') {
-        throw MetadataReadError("expected a parenthesized FAB header expression");
-    }
-    int depth = 0;
-    for (std::size_t i = start; i < text.size(); ++i) {
-        depth += text[i] == '(' ? 1 : text[i] == ')' ? -1 : 0;
-        if (depth == 0) return i + 1;
-    }
-    throw MetadataReadError("unterminated FAB header expression");
+    return detail::balancedExpressionEnd<MetadataReadError>(text, start);
 }
 
 std::pair<FabRealPrecision, std::size_t> parsePrecision(
     const std::string& descriptor)
 {
-    const auto values = parseIntegers(descriptor);
-    constexpr std::size_t start = 1;
-    constexpr std::array<int, 8> ieee32{32, 8, 23, 0, 1, 9, 0, 127};
-    constexpr std::array<int, 8> ieee64{64, 11, 52, 0, 1, 12, 0, 1023};
-    if (values.size() >= 9
-        && std::equal(ieee32.begin(), ieee32.end(), values.begin() + start)) {
-        return {FabRealPrecision::Single, 4};
-    }
-    if (values.size() >= 9
-        && std::equal(ieee64.begin(), ieee64.end(), values.begin() + start)) {
-        return {FabRealPrecision::Double, 8};
-    }
-    throw MetadataReadError("only IEEE-32 and IEEE-64 FAB data are supported");
+    // The strict shared parse: unlike the previous catalog-local variant it
+    // also validates the format-entry count and the byte order, so a
+    // descriptor that would fail at the first block read now fails at
+    // cataloging too instead of slipping through.
+    const auto parsed
+        = detail::parseRealDescriptor<MetadataReadError>(descriptor);
+    return {parsed.bytes == 4 ? FabRealPrecision::Single
+                              : FabRealPrecision::Double,
+        parsed.bytes};
 }
 
 IntBox parseBox(const std::string& text, int& dimension)
 {
-    const auto firstTuple = text.find('(', 1);
-    const auto firstEnd = text.find(')', firstTuple);
-    if (firstTuple == std::string::npos || firstEnd == std::string::npos) {
-        throw MetadataReadError("cannot infer FAB dimension");
-    }
-    dimension = static_cast<int>(
-        parseIntegers(text.substr(firstTuple, firstEnd - firstTuple + 1)).size());
-    const auto values = parseIntegers(text);
-    if (dimension < 1 || dimension > 3
-        || values.size() != static_cast<std::size_t>(dimension * 3)) {
-        throw MetadataReadError("malformed AMReX Box in FAB header");
-    }
-    IntBox box;
-    for (int axis = 0; axis < dimension; ++axis) {
-        const auto i = static_cast<std::size_t>(axis);
-        box.lower[i] = values[i];
-        box.upper[i] = values[static_cast<std::size_t>(dimension + axis)];
-        box.centering[i] = values[static_cast<std::size_t>(2 * dimension + axis)];
-    }
-    return box;
+    return detail::parseAmrexBoxInferDimension<MetadataReadError>(
+        text, dimension);
 }
 
 std::uint64_t payloadBytes(
@@ -175,24 +132,7 @@ std::filesystem::path companionHeaderPath(
 IntBox storedBox(
     const IntBox& validBox, const Int3& ghostWidth, int dimension)
 {
-    auto result = validBox;
-    for (int axis = 0; axis < dimension; ++axis) {
-        const auto index = static_cast<std::size_t>(axis);
-        const auto lower = static_cast<std::int64_t>(validBox.lower[index])
-            - ghostWidth[index];
-        const auto upper = static_cast<std::int64_t>(validBox.upper[index])
-            + ghostWidth[index];
-        if (lower < std::numeric_limits<int>::min()
-            || lower > std::numeric_limits<int>::max()
-            || upper < std::numeric_limits<int>::min()
-            || upper > std::numeric_limits<int>::max()) {
-            throw MetadataReadError(
-                "companion MultiFab ghost-grown FAB box exceeds integer range");
-        }
-        result.lower[index] = static_cast<int>(lower);
-        result.upper[index] = static_cast<int>(upper);
-    }
-    return result;
+    return detail::grownBox<MetadataReadError>(validBox, ghostWidth, dimension);
 }
 
 std::vector<FabRecord> recordsFromCompanion(

--- a/src/io/plotfile/PlotfileBlockReader.cpp
+++ b/src/io/plotfile/PlotfileBlockReader.cpp
@@ -1,4 +1,5 @@
 #include <amrexplorer/io/PlotfileBlockReader.hpp>
+#include <amrexplorer/io/detail/FabHeaderParsing.hpp>
 
 #include <algorithm>
 #include <array>
@@ -17,104 +18,23 @@
 namespace amrvis {
 namespace {
 
-struct RealEncoding {
-    std::size_t bytes = 0;
-    bool littleEndian = false;
-};
-
-std::vector<int> parseIntegers(const std::string& text)
-{
-    std::string numbers = text;
-    std::replace_if(numbers.begin(), numbers.end(), [](char character) {
-        return !(character >= '0' && character <= '9')
-            && character != '-' && character != '+';
-    }, ' ');
-    std::istringstream input(numbers);
-    std::vector<int> values;
-    int value = 0;
-    while (input >> value) {
-        values.push_back(value);
-    }
-    return values;
-}
+// Shared strict parsers from FabHeaderParsing.hpp, bound to this reader's
+// error type.
+using RealEncoding = detail::ParsedRealDescriptor;
 
 IntBox parseAmrexBox(const std::string& text, int dimension)
 {
-    const auto values = parseIntegers(text);
-    if (values.size() != static_cast<std::size_t>(dimension * 3)) {
-        throw BlockReadError("malformed AMReX Box in FAB header");
-    }
-    IntBox box;
-    for (int axis = 0; axis < dimension; ++axis) {
-        const auto i = static_cast<std::size_t>(axis);
-        box.lower[i] = values[i];
-        box.upper[i] = values[static_cast<std::size_t>(dimension + axis)];
-        box.centering[i] = values[static_cast<std::size_t>(2 * dimension + axis)];
-    }
-    return box;
+    return detail::parseAmrexBox<BlockReadError>(text, dimension);
 }
 
 std::size_t balancedExpressionEnd(const std::string& text, std::size_t start)
 {
-    if (start >= text.size() || text[start] != '(') {
-        throw BlockReadError("expected a parenthesized FAB header expression");
-    }
-    int depth = 0;
-    for (std::size_t i = start; i < text.size(); ++i) {
-        if (text[i] == '(') {
-            ++depth;
-        } else if (text[i] == ')') {
-            --depth;
-            if (depth == 0) {
-                return i + 1;
-            }
-        }
-    }
-    throw BlockReadError("unterminated FAB header expression");
+    return detail::balancedExpressionEnd<BlockReadError>(text, start);
 }
 
 RealEncoding parseRealDescriptor(const std::string& descriptor)
 {
-    const auto values = parseIntegers(descriptor);
-    constexpr std::size_t formatCountIndex = 0;
-    constexpr std::size_t formatStartIndex = 1;
-    constexpr std::size_t formatEntries = 8;
-    constexpr std::size_t orderCountIndex = formatStartIndex + formatEntries;
-    if (values.size() <= orderCountIndex
-        || values[formatCountIndex] != static_cast<int>(formatEntries)) {
-        throw BlockReadError("malformed FAB RealDescriptor");
-    }
-
-    constexpr std::array<int, formatEntries> ieee32{
-        32, 8, 23, 0, 1, 9, 0, 127};
-    constexpr std::array<int, formatEntries> ieee64{
-        64, 11, 52, 0, 1, 12, 0, 1023};
-    const auto matchesFormat = [&values](const auto& expected) {
-        return std::equal(expected.begin(), expected.end(),
-            values.begin() + static_cast<std::ptrdiff_t>(formatStartIndex));
-    };
-    const auto bytes = matchesFormat(ieee32) ? 4
-        : matchesFormat(ieee64) ? 8 : 0;
-    if (bytes == 0) {
-        throw BlockReadError("only IEEE-32 and IEEE-64 FAB data are supported");
-    }
-
-    if (values[orderCountIndex] != bytes
-        || values.size() < orderCountIndex + 1 + static_cast<std::size_t>(bytes)) {
-        throw BlockReadError("malformed FAB byte-order descriptor");
-    }
-
-    bool ascending = true;
-    bool descending = true;
-    for (int byte = 0; byte < bytes; ++byte) {
-        const auto value = values[orderCountIndex + 1 + static_cast<std::size_t>(byte)];
-        ascending = ascending && value == byte + 1;
-        descending = descending && value == bytes - byte;
-    }
-    if (!ascending && !descending) {
-        throw BlockReadError("unsupported non-contiguous FAB byte order");
-    }
-    return {static_cast<std::size_t>(bytes), descending};
+    return detail::parseRealDescriptor<BlockReadError>(descriptor);
 }
 
 struct FabHeader {
@@ -164,21 +84,7 @@ FabHeader readFabHeader(
 
 IntBox grownBox(const IntBox& source, const Int3& ghost, int dimension)
 {
-    auto result = source;
-    for (int axis = 0; axis < dimension; ++axis) {
-        const auto i = static_cast<std::size_t>(axis);
-        const auto lower = static_cast<std::int64_t>(source.lower[i]) - ghost[i];
-        const auto upper = static_cast<std::int64_t>(source.upper[i]) + ghost[i];
-        if (lower < std::numeric_limits<int>::min()
-            || lower > std::numeric_limits<int>::max()
-            || upper < std::numeric_limits<int>::min()
-            || upper > std::numeric_limits<int>::max()) {
-            throw BlockReadError("ghost-grown FAB box exceeds supported integer range");
-        }
-        result.lower[i] = static_cast<int>(lower);
-        result.upper[i] = static_cast<int>(upper);
-    }
-    return result;
+    return detail::grownBox<BlockReadError>(source, ghost, dimension);
 }
 
 std::uint64_t pointCount(const IntBox& box, int dimension)

--- a/src/io/plotfile/PlotfileMetadataReader.cpp
+++ b/src/io/plotfile/PlotfileMetadataReader.cpp
@@ -1,4 +1,5 @@
 #include <amrexplorer/io/PlotfileMetadataReader.hpp>
+#include <amrexplorer/io/detail/FabHeaderParsing.hpp>
 #include <amrexplorer/io/PlotfileBlockReader.hpp>
 #include <amrexplorer/io/detail/VisMfIndex.hpp>
 
@@ -90,21 +91,7 @@ IntBox readAmrexBox(std::istream& input, int dimension, std::string_view descrip
     return box;
 }
 
-std::vector<int> parseIntegers(const std::string& line)
-{
-    std::string numbers = line;
-    std::replace_if(numbers.begin(), numbers.end(), [](char character) {
-        return !(character >= '0' && character <= '9')
-            && character != '-' && character != '+';
-    }, ' ');
-    std::istringstream input(numbers);
-    std::vector<int> values;
-    int value = 0;
-    while (input >> value) {
-        values.push_back(value);
-    }
-    return values;
-}
+using detail::parseIntegers;
 
 // Rejects a metadata-derived path that could redirect reads outside the
 // plotfile directory when joined to the plotfile root: an absolute path

--- a/src/io/plotfile/StandaloneMetadataReader.cpp
+++ b/src/io/plotfile/StandaloneMetadataReader.cpp
@@ -1,4 +1,5 @@
 #include <amrexplorer/io/StandaloneMetadataReader.hpp>
+#include <amrexplorer/io/detail/FabHeaderParsing.hpp>
 #include <amrexplorer/io/FabCatalog.hpp>
 #include <amrexplorer/io/PlotfileBlockReader.hpp>
 #include <amrexplorer/io/detail/VisMfIndex.hpp>
@@ -17,21 +18,7 @@
 namespace amrvis {
 namespace {
 
-std::vector<int> parseIntegers(const std::string& text)
-{
-    std::string numbers = text;
-    std::replace_if(numbers.begin(), numbers.end(), [](char character) {
-        return !(character >= '0' && character <= '9')
-            && character != '-' && character != '+';
-    }, ' ');
-    std::istringstream input(numbers);
-    std::vector<int> result;
-    int value = 0;
-    while (input >> value) {
-        result.push_back(value);
-    }
-    return result;
-}
+using detail::parseIntegers;
 
 int inferBoxDimension(const std::string& boxText)
 {
@@ -143,12 +130,9 @@ PlotfileMetadataResult makeSelectedFabMetadata(
         throw MetadataReadError("selected FAB index is unavailable");
     }
     const auto& sourceBlock = sourceLevel.blocks[blockIndex];
-    auto storedBox = sourceBlock.box;
-    for (int axis = 0; axis < source.dimension; ++axis) {
-        const auto i = static_cast<std::size_t>(axis);
-        storedBox.lower[i] -= sourceLevel.ghostWidth[i];
-        storedBox.upper[i] += sourceLevel.ghostWidth[i];
-    }
+    // Overflow-guarded shared grow (this copy previously used plain int).
+    auto storedBox = detail::grownBox<MetadataReadError>(
+        sourceBlock.box, sourceLevel.ghostWidth, source.dimension);
     if (sourceLevel.visMfHeaderVersion == 1) {
         storedBox = inspectFabRecord(
             dataRoot / sourceBlock.filePath, sourceBlock.fileOffset).storedBox;

--- a/src/qt/DatasetExtract.hpp
+++ b/src/qt/DatasetExtract.hpp
@@ -65,12 +65,7 @@ inline std::array<int, 2> inPlaneAxes(int dimension, int normalAxis) noexcept
 // The shared overflow-checked helpers (this header previously carried its
 // own unchecked fabValueOffset variant — the drift the consolidation fixed).
 using amrvis::detail::intersects;
-
-inline std::size_t fabValueOffset(const IntBox& box, int i, int j, int k,
-    int dimension)
-{
-    return amrvis::detail::valueOffset(box, Int3{{i, j, k}}, dimension);
-}
+using amrvis::detail::valueOffset;
 
 } // namespace dataset_extract_detail
 
@@ -210,7 +205,6 @@ inline std::size_t fabValueOffset(const IntBox& box, int i, int j, int k,
         const auto iUpper = std::min(validBox.upper[xAxis], extract.upper[0]);
         const auto jLower = std::max(validBox.lower[yAxis], extract.lower[1]);
         const auto jUpper = std::min(validBox.upper[yAxis], extract.upper[1]);
-        const auto k = metadata.dimension == 3 ? extract.sliceIndex : 0;
         for (auto j = jLower; j <= jUpper; ++j) {
             if (cancellation.stop_requested()) {
                 throw ReadCancelled();
@@ -218,9 +212,20 @@ inline std::size_t fabValueOffset(const IntBox& box, int i, int j, int k,
             const auto valueY = static_cast<std::size_t>(
                 static_cast<std::int64_t>(j) - extract.lower[1]);
             for (auto i = iLower; i <= iUpper; ++i) {
-                const auto value = fab.values[
-                    dataset_extract_detail::fabValueOffset(
-                        fab.box, i, j, k, metadata.dimension)];
+                // Place the in-plane indices (i, j) and, in 3-D, the slice
+                // index at their actual axes: the FAB is laid out in global
+                // index space and a grid box need not start at the origin
+                // (finer AMR levels especially), so a positional (i, j, k)
+                // lookup is only correct for a 2-D or xy slice.
+                Int3 cell{};
+                cell[xAxis] = i;
+                cell[yAxis] = j;
+                if (metadata.dimension == 3) {
+                    cell[static_cast<std::size_t>(normalAxis)]
+                        = extract.sliceIndex;
+                }
+                const auto value = fab.values[dataset_extract_detail::valueOffset(
+                    fab.box, cell, metadata.dimension)];
                 const auto valueX = static_cast<std::size_t>(
                     static_cast<std::int64_t>(i) - extract.lower[0]);
                 const auto offset = valueX

--- a/src/qt/DatasetExtract.hpp
+++ b/src/qt/DatasetExtract.hpp
@@ -9,6 +9,7 @@
 #include <amrexplorer/core/StopToken.hpp>
 #include <amrexplorer/io/PlotfileBlockReader.hpp>
 #include <amrexplorer/io/PlotfileDataset.hpp>
+#include <amrexplorer/query/detail/BlockLookup.hpp>
 
 #include <algorithm>
 #include <array>
@@ -61,43 +62,14 @@ inline std::array<int, 2> inPlaneAxes(int dimension, int normalAxis) noexcept
     return axes;
 }
 
-inline bool intersects(const IntBox& left, const IntBox& right,
-    int dimension) noexcept
-{
-    for (int axis = 0; axis < dimension; ++axis) {
-        const auto i = static_cast<std::size_t>(axis);
-        if (left.upper[i] < right.lower[i] || right.upper[i] < left.lower[i]) {
-            return false;
-        }
-    }
-    return true;
-}
+// The shared overflow-checked helpers (this header previously carried its
+// own unchecked fabValueOffset variant — the drift the consolidation fixed).
+using amrvis::detail::intersects;
 
-// Offset into a FAB's component-major values (first axis fastest); the point
-// must lie inside box. Mirrors SliceQuery's valueOffset without the overflow
-// checks: the caller only passes points of the intersected valid box.
 inline std::size_t fabValueOffset(const IntBox& box, int i, int j, int k,
-    int dimension) noexcept
+    int dimension)
 {
-    const auto extent = [&box](std::size_t axis) {
-        return static_cast<std::uint64_t>(
-            static_cast<std::int64_t>(box.upper[axis]) - box.lower[axis] + 1);
-    };
-    const auto nx = extent(0);
-    const auto x = static_cast<std::uint64_t>(
-        static_cast<std::int64_t>(i) - box.lower[0]);
-    if (dimension == 1) {
-        return static_cast<std::size_t>(x);
-    }
-    const auto ny = extent(1);
-    const auto y = static_cast<std::uint64_t>(
-        static_cast<std::int64_t>(j) - box.lower[1]);
-    if (dimension == 2) {
-        return static_cast<std::size_t>(x + nx * y);
-    }
-    const auto z = static_cast<std::uint64_t>(
-        static_cast<std::int64_t>(k) - box.lower[2]);
-    return static_cast<std::size_t>(x + nx * (y + ny * z));
+    return amrvis::detail::valueOffset(box, Int3{{i, j, k}}, dimension);
 }
 
 } // namespace dataset_extract_detail

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -17,6 +17,7 @@
 
 #include <amrexplorer/io/PlotfileDataset.hpp>
 #include <amrexplorer/io/FabCatalog.hpp>
+#include <amrexplorer/io/detail/FabHeaderParsing.hpp>
 #include <amrexplorer/io/StandaloneMetadataReader.hpp>
 #include <amrexplorer/core/Statistics.hpp>
 #include <amrexplorer/pipeline/SliceRangeResolver.hpp>
@@ -2976,12 +2977,10 @@ FabSelectorBuild buildFabSelector(
         build.entries.reserve(level.blocks.size());
         for (std::size_t index = 0; index < level.blocks.size(); ++index) {
             const auto& block = level.blocks[index];
-            auto storedBox = block.box;
-            for (int axis = 0; axis < metadata.dimension; ++axis) {
-                const auto coordinate = static_cast<std::size_t>(axis);
-                storedBox.lower[coordinate] -= level.ghostWidth[coordinate];
-                storedBox.upper[coordinate] += level.ghostWidth[coordinate];
-            }
+            // Overflow-guarded shared grow (this copy previously used
+            // plain int).
+            auto storedBox = amrvis::detail::grownBox<MetadataReadError>(
+                block.box, level.ghostWidth, metadata.dimension);
             auto precision = FabRealPrecision::Double;
             if (level.visMfHeaderVersion == 1) {
                 const auto record = inspectFabRecord(

--- a/src/qt/NumberFormat.cpp
+++ b/src/qt/NumberFormat.cpp
@@ -58,6 +58,42 @@ bool isValidNumberFormat(const QString& format)
     return specifiers == 1;
 }
 
+QString conversionSpecifier(const QString& format)
+{
+    const auto bytes = format.toUtf8();
+    const auto size = bytes.size();
+    for (qsizetype index = 0; index < size; ++index) {
+        if (bytes[index] != '%') {
+            continue;
+        }
+        const auto start = index++;
+        if (index >= size || bytes[index] == '%') {
+            continue;
+        }
+        while (index < size && (bytes[index] == '-' || bytes[index] == '+'
+                || bytes[index] == '0' || bytes[index] == ' '
+                || bytes[index] == '#')) {
+            ++index;
+        }
+        while (index < size && bytes[index] >= '0' && bytes[index] <= '9') {
+            ++index;
+        }
+        if (index < size && bytes[index] == '.') {
+            ++index;
+            while (index < size && bytes[index] >= '0' && bytes[index] <= '9') {
+                ++index;
+            }
+        }
+        if (index < size && (bytes[index] == 'e' || bytes[index] == 'E'
+                || bytes[index] == 'f' || bytes[index] == 'g'
+                || bytes[index] == 'G')) {
+            return QString::fromLatin1(
+                bytes.constData() + start, index - start + 1);
+        }
+    }
+    return defaultNumberFormat();
+}
+
 QString formatNumber(double value, const QString& format)
 {
     if (!isValidNumberFormat(format)) {

--- a/src/qt/NumberFormat.hpp
+++ b/src/qt/NumberFormat.hpp
@@ -17,6 +17,13 @@ QString defaultNumberFormat();
 // specifier).
 bool isValidNumberFormat(const QString& format);
 
+// The '%...X' conversion-specifier substring of a format that passes
+// isValidNumberFormat (flags, width, precision, and one eEfgG conversion).
+// Unlike the scanner this consolidates (ScientificDoubleSpinBox's), it also
+// checks the conversion character, so an unvalidated input cannot yield a
+// non-float specifier: anything invalid returns defaultNumberFormat().
+QString conversionSpecifier(const QString& format);
+
 // snprintf()s value through the validated format into a 128-byte buffer
 // (C locale; Qt never installs another one). An invalid format or a result
 // that does not fit falls back to 'g' with 7 significant digits.

--- a/src/qt/ScientificDoubleSpinBox.cpp
+++ b/src/qt/ScientificDoubleSpinBox.cpp
@@ -19,41 +19,6 @@ QLocale cNumberLocale()
     return result;
 }
 
-QString conversionSpecifier(const QString& format)
-{
-    const auto bytes = format.toUtf8();
-    for (qsizetype index = 0; index < bytes.size(); ++index) {
-        if (bytes[index] != '%') {
-            continue;
-        }
-        const auto start = index++;
-        if (index >= bytes.size() || bytes[index] == '%') {
-            continue;
-        }
-        while (index < bytes.size() && (bytes[index] == '-'
-                || bytes[index] == '+' || bytes[index] == '0'
-                || bytes[index] == ' ' || bytes[index] == '#')) {
-            ++index;
-        }
-        while (index < bytes.size()
-            && bytes[index] >= '0' && bytes[index] <= '9') {
-            ++index;
-        }
-        if (index < bytes.size() && bytes[index] == '.') {
-            ++index;
-            while (index < bytes.size()
-                && bytes[index] >= '0' && bytes[index] <= '9') {
-                ++index;
-            }
-        }
-        if (index < bytes.size()) {
-            return QString::fromLatin1(
-                bytes.constData() + start, index - start + 1);
-        }
-    }
-    return defaultNumberFormat();
-}
-
 QValidator::State validateNumber(const QString& text, int position,
     double minimum, double maximum, const QLocale& locale)
 {

--- a/src/query/LineQuery.cpp
+++ b/src/query/LineQuery.cpp
@@ -1,4 +1,5 @@
 #include <amrexplorer/query/LineQuery.hpp>
+#include <amrexplorer/query/detail/BlockLookup.hpp>
 
 #include <algorithm>
 #include <cmath>
@@ -13,10 +14,11 @@
 namespace amrvis {
 namespace {
 
-struct LoadedBlock {
-    IntBox validBox;
-    PlotfileDataset::BlockCache::Handle data;
-};
+using detail::LoadedBlock;
+using detail::intersects;
+using detail::contains;
+using detail::physicalToIndex;
+using detail::valueOffset;
 
 // A covering cell hit during the line walk: which level won, the cell index,
 // and the cell-centered value there.
@@ -26,83 +28,7 @@ struct Cover {
     float value = 0.0F;
 };
 
-bool intersects(const IntBox& left, const IntBox& right, int dimension)
-{
-    for (int axis = 0; axis < dimension; ++axis) {
-        const auto i = static_cast<std::size_t>(axis);
-        if (left.upper[i] < right.lower[i] || right.upper[i] < left.lower[i]) {
-            return false;
-        }
-    }
-    return true;
-}
 
-bool contains(const IntBox& box, const Int3& point, int dimension)
-{
-    for (int axis = 0; axis < dimension; ++axis) {
-        const auto i = static_cast<std::size_t>(axis);
-        if (point[i] < box.lower[i] || point[i] > box.upper[i]) {
-            return false;
-        }
-    }
-    return true;
-}
-
-int physicalToIndex(double position, const DatasetMetadata& metadata,
-    const LevelMetadata& level, int axis)
-{
-    (void) metadata;
-    return sampleIndex(level, axis, position);
-}
-
-std::size_t valueOffset(const IntBox& box, const Int3& point, int dimension)
-{
-    const auto extent = [&box](std::size_t axis) {
-        const auto value = static_cast<std::int64_t>(box.upper[axis])
-            - box.lower[axis] + 1;
-        if (value <= 0) {
-            throw std::overflow_error("FAB extent is not positive");
-        }
-        return static_cast<std::uint64_t>(value);
-    };
-    const auto relative = [&box, &point](std::size_t axis) {
-        const auto value = static_cast<std::int64_t>(point[axis]) - box.lower[axis];
-        if (value < 0) {
-            throw std::overflow_error("FAB point precedes its indexed box");
-        }
-        return static_cast<std::uint64_t>(value);
-    };
-    const auto nx = extent(0);
-    const auto x = relative(0);
-    if (dimension == 1) {
-        return static_cast<std::size_t>(x);
-    }
-    const auto ny = extent(1);
-    const auto y = relative(1);
-    if (dimension == 2) {
-        if (y > (std::numeric_limits<std::uint64_t>::max() - x) / nx) {
-            throw std::overflow_error("2-D FAB offset overflows");
-        }
-        const auto offset = x + nx * y;
-        if (offset > std::numeric_limits<std::size_t>::max()) {
-            throw std::overflow_error("2-D FAB offset exceeds addressable memory");
-        }
-        return static_cast<std::size_t>(offset);
-    }
-    const auto z = relative(2);
-    if (z > (std::numeric_limits<std::uint64_t>::max() - y) / ny) {
-        throw std::overflow_error("3-D FAB row offset overflows");
-    }
-    const auto row = y + ny * z;
-    if (row > (std::numeric_limits<std::uint64_t>::max() - x) / nx) {
-        throw std::overflow_error("3-D FAB offset overflows");
-    }
-    const auto offset = x + nx * row;
-    if (offset > std::numeric_limits<std::size_t>::max()) {
-        throw std::overflow_error("3-D FAB offset exceeds addressable memory");
-    }
-    return static_cast<std::size_t>(offset);
-}
 
 } // namespace
 

--- a/src/query/SliceQuery.cpp
+++ b/src/query/SliceQuery.cpp
@@ -1,4 +1,5 @@
 #include <amrexplorer/query/SliceQuery.hpp>
+#include <amrexplorer/query/detail/BlockLookup.hpp>
 
 #include <algorithm>
 #include <array>
@@ -14,10 +15,11 @@
 namespace amrvis {
 namespace {
 
-struct LoadedBlock {
-    IntBox validBox;
-    PlotfileDataset::BlockCache::Handle data;
-};
+using detail::LoadedBlock;
+using detail::intersects;
+using detail::contains;
+using detail::physicalToIndex;
+using detail::valueOffset;
 
 // The blocks of one level that intersect the planning region. Levels are
 // processed finest first so the composed per-point lookup resolves fine
@@ -27,34 +29,6 @@ struct LevelBlocks {
     std::vector<LoadedBlock> blocks;
 };
 
-bool intersects(const IntBox& left, const IntBox& right, int dimension)
-{
-    for (int axis = 0; axis < dimension; ++axis) {
-        const auto i = static_cast<std::size_t>(axis);
-        if (left.upper[i] < right.lower[i] || right.upper[i] < left.lower[i]) {
-            return false;
-        }
-    }
-    return true;
-}
-
-bool contains(const IntBox& box, const Int3& point, int dimension)
-{
-    for (int axis = 0; axis < dimension; ++axis) {
-        const auto i = static_cast<std::size_t>(axis);
-        if (point[i] < box.lower[i] || point[i] > box.upper[i]) {
-            return false;
-        }
-    }
-    return true;
-}
-
-int physicalToIndex(double position, const DatasetMetadata& metadata,
-    const LevelMetadata& level, int axis)
-{
-    (void) metadata;
-    return sampleIndex(level, axis, position);
-}
 
 // The index box a physical region covers at one level. Piecewise sampling
 // passes the visible region; linear sampling passes a halo-expanded region
@@ -98,54 +72,6 @@ std::array<int, 2> planeAxes(int dimension, int normalDirection)
     return axes;
 }
 
-std::size_t valueOffset(const IntBox& box, const Int3& point, int dimension)
-{
-    const auto extent = [&box](std::size_t axis) {
-        const auto value = static_cast<std::int64_t>(box.upper[axis])
-            - box.lower[axis] + 1;
-        if (value <= 0) {
-            throw std::overflow_error("FAB extent is not positive");
-        }
-        return static_cast<std::uint64_t>(value);
-    };
-    const auto relative = [&box, &point](std::size_t axis) {
-        const auto value = static_cast<std::int64_t>(point[axis]) - box.lower[axis];
-        if (value < 0) {
-            throw std::overflow_error("FAB point precedes its indexed box");
-        }
-        return static_cast<std::uint64_t>(value);
-    };
-    const auto nx = extent(0);
-    const auto x = relative(0);
-    if (dimension == 1) {
-        return static_cast<std::size_t>(x);
-    }
-    const auto ny = extent(1);
-    const auto y = relative(1);
-    if (dimension == 2) {
-        if (y > (std::numeric_limits<std::uint64_t>::max() - x) / nx) {
-            throw std::overflow_error("2-D FAB offset overflows");
-        }
-        const auto offset = x + nx * y;
-        if (offset > std::numeric_limits<std::size_t>::max()) {
-            throw std::overflow_error("2-D FAB offset exceeds addressable memory");
-        }
-        return static_cast<std::size_t>(offset);
-    }
-    const auto z = relative(2);
-    if (z > (std::numeric_limits<std::uint64_t>::max() - y) / ny) {
-        throw std::overflow_error("3-D FAB row offset overflows");
-    }
-    const auto row = y + ny * z;
-    if (row > (std::numeric_limits<std::uint64_t>::max() - x) / nx) {
-        throw std::overflow_error("3-D FAB offset overflows");
-    }
-    const auto offset = x + nx * row;
-    if (offset > std::numeric_limits<std::size_t>::max()) {
-        throw std::overflow_error("3-D FAB offset exceeds addressable memory");
-    }
-    return static_cast<std::size_t>(offset);
-}
 
 } // namespace
 

--- a/src/render2d/Contours.cpp
+++ b/src/render2d/Contours.cpp
@@ -1,4 +1,5 @@
 #include <amrexplorer/render2d/Contours.hpp>
+#include <amrexplorer/render2d/detail/PlaneValidation.hpp>
 
 #include <algorithm>
 #include <array>
@@ -47,14 +48,7 @@ std::vector<double> contourValues(
 std::vector<ContourSegment> generateContours(
     const ScalarPlane& plane, const std::vector<double>& values)
 {
-    if (plane.width < 0 || plane.height < 0) {
-        throw std::invalid_argument("scalar plane dimensions must not be negative");
-    }
-    const auto pixelCount = static_cast<std::size_t>(plane.width)
-        * static_cast<std::size_t>(plane.height);
-    if (plane.values.size() != pixelCount || plane.valid.size() != pixelCount) {
-        throw std::invalid_argument("scalar plane storage does not match its dimensions");
-    }
+    detail::validatePlaneStorage(plane, detail::PlaneExtent::AllowEmpty);
 
     std::vector<ContourSegment> segments;
     if (plane.width < 2 || plane.height < 2) {

--- a/src/render2d/ScalarRenderer.cpp
+++ b/src/render2d/ScalarRenderer.cpp
@@ -1,4 +1,5 @@
 #include <amrexplorer/render2d/ScalarRenderer.hpp>
+#include <amrexplorer/render2d/detail/PlaneValidation.hpp>
 
 #include <algorithm>
 #include <array>
@@ -41,6 +42,9 @@ std::array<std::uint8_t, 3> sampleViridis(double normalized) noexcept
 ImageBuffer renderScalarPlane(
     const ScalarPlane& plane, const ScalarRenderSettings& settings)
 {
+    // Check order is pinned by the unit test: positive extent, then the
+    // stride representation, then the shared storage-match rule (extent is
+    // already vetted here, so AllowEmpty cannot actually pass an empty plane).
     if (plane.width <= 0 || plane.height <= 0) {
         throw std::invalid_argument("scalar plane dimensions must be positive");
     }
@@ -48,13 +52,7 @@ ImageBuffer renderScalarPlane(
             / static_cast<int>(sizeof(std::uint32_t))) {
         throw std::overflow_error("scalar plane row stride exceeds the image representation");
     }
-    const auto pixelCount = static_cast<std::uint64_t>(plane.width)
-        * static_cast<std::uint64_t>(plane.height);
-    if (pixelCount > std::numeric_limits<std::size_t>::max()
-        || plane.values.size() != static_cast<std::size_t>(pixelCount)
-        || plane.valid.size() != static_cast<std::size_t>(pixelCount)) {
-        throw std::invalid_argument("scalar plane storage does not match its dimensions");
-    }
+    detail::validatePlaneStorage(plane, detail::PlaneExtent::AllowEmpty);
     if (!(settings.minimum < settings.maximum)) {
         throw std::invalid_argument("scalar render range must have positive extent");
     }
@@ -76,7 +74,7 @@ ImageBuffer renderScalarPlane(
     image.width = plane.width;
     image.height = plane.height;
     image.strideBytes = plane.width * static_cast<int>(sizeof(std::uint32_t));
-    image.rgba.resize(static_cast<std::size_t>(pixelCount));
+    image.rgba.resize(plane.values.size());
     const Palette& palette = settings.palette != nullptr
         ? *settings.palette : builtinPalette(BuiltinPalette::Rainbow);
     for (std::size_t pixel = 0; pixel < image.rgba.size(); ++pixel) {

--- a/src/render2d/VectorGlyphs.cpp
+++ b/src/render2d/VectorGlyphs.cpp
@@ -1,4 +1,5 @@
 #include <amrexplorer/render2d/VectorGlyphs.hpp>
+#include <amrexplorer/render2d/detail/PlaneValidation.hpp>
 
 #include <algorithm>
 #include <cmath>
@@ -16,11 +17,10 @@ constexpr double headSide = 0.125;
 
 void validatePlane(const ScalarPlane& plane)
 {
-    const auto pixelCount = static_cast<std::size_t>(plane.width)
-        * static_cast<std::size_t>(plane.height);
-    if (plane.values.size() != pixelCount || plane.valid.size() != pixelCount) {
-        throw std::invalid_argument("scalar plane storage does not match its dimensions");
-    }
+    // AllowEmpty keeps the caller's own positive-extent check authoritative;
+    // the shared validator adds the negative-dimension rejection this copy
+    // previously lacked.
+    detail::validatePlaneStorage(plane, detail::PlaneExtent::AllowEmpty);
 }
 
 } // namespace

--- a/tests/integration/test_dataset_extract.cpp
+++ b/tests/integration/test_dataset_extract.cpp
@@ -100,6 +100,56 @@ amrvis::RealBox box2d(double lo, double hi)
     return box;
 }
 
+// Single-level 3-D plotfile, domain (0,0,0)-(3,3,3), unit cells, split into
+// two grids along x: grid 0 = (0,0,0)-(1,3,3), grid 1 = (2,0,0)-(3,3,3).
+// Grid 1 is OFF-ORIGIN on x (lower = {2,0,0}) — the shape a finer AMR level's
+// patch has, and the case that exposed the wrong-axis offset bug in the
+// Dataset window: a yz slice iterates y/z but the offset used them as x/y.
+// q = 100*x + 10*y + z everywhere.
+void writeSplitXPlotfile3d(const std::filesystem::path& root)
+{
+    std::filesystem::create_directories(root / "Level_0");
+    writeText(root / "Header",
+        "HyperCLaw-V1.1\n"
+        "1\nq\n"
+        "3\n0.0\n0\n"
+        "0.0 0.0 0.0\n4.0 4.0 4.0\n\n"
+        "((0,0,0) (3,3,3) (0,0,0))\n"
+        "0\n1.0 1.0 1.0\n0\n0\n"
+        "0 2 0.0\n0\n"
+        "0.0 2.0\n0.0 4.0\n0.0 4.0\n"
+        "2.0 4.0\n0.0 4.0\n0.0 4.0\n"
+        "Level_0/Cell\n");
+    writeText(root / "Level_0" / "Cell_H",
+        "1\n1\n1\n0\n"
+        "(2 0\n"
+        "((0,0,0) (1,3,3) (0,0,0))\n"
+        "((2,0,0) (3,3,3) (0,0,0))\n"
+        ")\n"
+        "2\n"
+        "FabOnDisk: Cell_D_00000 0\n"
+        "FabOnDisk: Cell_D_00001 0\n"
+        "\n"
+        "2,1\n0.0,\n200.0,\n\n2,1\n133.0,\n333.0,\n");
+    const auto blockValues = [](int xLo, int xHi) {
+        std::vector<double> values;  // axis-0 (x) fastest, then y, then z
+        for (int z = 0; z <= 3; ++z) {
+            for (int y = 0; y <= 3; ++y) {
+                for (int x = xLo; x <= xHi; ++x) {
+                    values.push_back(100.0 * x + 10.0 * y + z);
+                }
+            }
+        }
+        return values;
+    };
+    const auto gridA = blockValues(0, 1);
+    const auto gridB = blockValues(2, 3);
+    writeFab(root / "Level_0" / "Cell_D_00000",
+        "((0,0,0) (1,3,3) (0,0,0))", gridA);
+    writeFab(root / "Level_0" / "Cell_D_00001",
+        "((2,0,0) (3,3,3) (0,0,0))", gridB);
+}
+
 } // namespace
 
 int main()
@@ -198,6 +248,42 @@ int main()
             box2d(10.0, 12.0), 1, 0.0, datasetExtractMaxExtent);
         require(extract.nx == 0 && extract.ny == 0,
             "a region outside the domain should extract nothing");
+    }
+
+    // --- 3-D yz slice through an off-origin grid ---------------------------
+    // Regression: extraction offsets must map the in-plane and slice indices
+    // to their real axes using the FAB box. When a grid is off-origin (a
+    // finer level's patch; here grid 1 at x in [2,3]), a yz slice previously
+    // used the y coordinate as x and read the wrong cell — with the checked
+    // offset that surfaced as "FAB point precedes its indexed box".
+    {
+        const auto root3d = std::filesystem::temp_directory_path()
+            / ("amrexplorer-dataset-extract-3d-" + std::to_string(unique));
+        writeSplitXPlotfile3d(root3d);
+        PlotfileDataset dataset3d(root3d, DatasetId{2}, 1ULL << 20);
+
+        RealBox full;
+        full.lower = {{0.0, 0.0, 0.0}};
+        full.upper = {{4.0, 4.0, 4.0}};
+        // normal = 0 (yz plane), slice at the x=3 cell center (3.5).
+        const auto yz = extractDatasetLevel(dataset3d, FieldId{0}, 0, full,
+            /*normalAxis=*/0, /*slicePosition=*/3.5, datasetExtractMaxExtent);
+        require(yz.nx == 4 && yz.ny == 4, "yz-slice extent is wrong");
+        require(yz.sliceIndex == 3, "yz slice did not land on the x=3 cell");
+        // In-plane axis 0 is y, axis 1 is z; value at (y, z) for x=3 is
+        // 300 + 10*y + z. Grid 1 (x in [2,3]) covers the whole slice.
+        const auto at = [&](int y, int z) {
+            return yz.values[static_cast<std::size_t>(y)
+                + static_cast<std::size_t>(yz.nx)
+                    * static_cast<std::size_t>(z)];
+        };
+        require(yz.covered[0] != 0, "yz slice cell (0,0) is uncovered");
+        require(at(0, 0) == 300.0, "yz slice corner value is wrong");
+        require(at(1, 2) == 312.0, "yz slice value maps the wrong axes");
+        require(at(3, 3) == 333.0, "yz slice far value is wrong");
+
+        std::error_code cleanup3d;
+        std::filesystem::remove_all(root3d, cleanup3d);
     }
 
     std::error_code cleanupError;


### PR DESCRIPTION
FAB/plotfile header parsing (four parseIntegers copies, two box parsers, two descriptor parsers, five ghost-grow variants), the query layer's block-lookup helpers (verified byte-identical between SliceQuery and LineQuery), scalar plane validation (three drifting variants), and printf-format scanning each get one definition. Every drift resolves toward the strict variant: catalog descriptors now validate byte order up front, DatasetExtract uses the overflow-checked valueOffset, VectorGlyphs rejects negative dimensions, and conversionSpecifier checks the conversion character. Throwing io helpers are templated on the reader's error type so no thrown types change.