### PR TITLE
refactor into ParticleProjection pipeline

### DIFF
--- a/include/amrexplorer/pipeline/ParticleProjection.hpp
+++ b/include/amrexplorer/pipeline/ParticleProjection.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <amrexplorer/core/Result.hpp>
+#include <amrexplorer/io/ParticleReader.hpp>
+
+#include <span>
+#include <vector>
+
+namespace amrvis {
+
+struct ParticlePixel {
+    double x = 0.0;
+    double y = 0.0;
+};
+
+// Projects physical particle positions into a slice plane's raster scene
+// coordinates. The in-plane physical bounds map inclusively to the raster
+// edges: x increases from 0 to width, while y is flipped from height to 0 to
+// match the Qt image scene. The normal coordinate is deliberately ignored;
+// particles are projected through the full volume rather than filtered to a
+// slice thickness.
+[[nodiscard]] std::vector<ParticlePixel>
+projectParticlePoints(std::span<const ParticlePoint> particles,
+                      const ScalarPlane& plane, int dimension, int normalDirection);
+
+} // namespace amrvis

--- a/src/pipeline/CMakeLists.txt
+++ b/src/pipeline/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library(amrexplorer_pipeline
     DisplayCoordinator.cpp
+    ParticleProjection.cpp
     SlicePipeline.cpp
     SliceRangeResolver.cpp
 )

--- a/src/pipeline/ParticleProjection.cpp
+++ b/src/pipeline/ParticleProjection.cpp
@@ -1,0 +1,48 @@
+#include <amrexplorer/pipeline/ParticleProjection.hpp>
+
+#include <amrexplorer/pipeline/SlicePipeline.hpp>
+
+#include <cmath>
+
+namespace amrvis {
+
+std::vector<ParticlePixel>
+projectParticlePoints(std::span<const ParticlePoint> particles,
+                      const ScalarPlane& plane, int dimension, int normalDirection)
+{
+    if ((dimension != 2 && dimension != 3)
+        || (dimension == 3 && (normalDirection < 0 || normalDirection >= dimension))
+        || plane.width <= 0 || plane.height <= 0) {
+        return {};
+    }
+
+    const auto axes = slicePlaneAxes(dimension, normalDirection);
+    const auto xAxis = static_cast<std::size_t>(axes[0]);
+    const auto yAxis = static_cast<std::size_t>(axes[1]);
+    const auto& region = plane.physicalRegion;
+    const auto xExtent = region.upper[xAxis] - region.lower[xAxis];
+    const auto yExtent = region.upper[yAxis] - region.lower[yAxis];
+    if (!(xExtent > 0.0) || !(yExtent > 0.0) || !std::isfinite(xExtent)
+        || !std::isfinite(yExtent)) {
+        return {};
+    }
+
+    std::vector<ParticlePixel> projected;
+    projected.reserve(particles.size());
+    for (const auto& particle : particles) {
+        const auto x = particle.position[xAxis];
+        const auto y = particle.position[yAxis];
+        if (!std::isfinite(x) || !std::isfinite(y) || x < region.lower[xAxis]
+            || x > region.upper[xAxis] || y < region.lower[yAxis]
+            || y > region.upper[yAxis]) {
+            continue;
+        }
+        projected.push_back(
+            {.x = (x - region.lower[xAxis]) / xExtent * plane.width,
+             .y = plane.height
+                  - (y - region.lower[yAxis]) / yExtent * plane.height});
+    }
+    return projected;
+}
+
+} // namespace amrvis

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -20,6 +20,7 @@
 #include <amrexplorer/io/detail/FabHeaderParsing.hpp>
 #include <amrexplorer/io/StandaloneMetadataReader.hpp>
 #include <amrexplorer/core/Statistics.hpp>
+#include <amrexplorer/pipeline/ParticleProjection.hpp>
 #include <amrexplorer/pipeline/SliceRangeResolver.hpp>
 #include <amrexplorer/query/LineQuery.hpp>
 #include <amrexplorer/query/SliceQuery.hpp>
@@ -1993,33 +1994,18 @@ void MainWindow::updateParticleOverlay(PlaneViewState& state)
     constexpr std::array<Qt::GlobalColor, 7> colors{
         Qt::white, Qt::yellow, Qt::cyan, Qt::magenta,
         Qt::green, Qt::red, Qt::lightGray};
-    const auto axes = displayAxes(state.normal);
-    const auto xAxis = static_cast<std::size_t>(axes[0]);
-    const auto yAxis = static_cast<std::size_t>(axes[1]);
-    const auto& region = state.plane->physicalRegion;
-    const auto xExtent = region.upper[xAxis] - region.lower[xAxis];
-    const auto yExtent = region.upper[yAxis] - region.lower[yAxis];
-    if (!(xExtent > 0.0) || !(yExtent > 0.0)) {
-        state.view->setPointOverlays(overlays);
-        return;
-    }
     overlays.reserve(m_particleSamples.size());
     for (std::size_t sampleIndex = 0;
          sampleIndex < m_particleSamples.size(); ++sampleIndex) {
         PointOverlay overlay;
         overlay.color = QColor(colors[sampleIndex % colors.size()]);
         overlay.size = static_cast<float>(m_particlePointSize);
-        for (const auto& particle : m_particleSamples[sampleIndex].points) {
-            const auto x = particle.position[xAxis];
-            const auto y = particle.position[yAxis];
-            if (x < region.lower[xAxis] || x > region.upper[xAxis]
-                || y < region.lower[yAxis] || y > region.upper[yAxis]) {
-                continue;
-            }
-            overlay.points.emplace_back(
-                (x - region.lower[xAxis]) / xExtent * state.plane->width,
-                state.plane->height
-                    - (y - region.lower[yAxis]) / yExtent * state.plane->height);
+        const auto projected = projectParticlePoints(
+            m_particleSamples[sampleIndex].points, *state.plane,
+            m_dataset->metadata().dimension, state.normal);
+        overlay.points.reserve(projected.size());
+        for (const auto& point : projected) {
+            overlay.points.emplace_back(point.x, point.y);
         }
         overlays.push_back(std::move(overlay));
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -61,6 +61,13 @@ target_link_libraries(
 )
 add_test(NAME display_coordinator COMMAND test_display_coordinator)
 
+add_executable(test_particle_projection unit/test_particle_projection.cpp)
+target_link_libraries(
+    test_particle_projection
+    PRIVATE amrexplorer::pipeline amrexplorer::warnings
+)
+add_test(NAME particle_projection COMMAND test_particle_projection)
+
 add_executable(test_slice_range_resolver unit/test_slice_range_resolver.cpp)
 target_link_libraries(
     test_slice_range_resolver

--- a/tests/integration/test_display_transitions.cpp
+++ b/tests/integration/test_display_transitions.cpp
@@ -13,6 +13,7 @@
 
 #include <amrexplorer/io/PlotfileDataset.hpp>
 #include <amrexplorer/pipeline/DisplayCoordinator.hpp>
+#include <amrexplorer/pipeline/ParticleProjection.hpp>
 #include <amrexplorer/pipeline/SlicePipeline.hpp>
 #include <amrexplorer/render2d/ScalarRenderer.hpp>
 
@@ -334,6 +335,38 @@ int main()
             "a non-intersecting zoom did not fall back to the whole domain");
         requireDisplayInvariants(result.dataset->metadata(), d, palette,
             "region fallback");
+    }
+    {
+        // Particle projection follows the displayed plane's physical region:
+        // a zoom both clips the full-domain endpoints and remaps its midpoint.
+        amrvis::FrameSliceSpec spec;
+        const auto full = load2d(spec);
+        const std::vector particles{
+            amrvis::ParticlePoint{.id = 0, .position = {{0.0, 0.0, 0.0}}},
+            amrvis::ParticlePoint{
+                .id = 0, .position = {{0.625, 0.625, 0.0}}},
+            amrvis::ParticlePoint{.id = 0, .position = {{1.0, 1.0, 0.0}}}
+        };
+        const auto fullProjection = amrvis::projectParticlePoints(
+            particles, full.displays.front().slice.plane, 2, 1);
+        require(fullProjection.size() == 3,
+            "full-domain particle projection clipped an in-bounds point");
+
+        amrvis::RealBox zoom;
+        zoom.lower = {{0.5, 0.5, 0.0}};
+        zoom.upper = {{0.75, 0.75, 0.0}};
+        spec.visibleRegions = {zoom};
+        const auto zoomed = load2d(spec);
+        const auto& zoomedPlane = zoomed.displays.front().slice.plane;
+        const auto zoomedProjection = amrvis::projectParticlePoints(
+            particles, zoomedPlane, 2, 1);
+        require(zoomedProjection.size() == 1,
+            "zoomed particle projection did not clip the full-domain endpoints");
+        require(nearlyEqual(zoomedProjection.front().x,
+                    0.5 * zoomedPlane.width)
+                && nearlyEqual(zoomedProjection.front().y,
+                    0.5 * zoomedPlane.height),
+            "zoomed particle projection did not remap the physical midpoint");
     }
     {
         // An out-of-range exact level falls back to finest available.

--- a/tests/unit/test_particle_projection.cpp
+++ b/tests/unit/test_particle_projection.cpp
@@ -1,0 +1,132 @@
+#include <amrexplorer/pipeline/ParticleProjection.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdlib>
+#include <iostream>
+#include <limits>
+#include <vector>
+
+namespace {
+
+void require(bool condition, const char* message)
+{
+    if (!condition) {
+        std::cerr << "FAILED: " << message << '\n';
+        std::exit(1);
+    }
+}
+
+bool nearlyEqual(double a, double b, double tolerance = 1.0e-12)
+{
+    return std::fabs(a - b)
+           <= tolerance * std::max({1.0, std::fabs(a), std::fabs(b)});
+}
+
+amrvis::ParticlePoint point(double x, double y, double z = 0.0)
+{
+    amrvis::ParticlePoint result;
+    result.position = {{x, y, z}};
+    return result;
+}
+
+amrvis::ScalarPlane plane(int width, int height, amrvis::Real3 lower,
+                          amrvis::Real3 upper)
+{
+    amrvis::ScalarPlane result;
+    result.width = width;
+    result.height = height;
+    result.physicalRegion.lower = lower;
+    result.physicalRegion.upper = upper;
+    return result;
+}
+
+} // namespace
+
+int main()
+{
+    {
+        const auto display =
+            plane(200, 100, {{10.0, -2.0, 0.0}}, {{20.0, 2.0, 0.0}});
+        const std::vector particles{
+            point(10.0, -2.0), point(15.0, 0.0),  point(20.0, 2.0), point(9.0, 0.0),
+            point(21.0, 0.0),  point(15.0, -3.0), point(15.0, 3.0)};
+        const auto projected =
+            amrvis::projectParticlePoints(particles, display, 2, 1);
+        require(projected.size() == 3,
+                "2-D projection did not clip outside points");
+        require(nearlyEqual(projected[0].x, 0.0)
+                    && nearlyEqual(projected[0].y, 100.0),
+                "lower physical boundary did not map to the lower-left raster "
+                "edge");
+        require(nearlyEqual(projected[1].x, 100.0)
+                    && nearlyEqual(projected[1].y, 50.0),
+                "physical midpoint did not map to the raster midpoint");
+        require(nearlyEqual(projected[2].x, 200.0)
+                    && nearlyEqual(projected[2].y, 0.0),
+                "upper physical boundary did not map to the upper-right raster "
+                "edge");
+    }
+
+    {
+        const auto display =
+            plane(100, 80, {{10.0, 20.0, -1.0}}, {{20.0, 40.0, 1.0}});
+        const std::vector particles{point(12.0, 35.0, -0.5)};
+        const auto yz = amrvis::projectParticlePoints(particles, display, 3, 0);
+        const auto xz = amrvis::projectParticlePoints(particles, display, 3, 1);
+        const auto xy = amrvis::projectParticlePoints(particles, display, 3, 2);
+        require(yz.size() == 1 && nearlyEqual(yz[0].x, 75.0)
+                    && nearlyEqual(yz[0].y, 60.0),
+                "normal 0 did not project the YZ axes");
+        require(xz.size() == 1 && nearlyEqual(xz[0].x, 20.0)
+                    && nearlyEqual(xz[0].y, 60.0),
+                "normal 1 did not project the XZ axes");
+        require(xy.size() == 1 && nearlyEqual(xy[0].x, 20.0)
+                    && nearlyEqual(xy[0].y, 20.0),
+                "normal 2 did not project the XY axes");
+
+        const std::vector throughVolume{point(12.0, 35.0, 100.0)};
+        const auto projectedThroughVolume =
+            amrvis::projectParticlePoints(throughVolume, display, 3, 2);
+        require(projectedThroughVolume.size() == 1,
+                "projection incorrectly clipped on the plane-normal coordinate");
+    }
+
+    {
+        const auto display = plane(20, 10, {{0.5, 0.25, 0.0}}, {{0.75, 0.75, 0.0}});
+        const std::vector particles{point(0.625, 0.5), point(0.25, 0.5),
+                                    point(0.875, 0.5)};
+        const auto projected =
+            amrvis::projectParticlePoints(particles, display, 2, 1);
+        require(projected.size() == 1 && nearlyEqual(projected[0].x, 10.0)
+                    && nearlyEqual(projected[0].y, 5.0),
+                "zoomed physical region did not remap and clip particles");
+    }
+
+    {
+        const auto valid = plane(20, 10, {{0.0, 0.0, 0.0}}, {{1.0, 1.0, 1.0}});
+        auto nonfinite = point(0.5, 0.5);
+        nonfinite.position[0] = std::numeric_limits<double>::quiet_NaN();
+        const std::vector particles{nonfinite};
+        require(amrvis::projectParticlePoints(particles, valid, 2, 1).empty(),
+                "non-finite particle coordinate was projected");
+
+        auto empty = valid;
+        empty.width = 0;
+        require(amrvis::projectParticlePoints(particles, empty, 2, 1).empty(),
+                "empty raster accepted a particle projection");
+
+        auto degenerate = valid;
+        degenerate.physicalRegion.upper[0] = degenerate.physicalRegion.lower[0];
+        require(amrvis::projectParticlePoints(std::vector{point(0.0, 0.5)},
+                                              degenerate, 2, 1)
+                    .empty(),
+                "degenerate physical region accepted a particle projection");
+        require(
+            amrvis::projectParticlePoints(std::vector{point(0.5, 0.5)}, valid, 3, 3)
+                .empty(),
+            "invalid 3-D normal accepted a particle projection");
+    }
+
+    return 0;
+}


### PR DESCRIPTION
Refactors particle plotting into a pipeline, outside of MainWindow.

Fixes https://github.com/AMReX-Codes/amrexplorer/issues/58.