### PR TITLE
Consolidate MainWindow control-enable and active-view sync duplication

### DIFF
--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -866,6 +866,11 @@ void MainWindow::setActiveView(PlaneViewState& state)
     if (state.plane->width <= 0 || state.plane->height <= 0) {
         return;
     }
+    syncActiveViewColorControls(state);
+}
+
+void MainWindow::syncActiveViewColorControls(const PlaneViewState& state)
+{
     // The color scale and range boxes track the active view.
     m_colorBar->setLogarithmic(state.displayLogarithmic);
     m_colorBar->setFieldRange(state.displayLogarithmic
@@ -3816,6 +3821,25 @@ void MainWindow::requestInitialSlice(
     }));
 }
 
+void MainWindow::enableDatasetControls(const DatasetMetadata& metadata)
+{
+    m_controlsReady = true;
+    m_fieldSelector->setEnabled(true);
+    m_levelSelector->setEnabled(true);
+    m_rangeMode->setEnabled(true);
+    m_logarithmic->setEnabled(true);
+    m_boxesAction->setEnabled(true);
+    m_slicePlanesAction->setEnabled(metadata.dimension == 3);
+    const auto userRange = static_cast<RangeMode>(
+        m_rangeMode->currentData().toInt()) == RangeMode::User;
+    m_rangeMinimum->setEnabled(userRange);
+    m_rangeMaximum->setEnabled(userRange);
+    rebuildLevelMenu();
+    m_levelMenu->setEnabled(true);
+    m_contoursAction->setEnabled(true);
+    m_datasetAction->setEnabled(true);
+}
+
 void MainWindow::configureSliceControls()
 {
     if (!m_dataset) {
@@ -3835,21 +3859,7 @@ void MainWindow::configureSliceControls()
     populateLevelCombo(m_levelSelector, metadata.finestLevel);
     m_levelSelector->setCurrentIndex(0);
 
-    m_controlsReady = true;
-    m_fieldSelector->setEnabled(true);
-    m_levelSelector->setEnabled(true);
-    m_rangeMode->setEnabled(true);
-    m_logarithmic->setEnabled(true);
-    m_boxesAction->setEnabled(true);
-    m_slicePlanesAction->setEnabled(metadata.dimension == 3);
-    const auto userRange = static_cast<RangeMode>(
-        m_rangeMode->currentData().toInt()) == RangeMode::User;
-    m_rangeMinimum->setEnabled(userRange);
-    m_rangeMaximum->setEnabled(userRange);
-    rebuildLevelMenu();
-    m_levelMenu->setEnabled(true);
-    m_contoursAction->setEnabled(true);
-    m_datasetAction->setEnabled(true);
+    enableDatasetControls(metadata);
 
     rebuildVariableMenu();
     updateRangeModeAvailability();
@@ -4525,23 +4535,9 @@ void MainWindow::showSlice(PlaneViewState& state, const SliceDisplayResult& disp
     state.cachedVectorVField = display.vectorVField;
     state.cachedContourCount = display.contourCount;
     if (m_activeView == &state) {
-        m_colorBar->setLogarithmic(display.logarithmic);
-        m_colorBar->setFieldRange(
-            display.logarithmic ? fieldName + tr(" (log)") : fieldName,
-            display.minimum, display.maximum);
-        // If log was requested but fell back to linear, reflect that in the
-        // checkbox so the user sees log did not apply.
-        if (m_logarithmic->isChecked() != display.logarithmic) {
-            const QSignalBlocker logarithmicBlocker(m_logarithmic);
-            m_logarithmic->setChecked(display.logarithmic);
-        }
-        if (static_cast<RangeMode>(m_rangeMode->currentData().toInt())
-            != RangeMode::User) {
-            const QSignalBlocker minimumBlocker(m_rangeMinimum);
-            const QSignalBlocker maximumBlocker(m_rangeMaximum);
-            m_rangeMinimum->setValue(display.minimum);
-            m_rangeMaximum->setValue(display.maximum);
-        }
+        // Tracks the active view; if log was requested but fell back to linear,
+        // the checkbox reflects that log did not apply.
+        syncActiveViewColorControls(state);
     }
     updateGridBoxes(state);
     updateOverlay(state);
@@ -4931,21 +4927,7 @@ void MainWindow::configureSequenceControls(bool defaultPositions)
         setActiveView(isThreeDimensional ? m_planeViews[2] : m_view2d);
     }
 
-    m_controlsReady = true;
-    m_fieldSelector->setEnabled(true);
-    m_levelSelector->setEnabled(true);
-    m_rangeMode->setEnabled(true);
-    m_logarithmic->setEnabled(true);
-    m_boxesAction->setEnabled(true);
-    m_slicePlanesAction->setEnabled(metadata.dimension == 3);
-    const auto userRange = static_cast<RangeMode>(
-        m_rangeMode->currentData().toInt()) == RangeMode::User;
-    m_rangeMinimum->setEnabled(userRange);
-    m_rangeMaximum->setEnabled(userRange);
-    rebuildLevelMenu();
-    m_levelMenu->setEnabled(true);
-    m_contoursAction->setEnabled(true);
-    m_datasetAction->setEnabled(true);
+    enableDatasetControls(metadata);
     m_exportAnimationAction->setEnabled(true);
     rebuildVariableMenu();
     ensureVectorFieldDefaults();

--- a/src/qt/MainWindow.hpp
+++ b/src/qt/MainWindow.hpp
@@ -330,6 +330,9 @@ private:
     void wireView(PlaneViewState& state);
     [[nodiscard]] std::vector<PlaneViewState*> currentViews();
     void setActiveView(PlaneViewState& state);
+    // Point the color scale and range spin boxes at the active view's display
+    // state. Shared by setActiveView and showSlice's active-view branch.
+    void syncActiveViewColorControls(const PlaneViewState& state);
     [[nodiscard]] std::array<int, 2> displayAxes(int normal) const;
     void probeMoved(PlaneViewState& state, int x, int displayY);
     void probeClicked(PlaneViewState& state, int x, int displayY);
@@ -407,6 +410,11 @@ private:
         std::filesystem::path dataRoot = {},
         std::optional<FrameSliceSpec> initialSpec = std::nullopt);
     void configureSliceControls();
+    // Enable the dataset-dependent field/level/range/menu controls once a
+    // dataset (single or sequence frame) is loaded. Shared by
+    // configureSliceControls and configureSequenceControls; the export-animation
+    // action is sequence-only and stays at that call site.
+    void enableDatasetControls(const DatasetMetadata& metadata);
     void appendLinePlotCurve(const LineResult& line, const std::string& fieldName,
         int dimension, int primaryFixedAxis, int lineAxis,
         const std::array<double, 3>& fixedCoordinates, int maximumLevel,


### PR DESCRIPTION
Two drift-prone duplications in MainWindow (the #14 extraction residue) now have single sources of truth.

- enableDatasetControls(const DatasetMetadata&) holds the verbatim control-enable block that configureSliceControls and configureSequenceControls both carried. The sequence-only m_exportAnimationAction->setEnabled(true) stays at that call site — it is gated on hasSequence() everywhere else, so it must not enter the shared helper.
- syncActiveViewColorControls(const PlaneViewState&) holds the active-view color-bar/log/range-box sync that setActiveView and showSlice's active-view branch each inlined. showSlice populates state from the display result just above the sync, so passing state is behavior-identical.

The third occurrence — the 3-D shared-Visible-range sync in the syncVisibleRanges completion — is left inline on purpose: it uses the shared globalMin/globalMax, skips the log-checkbox sync, and omits the User-mode guard (inert only in that Visible-only context). Folding it in would trade a clear duplicate for context-dependent reasoning.