### PR TITLE
fix line query infinite loop at large coordinate offset

### DIFF
--- a/src/query/LineQuery.cpp
+++ b/src/query/LineQuery.cpp
@@ -162,10 +162,10 @@ LineQueryResult LineQuery::execute(
     // points. Uncovered stretches (ExactLevel outside coverage, or out of
     // domain) become invalid samples so the polyline breaks there.
     auto x = physicalStart;
-    // Relative to the cell size (matching cellStepNudge below): an absolute
-    // 1e-9 epsilon truncates domains whose physical extent is near that scale
-    // (micro/nano-scale SI-unit geometries), dropping the tail samples or
-    // yielding an empty line with no error.
+    // Relative to the cell size: an absolute 1e-9 epsilon truncates domains
+    // whose physical extent is near that scale (micro/nano-scale SI-unit
+    // geometries), dropping the tail samples or yielding an empty line with no
+    // error.
     const double endEpsilon = 1e-9 * finestCellSize;
     while (x < physicalEnd - endEpsilon) {
         if ((result.line.positions.size() & 31U) == 0U
@@ -185,18 +185,23 @@ LineQueryResult LineQuery::execute(
                 result.line.valid.push_back(1);
                 result.line.sourceLevel.push_back(static_cast<std::int16_t>(cover.level));
             }
-            // Advance to the far boundary of this cell, then nudge a tiny
-            // fraction of a cell into the next one. The next iteration
-            // re-derives the cell index via floor((x - probLo) / cellSize);
-            // landing exactly on a boundary makes that floor rounding-sensitive,
-            // and for a non-zero physical origin with a non-dyadic cell size
-            // (prob_lo + cellSize) - prob_lo can round below cellSize, so the
-            // same cell is selected again and x never advances -> infinite loop.
-            // The nudge is far below a cell, so it never skips one (including a
-            // finer cell across a coarse/fine boundary in a composite).
-            constexpr double cellStepNudge = 1e-9;
-            x = center + 0.5 * level.cellSize[lineAxis]
-                + cellStepNudge * level.cellSize[lineAxis];
+            // Step just past the far boundary of this cell into the next one.
+            // The step is half of the *finest* cell: small enough to never skip
+            // a finer patch that begins at the boundary (it lands inside the
+            // first finest cell past the edge), yet an absolute length that
+            // clears one ULP of x for any addressable domain. A step scaled to
+            // *this* cell instead -- the old 1e-9 * cellSize nudge -- falls below
+            // an ULP of x once |x|/dx exceeds ~4.5e6: the addition rounds back,
+            // floor re-derives the same cell, and the walk spins forever
+            // (line-query-walk-stalls-at-large-offset).
+            x = center + 0.5 * level.cellSize[lineAxis] + 0.5 * finestCellSize;
+            // Hard progress guarantee for the pathological tail: if round-off
+            // still failed to advance the derived index, jump to the next cell
+            // center by index (exact in index space) so the loop cannot stall.
+            if (physicalToIndex(x, metadata, level, request.axis)
+                <= cover.point[lineAxis]) {
+                x = samplePosition(level, request.axis, cover.point[lineAxis] + 1);
+            }
         } else {
             Int3 point{};
             for (int axis = 0; axis < metadata.dimension; ++axis) {
@@ -216,11 +221,10 @@ LineQueryResult LineQuery::execute(
                 result.line.valid.push_back(0);
                 result.line.sourceLevel.push_back(-1);
             }
-            // Advance past the far boundary into the next cell; see the covered
-            // branch above for why a bare boundary advance can stall the walk.
-            constexpr double cellStepNudge = 1e-9;
-            x = center + 0.5 * finestCellSize
-                + cellStepNudge * finestCellSize;
+            // Advance to the next finest cell center by index. This branch
+            // always samples at the finest level, so index + 1 is exact and
+            // immune to the large-|x|/dx stall described in the covered branch.
+            x = samplePosition(samplingLevel, request.axis, point[lineAxis] + 1);
         }
     }
     return result;

--- a/tests/integration/test_line_query.cpp
+++ b/tests/integration/test_line_query.cpp
@@ -554,6 +554,85 @@ void testTinyDomain(const std::filesystem::path& source, const std::filesystem::
     require(ranToCompletion, "tiny-domain line query hung");
 }
 
+// Regression for the large-offset walk stall: the native walk advanced x by a
+// nudge relative to the cell size, but the rounding error of the boundary
+// position is relative to the coordinate magnitude (~|x| * 2^-53). Once
+// |x|/dx exceeds ~4.5e6 the nudge falls below one ULP of x, so the addition
+// rounds back, floor re-derives the same cell, and the walk spins forever
+// while re-pushing the same sample (a hang plus unbounded memory growth). The
+// pre-existing testOffsetGeometry/testTinyDomain only reach |x|/dx ~= 1e2.
+// Geometry: prob_lo 1e5, cell size 1e-5 (|x|/dx = 1e10) -- the old walk stalls
+// on the very first cell here.
+void testLargeOffset(const std::filesystem::path& source, const std::filesystem::path& work)
+{
+    const auto root = materializeFixture(source, work / "plotfile_3d_large_offset");
+    writeFab(root / "Level_0" / "Cell_D_00000", 0,
+        "((0,0,0) (3,3,3) (0,0,0))", 1, field3d());
+    {
+        std::ofstream header(root / "Header", std::ios::binary | std::ios::trunc);
+        require(static_cast<bool>(header), "could not open large-offset Header for writing");
+        // prob_hi = prob_lo + 4 * cellSize; the grid bounds round back to the
+        // index box ((0,0,0) (3,3,3) ...) via physicalBoundsToCellBox. The
+        // offset is 1e10 cell widths from the origin, well past the ~4.5e6
+        // ratio where the old cell-relative nudge sank below an ULP of x.
+        header <<
+            "HyperCLaw-V1.1\n"
+            "1\n"
+            "q\n"
+            "3\n"
+            "0.0\n"
+            "0\n"
+            "100000.0 100000.0 100000.0\n"
+            "100000.00004 100000.00004 100000.00004\n"
+            "\n"
+            "((0,0,0) (3,3,3) (0,0,0))\n"
+            "0\n"
+            "1e-5 1e-5 1e-5\n"
+            "0\n"
+            "0\n"
+            "0 1 0.0\n"
+            "0\n"
+            "100000.0 100000.00004\n"
+            "100000.0 100000.00004\n"
+            "100000.0 100000.00004\n"
+            "Level_0/Cell\n";
+    }
+
+    amrvis::PlotfileDataset dataset(root, amrvis::DatasetId{23}, 1024 * 1024);
+    amrvis::LineQuery lines(dataset);
+    const auto& metadata = dataset.metadata();
+    require(metadata.dimension == 3 && metadata.finestLevel == 0,
+        "large-offset fixture parsed unexpected dimension or level count");
+
+    amrvis::LineRequest request;
+    request.dataset.value = 23;
+    request.field.value = 0;
+    request.axis = 0;
+    const double center = 0.5 * (metadata.physicalDomain.lower[1]
+        + metadata.physicalDomain.upper[1]);
+    request.fixedCoordinates = {center, center, center};
+    request.maximumLevel = 0;
+    request.region = amrvis::RealBox{metadata.physicalDomain.lower,
+        metadata.physicalDomain.upper};
+
+    // Watchdog: the regressed walk loops forever and would hang ctest. Run it on
+    // a worker and fail loudly instead of hanging if it does not return.
+    auto ranToCompletion = runWithTimeout(
+        [&] {
+            const auto result = lines.execute(request);
+            require(result.line.positions.size() == 4,
+                "large-offset line query did not sample every cell");
+            for (std::size_t sample = 0; sample < 4; ++sample) {
+                require(result.line.valid[sample] == 1
+                        && result.line.sourceLevel[sample] == 0,
+                    "large-offset line query left a hole or reported a wrong level");
+            }
+        },
+        10);
+    require(ranToCompletion,
+        "large-offset line query hung (regression: nudge below an ULP of x)");
+}
+
 } // namespace
 
 int main(int argc, char* argv[])
@@ -575,6 +654,7 @@ int main(int argc, char* argv[])
     test3d(plotfile3d, work);
     testOffsetGeometry(plotfile3d, work);
     testTinyDomain(plotfile3d, work);
+    testLargeOffset(plotfile3d, work);
 
     std::filesystem::remove_all(work);
     return 0;


### PR DESCRIPTION
The native-resolution walk advanced x by a nudge relative to the cell size (1e-9 * cellSize), but the rounding error of the far-boundary position center + 0.5*cellSize is relative to the coordinate magnitude (~|x| * 2^-53). Once |x|/dx exceeds ~4.5e6 the nudge falls below one ULP of x: the addition rounds back, floor re-derives the same cell, and the walk spins forever while re-pushing the same sample -- a hang plus unbounded memory growth on the worker (e.g. micron cells a meter from the origin).

Step by half of the finest cell instead: an absolute length that clears an ULP of x for any addressable domain, yet at most half a cell so a finer patch beginning at the boundary is never skipped. A hard index guard forces samplePosition(level, idx+1) if the derived index still fails to advance. The uncovered branch advances by finest index directly.

Add testLargeOffset (prob_lo 1e5, dx 1e-5, |x|/dx = 1e10) under the runWithTimeout watchdog; it hangs on the pre-fix code and passes now.