### PR TITLE
Add v1 FAB-header reconciliation and selected-FAB tests

### DIFF
--- a/tests/integration/test_fab_catalog.cpp
+++ b/tests/integration/test_fab_catalog.cpp
@@ -289,6 +289,35 @@ int main()
         && fab.metadata->levels[0].domain.upper[1] == 3,
         "MultiFab ghost points were not included in selected FAB mode");
 
+    // makeSelectedFabMetadata's version-1 branch takes the selected FAB's box
+    // from its own inline header (via inspectFabRecord) instead of growing the
+    // source box by the level ghost width (the v2 path checked above). Point a
+    // v1 source at the raw FAB written at the top of this test — inline box
+    // ((0,0) (1,0)) — but give it a ghost width that would grow to a *different*
+    // box, so this can only pass if the inline header supplied the domain.
+    amrvis::DatasetMetadata v1Source;
+    v1Source.dimension = 2;
+    v1Source.finestLevel = 0;
+    v1Source.fields.push_back(
+        {"value", amrvis::Centering::Cell, {"value"}});
+    v1Source.levels.resize(1);
+    auto& v1Level = v1Source.levels.front();
+    v1Level.domain = {{{0, 0, 0}}, {{1, 1, 0}}, {{0, 0, 0}}};
+    v1Level.boxes.push_back(v1Level.domain);
+    v1Level.blocks.push_back({v1Level.domain, "raw_fabs", 0, std::nullopt});
+    v1Level.ghostWidth = {{1, 2, 0}};   // v2 would grow this to ((-1,-2) (2,3))
+    v1Level.storedComponents = 1;
+    v1Level.visMfHeaderVersion = 1;
+    const auto v1Fab = amrvis::makeSelectedFabMetadata(v1Source, 0, 0, root);
+    require(v1Fab.metadata->levels[0].domain.lower[0] == 0
+        && v1Fab.metadata->levels[0].domain.upper[0] == 1
+        && v1Fab.metadata->levels[0].domain.lower[1] == 0
+        && v1Fab.metadata->levels[0].domain.upper[1] == 0,
+        "v1 selected FAB did not take its box from the inline FAB header");
+    require(v1Fab.metadata->levels[0].blocks[0].box
+                == v1Fab.metadata->levels[0].domain,
+        "v1 selected FAB block box disagrees with its domain");
+
     std::filesystem::remove_all(root);
     return 0;
 }

--- a/tests/integration/test_selective_block_read.cpp
+++ b/tests/integration/test_selective_block_read.cpp
@@ -166,6 +166,51 @@ void testRejectsOversizedBox(const std::filesystem::path& base)
     require(threw, "an oversized FAB box was not rejected before allocation");
 }
 
+// In version 1 each FAB's own inline header carries the component count, which
+// the block reader cross-checks against the VisMF _H metadata. When they
+// disagree the read must be rejected rather than strided with the wrong
+// component count. (For version >= 2 the header is filled from the metadata, so
+// this reconciliation is a no-op there and only bites on v1.)
+void testRejectsV1FabComponentDisagreement(const std::filesystem::path& base)
+{
+    const auto root = base / "v1_component_disagreement";
+    std::filesystem::create_directories(root / "Level_0");
+    writeText(root / "Header", minimalHeader("Level_0/Cell"));
+    // Version-1 _H: one box, one component (matching the plotfile Header).
+    writeText(root / "Level_0" / "Cell_H",
+        "1\n1\n1\n0\n"
+        "(1 0\n((0,0) (1,1) (0,0))\n)\n"
+        "1\nFabOnDisk: Cell_D_00000 0\n\n"
+        "1,1\n1.0,\n\n1,1\n4.0,\n");
+    {
+        std::ofstream data(root / "Level_0" / "Cell_D_00000", std::ios::binary);
+        require(static_cast<bool>(data), "could not create v1 disagreement payload");
+        // The FAB inline header claims two components; the _H declared one.
+        data << "FAB ((8, (64 11 52 0 1 12 0 1023)),"
+                "(8, (8 7 6 5 4 3 2 1)))((0,0) (1,1) (0,0)) 2\n";
+        const std::array<double, 4> values{1.0, 2.0, 3.0, 4.0};
+        data.write(reinterpret_cast<const char*>(values.data()),
+            static_cast<std::streamsize>(sizeof(values)));
+    }
+
+    const auto metadata = amrvis::PlotfileMetadataReader{}.read(root);
+    amrvis::PlotfileBlockReader reader(root, metadata.metadata);
+    amrvis::BlockRequest request;
+    request.dataset.value = 1;
+    request.field.value = 0;
+    bool threw = false;
+    try {
+        (void)reader.readBlock(request);
+    } catch (const amrvis::BlockReadError& error) {
+        // Pin to the reconciliation message so an incidental failure (e.g. a
+        // payload-size guard) cannot pass this in its place.
+        threw = std::string(error.what()).find("component counts disagree")
+            != std::string::npos;
+    }
+    require(threw,
+        "a v1 FAB header disagreeing with the VisMF component count was not rejected");
+}
+
 } // namespace
 
 int main()
@@ -279,6 +324,7 @@ int main()
     testBigEndianDecode(root);
     testRejectsEscapingDataPath(root);
     testRejectsOversizedBox(root);
+    testRejectsV1FabComponentDisagreement(root);
 
     std::filesystem::remove_all(root);
     return 0;


### PR DESCRIPTION
Close the last two parser malformed-input gaps, both in the version-1 FAB path where each FAB's inline header is authoritative.  Test-only.

test_selective_block_read.cpp: testRejectsV1FabComponentDisagreement builds a v1 plotfile whose _D FAB inline header declares a different component count than its _H, and asserts the block reader throws "FAB and VisMF component counts disagree". The reconciliation is inert for v2 (which fills the header from metadata), so it only bites on v1.

test_fab_catalog.cpp: makeSelectedFabMetadata's v1 branch takes the selected FAB's box from its inline header (inspectFabRecord) rather than growing the source box by the level ghost width. The new case points a v1 source at the raw FAB written earlier in the test (inline box ((0,0) (1,0))) with a ghost width that would grow to a different box, so the domain assertion passes only if the inline header supplied it