### PR TITLE
fix window close clearing the shared thread pool and wedging other windows

### DIFF
--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -874,9 +874,17 @@ MainWindow::MainWindow(QWidget* parent)
     restoreSettings();
     // Cancel in-flight async work on any quit path (last-window close, Cmd-Q,
     // menu Quit) so QThreadPool teardown does not block on an outstanding read
-    // and the process can exit promptly.
-    connect(qApp, &QCoreApplication::aboutToQuit, this,
-        &MainWindow::cancelInFlight);
+    // and the process can exit promptly. Only here -- where every window is
+    // going away -- is it safe to also drop the shared global pool's queued
+    // jobs, so teardown skips starting work that would only observe its stop
+    // token and exit; a per-window close must not (see cancelInFlight and
+    // window-close-clears-shared-thread-pool).
+    connect(qApp, &QCoreApplication::aboutToQuit, this, [this] {
+        cancelInFlight();
+        if (auto* pool = QThreadPool::globalInstance()) {
+            pool->clear();
+        }
+    });
 }
 
 void MainWindow::wireView(PlaneViewState& state)
@@ -3257,17 +3265,24 @@ void MainWindow::closeEvent(QCloseEvent* event)
 
 void MainWindow::cancelInFlight()
 {
-    // Application shutdown: stop the timers that resubmit work, request stop on
-    // every async task this window can launch, and clear the queued jobs from
-    // the global thread pool. The slice/prefetch/line-query/initial-load tasks
-    // run on QThreadPool::globalInstance() via QtConcurrent::run, and that
-    // pool's destructor calls waitForDone() with no timeout. A task caught
-    // mid-read holds the global AMReX I/O mutex and only re-checks its
-    // cancellation token at the next chunk boundary (PlotfileBlockReader
-    // checks every 1 MiB / 4096 values), so unless it is told to stop the process lingers
-    // "not responding" at quit -- which is what made closing the window look
-    // like a hang. request_stop is the cooperative signal those tasks poll, so
-    // once set a running task bails promptly and teardown unblocks.
+    // Stop the timers that resubmit work and request stop on every async task
+    // this window can launch. The slice/prefetch/line-query/initial-load tasks
+    // run on QThreadPool::globalInstance() via QtConcurrent::run; that pool's
+    // destructor calls waitForDone() with no timeout, and a task caught mid-read
+    // holds the global AMReX I/O mutex and only re-checks its cancellation token
+    // at the next chunk boundary (PlotfileBlockReader checks every 1 MiB / 4096
+    // values). request_stop is the cooperative signal those tasks poll, so once
+    // set a running task bails promptly and teardown unblocks -- which is what
+    // keeps closing a window (or quitting) from looking like a hang.
+    //
+    // This must NOT clear() the global pool: it is shared by every MainWindow
+    // (File -> Open New Window), and clear() discards *other* windows' queued-
+    // but-unstarted runnables, whose QFutureWatchers then never fire, wedging
+    // those windows on "Loading..." forever (see
+    // window-close-clears-shared-thread-pool). Cancellation is per-task via the
+    // stop tokens above; a queued task starts, observes its token, and exits
+    // cheaply. clear() belongs only on the aboutToQuit path (every window is
+    // going away), where it is wired in the constructor.
     if (m_sliceDebounce != nullptr) {
         m_sliceDebounce->stop();
     }
@@ -3282,9 +3297,6 @@ void MainWindow::cancelInFlight()
     m_view2d.stopSource.request_stop();
     for (auto& state : m_planeViews) {
         state.stopSource.request_stop();
-    }
-    if (auto* pool = QThreadPool::globalInstance()) {
-        pool->clear();
     }
 }
 

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -3226,10 +3226,12 @@ void MainWindow::closeEvent(QCloseEvent* event)
     // Mark this window closing so asynchronous completion handlers that fire
     // during or after shutdown do not pop modal dialogs or reopen windows.
     m_closing = true;
-    // Stop resubmit timers, request cancellation on every async task, and
-    // clear queued global-pool jobs. Running tasks re-check their stop token
-    // and bail promptly; without this a task mid-read can leave the process
-    // lingering at quit. (aboutToQuit also calls this, as a fallback.)
+    // Stop resubmit timers and request cancellation on every async task this
+    // window owns; running tasks re-check their stop token and bail promptly,
+    // so a task mid-read cannot leave the process lingering at quit. This does
+    // NOT clear the shared global pool -- that would strand other windows'
+    // queued work; the pool clear happens only on aboutToQuit (see
+    // cancelInFlight).
     cancelInFlight();
     // Secondary top-level windows are parentless or non-modal; close them with
     // the main window so none lingers and keeps the process alive.

--- a/src/qt/MainWindow.hpp
+++ b/src/qt/MainWindow.hpp
@@ -504,10 +504,13 @@ private:
     void applyParticleSelection(
         std::vector<std::string> species, double fraction, int pointSize,
         std::uint64_t seed);
-    // Stop timers, request stop on every async task this window can launch,
-    // and clear queued thread-pool work. Wired to aboutToQuit so the process
-    // exits promptly instead of blocking QThreadPool teardown on an in-flight
-    // read that holds the global I/O mutex.
+    // Stop timers and request stop on every async task this window can launch,
+    // so an in-flight read that holds the global I/O mutex bails promptly and
+    // does not block QThreadPool teardown. Called from closeEvent and (via a
+    // lambda that additionally clears the shared pool) from aboutToQuit. It
+    // must not clear() the global pool itself: the pool is shared across
+    // windows and clearing it from a per-window close strands other windows'
+    // queued work (see window-close-clears-shared-thread-pool).
     void cancelInFlight();
 
     QStackedWidget* m_stack = nullptr;

--- a/src/qt/main.cpp
+++ b/src/qt/main.cpp
@@ -17,14 +17,18 @@
 #include <QPushButton>
 #include <QStandardPaths>
 #include <QSignalBlocker>
+#include <QRunnable>
 #include <QTableView>
 #include <QTextStream>
+#include <QThreadPool>
 #include <QTimer>
 
 #include <amrexplorer/render2d/Contours.hpp>
 
 #include <algorithm>
 #include <array>
+#include <atomic>
+#include <chrono>
 #include <cmath>
 #include <cstdio>
 #include <cstdlib>
@@ -32,6 +36,7 @@
 #include <filesystem>
 #include <memory>
 #include <string_view>
+#include <thread>
 #include <vector>
 
 namespace {
@@ -1101,6 +1106,47 @@ int main(int argc, char* argv[])
             &application, [&application] { application.exit(1); });
         QTimer::singleShot(0, &window, [&window, first, second] {
             window.openSequence({first, second});
+        });
+    } else if (argc == 3
+        && std::string_view(argv[1]) == "--window-close-pool-smoke-test") {
+        // Regression for window-close-clears-shared-thread-pool: opening and
+        // closing a second window must not discard the first window's queued
+        // work on the shared global pool (which would strand it on
+        // "Loading..." forever). Constrain the pool to one thread and occupy
+        // that thread with a gate runnable, so this window's initial-load
+        // worker is genuinely queued (not running) when the second window
+        // closes. The pre-fix closeEvent called QThreadPool::clear(), which
+        // dropped that queued worker; the fix keeps clear() off the per-window
+        // path, so the worker survives, runs once the gate releases, and the
+        // load completes. A watchdog fails instead of hanging on a strand.
+        const std::filesystem::path path(argv[2]);
+        auto* pool = QThreadPool::globalInstance();
+        pool->setMaxThreadCount(1);
+        auto gate = std::make_shared<std::atomic<bool>>(false);
+        pool->start(QRunnable::create([gate] {
+            while (!gate->load()) {
+                std::this_thread::sleep_for(std::chrono::milliseconds(2));
+            }
+        }));
+        QObject::connect(&window,
+            &amrvis::qt::MainWindow::initialSliceFinished,
+            &application, [&application](bool success) {
+                application.exit(success ? 0 : 1);
+            });
+        QTimer::singleShot(15000, &application,
+            [&application] { application.exit(1); });
+        QTimer::singleShot(0, &window, [&window, path, gate] {
+            // Queue this window's metadata/initial-load worker behind the gate.
+            window.openDataset(path);
+            // A second window, opened and closed while that worker is still
+            // queued. Its closeEvent runs synchronously here, so the pre-fix
+            // clear() would drop the queued worker before the gate releases.
+            auto* second = new amrvis::qt::MainWindow;
+            second->show();
+            second->close();
+            second->deleteLater();
+            // Release the gate so the surviving worker (with the fix) can run.
+            gate->store(true);
         });
     } else if (argc == 3
         && std::string_view(argv[1]) == "--quit-smoke-test") {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -474,6 +474,17 @@ if(TARGET amrexplorer_qt)
     )
     set_tests_properties(qt_quit_smoke_3d PROPERTIES TIMEOUT 30)
     add_test(
+        NAME qt_window_close_pool_smoke_3d
+        COMMAND "${CMAKE_COMMAND}"
+            "-DMATERIALIZER=$<TARGET_FILE:fixture_materializer>"
+            "-DAMREXPLORER_QT=$<TARGET_FILE:amrexplorer_qt>"
+            "-DSOURCE=${CMAKE_CURRENT_SOURCE_DIR}/data/plotfile_3d"
+            "-DWORK=${CMAKE_CURRENT_BINARY_DIR}/fixtures_window_close_pool_3d"
+            -DMODE=window-close-pool
+            -P "${CMAKE_CURRENT_SOURCE_DIR}/qt_smoke_driver.cmake"
+    )
+    set_tests_properties(qt_window_close_pool_smoke_3d PROPERTIES TIMEOUT 30)
+    add_test(
         NAME qt_quit_on_failure_smoke_3d
         COMMAND "${CMAKE_COMMAND}"
             "-DMATERIALIZER=$<TARGET_FILE:fixture_materializer>"

--- a/tests/qt_smoke_driver.cmake
+++ b/tests/qt_smoke_driver.cmake
@@ -6,7 +6,8 @@
 #   SOURCE        fixture source directory (e.g. tests/data/plotfile_2d)
 #   WORK          directory the materialized copies are written into
 #   MODE          slice | sequence | missing-range | non-finite | raw-fab |
-#                 multifab-fab | quit | quit-on-failure | export-quit |
+#                 multifab-fab | quit | quit-on-failure | window-close-pool |
+#                 export-quit |
 #                 contour-sync | raster-zoom | rubber-zoom-sync |
 #                 particle-visible-range |
 #                 rubber-zoom-local | rubber-overzoom | pan-zoom |
@@ -129,6 +130,9 @@ elseif(MODE STREQUAL "cache-budget")
 elseif(MODE STREQUAL "quit")
     run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt")
     run_or_die("${AMREXPLORER_QT}" --quit-smoke-test "${WORK}/plt")
+elseif(MODE STREQUAL "window-close-pool")
+    run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt")
+    run_or_die("${AMREXPLORER_QT}" --window-close-pool-smoke-test "${WORK}/plt")
 elseif(MODE STREQUAL "quit-on-failure")
     run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt")
     # Drop the FAB payloads so the slice read fails while metadata stays valid


### PR DESCRIPTION
cancelInFlight() ended with QThreadPool::globalInstance()->clear(), and closeEvent calls it on every per-window close. That pool is shared by all MainWindows (File -> Open New Window), so closing one window discarded another window's queued-but-unstarted runnables. A deleted QtConcurrent runnable never reports finished, so the other window's QFutureWatchers never fired: m_activeRequests stayed nonzero forever, "Loading..." stuck permanently, interactiveSlicesSettled never emitted, with no recovery short of reopening the dataset.

Take the token route: drop clear() from cancelInFlight() -- it now only stops the resubmit timers and requests stop on each per-task stop source, which a queued task observes and exits cheaply. Move clear() into the aboutToQuit connection (a lambda that runs cancelInFlight() then clears), the one path where every window is going away, so teardown still skips starting work that would only observe its token and exit.

Add qt_window_close_pool_smoke_3d (--window-close-pool-smoke-test): caps the global pool to one thread and occupies it with a gate runnable so the window's initial-load worker is genuinely queued when a second window is opened and closed; the fix keeps that worker alive so the load completes and initialSliceFinished fires. It hangs to the 15 s watchdog against the pre-fix clear() and passes after; the existing quit smoke tests still pass, confirming the retained aboutToQuit clear keeps shutdown prompt.