### PR TITLE
Resolve plotfile-picker selections up to the enclosing plotfile

### DIFF
--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -2884,7 +2884,22 @@ void MainWindow::chooseDataset()
     if (directory.isEmpty()) {
         return;
     }
-    openDataset(directory.toStdString());
+    // Directory pickers descend into a plotfile on double-click instead of
+    // selecting it, so the choice easily lands on an inner directory
+    // (Level_1, a particle species, ...). Such a selection resolves up to
+    // the enclosing plotfile rather than failing on the subdirectory.
+    auto path = std::filesystem::path(directory.toStdString());
+    for (auto candidate = path; !candidate.empty();
+        candidate = candidate.parent_path()) {
+        if (isAmrexPlotfile(candidate)) {
+            path = candidate;
+            break;
+        }
+        if (candidate.parent_path() == candidate) {
+            break;
+        }
+    }
+    openDataset(path);
 }
 
 void MainWindow::chooseStandaloneDataset(const QString& caption, bool rawFab)


### PR DESCRIPTION
In the Open Plotfile Directory dialog, double-clicking a plotfile enters it instead of selecting it, so the choice easily lands on an inner directory such as Level_1 or a particle species. The failed open then saved lastOpenDirectory as the plotfile itself, so the dialog kept reopening inside it with only the inner directories visible — there was no way back to selecting plt00010.

chooseDataset now walks the selection up through its parents and opens the first directory that passes the isAmrexPlotfile structural check (Header plus a Level_N subdirectory), so any selection inside a plotfile opens the plotfile itself. The successful open then stores the plotfile's parent, restoring the saved start directory. A selection outside any plotfile is passed through unchanged and fails with the usual error.