### PR TITLE
Drop invented level and time from standalone FAB/MultiFab displays

### DIFF
--- a/src/io/plotfile/StandaloneMetadataReader.cpp
+++ b/src/io/plotfile/StandaloneMetadataReader.cpp
@@ -11,7 +11,6 @@
 #include <optional>
 #include <sstream>
 #include <string>
-#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -52,7 +51,7 @@ int inferMultiFabDimension(const std::filesystem::path& headerPath)
 }
 
 std::shared_ptr<DatasetMetadata> makeSingleLevelMetadata(
-    int dimension, const IntBox& domain, int components, std::string_view fieldPrefix)
+    int dimension, const IntBox& domain, int components)
 {
     auto metadata = std::make_shared<DatasetMetadata>();
     metadata->dimension = dimension;
@@ -65,7 +64,8 @@ std::shared_ptr<DatasetMetadata> makeSingleLevelMetadata(
     }
     metadata->fields.reserve(static_cast<std::size_t>(components));
     for (int component = 0; component < components; ++component) {
-        auto name = std::string(fieldPrefix) + std::to_string(component);
+        // Neither format stores field names; components are numbered.
+        auto name = "Field_" + std::to_string(component);
         metadata->fields.push_back({
             name, centeringFromIndexType(domain.centering, dimension), {name}});
     }
@@ -96,7 +96,7 @@ PlotfileMetadataResult StandaloneMetadataReader::readFab(
     const auto record = inspectFabRecord(fabPath, offset);
 
     auto metadata = makeSingleLevelMetadata(
-        record.dimension, record.storedBox, record.components, "Fab_");
+        record.dimension, record.storedBox, record.components);
     metadata->isFab = true;
     auto& level = metadata->levels.front();
     level.boxes.push_back(record.storedBox);
@@ -195,7 +195,7 @@ PlotfileMetadataResult StandaloneMetadataReader::readMultiFab(
         }
     }
     auto metadata = makeSingleLevelMetadata(
-        dimension, domain, index.components, "MultiFab_");
+        dimension, domain, index.components);
     auto& level = metadata->levels.front();
     level.boxes = index.boxes;
     level.ghostWidth = index.ghostWidth;

--- a/src/qt/DatasetWindow.cpp
+++ b/src/qt/DatasetWindow.cpp
@@ -279,7 +279,13 @@ void DatasetWindow::populateTabs()
         auto* pageLayout = new QVBoxLayout(page);
         pageLayout->addWidget(info);
         pageLayout->addWidget(table, 1);
-        auto label = tr("Level %1").arg(levelData.level);
+        // Standalone MultiFabs and FABs have no AMR hierarchy, so a
+        // "Level 0" tab would suggest a concept those formats lack; their
+        // single tab is named after the format instead.
+        const auto& metadata = m_request.dataset->metadata();
+        auto label = metadata.hasPhysicalGeometry
+            ? tr("Level %1").arg(levelData.level)
+            : metadata.isFab ? tr("FAB") : tr("MultiFab");
         if (extract.truncatedX || extract.truncatedY) {
             label += tr(" (truncated)");
         }

--- a/src/qt/DatasetWindow.hpp
+++ b/src/qt/DatasetWindow.hpp
@@ -37,8 +37,10 @@ struct DatasetRequest {
 };
 
 // Modeless spreadsheet of the raw sample values in the active view's region
-// (the legacy Dataset window): one tab per AMR level with the i/j sample
-// indices as headers and the level min/max above the table; clicking a value
+// (the legacy Dataset window): one tab per AMR level (for standalone
+// MultiFabs and FABs, which have no AMR hierarchy, the single tab is named
+// after the format instead) with the i/j sample indices as headers and the
+// level min/max above the table; clicking a value
 // highlights the corresponding sample in the image. Reads run off the GUI
 // thread and are cancelled on close or refresh.
 class DatasetWindow final : public QWidget {

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -2212,14 +2212,19 @@ QString MainWindow::probeReadout(
         boxText = tr("box=none");
     }
 
-    return tr("%1=%2 %3=%4 value=%5 level=%6 %7=(%8) %9")
+    // Standalone FABs and MultiFabs have no AMR hierarchy, so their readout
+    // omits the level.
+    const auto levelText = metadata.hasPhysicalGeometry
+        ? tr(" level=%1").arg(level)
+        : QString();
+    return tr("%1=%2 %3=%4 value=%5%6 %7=(%8) %9")
         .arg(QString::fromLatin1(axisNames[xAxis]))
         .arg(formatNumber(position[xAxis], m_numberFormat))
         .arg(QString::fromLatin1(axisNames[yAxis]))
         .arg(formatNumber(position[yAxis], m_numberFormat))
         .arg(formatNumber(static_cast<double>(plane.values[offset]),
             m_numberFormat))
-        .arg(level)
+        .arg(levelText)
         .arg(QString::fromLatin1(indexKind))
         .arg(join(cell))
         .arg(boxText);
@@ -2847,10 +2852,12 @@ void MainWindow::updateWindowTitle()
     if (name.isEmpty()) {
         name = QString::fromStdString(m_datasetPath.string());
     }
+    // Standalone FABs and MultiFabs carry neither a simulation time nor an
+    // AMR hierarchy, so their titles show just the format name.
     if (m_fabMode) {
-        setWindowTitle(tr("AMReXplorer — %1 — FAB  T = %2")
-            .arg(name)
-            .arg(metadata.time, 0, 'g', 12));
+        setWindowTitle(tr("AMReXplorer — %1 — FAB").arg(name));
+    } else if (!metadata.hasPhysicalGeometry) {
+        setWindowTitle(tr("AMReXplorer — %1 — MultiFab").arg(name));
     } else {
         setWindowTitle(
             tr("AMReXplorer — %1  T = %2  Levels: 0..%3  Finest Level: %3")
@@ -4317,11 +4324,17 @@ void MainWindow::showMetadata(
         new QTreeWidgetItem(m_metadataTree, {name, value});
     };
 
+    // Standalone FABs and MultiFabs carry neither a simulation time nor an
+    // AMR hierarchy, so those rows (and the per-level listing below) would
+    // show invented values; they are skipped for such data.
+    const bool standalone = !metadata.hasPhysicalGeometry;
     addValue(tr("Dataset"), QString::fromStdString(path.string()));
     addValue(tr("Format"), QString::fromStdString(result.fileVersion));
     addValue(tr("Dimension"), QString::number(metadata.dimension));
-    addValue(tr("Time"), QString::number(metadata.time, 'g', 17));
-    addValue(tr("Finest level"), QString::number(metadata.finestLevel));
+    if (!standalone) {
+        addValue(tr("Time"), QString::number(metadata.time, 'g', 17));
+        addValue(tr("Finest level"), QString::number(metadata.finestLevel));
+    }
 
     auto* fields = new QTreeWidgetItem(
         m_metadataTree, {tr("Fields"), QString::number(metadata.fields.size())});
@@ -4344,14 +4357,20 @@ void MainWindow::showMetadata(
         });
     }
 
-    auto* levels = new QTreeWidgetItem(
-        m_metadataTree, {tr("Levels"), QString::number(metadata.levels.size())});
-    for (const auto& level : metadata.levels) {
-        new QTreeWidgetItem(levels, {
-            tr("Level %1").arg(level.level),
-            tr("%1 grid(s), %2").arg(level.boxes.size()).arg(
-                QString::fromStdString(level.dataPath))
-        });
+    if (standalone) {
+        const auto& level = metadata.levels.front();
+        addValue(tr("Grids"), tr("%1 grid(s), %2").arg(level.boxes.size()).arg(
+            QString::fromStdString(level.dataPath)));
+    } else {
+        auto* levels = new QTreeWidgetItem(m_metadataTree,
+            {tr("Levels"), QString::number(metadata.levels.size())});
+        for (const auto& level : metadata.levels) {
+            new QTreeWidgetItem(levels, {
+                tr("Level %1").arg(level.level),
+                tr("%1 grid(s), %2").arg(level.boxes.size()).arg(
+                    QString::fromStdString(level.dataPath))
+            });
+        }
     }
     m_metadataTree->expandAll();
 
@@ -4361,8 +4380,13 @@ void MainWindow::showMetadata(
 
     m_lastFilesRead = result.metrics.filesRead;
     m_lastBytesRead = result.metrics.bytesRead;
-    statusBar()->showMessage(tr("Metadata loaded: %1 field(s), %2 level(s)")
-        .arg(metadata.fields.size()).arg(metadata.levels.size()));
+    statusBar()->showMessage(standalone
+        ? tr("Metadata loaded: %1 field(s), %2 grid(s)")
+              .arg(metadata.fields.size())
+              .arg(metadata.levels.front().boxes.size())
+        : tr("Metadata loaded: %1 field(s), %2 level(s)")
+              .arg(metadata.fields.size())
+              .arg(metadata.levels.size()));
 }
 
 std::optional<QRectF> MainWindow::preservedDataWindow(


### PR DESCRIPTION
Standalone FABs and MultiFabs have no AMR hierarchy and no simulation time, but the UI presented both: the Dataset window labeled its single tab "Level 0", the window title showed "T = 0" plus "Levels: 0..0 Finest Level: 0", the bottom probe readout appended "level=0", and the metadata panel listed Time, Finest level, and a "Level 0" entry.

All of these now key off metadata.hasPhysicalGeometry, which is false exactly for standalone data. The Dataset window names its single tab after the format (FAB or MultiFab), the window title shows just the name and format, the probe readout omits the level segment, and the metadata panel replaces the Time/Finest level rows and per-level listing with a single Grids row; the "Metadata loaded" status message counts grids instead of levels. Plotfiles, including single-level ones, are unchanged.