### PR TITLE
fix contour plateau hatching and corner-hit zero-length segments

### DIFF
--- a/src/render2d/Contours.cpp
+++ b/src/render2d/Contours.cpp
@@ -135,14 +135,25 @@ std::vector<ContourSegment> generateContours(
             const double invDXb = (br != bl) ? 1.0 / (br - bl) : 0.0;
             const double invDXt = (tr != tl) ? 1.0 / (tr - tl) : 0.0;
             for (double value : finiteValues) {
-                const bool left   = (bl <= value && value <= tl)
-                    || (bl >= value && value >= tl);
-                const bool right  = (br <= value && value <= tr)
-                    || (br >= value && value >= tr);
-                const bool bottom = (bl <= value && value <= br)
-                    || (bl >= value && value >= br);
-                const bool top    = (tl <= value && value <= tr)
-                    || (tl >= value && value >= tr);
+                // Half-open edge-crossing test: an edge is crossed when its two
+                // endpoints fall on opposite sides of `value`, classifying a
+                // corner exactly equal to `value` as "not above". An inclusive
+                // both-ends test (bl <= value && value <= tl, ...) instead fired
+                // on every edge of a cell whose four corners all equal the value
+                // -- an interior plateau sitting exactly on a contour level --
+                // collapsing the crossings onto corners and hatching the region
+                // with the saddle else-arm's left/bottom edges; the half-open
+                // form yields no crossings there. It also assigns a corner-exact
+                // hit to one side only. For any cell with no corner exactly on
+                // `value` the two tests are identical.
+                const bool aboveBl = bl > value;
+                const bool aboveBr = br > value;
+                const bool aboveTl = tl > value;
+                const bool aboveTr = tr > value;
+                const bool left   = aboveBl != aboveTl;
+                const bool right  = aboveBr != aboveTr;
+                const bool bottom = aboveBl != aboveBr;
+                const bool top    = aboveTl != aboveTr;
                 if (!left && !right && !bottom && !top) {
                     continue;
                 }
@@ -157,12 +168,20 @@ std::vector<ContourSegment> generateContours(
                 if (top)    xT = x0 + static_cast<float>((value - tl) * invDXt);
 
                 const auto emit = [&](float ax, float ay, float bx, float by) {
+                    // Drop zero-length segments: a contour passing exactly
+                    // through a grid corner interpolates both incident edge
+                    // crossings onto that corner, collapsing them to one point.
+                    // Chaining such a segment would inject a duplicate vertex or
+                    // a one-point "closed" polyline.
+                    if (ax == bx && ay == by) {
+                        return;
+                    }
                     segments.push_back({ax, ay, bx, by, value});
                 };
 
                 if (left && right && bottom && top) {
                     const double center = (bl + br + tl + tr) / 4.0;
-                    if ((bl > value) != (center > value)) {
+                    if (aboveBl != (center > value)) {
                         emit(xL, yL, xB, yB);
                         emit(xT, yT, xR, yR);
                     } else {

--- a/tests/unit/test_contours.cpp
+++ b/tests/unit/test_contours.cpp
@@ -422,5 +422,74 @@ int main()
             "an Nx1 plane produced contour polylines");
     }
 
+    // (o) A plateau exactly on a contour level must not hatch its interior.
+    // 5x5 field: an interior 3x3 block of points (indices 1..3) at 5.0, a
+    // border ring at 10.0, so the value-5 contour traces the plateau boundary
+    // (the square x,y in {1,3}) and leaves the interior empty. The inclusive
+    // predicate emitted the left+bottom edge of every interior cell, hatching
+    // x=2 / y=2 with a grid of segments (contour-plateau-and-corner-artifacts).
+    {
+        amrvis::ScalarPlane plateau;
+        plateau.width = 5;
+        plateau.height = 5;
+        plateau.values.resize(25);
+        plateau.valid.assign(25, 1);
+        plateau.sourceLevel.assign(25, 0);
+        for (int y = 0; y < 5; ++y) {
+            for (int x = 0; x < 5; ++x) {
+                const bool interior = x >= 1 && x <= 3 && y >= 1 && y <= 3;
+                plateau.values[static_cast<std::size_t>(x + 5 * y)]
+                    = interior ? 5.0F : 10.0F;
+            }
+        }
+        const auto plateauSegments = amrvis::generateContours(plateau, {5.0});
+        require(!plateauSegments.empty(),
+            "the plateau boundary contour was fully suppressed");
+        for (const auto& segment : plateauSegments) {
+            const bool startInside = segment.x0 > 1.0F && segment.x0 < 3.0F
+                && segment.y0 > 1.0F && segment.y0 < 3.0F;
+            const bool endInside = segment.x1 > 1.0F && segment.x1 < 3.0F
+                && segment.y1 > 1.0F && segment.y1 < 3.0F;
+            require(!startInside && !endInside,
+                "a segment hatched the interior of a value-exact plateau");
+        }
+    }
+
+    // (p) A contour passing exactly through grid corners must emit no
+    // zero-length segments. value(x, y) = x - y on a 3x3 grid: the v = 0
+    // iso-line runs along the main diagonal through the corners (0,0), (1,1),
+    // (2,2). Cells straddling the diagonal interpolate their crossings onto
+    // those shared corners; the reader must draw the diagonal while dropping
+    // the degenerate zero-length touches (else chaining injects a duplicate
+    // vertex or a one-point "closed" polyline).
+    {
+        amrvis::ScalarPlane corner;
+        corner.width = 3;
+        corner.height = 3;
+        corner.values.resize(9);
+        corner.valid.assign(9, 1);
+        corner.sourceLevel.assign(9, 0);
+        for (int y = 0; y < 3; ++y) {
+            for (int x = 0; x < 3; ++x) {
+                corner.values[static_cast<std::size_t>(x + 3 * y)]
+                    = static_cast<float>(x - y);
+            }
+        }
+        const auto cornerSegments = amrvis::generateContours(corner, {0.0});
+        for (const auto& segment : cornerSegments) {
+            require(!(segment.x0 == segment.x1 && segment.y0 == segment.y1),
+                "a corner-exact contour emitted a zero-length segment");
+        }
+        require(hasSegment(cornerSegments, 0.0, 0.0, 1.0, 1.0)
+                && hasSegment(cornerSegments, 1.0, 1.0, 2.0, 2.0),
+            "corner-exact contour dropped the real diagonal iso-line");
+        const auto cornerLines =
+            amrvis::generateContourPolylines(corner, {0.0}, 0);
+        for (const auto& line : cornerLines) {
+            require(line.points.size() >= 2,
+                "corner-exact contour produced a one-point polyline");
+        }
+    }
+
     return 0;
 }


### PR DESCRIPTION
generateContours used inclusive-on-both-ends marching-squares edge predicates (bl <= value && value <= tl, ...), which broke two ways on integer-valued / clamped fields (tag / material / level data):

- A cell whose four corners all equal a contour level had every edge "cross"; the crossings collapsed onto corners and the saddle else-arm emitted the cell's left+bottom edges, hatching every interior plateau cell into a grid of spurious segments that chaining welds into long snaking polylines.
- A contour through a grid corner interpolated both incident edge crossings onto that corner, emitting a zero-length segment that chaining turned into a duplicate vertex or a one-point "closed" polyline.

Switch the four predicates to the conventional half-open form (a > value) != (b > value), classifying a corner exactly on the level as "not above": an all-equal plateau cell yields no crossings (interior hatching gone, boundary contour still traced) and a corner-exact hit belongs to one side only. For any cell with no corner exactly on the level the two tests are identical, so non-degenerate fields are unchanged. Also drop zero-length segments in the emit lambda for the residual corner-touch case, and reuse the aboveBl classification in the saddle decider.

Add contour tests (o)/(p): an interior plateau exactly on a level emits no segment strictly inside it (boundary still drawn), and value = x - y (v=0 diagonal through corners) emits no zero-length segment, still draws the diagonal, and chains without a one-point polyline. Each fails when its half of the fix is reverted.