### PR TITLE
accept non-finite text in VisMF min/max statistics so overflowed plotfiles open

### DIFF
--- a/src/io/plotfile/PlotfileMetadataReader.cpp
+++ b/src/io/plotfile/PlotfileMetadataReader.cpp
@@ -4,12 +4,15 @@
 #include <amrexplorer/io/detail/VisMfIndex.hpp>
 
 #include <algorithm>
+#include <cctype>
 #include <cmath>
 #include <cstddef>
+#include <cstdlib>
 #include <fstream>
 #include <limits>
 #include <optional>
 #include <sstream>
+#include <string>
 #include <string_view>
 #include <system_error>
 #include <utility>
@@ -27,6 +30,39 @@ T readRequired(std::istream& input, std::string_view description)
 {
     T value{};
     if (!(input >> value)) {
+        throw MetadataReadError("malformed plotfile Header while reading "
+            + std::string(description));
+    }
+    return value;
+}
+
+// Reads one VisMF min/max statistic, which -- unlike the geometry fields --
+// may be non-finite. AMReX's FArrayBox::min/max propagate +/-inf (and can
+// leave a NaN) from an overflowed run, and its plotfile headers carry those
+// per-block/FabArray extrema serialized as the "inf" / "-inf" / "nan" text
+// C++ ostreams emit. operator>>(double) cannot parse that text, so a plain
+// readRequired<double> made the whole (loadable) plotfile refuse to open --
+// exactly the run a user opens a viewer to debug. std::strtod does accept
+// those tokens, so read a comma/whitespace-delimited token and strtod it;
+// genuinely malformed tokens still fault. The non-finite value is stored
+// as-is: metadataValueRange discards non-finite block statistics, so File/
+// Level range modes degrade to Visible rather than the open failing (see
+// nonfinite-header-statistics-unopenable).
+double readStatisticValue(std::istream& input, std::string_view description)
+{
+    input >> std::ws;
+    std::string token;
+    for (auto next = input.peek();
+         next != std::char_traits<char>::eof()
+             && next != ','
+             && std::isspace(static_cast<unsigned char>(next)) == 0;
+         next = input.peek()) {
+        token.push_back(static_cast<char>(input.get()));
+    }
+    const char* begin = token.c_str();
+    char* end = nullptr;
+    const double value = std::strtod(begin, &end);
+    if (token.empty() || end != begin + token.size()) {
         throw MetadataReadError("malformed plotfile Header while reading "
             + std::string(description));
     }
@@ -144,7 +180,7 @@ std::vector<std::vector<double>> readRealMatrix(
         std::vector<double>(static_cast<std::size_t>(columns)));
     for (auto& row : matrix) {
         for (auto& value : row) {
-            value = readRequired<double>(input, description);
+            value = readStatisticValue(input, description);
             if (!(input >> comma) || comma != ',') {
                 throw MetadataReadError("malformed comma-separated VisMF matrix");
             }
@@ -248,13 +284,15 @@ detail::VisMfIndex detail::readVisMfIndex(
         index.maximum.push_back({});
         char comma = '\0';
         for (int component = 0; component < index.components; ++component) {
-            index.minimum.front().push_back(readRequired<double>(input, "FabArray minimum"));
+            index.minimum.front().push_back(
+                readStatisticValue(input, "FabArray minimum"));
             if (!(input >> comma) || comma != ',') {
                 throw MetadataReadError("malformed FabArray minima");
             }
         }
         for (int component = 0; component < index.components; ++component) {
-            index.maximum.front().push_back(readRequired<double>(input, "FabArray maximum"));
+            index.maximum.front().push_back(
+                readStatisticValue(input, "FabArray maximum"));
             if (!(input >> comma) || comma != ',') {
                 throw MetadataReadError("malformed FabArray maxima");
             }

--- a/tests/unit/test_vismf_index.cpp
+++ b/tests/unit/test_vismf_index.cpp
@@ -9,6 +9,7 @@
 #include <amrexplorer/io/PlotfileMetadataReader.hpp>
 #include <amrexplorer/io/StandaloneMetadataReader.hpp>
 
+#include <cmath>
 #include <cstdlib>
 #include <filesystem>
 #include <fstream>
@@ -186,6 +187,72 @@ void testVersion4(const std::filesystem::path& path)
             && index.maximum.front()[0] == 1.0
             && index.maximum.front()[1] == 101.0,
         "v4 FabArray maxima parsed wrong");
+}
+
+void testAcceptsNonFiniteV1(const std::filesystem::path& path)
+{
+    // Regression for nonfinite-header-statistics-unopenable: an overflowed run
+    // leaves +/-inf (and possibly NaN) in AMReX's per-block min/max, serialized
+    // as "inf" / "-inf" / "nan" text that operator>>(double) cannot parse. The
+    // reader must accept those tokens so the (loadable) plotfile still opens;
+    // metadataValueRange discards the non-finite stats downstream (File/Level
+    // range then falls back to Visible), so the values are stored as-is here.
+    writeHeader(path,
+        "1\n1\n2\n0\n"
+        "(2 0\n"
+        "((0,0) (1,3) (0,0))\n"
+        "((2,0) (3,3) (0,0))\n"
+        ")\n"
+        "2\n"
+        "FabOnDisk: Cell_D_00000 0\n"
+        "FabOnDisk: Cell_D_00000 4096\n"
+        "\n"
+        "2,2\n"                                  // per-block minima shape
+        "inf,-inf,\n"                            // box 0: +inf, -inf
+        "nan,2.00000000000000000e+00,\n"         // box 1: nan, finite
+        "\n"
+        "2,2\n"                                  // per-block maxima shape
+        "1.00000000000000000e+00,1.01000000000000000e+02,\n"
+        "3.00000000000000000e+00,1.03000000000000000e+02,\n");
+    const auto index = readHeader(path, 2, "1-nonfinite");
+    require(index.hasPerBlockStatistics,
+        "non-finite v1 statistics were not parsed");
+    require(index.minimum.size() == 2 && index.minimum.front().size() == 2,
+        "non-finite v1 minima shape mismatch");
+    require(std::isinf(index.minimum[0][0]) && index.minimum[0][0] > 0.0,
+        "v1 +inf minimum not parsed");
+    require(std::isinf(index.minimum[0][1]) && index.minimum[0][1] < 0.0,
+        "v1 -inf minimum not parsed");
+    require(std::isnan(index.minimum[1][0]), "v1 nan minimum not parsed");
+    require(index.minimum[1][1] == 2.0,
+        "a finite value alongside non-finite ones was mis-parsed");
+}
+
+void testAcceptsNonFiniteV4(const std::filesystem::path& path)
+{
+    // The same leniency on the version-4 FabArray-wide min/max list.
+    writeHeader(path,
+        "4\n1\n2\n0\n"
+        "(2 0\n"
+        "((0,0) (1,3) (0,0))\n"
+        "((2,0) (3,3) (0,0))\n"
+        ")\n"
+        "2\n"
+        "FabOnDisk: Cell_D_00000 0\n"
+        "FabOnDisk: Cell_D_00000 4096\n"
+        "-inf,inf,\n"                            // FA minima: -inf, +inf
+        "nan,1.01000000000000000e+02,\n"         // FA maxima: nan, finite
+        "((8, (64 11 52 0 1 12 0 1023)),(8, (8 7 6 5 4 3 2 1)))\n");
+    const auto index = readHeader(path, 2, "4-nonfinite");
+    require(index.minimum.size() == 1 && index.minimum.front().size() == 2,
+        "non-finite v4 minima shape mismatch");
+    require(std::isinf(index.minimum.front()[0]) && index.minimum.front()[0] < 0.0,
+        "v4 -inf minimum not parsed");
+    require(std::isinf(index.minimum.front()[1]) && index.minimum.front()[1] > 0.0,
+        "v4 +inf minimum not parsed");
+    require(std::isnan(index.maximum.front()[0]), "v4 nan maximum not parsed");
+    require(index.realDescriptor == kRealDescriptor,
+        "v4 RealDescriptor not parsed after non-finite statistics");
 }
 
 // A crafted header must be rejected with MetadataReadError specifically (not
@@ -407,6 +474,8 @@ int main()
     testVersion2(scratch / "v2_H");
     testVersion3(scratch / "v3_H");
     testVersion4(scratch / "v4_H");
+    testAcceptsNonFiniteV1(scratch / "v1_nonfinite_H");
+    testAcceptsNonFiniteV4(scratch / "v4_nonfinite_H");
     testRejectsOversizedMatrix(scratch / "bad_matrix_H");
     testRejectsMatrixShapeMismatch(scratch / "bad_shape_H");
     testRejectsMalformedMatrixDimensions(scratch / "bad_dims_H");


### PR DESCRIPTION
The per-block/FabArray min/max in a VisMF _H header were parsed with readRequired<double> (input >> value), and libstdc++'s operator>>(double) cannot parse the "inf" / "-inf" / "nan" text that C++ ostreams emit for non-finite doubles. AMReX's FArrayBox::min/max propagate +/-inf (and can leave a NaN) from an overflowed run, and its default header carries those extrema, so a blown-up plotfile -- exactly the run a user opens a viewer to debug -- refused to open with "malformed plotfile Header while reading per-block minima". The same path is reached for standalone MultiFabs.

Add readStatisticValue(), used only for the VisMF statistics values (v1/v3 readRealMatrix and the v4 FabArray min/max): read one comma/whitespace- delimited token and strtod it (strtod accepts inf/-inf/nan), faulting on genuinely malformed tokens. Geometry fields keep strict readRequired<double>. The non-finite value is stored as-is; metadataValueRange already discards non-finite block statistics, so File/Level range modes disable and the color bar auto-ranges via Visible rather than the open failing. Non-finite data pixels, separately, already render in the renderer's nanColor.

Add testAcceptsNonFiniteV1/V4 to test_vismf_index: assert +/-inf and NaN parse and store in both header layouts. They fail with the original "malformed plotfile Header" against the strict parser and pass after; the existing malformed-value/missing-comma rejections still hold (the token parse stops at whitespace, so "3.0 4.0," still faults).