### PR TITLE
Add validateMetadata negative-path battery and VisMF v4 tests

### DIFF
--- a/tests/unit/test_core_metadata.cpp
+++ b/tests/unit/test_core_metadata.cpp
@@ -5,6 +5,7 @@
 #include <cstdlib>
 #include <cmath>
 #include <iostream>
+#include <limits>
 
 namespace {
 
@@ -21,6 +22,21 @@ bool hasIssue(const std::vector<amrvis::MetadataIssue>& issues,
 {
     for (const auto& issue : issues) {
         if (issue.path.rfind(pathPrefix, 0) == 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
+// Exact-path variant for the negative-path battery: a perturbation may
+// cascade a second, derived issue (e.g. an out-of-domain box once its level
+// domain is corrupted), so matching the precise path keeps each case pinned
+// to the check it targets rather than to a prefix a neighbour also shares.
+bool hasExactIssue(const std::vector<amrvis::MetadataIssue>& issues,
+    const char* path)
+{
+    for (const auto& issue : issues) {
+        if (issue.path == path) {
             return true;
         }
     }
@@ -149,6 +165,138 @@ int main()
         bad.levels.push_back(std::move(badLevel));
         require(hasIssue(amrvis::validateMetadata(bad), "levels[0].blocks"),
             "a blocks/boxes size mismatch was not reported");
+    }
+
+    // Negative-path battery: a known-good baseline perturbed one way per case.
+    // Every check in validateMetadata that lacked a negative test above is
+    // exercised here. The baseline must validate clean first, or the cases
+    // below prove nothing.
+    auto makeValid = [] {
+        amrvis::DatasetMetadata m;
+        m.dimension = 2;
+        m.finestLevel = 0;
+        m.physicalDomain = {{{0.0, 0.0, 0.0}}, {{1.0, 1.0, 0.0}}};
+        m.fields.push_back({"density", amrvis::Centering::Cell, {"density"}});
+        amrvis::LevelMetadata baseLevel;
+        baseLevel.level = 0;
+        baseLevel.domain = {{{0, 0, 0}}, {{3, 3, 0}}, {{0, 0, 0}}};
+        baseLevel.cellSize = {{0.25, 0.25, 1.0}};
+        baseLevel.storedComponents = 1;
+        baseLevel.boxes.push_back(baseLevel.domain);
+        baseLevel.blocks.push_back({baseLevel.domain, "Cell_D_00000", 0,
+            amrvis::BlockStatistics{{-2.0}, {7.0}}});
+        baseLevel.dataPath = "Level_0/Cell";
+        m.levels.push_back(std::move(baseLevel));
+        return m;
+    };
+    require(amrvis::validateMetadata(makeValid()).empty(),
+        "the negative-path baseline was itself rejected");
+
+    {
+        auto m = makeValid();
+        m.finestLevel = -1;
+        require(hasExactIssue(amrvis::validateMetadata(m), "finestLevel"),
+            "a negative finestLevel was not reported");
+    }
+    {
+        auto m = makeValid();
+        m.physicalDomain.upper[0] = 0.0;  // zero extent in x
+        require(hasExactIssue(amrvis::validateMetadata(m), "physicalDomain"),
+            "a degenerate physical domain was not reported");
+    }
+    {
+        auto m = makeValid();
+        m.finestLevel = 1;  // now expects two levels, only one present
+        require(hasExactIssue(amrvis::validateMetadata(m), "levels"),
+            "a levels-size mismatch was not reported");
+    }
+    {
+        auto m = makeValid();
+        m.fields[0].name.clear();
+        require(hasExactIssue(amrvis::validateMetadata(m), "fields[0].name"),
+            "an empty field name was not reported");
+    }
+    {
+        auto m = makeValid();
+        m.fields[0].componentNames = {"a", "b"};
+        require(hasExactIssue(
+                    amrvis::validateMetadata(m), "fields[0].componentNames"),
+            "a multi-entry componentNames was not reported");
+    }
+    {
+        auto m = makeValid();
+        m.levels[0].level = 5;  // disagrees with its position
+        require(hasExactIssue(amrvis::validateMetadata(m), "levels[0].level"),
+            "a level index/position mismatch was not reported");
+    }
+    {
+        auto m = makeValid();
+        m.levels[0].domain.lower[0] = 5;  // lower > upper
+        require(hasExactIssue(amrvis::validateMetadata(m), "levels[0].domain"),
+            "an invalid level domain was not reported");
+    }
+    {
+        auto m = makeValid();
+        m.levels[0].domain.centering[0] = 2;  // neither cell (0) nor node (1)
+        require(hasExactIssue(
+                    amrvis::validateMetadata(m), "levels[0].domain.centering"),
+            "an invalid domain index type was not reported");
+    }
+    {
+        auto m = makeValid();
+        m.levels[0].cellSize[0] = 0.0;
+        require(hasExactIssue(amrvis::validateMetadata(m), "levels[0].cellSize"),
+            "a non-positive cell size was not reported");
+    }
+    {
+        auto m = makeValid();
+        m.levels[0].indexOrigin[0] = std::numeric_limits<double>::quiet_NaN();
+        require(hasExactIssue(amrvis::validateMetadata(m), "levels[0].indexOrigin"),
+            "a non-finite index origin was not reported");
+    }
+    {
+        auto m = makeValid();
+        // Keep the block box in step so only the box itself is faulted.
+        m.levels[0].boxes[0].lower[0] = 5;  // lower > upper
+        m.levels[0].blocks[0].box = m.levels[0].boxes[0];
+        require(hasExactIssue(amrvis::validateMetadata(m), "levels[0].boxes[0]"),
+            "an invalid level box was not reported");
+    }
+    {
+        auto m = makeValid();
+        m.levels[0].boxes[0].upper[0] = 5;  // reaches outside the domain (0..3)
+        m.levels[0].blocks[0].box = m.levels[0].boxes[0];
+        require(hasExactIssue(amrvis::validateMetadata(m), "levels[0].boxes[0]"),
+            "a box reaching outside the level domain was not reported");
+    }
+    {
+        auto m = makeValid();
+        m.levels[0].boxes[0].centering[0] = 1;  // domain is cell-centered (0)
+        m.levels[0].blocks[0].box = m.levels[0].boxes[0];
+        require(hasExactIssue(
+                    amrvis::validateMetadata(m), "levels[0].boxes[0].centering"),
+            "a box/domain centering mismatch was not reported");
+    }
+    {
+        auto m = makeValid();
+        m.levels[0].blocks[0].box.upper[0] = 2;  // no longer equals boxes[0]
+        require(hasExactIssue(
+                    amrvis::validateMetadata(m), "levels[0].blocks[0].box"),
+            "a block box disagreeing with its level box was not reported");
+    }
+    {
+        auto m = makeValid();
+        m.levels[0].blocks[0].filePath.clear();
+        require(hasExactIssue(
+                    amrvis::validateMetadata(m), "levels[0].blocks[0].filePath"),
+            "an empty block file path was not reported");
+    }
+    {
+        auto m = makeValid();
+        m.levels[0].blocks[0].statistics->minimum = {0.0, 1.0};  // 2 != 1 stored
+        require(hasExactIssue(
+                    amrvis::validateMetadata(m), "levels[0].blocks[0].statistics"),
+            "a statistics component-count mismatch was not reported");
     }
 
     return 0;

--- a/tests/unit/test_vismf_index.cpp
+++ b/tests/unit/test_vismf_index.cpp
@@ -1,8 +1,10 @@
-// Regression test for VisMF _H header parsing across header versions 1-3.
+// Regression test for VisMF _H header parsing across header versions 1-4.
 // AMReX writes a blank separator line before the RealDescriptor in versions 2
 // and 3 (a trailing '\n' after the FabOnDisk list, and after each per-block
 // min/max matrix). The reader must skip those blanks and still find the
-// descriptor; otherwise v2/v3 plotfiles are unopenable.
+// descriptor; otherwise v2/v3 plotfiles are unopenable. Version 4
+// (NoFabHeaderFAMinMax) instead stores one FabArray-wide min/max per component
+// and writes no separator before the descriptor.
 #include <amrexplorer/io/detail/VisMfIndex.hpp>
 #include <amrexplorer/io/PlotfileMetadataReader.hpp>
 #include <amrexplorer/io/StandaloneMetadataReader.hpp>
@@ -147,6 +149,45 @@ void testVersion3(const std::filesystem::path& path)
         "v3 per-block statistics count mismatch");
 }
 
+void testVersion4(const std::filesystem::path& path)
+{
+    // NoFabHeaderFAMinMax: one FabArray-wide min/max per component (each value
+    // comma-terminated) replaces the per-block matrices, and — unlike v2/v3 —
+    // no blank separator precedes the RealDescriptor. This branch had no test.
+    writeHeader(path,
+        "4\n"
+        "1\n"
+        "2\n"                                    // ncomp
+        "0\n"
+        "(2 0\n"
+        "((0,0) (1,3) (0,0))\n"
+        "((2,0) (3,3) (0,0))\n"
+        ")\n"
+        "2\n"
+        "FabOnDisk: Cell_D_00000 0\n"
+        "FabOnDisk: Cell_D_00000 4096\n"
+        "0.00000000000000000e+00,1.00000000000000000e+02,\n"  // FA minima, 2 comps
+        "1.00000000000000000e+00,1.01000000000000000e+02,\n"  // FA maxima, 2 comps
+        "((8, (64 11 52 0 1 12 0 1023)),(8, (8 7 6 5 4 3 2 1)))\n");
+    const auto index = readHeader(path, 2, "4");
+    require(index.version == 4, "v4 version mismatch");
+    require(index.realDescriptor == kRealDescriptor,
+        "v4 RealDescriptor not parsed (no separator precedes it)");
+    require(index.boxes.size() == 2, "v4 box count mismatch");
+    require(!index.hasPerBlockStatistics,
+        "v4 carries FabArray-wide, not per-block, statistics");
+    require(index.minimum.size() == 1 && index.maximum.size() == 1,
+        "v4 should hold a single FabArray-wide min/max entry");
+    require(index.minimum.front().size() == 2
+            && index.minimum.front()[0] == 0.0
+            && index.minimum.front()[1] == 100.0,
+        "v4 FabArray minima parsed wrong");
+    require(index.maximum.front().size() == 2
+            && index.maximum.front()[0] == 1.0
+            && index.maximum.front()[1] == 101.0,
+        "v4 FabArray maxima parsed wrong");
+}
+
 // A crafted header must be rejected with MetadataReadError specifically (not
 // std::bad_alloc from over-allocating, and not some other exception). When
 // expectedMessage is set, the error text must contain it — this pins the
@@ -247,6 +288,27 @@ void testRejectsAbsolutePath(const std::filesystem::path& path)
         "relative path");
 }
 
+void testRejectsV4MissingComma(const std::filesystem::path& path)
+{
+    // A v4 FabArray minimum not terminated by a comma is malformed; the reader
+    // must fault it rather than silently accept a truncated min/max list.
+    expectRejected(path,
+        "4\n1\n2\n0\n"
+        "(2 0\n"
+        "((0,0) (1,3) (0,0))\n"
+        "((2,0) (3,3) (0,0))\n"
+        ")\n"
+        "2\n"
+        "FabOnDisk: Cell_D_00000 0\n"
+        "FabOnDisk: Cell_D_00000 4096\n"
+        "0.0 100.0,\n"                          // missing comma after first min
+        "1.0,101.0,\n"
+        "((8, (64 11 52 0 1 12 0 1023)),(8, (8 7 6 5 4 3 2 1)))\n",
+        2,
+        "a v4 body with a missing min separator was not rejected",
+        "malformed FabArray minima");
+}
+
 } // namespace
 
 int main()
@@ -258,10 +320,12 @@ int main()
     testVersion1(scratch / "v1_H");
     testVersion2(scratch / "v2_H");
     testVersion3(scratch / "v3_H");
+    testVersion4(scratch / "v4_H");
     testRejectsOversizedMatrix(scratch / "bad_matrix_H");
     testRejectsMatrixShapeMismatch(scratch / "bad_shape_H");
     testRejectsRelativeTraversal(scratch / "traversal_H");
     testRejectsAbsolutePath(scratch / "absolute_H");
+    testRejectsV4MissingComma(scratch / "bad_v4_H");
 
     std::error_code removeError;
     std::filesystem::remove_all(scratch, removeError);


### PR DESCRIPTION
Fill the two highest-priority test-coverage gaps (issue #17). Test-only; no production code changes.

test_core_metadata: a makeValid() baseline (asserted clean) is perturbed one way per case to exercise every previously-untested validateMetadata check — finestLevel, physicalDomain, levels-size, empty field name, componentNames, level index, domain validity/centering, cellSize, indexOrigin, box validity/within-domain/centering, block-box match, filePath, and statistics component-count — on top of the existing dimension and blocks/boxes cases. A new hasExactIssue helper keeps each case pinned to its target check when a perturbation cascades a second, derived issue.

test_vismf_index: testVersion4 exercises the NoFabHeaderFAMinMax (v4) parse path that was never run — the FabArray-wide min/max per component and the descriptor with no separator preceding it — and testRejectsV4MissingComma covers the malformed-minima throw.