### PR TITLE
Prune dead and misleading request/metadata surface

### DIFF
--- a/include/amrexplorer/cache/BlockKey.hpp
+++ b/include/amrexplorer/cache/BlockKey.hpp
@@ -9,13 +9,11 @@ namespace amrvis {
 
 struct BlockKey {
     DatasetId dataset;
-    int timestep = 0;
     int level = 0;
     int grid = 0;
     FieldId field;
     int firstComponent = 0;
     int componentCount = 1;
-    int ghostWidth = 0;
 
     friend bool operator==(const BlockKey&, const BlockKey&) = default;
 };
@@ -27,13 +25,11 @@ struct BlockKeyHash {
         const auto combine = [&seed](std::size_t value) {
             seed ^= value + 0x9e3779b9U + (seed << 6U) + (seed >> 2U);
         };
-        combine(std::hash<int>{}(key.timestep));
         combine(std::hash<int>{}(key.level));
         combine(std::hash<int>{}(key.grid));
         combine(std::hash<std::uint32_t>{}(key.field.value));
         combine(std::hash<int>{}(key.firstComponent));
         combine(std::hash<int>{}(key.componentCount));
-        combine(std::hash<int>{}(key.ghostWidth));
         return seed;
     }
 };
@@ -42,13 +38,11 @@ struct BlockKeyHash {
 {
     return {
         request.dataset,
-        request.timestep,
         request.level,
         request.gridIndex,
         request.field,
         request.firstComponent,
-        request.componentCount,
-        request.ghostWidth
+        request.componentCount
     };
 }
 

--- a/include/amrexplorer/core/Metadata.hpp
+++ b/include/amrexplorer/core/Metadata.hpp
@@ -18,13 +18,14 @@ enum class Centering : std::uint8_t {
     EdgeX,
     EdgeY,
     EdgeZ,
-    Mixed,
-    Unknown
+    // Defensive fallback for an index type the classifier does not recognize.
+    // Not produced today (centeringFromIndexType covers all cases), kept as an
+    // escape hatch if that logic ever changes.
+    Mixed
 };
 
 struct FieldMetadata {
     std::string name;
-    int componentCount = 1;
     Centering centering = Centering::Cell;
     std::vector<std::string> componentNames;
 };
@@ -45,7 +46,6 @@ struct LevelMetadata {
     int level = 0;
     int step = 0;
     IntBox domain;
-    Int3 refinementRatioToNext{{1, 1, 1}};
     Real3 cellSize{{1.0, 1.0, 1.0}};
     // Physical coordinate of nodal index zero on each axis. A sample at
     // integer index i is located at indexOrigin+i*dx on nodal axes and at

--- a/include/amrexplorer/core/Request.hpp
+++ b/include/amrexplorer/core/Request.hpp
@@ -34,13 +34,11 @@ enum class CompositionPolicy : std::uint8_t {
 
 struct BlockRequest {
     DatasetId dataset;
-    int timestep = 0;
     int level = 0;
     int gridIndex = 0;
     FieldId field;
     int firstComponent = 0;
     int componentCount = 1;
-    int ghostWidth = 0;
 };
 
 struct SliceRequest {

--- a/src/core/Metadata.cpp
+++ b/src/core/Metadata.cpp
@@ -112,12 +112,10 @@ std::vector<MetadataIssue> validateMetadata(const DatasetMetadata& metadata)
         } else if (!fieldNames.insert(field.name).second) {
             add(path + ".name", "must be unique");
         }
-        if (field.componentCount <= 0) {
-            add(path + ".componentCount", "must be positive");
-        }
-        if (!field.componentNames.empty()
-            && field.componentNames.size() != static_cast<std::size_t>(field.componentCount)) {
-            add(path + ".componentNames", "size must equal componentCount when provided");
+        // Each field is a single stored component, so componentNames carries at
+        // most one entry when provided.
+        if (field.componentNames.size() > 1) {
+            add(path + ".componentNames", "must not exceed one entry per field");
         }
     }
 
@@ -157,12 +155,6 @@ std::vector<MetadataIssue> validateMetadata(const DatasetMetadata& metadata)
             if (!std::isfinite(level.indexOrigin[i])) {
                 add(path + ".indexOrigin",
                     "must be finite in every active direction");
-                break;
-            }
-            if (levelIndex + 1 < metadata.levels.size()
-                && level.refinementRatioToNext[i] <= 0) {
-                add(path + ".refinementRatioToNext",
-                    "must be positive in every active direction");
                 break;
             }
         }

--- a/src/core/Request.cpp
+++ b/src/core/Request.cpp
@@ -20,9 +20,6 @@ std::vector<std::string> validateBlockRequest(const BlockRequest& request)
     if (request.componentCount <= 0) {
         errors.emplace_back("component count must be positive");
     }
-    if (request.ghostWidth < 0) {
-        errors.emplace_back("ghost width must be non-negative");
-    }
     return errors;
 }
 

--- a/src/io/plotfile/PlotfileMetadataReader.cpp
+++ b/src/io/plotfile/PlotfileMetadataReader.cpp
@@ -342,7 +342,7 @@ PlotfileMetadataResult PlotfileMetadataReader::read(
     metadata->fields.reserve(static_cast<std::size_t>(componentCount));
     for (int component = 0; component < componentCount; ++component) {
         auto name = readNonEmptyLine(input, "component name");
-        metadata->fields.push_back({name, 1, Centering::Cell, {std::move(name)}});
+        metadata->fields.push_back({name, Centering::Cell, {std::move(name)}});
     }
 
     metadata->dimension = readRequired<int>(input, "space dimension");
@@ -379,26 +379,6 @@ PlotfileMetadataResult PlotfileMetadataReader::read(
         levelMetadata.level = static_cast<int>(level);
         levelMetadata.domain = readAmrexBox(
             input, metadata->dimension, "level domain");
-        levelMetadata.refinementRatioToNext = {{1, 1, 1}};
-    }
-    for (std::size_t level = 0; level + 1 < levelCount; ++level) {
-        for (int axis = 0; axis < metadata->dimension; ++axis) {
-            const auto i = static_cast<std::size_t>(axis);
-            const auto coarseLength =
-                static_cast<std::int64_t>(metadata->levels[level].domain.upper[i])
-                - metadata->levels[level].domain.lower[i] + 1;
-            const auto fineLength =
-                static_cast<std::int64_t>(metadata->levels[level + 1].domain.upper[i])
-                - metadata->levels[level + 1].domain.lower[i] + 1;
-            if (coarseLength <= 0 || fineLength <= 0
-                || fineLength % coarseLength != 0
-                || fineLength / coarseLength > std::numeric_limits<int>::max()) {
-                throw MetadataReadError(
-                    "level domains do not define an integral refinement ratio");
-            }
-            metadata->levels[level].refinementRatioToNext[i] =
-                static_cast<int>(fineLength / coarseLength);
-        }
     }
 
     for (auto& level : metadata->levels) {

--- a/src/io/plotfile/StandaloneMetadataReader.cpp
+++ b/src/io/plotfile/StandaloneMetadataReader.cpp
@@ -67,7 +67,7 @@ std::shared_ptr<DatasetMetadata> makeSingleLevelMetadata(
     for (int component = 0; component < components; ++component) {
         auto name = std::string(fieldPrefix) + std::to_string(component);
         metadata->fields.push_back({
-            name, 1, centeringFromIndexType(domain.centering, dimension), {name}});
+            name, centeringFromIndexType(domain.centering, dimension), {name}});
     }
     metadata->levels.resize(1);
     metadata->levels.front().domain = domain;

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -4326,9 +4326,21 @@ void MainWindow::showMetadata(
     auto* fields = new QTreeWidgetItem(
         m_metadataTree, {tr("Fields"), QString::number(metadata.fields.size())});
     for (const auto& field : metadata.fields) {
+        const char* centering = "cell";
+        switch (field.centering) {
+        case amrvis::Centering::Node: centering = "node"; break;
+        case amrvis::Centering::FaceX: centering = "face-x"; break;
+        case amrvis::Centering::FaceY: centering = "face-y"; break;
+        case amrvis::Centering::FaceZ: centering = "face-z"; break;
+        case amrvis::Centering::EdgeX: centering = "edge-x"; break;
+        case amrvis::Centering::EdgeY: centering = "edge-y"; break;
+        case amrvis::Centering::EdgeZ: centering = "edge-z"; break;
+        case amrvis::Centering::Mixed: centering = "mixed"; break;
+        case amrvis::Centering::Cell: break;
+        }
         new QTreeWidgetItem(fields, {
             QString::fromStdString(field.name),
-            tr("%1 component(s)").arg(field.componentCount)
+            QString::fromLatin1(centering)
         });
     }
 

--- a/tests/integration/test_fab_catalog.cpp
+++ b/tests/integration/test_fab_catalog.cpp
@@ -205,7 +205,7 @@ int main()
     source.dimension = 2;
     source.finestLevel = 0;
     source.fields.push_back(
-        {"value", 1, amrvis::Centering::Cell, {"value"}});
+        {"value", amrvis::Centering::Cell, {"value"}});
     source.levels.resize(1);
     auto& level = source.levels.front();
     level.domain = {{{0, 0, 0}}, {{1, 1, 0}}, {{0, 0, 0}}};

--- a/tests/integration/test_plotfile_metadata.cpp
+++ b/tests/integration/test_plotfile_metadata.cpp
@@ -1,6 +1,8 @@
 #include <amrexplorer/io/PlotfileMetadataReader.hpp>
 #include <amrexplorer/io/StandaloneMetadataReader.hpp>
 
+#include <algorithm>
+#include <cmath>
 #include <cstdlib>
 #include <filesystem>
 #include <iostream>
@@ -13,6 +15,11 @@ void require(bool condition, const char* message)
         std::cerr << "FAILED: " << message << '\n';
         std::exit(1);
     }
+}
+
+bool nearlyEqual(double a, double b)
+{
+    return std::fabs(a - b) <= 1.0e-9 * std::max({1.0, std::fabs(a), std::fabs(b)});
 }
 
 } // namespace
@@ -54,10 +61,18 @@ int main(int argc, char* argv[])
     require(amrvis::validateMetadata(metadata).empty(), "parsed metadata is invalid");
 
     const auto nonuniform = amrvis::PlotfileMetadataReader{}.read(argv[2]);
-    require(nonuniform.metadata->levels[0].refinementRatioToNext.values[0] == 2,
-        "x refinement ratio mismatch");
-    require(nonuniform.metadata->levels[0].refinementRatioToNext.values[1] == 3,
-        "y refinement ratio mismatch");
+    // Anisotropic 2:3 refinement between levels 0 and 1. Visualization relates
+    // levels through per-level cell geometry (see SliceQuery), so the finer
+    // level's cell size is the coarser's divided by the per-axis ratio; that
+    // is what the reader must get right.
+    require(nonuniform.metadata->levels.size() == 2,
+        "nonuniform plotfile should have two levels");
+    const auto& coarse = nonuniform.metadata->levels[0];
+    const auto& fine = nonuniform.metadata->levels[1];
+    require(nearlyEqual(coarse.cellSize.values[0], 2.0 * fine.cellSize.values[0]),
+        "x refinement (cell-size ratio) mismatch");
+    require(nearlyEqual(coarse.cellSize.values[1], 3.0 * fine.cellSize.values[1]),
+        "y refinement (cell-size ratio) mismatch");
     require(nonuniform.metrics.payloadFilesRead == 0,
         "nonuniform metadata read a FAB payload file");
 

--- a/tests/unit/test_core_metadata.cpp
+++ b/tests/unit/test_core_metadata.cpp
@@ -35,10 +35,9 @@ int main()
     metadata.dimension = 2;
     metadata.finestLevel = 0;
     metadata.physicalDomain = {{{0.0, 0.0, 0.0}}, {{1.0, 1.0, 0.0}}};
-    metadata.fields.push_back({"density", 1, amrvis::Centering::Cell, {"density"}});
+    metadata.fields.push_back({"density", amrvis::Centering::Cell, {"density"}});
     amrvis::LevelMetadata level;
     level.domain = {{{0, 0, 0}}, {{3, 3, 0}}, {{0, 0, 0}}};
-    level.refinementRatioToNext = {{1, 1, 1}};
     level.cellSize = {{0.25, 0.25, 1.0}};
     level.boxes.push_back(level.domain);
     level.storedComponents = 1;
@@ -115,7 +114,7 @@ int main()
         bad.dimension = 5;
         bad.finestLevel = 0;
         bad.physicalDomain = {{{0.0, 0.0, 0.0}}, {{1.0, 1.0, 1.0}}};
-        bad.fields.push_back({"phi", 1, amrvis::Centering::Cell, {"phi"}});
+        bad.fields.push_back({"phi", amrvis::Centering::Cell, {"phi"}});
         amrvis::LevelMetadata badLevel;
         badLevel.domain = {{{0, 0, 0}}, {{3, 3, 3}}, {{0, 0, 0}}};
         badLevel.cellSize = {{0.25, 0.25, 0.25}};
@@ -136,7 +135,7 @@ int main()
         bad.dimension = 2;
         bad.finestLevel = 0;
         bad.physicalDomain = {{{0.0, 0.0, 0.0}}, {{1.0, 1.0, 0.0}}};
-        bad.fields.push_back({"phi", 1, amrvis::Centering::Cell, {"phi"}});
+        bad.fields.push_back({"phi", amrvis::Centering::Cell, {"phi"}});
         amrvis::LevelMetadata badLevel;
         badLevel.domain = {{{0, 0, 0}}, {{3, 3, 0}}, {{0, 0, 0}}};
         badLevel.cellSize = {{0.25, 0.25, 1.0}};

--- a/tests/unit/test_slice_range_resolver.cpp
+++ b/tests/unit/test_slice_range_resolver.cpp
@@ -40,7 +40,7 @@ amrvis::DatasetMetadata makeMetadata(
     amrvis::DatasetMetadata metadata;
     metadata.dimension = 2;
     metadata.finestLevel = 1;
-    metadata.fields.push_back({"density", 1, amrvis::Centering::Cell, {}});
+    metadata.fields.push_back({"density", amrvis::Centering::Cell, {}});
     for (const auto& range : {level0, level1}) {
         amrvis::LevelMetadata level;
         level.level = static_cast<int>(metadata.levels.size());


### PR DESCRIPTION
Strip public fields that promised capabilities the implementation ignored or rejected — a silent-failure trap for the next reader author:

- BlockRequest::ghostWidth / ::timestep: no reader consumed them; ghost cells come from LevelMetadata::ghostWidth + grownBox. Removed from the request, its validator, and the cache key (BlockKey + hash + makeBlockKey).
- LevelMetadata::refinementRatioToNext: multi-level compositing works in physical space via per-level cellSize/indexOrigin; the integer ratio was never consulted. Removed the field, its derivation loop, and validation. The integration test now asserts the cellSize ratio directly.
- Centering::Unknown: unreachable, removed. Centering::Mixed kept as a documented defensive fallback.
- FieldMetadata::componentCount: always 1 (each stored component is its own single-component field). Removed the field, the componentCount/componentNames validation coupling, and the misleading "N component(s)" metadata-tree line (now shows the field centering).