### PR TITLE
reset FAB view state when opening a plotfile sequence

### DIFF
--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -4091,6 +4091,18 @@ void MainWindow::openDataset(
         path, metadataOnly, std::nullopt, {}, false, std::nullopt);
 }
 
+void MainWindow::resetFabState()
+{
+    m_fabMode = false;
+    m_multifabReturn.reset();
+    m_fabSourceMetadata.reset();
+    m_fabSourcePath.clear();
+    m_fabDataRoot.clear();
+    m_fabSelectorDock->setEntries({});
+    m_fabSelectorDock->setBackAvailable(false);
+    m_fabSelectorDock->setVisible(false);
+}
+
 void MainWindow::openDatasetImpl(const std::filesystem::path& path,
     bool metadataOnly,
     std::optional<PlotfileMetadataResult> preparedMetadata,
@@ -4098,14 +4110,7 @@ void MainWindow::openDatasetImpl(const std::filesystem::path& path,
     std::optional<FrameSliceSpec> initialSpec)
 {
     if (!preserveFabSelector) {
-        m_fabMode = false;
-        m_multifabReturn.reset();
-        m_fabSourceMetadata.reset();
-        m_fabSourcePath.clear();
-        m_fabDataRoot.clear();
-        m_fabSelectorDock->setEntries({});
-        m_fabSelectorDock->setBackAvailable(false);
-        m_fabSelectorDock->setVisible(false);
+        resetFabState();
     }
     // Opening a single dataset ends any plotfile sequence and stops playback
     // of either animation mode.
@@ -5572,6 +5577,15 @@ void MainWindow::openSequence(const std::vector<std::filesystem::path>& frames)
                "plotfile directory."));
         return;
     }
+
+    // A sequence replaces any standalone FAB/MultiFab with plotfile frames.
+    // openSequence does not go through openDatasetImpl, so clear the FAB view
+    // state here too; otherwise m_fabMode keeps every frame's title suffixed
+    // "— FAB" and the stale selector dock's clicks reopen the old file (see
+    // open-sequence-stale-fab-state). Only after the validity check above, so a
+    // rejected selection leaves the current FAB view untouched. The first
+    // frame's display refreshes the title with m_fabMode now false.
+    resetFabState();
 
     m_animationPanel->setSequenceFrameCount(static_cast<int>(sorted.size()));
     m_animationPanel->setSequenceVisible(true);

--- a/src/qt/MainWindow.hpp
+++ b/src/qt/MainWindow.hpp
@@ -289,6 +289,12 @@ private:
         std::optional<PlotfileMetadataResult> preparedMetadata,
         std::filesystem::path dataRoot, bool preserveFabSelector,
         std::optional<FrameSliceSpec> initialSpec);
+    // Clears standalone FAB/MultiFab view state (mode flag, MultiFab-return
+    // record, source metadata/paths) and hides the FAB selector dock. Any path
+    // that replaces the displayed dataset with a non-FAB one -- a plain dataset
+    // open, or a plotfile sequence -- must call this or stale FAB state leaks
+    // into the new view (see open-sequence-stale-fab-state).
+    void resetFabState();
     void viewFab(std::size_t entry);
     void backToMultiFab();
     // A fresh independent top-level window (WA_DeleteOnClose) for the

--- a/src/qt/main.cpp
+++ b/src/qt/main.cpp
@@ -1023,6 +1023,50 @@ int main(int argc, char* argv[])
         QTimer::singleShot(0, &window, [&window, first, second] {
             window.openSequence({first, second});
         });
+    } else if (argc == 5
+        && std::string_view(argv[1]) == "--sequence-after-fab-smoke-test") {
+        // Regression for open-sequence-stale-fab-state: open a raw FAB (enters
+        // FAB mode -- selector dock visible, "— FAB" title suffix), then open a
+        // plotfile sequence. openSequence does not go through openDatasetImpl,
+        // so without the reset the FAB mode, dock, and title leak into the
+        // frames. Exit 0 only if the first frame shows with the dock hidden and
+        // no "— FAB" title.
+        const std::filesystem::path fab(argv[2]);
+        const std::filesystem::path first(argv[3]);
+        const std::filesystem::path second(argv[4]);
+        const auto inFabMode = [](const amrvis::qt::MainWindow& w) {
+            const auto* selector = w.findChild<amrvis::qt::FabSelectorDock*>();
+            return selector != nullptr && selector->isVisible()
+                && w.windowTitle().endsWith(QStringLiteral(" FAB"));
+        };
+        auto opened = std::make_shared<bool>(false);
+        QObject::connect(&window, &amrvis::qt::MainWindow::initialSliceFinished,
+            &application, [&window, &application, first, second, opened,
+                inFabMode](bool success) {
+                if (*opened) {
+                    return;  // later FAB re-slices are irrelevant
+                }
+                // Precondition: the raw FAB really did enter FAB mode, so the
+                // sequence open below is exercising the leak.
+                if (!success || !inFabMode(window)) {
+                    application.exit(1);
+                    return;
+                }
+                *opened = true;
+                window.openSequence({first, second});
+            });
+        QObject::connect(&window, &amrvis::qt::MainWindow::sequenceFrameDisplayed,
+            &application, [&window, &application, inFabMode](int index) {
+                if (index != 0) {
+                    return;
+                }
+                application.exit(inFabMode(window) ? 1 : 0);
+            });
+        QObject::connect(&window, &amrvis::qt::MainWindow::sequenceFrameFailed,
+            &application, [&application] { application.exit(1); });
+        QTimer::singleShot(15000, &application,
+            [&application] { application.exit(1); });
+        QTimer::singleShot(0, &window, [&window, fab] { window.openDataset(fab); });
     } else if (argc == 4
         && std::string_view(argv[1])
             == "--sequence-spec-change-smoke-test") {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -593,6 +593,20 @@ if(TARGET amrexplorer_qt)
             -P "${CMAKE_CURRENT_SOURCE_DIR}/qt_smoke_driver.cmake"
     )
     set_tests_properties(qt_sequence_smoke PROPERTIES TIMEOUT 30)
+    # Regression for open-sequence-stale-fab-state: opening a plotfile sequence
+    # after a raw FAB must clear the FAB view state (dock hidden, no "— FAB"
+    # title), since openSequence does not go through openDatasetImpl.
+    add_test(
+        NAME qt_sequence_after_fab_smoke_2d
+        COMMAND "${CMAKE_COMMAND}"
+            "-DMATERIALIZER=$<TARGET_FILE:fixture_materializer>"
+            "-DAMREXPLORER_QT=$<TARGET_FILE:amrexplorer_qt>"
+            "-DSOURCE=${CMAKE_CURRENT_SOURCE_DIR}/data/plotfile_2d"
+            "-DWORK=${CMAKE_CURRENT_BINARY_DIR}/fixtures_sequence_after_fab"
+            -DMODE=sequence-after-fab
+            -P "${CMAKE_CURRENT_SOURCE_DIR}/qt_smoke_driver.cmake"
+    )
+    set_tests_properties(qt_sequence_after_fab_smoke_2d PROPERTIES TIMEOUT 30)
     # A normal slice-affecting control change while a foreground frame is
     # loading invalidates that frame specification. The replacement load must
     # complete instead of leaving sequence playback latched in-flight.

--- a/tests/qt_smoke_driver.cmake
+++ b/tests/qt_smoke_driver.cmake
@@ -5,7 +5,8 @@
 #   AMREXPLORER_QT     path to the amrexplorer_qt executable
 #   SOURCE        fixture source directory (e.g. tests/data/plotfile_2d)
 #   WORK          directory the materialized copies are written into
-#   MODE          slice | sequence | missing-range | non-finite | raw-fab |
+#   MODE          slice | sequence | sequence-after-fab | missing-range |
+#                 non-finite | raw-fab |
 #                 multifab-fab | quit | quit-on-failure | window-close-pool |
 #                 export-quit |
 #                 contour-sync | raster-zoom | rubber-zoom-sync |
@@ -47,6 +48,14 @@ elseif(MODE STREQUAL "sequence")
     run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt00010" "2.5")
     run_or_die("${AMREXPLORER_QT}" --sequence-smoke-test
         "${WORK}/plt00000" "${WORK}/plt00010")
+elseif(MODE STREQUAL "sequence-after-fab")
+    # Open a raw FAB first, then a plotfile sequence: the sequence must clear
+    # the stale FAB view state (dock, "— FAB" title).
+    run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt")
+    run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt00000")
+    run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt00010" "2.5")
+    run_or_die("${AMREXPLORER_QT}" --sequence-after-fab-smoke-test
+        "${WORK}/plt/Level_0/Cell_D_00000" "${WORK}/plt00000" "${WORK}/plt00010")
 elseif(MODE STREQUAL "sequence-spec-change")
     run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt00000")
     run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt00010" "2.5")


### PR DESCRIPTION
openDatasetImpl clears the standalone FAB/MultiFab view state (m_fabMode, the MultiFab-return record, source metadata/paths, and the selector dock), but openSequence does not go through it. So Open FAB... followed by Open Plotfile Sequence... left m_fabMode true: every frame's title rendered as "... — FAB", the stale selector dock stayed visible listing the previous file's records, and clicking an entry (or "Back to MultiFab") silently closed the running sequence and reopened the old standalone file.

Extract the reset block into a resetFabState() helper and call it from openSequence too, after the validity check (so a rejected selection leaves the current FAB view untouched) and before the frames reach the SequenceController. m_fabMode is now false before the first frame loads, so the metadata-display path's updateWindowTitle() renders a plain plotfile title and the dock is hidden; openDatasetImpl calls the same helper so the two paths cannot drift.

Add qt_sequence_after_fab_smoke_2d (--sequence-after-fab-smoke-test): open a raw FAB (asserting FAB mode is actually entered), then a sequence, and require the first displayed frame to have the dock hidden and no "— FAB" title. It fails with the stale state leaked when the openSequence reset is removed and passes with it.