### PR TITLE
Align toolbar naming and add group separators

### DIFF
--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -403,17 +403,27 @@ MainWindow::MainWindow(QWidget* parent)
             });
     }
     sliceToolbar->addWidget(m_slicePositionControls);
-    m_slicePositionControls->setVisible(false);
+    // Separator between the Position group and Scale. It tracks the Position
+    // group's visibility (see setSlicePositionControlsVisible) so it does not
+    // dangle beside the Level separator when no dataset is loaded.
+    m_positionSeparator = sliceToolbar->addSeparator();
+    setSlicePositionControlsVisible(false);
 
+    // A static "Scale:" label plus a state button, matching the Field:/Level:/
+    // Range: label-and-widget pairs elsewhere on this toolbar (and the
+    // View -> Scale menu name).
+    sliceToolbar->addWidget(new QLabel(tr("Scale:"), sliceToolbar));
     m_scaleButton = new QPushButton(tr("Fit"), sliceToolbar);
     m_scaleButton->setToolTip(
         tr("Zoom scale and rubber-band synchronization for panels"));
     m_scaleButton->setFocusPolicy(Qt::NoFocus);
     auto* scaleMenu = new QMenu(m_scaleButton);
-    // "Reset Zoom" restores the whole domain and refits (issue #45 renamed it
-    // from "Fit", which read as fit-the-current-region). The button label
-    // stays "Fit" as the *scale state*: auto-fit also holds for a panned
-    // crop (applyPanStep), where the region is not the whole domain.
+    // The clicked item stays "Reset Zoom" (the action verb): it restores the
+    // whole domain and refits (issue #45 renamed it from "Fit", which read as
+    // fit-the-current-region). The button shows just the *scale state* ("Fit"
+    // for auto-fit, which also holds for a panned crop in applyPanStep where
+    // the region is not the whole domain); the adjacent "Scale:" label names
+    // the control.
     auto* resetZoomAction = scaleMenu->addAction(tr("Reset Zoom"));
     connect(resetZoomAction, &QAction::triggered, this, [this] {
         m_scaleButton->setText(tr("Fit"));
@@ -470,12 +480,13 @@ MainWindow::MainWindow(QWidget* parent)
     m_rangeMinimum->setPrefix(tr("min "));
     m_rangeMaximum->setPrefix(tr("max "));
     m_rangeMaximum->setValue(1.0);
+    // Separate the Range group (mode + min/max) from Log and Palette, matching
+    // the per-group separators on the Slice Controls toolbar.
+    rangeToolbar->addSeparator();
     m_logarithmic = new QCheckBox(tr("Log"), rangeToolbar);
     m_logarithmic->setLayoutDirection(Qt::RightToLeft);
     rangeToolbar->addWidget(m_logarithmic);
-    auto* paletteSpacer = new QWidget(rangeToolbar);
-    paletteSpacer->setFixedWidth(12);
-    rangeToolbar->addWidget(paletteSpacer);
+    rangeToolbar->addSeparator();
     rangeToolbar->addWidget(new QLabel(tr("Palette:"), rangeToolbar));
     m_paletteSelector = new QComboBox(rangeToolbar);
     const QFontMetrics paletteFm(m_paletteSelector->font());
@@ -3496,7 +3507,7 @@ void MainWindow::openDatasetImpl(const std::filesystem::path& path,
     m_slicePlanesAction->setEnabled(false);
     m_rangeMinimum->setEnabled(false);
     m_rangeMaximum->setEnabled(false);
-    m_slicePositionControls->setVisible(false);
+    setSlicePositionControlsVisible(false);
     m_animationPanel->setSweepVisible(false);
     m_levelMenu->setEnabled(false);
     m_contoursAction->setEnabled(false);
@@ -3860,13 +3871,21 @@ void MainWindow::configureSliceControls()
     ensureVectorFieldDefaults();
 }
 
+void MainWindow::setSlicePositionControlsVisible(bool visible)
+{
+    m_slicePositionControls->setVisible(visible);
+    if (m_positionSeparator != nullptr) {
+        m_positionSeparator->setVisible(visible);
+    }
+}
+
 void MainWindow::configureSlicePositionControls()
 {
     if (!m_dataset) {
-        m_slicePositionControls->setVisible(false);
+        setSlicePositionControlsVisible(false);
         return;
     }
-    m_slicePositionControls->setVisible(true);
+    setSlicePositionControlsVisible(true);
     const auto& md = m_dataset->metadata();
 
     if (md.dimension != 3) {

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -484,7 +484,6 @@ MainWindow::MainWindow(QWidget* parent)
     // the per-group separators on the Slice Controls toolbar.
     rangeToolbar->addSeparator();
     m_logarithmic = new QCheckBox(tr("Log"), rangeToolbar);
-    m_logarithmic->setLayoutDirection(Qt::RightToLeft);
     rangeToolbar->addWidget(m_logarithmic);
     rangeToolbar->addSeparator();
     rangeToolbar->addWidget(new QLabel(tr("Palette:"), rangeToolbar));

--- a/src/qt/MainWindow.hpp
+++ b/src/qt/MainWindow.hpp
@@ -380,6 +380,9 @@ private:
 
     // Shared 3-D slice positions (physical coordinates per axis).
     void configureSlicePositionControls();
+    // Show or hide the Position group together with its trailing toolbar
+    // separator, so the separator never dangles when no dataset is loaded.
+    void setSlicePositionControlsVisible(bool visible);
     void setSlicePosition(int axis, double value);
     [[nodiscard]] int sliceIndexLevel() const;
     // Visible-range mode in 3-D: recompute the min/max from all three panels'
@@ -468,6 +471,7 @@ private:
     std::unordered_map<std::uint32_t, FieldRange> m_fieldRanges;
     std::uint32_t m_trackedField = 0;
     QWidget* m_slicePositionControls = nullptr;
+    QAction* m_positionSeparator = nullptr;
     std::array<QSpinBox*, 3> m_sliceSpinboxes{nullptr, nullptr, nullptr};
     QTimer* m_sliceDebounce = nullptr;
     QTimer* m_panDebounce = nullptr;


### PR DESCRIPTION
The Slice Controls toolbar labeled its scale control with a bare "Fit" button while the menu called it "Scale", and neither toolbar separated its control groups consistently.

Slice Controls:
- Add a static "Scale:" label before the state button, matching the Field:/Level:/Range: label-and-widget pairs and the View -> Scale menu. The button keeps showing just the state (Fit / 1x..32x / Custom / Mixed).
- Add a separator between the Position group and Scale. It tracks the Position group's visibility via a new setSlicePositionControlsVisible() helper, so it never dangles beside the Level separator when no dataset is loaded.

Color and Overlay Controls:
- Separate the Range group, Log, and Palette with native separators, replacing the ad-hoc 12px spacer that preceded Palette.