### PR TITLE
fix shared-range log render throwing on a mixed-sign field

### DIFF
--- a/include/amrexplorer/pipeline/DisplayCoordinator.hpp
+++ b/include/amrexplorer/pipeline/DisplayCoordinator.hpp
@@ -84,7 +84,6 @@ public:
         const ScalarPlane* plane = nullptr;            // display plane
         const ScalarPlane* contourFinePlane = nullptr; // contour modes only
         int contourFineFactor = 1;
-        bool logarithmic = false;      // the panel's effective log mapping
         std::array<int, 2> outputSize{0, 0};  // display size for contours
     };
     struct PanelSyncUpdate {
@@ -95,6 +94,11 @@ public:
     };
     struct SharedRangeSync {
         std::pair<double, double> range;
+        // One log flag for the whole panel set: the requested log mapping,
+        // kept only when the shared range minimum is positive (renderScalarPlane
+        // rejects a non-positive log minimum). Callers apply it to every panel
+        // and to the shared color bar so all three agree with the raster.
+        bool logarithmic = false;
         std::vector<PanelSyncUpdate> panels;  // parallel to the input span
     };
 

--- a/src/pipeline/DisplayCoordinator.cpp
+++ b/src/pipeline/DisplayCoordinator.cpp
@@ -96,6 +96,12 @@ void DisplayCoordinator::realignArrivalToRange(SliceDisplayResult& result,
 {
     result.minimum = range.first;
     result.maximum = range.second;
+    // The reused full-domain range is a superset of this arrival's own range,
+    // so it can cross zero even when the arrival was all-positive (log resolved
+    // true per panel). Log is only viable when the shared minimum is positive;
+    // degrade to linear otherwise so renderScalarPlane does not reject the
+    // non-positive minimum (see shared-log-range-render-throw-fails-load).
+    result.logarithmic = result.logarithmic && range.first > 0.0;
     if (!realignRasterAndContours) {
         return;
     }
@@ -141,6 +147,13 @@ DisplayCoordinator::renderPanelsToSharedRange(
     }
     SharedRangeSync sync;
     sync.range = *shared;
+    // One log flag for every panel: log only when the shared minimum is
+    // positive, matching how a single panel degrades to linear. Keeping it
+    // per-panel would render an all-positive plane logarithmically against a
+    // union that crosses zero, and renderScalarPlane rejects a non-positive
+    // log minimum -- which threw and failed the whole load
+    // (see shared-log-range-render-throw-fails-load).
+    sync.logarithmic = logarithmic && sync.range.first > 0.0;
     sync.panels.resize(panels.size());
     for (std::size_t index = 0; index < panels.size(); ++index) {
         const auto& panel = panels[index];
@@ -155,14 +168,14 @@ DisplayCoordinator::renderPanelsToSharedRange(
             && panel.contourFinePlane->width > 0) {
             update.contourPolylines = recomputeContourPolylines(
                 *panel.contourFinePlane, panel.contourFineFactor,
-                sync.range.first, sync.range.second, panel.logarithmic,
+                sync.range.first, sync.range.second, sync.logarithmic,
                 contourCount, panel.outputSize[0], panel.outputSize[1]);
             update.contoursRecomputed = true;
         }
         update.image = renderScalarPlane(*panel.plane, ScalarRenderSettings{
             .minimum = sync.range.first,
             .maximum = sync.range.second,
-            .logarithmic = panel.logarithmic,
+            .logarithmic = sync.logarithmic,
             .palette = &palette
         });
     }

--- a/src/pipeline/SlicePipeline.cpp
+++ b/src/pipeline/SlicePipeline.cpp
@@ -593,14 +593,23 @@ InitialSliceResult executeFrameLoad(const std::filesystem::path& path,
                 const auto [globalMin, globalMax] = shared.value_or(
                     spec.logarithmic ? std::pair{1.0, 10.0}
                                      : std::pair{0.0, 1.0});
+                // One log flag for all three panels: log only when the shared
+                // minimum is positive, matching how a single panel degrades to
+                // linear. A per-panel flag kept an all-positive plane
+                // logarithmic against a union that crosses zero, and
+                // renderScalarPlane rejects a non-positive log minimum -- which
+                // failed the whole frame load
+                // (see shared-log-range-render-throw-fails-load).
+                const bool sharedLog = spec.logarithmic && globalMin > 0.0;
                 for (auto& d : result.displays) {
                     d.minimum = globalMin;
                     d.maximum = globalMax;
+                    d.logarithmic = sharedLog;
                     d.image = renderScalarPlane(d.slice.plane,
                         ScalarRenderSettings{
                             .minimum = globalMin,
                             .maximum = globalMax,
-                            .logarithmic = d.logarithmic,
+                            .logarithmic = sharedLog,
                             .palette = &spec.palette
                         });
                     // Contours were extracted per view before the shared range

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -5361,7 +5361,6 @@ void MainWindow::syncVisibleRanges()
         std::shared_ptr<const ScalarPlane> plane;
         std::shared_ptr<const ScalarPlane> contourFinePlane;
         int contourFineFactor = 1;
-        bool logarithmic = false;
         std::array<int, 2> outputSize{0, 0};
     };
     std::array<PlaneViewState*, 3> views{
@@ -5370,8 +5369,7 @@ void MainWindow::syncVisibleRanges()
     for (std::size_t index = 0; index < views.size(); ++index) {
         const auto* state = views[index];
         snapshots[index] = {state->plane, state->contourFinePlane,
-            state->contourFineFactor, state->displayLogarithmic,
-            state->cachedRequest.outputSize};
+            state->contourFineFactor, state->cachedRequest.outputSize};
     }
 
     struct SyncOutcome {
@@ -5415,6 +5413,11 @@ void MainWindow::syncVisibleRanges()
                     }
                     state->displayMinimum = globalMin;
                     state->displayMaximum = globalMax;
+                    // One shared log flag across the panel set (see
+                    // shared-log-range-render-throw-fails-load): keep every
+                    // panel's stored flag, and thus the color bar below, in
+                    // agreement with the raster the sync just rendered.
+                    state->displayLogarithmic = outcome.sync->logarithmic;
                     if (update.contoursRecomputed) {
                         state->contourPolylines
                             = std::move(update.contourPolylines);
@@ -5472,7 +5475,7 @@ void MainWindow::syncVisibleRanges()
             const auto& snapshot = snapshots[index];
             inputs[index] = {snapshot.plane.get(),
                 snapshot.contourFinePlane.get(), snapshot.contourFineFactor,
-                snapshot.logarithmic, snapshot.outputSize};
+                snapshot.outputSize};
         }
         SyncOutcome outcome;
         outcome.sync = DisplayCoordinator::renderPanelsToSharedRange(

--- a/tests/integration/test_display_transitions.cpp
+++ b/tests/integration/test_display_transitions.cpp
@@ -147,6 +147,45 @@ void write3dPlotfile(const std::filesystem::path& root)
         "((0,0,0) (3,3,3) (0,0,0))", values);
 }
 
+// Single-level 3-D plotfile whose three default mid-planes are mixed-sign:
+// q = 5 + 0.1*(i + j + k) everywhere (all-positive), except cell (0,0,2) is
+// forced to -3. The x=0.5 (i=2) and y=0.5 (j=2) mid-planes are all-positive,
+// while the z=0.5 (k=2) mid-plane holds the single negative, so the shared
+// Visible union crosses zero even though two panels resolve log on their own.
+void write3dMixedSignPlotfile(const std::filesystem::path& root)
+{
+    std::filesystem::create_directories(root / "Level_0");
+    writeText(root / "Header",
+        "HyperCLaw-V1.1\n"
+        "1\nq\n"
+        "3\n0.0\n0\n"
+        "0.0 0.0 0.0\n1.0 1.0 1.0\n\n"
+        "((0,0,0) (3,3,3) (0,0,0))\n"
+        "0\n"
+        "0.25 0.25 0.25\n"
+        "0\n0\n"
+        "0 1 0.0\n0\n"
+        "0.0 1.0\n0.0 1.0\n0.0 1.0\n"
+        "Level_0/Cell\n");
+    writeText(root / "Level_0" / "Cell_H",
+        "1\n1\n1\n0\n"
+        "(1 0\n((0,0,0) (3,3,3) (0,0,0))\n)\n"
+        "1\nFabOnDisk: Cell_D_00000 0\n\n"
+        "1,1\n-3.0,\n\n1,1\n5.9,\n\n");
+    std::vector<double> values;
+    for (int k = 0; k <= 3; ++k) {
+        for (int j = 0; j <= 3; ++j) {
+            for (int i = 0; i <= 3; ++i) {
+                const bool negativeCell = i == 0 && j == 0 && k == 2;
+                values.push_back(negativeCell
+                    ? -3.0 : 5.0 + 0.1 * (i + j + k));
+            }
+        }
+    }
+    writeFab(root / "Level_0" / "Cell_D_00000",
+        "((0,0,0) (3,3,3) (0,0,0))", values);
+}
+
 // The per-display internal-consistency invariants (I2, I3, I5 above).
 void requireDisplayInvariants(const amrvis::DatasetMetadata& metadata,
     const amrvis::SliceDisplayResult& d, const amrvis::Palette& palette,
@@ -211,8 +250,10 @@ int main()
         / ("amrexplorer-display-transitions-" + std::to_string(unique));
     const auto root2d = base / "plt2d";
     const auto root3d = base / "plt3d";
+    const auto root3dMixed = base / "plt3dmixed";
     write2dPlotfile(root2d);
     write3dPlotfile(root3d);
+    write3dMixedSignPlotfile(root3dMixed);
 
     const amrvis::Palette palette;
     constexpr std::uint64_t bigBudget = 1ULL << 20;
@@ -399,6 +440,37 @@ int main()
                 "3-D Visible panels do not share one range");
             requireDisplayInvariants(result.dataset->metadata(), d, palette,
                 "3-D shared range");
+        }
+    }
+
+    // --- 3-D shared Visible range, log, mixed-sign field -------------------
+    {
+        // Regression for shared-log-range-render-throw-fails-load: log
+        // requested, two default mid-planes all-positive, but the shared union
+        // crosses zero. The per-panel log flag used to keep the positive
+        // panels logarithmic against the negative union minimum, so
+        // renderScalarPlane threw and executeFrameLoad failed the whole load.
+        amrvis::FrameSliceSpec spec;
+        spec.rangeMode = amrvis::RangeMode::Visible;
+        spec.logarithmic = true;
+        spec.displayMode = amrvis::DisplayMode::RasterContours;
+        spec.contourCount = 3;
+        const auto result = amrvis::executeFrameLoad(
+            root3dMixed, amrvis::DatasetId{nextId++}, spec, bigBudget, {});
+        require(result.displays.size() == 3, "mixed-sign 3-D load lost a panel");
+        const auto& first = result.displays.front();
+        require(first.minimum < 0.0,
+            "mixed-sign union did not cross zero as the fixture intends");
+        for (const auto& d : result.displays) {
+            // I1: one shared range across all panels.
+            require(nearlyEqual(d.minimum, first.minimum)
+                    && nearlyEqual(d.maximum, first.maximum),
+                "mixed-sign 3-D panels do not share one range");
+            // The whole set degrades to linear together (never per-panel).
+            require(!d.logarithmic,
+                "a panel stayed logarithmic against a union that crosses zero");
+            requireDisplayInvariants(result.dataset->metadata(), d, palette,
+                "mixed-sign 3-D shared range");
         }
     }
 

--- a/tests/unit/test_display_coordinator.cpp
+++ b/tests/unit/test_display_coordinator.cpp
@@ -201,9 +201,9 @@ int main()
         const auto fine = makePlane({2.0F, 6.0F});
         const amrvis::ScalarPlane empty;
         const std::array<DisplayCoordinator::PanelSyncInput, 3> inputs{{
-            {&a, &fine, 1, false, {2, 1}},
-            {&b, nullptr, 1, false, {2, 1}},
-            {&empty, nullptr, 1, false, {0, 0}},
+            {&a, &fine, 1, {2, 1}},
+            {&b, nullptr, 1, {2, 1}},
+            {&empty, nullptr, 1, {0, 0}},
         }};
 
         // No cached range: the union across panels drives every update.
@@ -234,10 +234,68 @@ int main()
         // Neither cache nor finite samples: nothing to synchronize to.
         coordinator.invalidateRangeCache();
         const std::array<DisplayCoordinator::PanelSyncInput, 1> emptyOnly{{
-            {&empty, nullptr, 1, false, {0, 0}}}};
+            {&empty, nullptr, 1, {0, 0}}}};
         require(!coordinator.syncPanelsToSharedRange(
                 key, emptyOnly, false, false, 3, palette).has_value(),
             "an empty panel set produced a sync");
+    }
+
+    // --- shared log degrades when the union crosses zero --------------------
+    {
+        // Regression for shared-log-range-render-throw-fails-load: with log
+        // requested and one panel all-positive but the union crossing zero,
+        // rendering each panel logarithmically against the negative shared
+        // minimum used to throw and fail the whole load.
+        const amrvis::Palette palette;
+        const auto positive = makePlane({2.0F, 6.0F});   // all-positive panel
+        const auto crossing = makePlane({-4.0F, 1.0F});  // crosses zero
+        const auto fine = makePlane({2.0F, 6.0F});
+        const std::array<DisplayCoordinator::PanelSyncInput, 2> mixed{{
+            {&positive, &fine, 1, {2, 1}},
+            {&crossing, nullptr, 1, {2, 1}},
+        }};
+        const auto sync = DisplayCoordinator::renderPanelsToSharedRange(
+            std::nullopt, mixed, true, true, 3, palette);
+        require(sync.has_value(), "mixed-sign log sync found no range");
+        require(nearlyEqual(sync->range.first, -4.0)
+                && nearlyEqual(sync->range.second, 6.0),
+            "mixed-sign log sync range is not the union");
+        require(!sync->logarithmic,
+            "log was not degraded for a union that crosses zero");
+        require(sync->panels[0].image.width > 0
+                && sync->panels[1].image.width > 0,
+            "mixed-sign log sync did not render every panel");
+
+        // An all-positive union keeps the requested log mapping.
+        const auto other = makePlane({3.0F, 5.0F});
+        const std::array<DisplayCoordinator::PanelSyncInput, 2> allPositive{{
+            {&positive, nullptr, 1, {2, 1}},
+            {&other, nullptr, 1, {2, 1}},
+        }};
+        const auto positiveSync = DisplayCoordinator::renderPanelsToSharedRange(
+            std::nullopt, allPositive, true, false, 3, palette);
+        require(positiveSync && positiveSync->logarithmic,
+            "log was dropped over an all-positive union");
+
+        // realignArrivalToRange degrades identically: a log arrival realigned
+        // to a full-domain range that crosses zero must render linear.
+        amrvis::SliceDisplayResult arrival;
+        arrival.slice.plane = makePlane({2.0F, 6.0F});
+        arrival.logarithmic = true;
+        DisplayCoordinator::realignArrivalToRange(
+            arrival, {-1.0, 10.0}, palette, true);
+        require(!arrival.logarithmic,
+            "realign kept log against a range that crosses zero");
+        require(arrival.image.valid() && arrival.image.width > 0,
+            "realign did not render the degraded raster");
+
+        amrvis::SliceDisplayResult positiveArrival;
+        positiveArrival.slice.plane = makePlane({2.0F, 6.0F});
+        positiveArrival.logarithmic = true;
+        DisplayCoordinator::realignArrivalToRange(
+            positiveArrival, {0.5, 10.0}, palette, true);
+        require(positiveArrival.logarithmic,
+            "realign dropped log over a positive range");
     }
 
     // --- planeDensitiesDiffer -----------------------------------------------


### PR DESCRIPTION
In 3-D Visible mode the three panels re-render against the union of their finite extrema, but the log flag stayed per-panel: an all-positive mid-plane kept log=true even when another plane crossed zero and the union minimum went negative. renderScalarPlane then rejected the non-positive log minimum and threw std::invalid_argument, and since the enclosing catch handles only CacheBudgetExceeded the whole open/frame load hard-failed with "Cannot load". The same flag/range mismatch sat in realignArrivalToRange and renderPanelsToSharedRange.

Resolve one shared log flag for the panel set -- log only when the shared minimum is positive, matching how a single panel degrades to linear in resolveDisplayRange -- and apply it at all three sites:

- executeFrameLoad: sharedLog = spec.logarithmic && globalMin > 0; every panel's raster, contours, and stored flag use it.
- renderPanelsToSharedRange: sync.logarithmic = logarithmic && range.first > 0 for all panels; drop the now-dead per-panel PanelSyncInput.logarithmic, return the resolved flag on SharedRangeSync, and have the GUI write it back to each panel's displayLogarithmic so the color bar agrees with the raster.
- realignArrivalToRange: result.logarithmic && range.first > 0 -- exact because the cached full-domain range is a superset of the arrival's own.

Add a mixed-sign + log unit block (test_display_coordinator) and a mixed-sign 3-D fixture with a Visible/log transition cell (test_display_transitions); both abort with "logarithmic scalar range must be positive" against the pre-fix render sites and pass after.