### PR TITLE
fix range-cache staleness races in the slice completion handler

### DIFF
--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -614,17 +614,25 @@ MainWindow::MainWindow(QWidget* parent)
                     applyFieldRange(newField);
                 }
             }
+            // A deferred full-domain range store (m_pendingRangeStore) is keyed
+            // to the field/level/mode in effect when it was queued. Changing any
+            // of them means a completing 3-D Visible sync would store its union
+            // under the wrong key, so drop the pending store here (the sync
+            // completion also re-checks the key; see range-cache-staleness-races).
+            m_pendingRangeStore.reset();
             updateRangeModeAvailability();
             scheduleSliceRequest();
         });
     connect(m_levelSelector, qOverload<int>(&QComboBox::currentIndexChanged),
         this, [this](int) {
             configureSlicePositionControls();
+            m_pendingRangeStore.reset();  // see the field selector above
             updateRangeModeAvailability();
             scheduleSliceRequest();
         });
     connect(m_rangeMode, qOverload<int>(&QComboBox::currentIndexChanged),
         this, [this](int) {
+            m_pendingRangeStore.reset();  // see the field selector above
             updateRangeModeAvailability();
             const auto userRange = static_cast<RangeMode>(
                 m_rangeMode->currentData().toInt()) == RangeMode::User;
@@ -4844,7 +4852,17 @@ void MainWindow::requestSlice(PlaneViewState& state, bool rasterDirty)
                     // Cache the full-domain range whenever we get a non-zoomed
                     // Visible-range slice; reuse it for zoomed (subregion)
                     // slices so the color bar stays stable during pan and zoom.
-                    const bool isFullDomain = !state.visibleRegion.has_value();
+                    // Whether this slice covered the full domain must come from
+                    // the request that produced it, not live view state:
+                    // rubber-band zoom / pan / reset-zoom mutate
+                    // state.visibleRegion without bumping sliceGeneration (they
+                    // only schedule the debounced re-slice), so a slice in
+                    // flight when one of those fires would be misclassified --
+                    // caching a subregion range as the full-domain range on a
+                    // reset, or dropping the full-domain range on a zoom
+                    // (range-cache-staleness-races).
+                    const bool isFullDomain = result.request.visibleRegion
+                        == datasetSampleBounds(dataset->metadata());
                     const DisplayCoordinator::RangeKey rangeKey{
                         result.request.dataset, result.request.field,
                         result.request.maximumLevel,
@@ -5467,8 +5485,25 @@ void MainWindow::syncVisibleRanges()
                 // queued the union is about to be recomputed with newer
                 // planes — leave the store for the rerun's completion.
                 if (m_pendingRangeStore && !m_visibleSyncRerun) {
-                    m_displayCoordinator.storeFullDomainRange(
-                        *m_pendingRangeStore, outcome.sync->range);
+                    // Only store if the pending key still describes the current
+                    // (dataset, field, level, composition): a full-domain
+                    // arrival's key can outlive its own sync (e.g. its
+                    // syncVisibleRanges early-returned because the mode was
+                    // File), and this sync's union is for the *current* field,
+                    // so storing it under the stale key would poison that
+                    // field's cached range (range-cache-staleness-races).
+                    const FieldId liveField{
+                        m_fieldSelector->currentData().toUInt()};
+                    const auto [liveComposition, liveMaximumLevel] =
+                        decodeLevelData(m_levelSelector->currentData().toInt(),
+                            m_dataset->metadata().finestLevel);
+                    const DisplayCoordinator::RangeKey liveKey{
+                        m_dataset->id(), liveField, liveMaximumLevel,
+                        liveComposition};
+                    if (*m_pendingRangeStore == liveKey) {
+                        m_displayCoordinator.storeFullDomainRange(
+                            *m_pendingRangeStore, outcome.sync->range);
+                    }
                     m_pendingRangeStore.reset();
                 }
             } else if (generation != m_generation) {


### PR DESCRIPTION
The slice-arrival completion consulted live view state instead of the request that produced the result.

(a) isFullDomain came from state.visibleRegion, but zoom/pan/reset mutate that member without bumping sliceGeneration (they only schedule the debounced re-slice). A full-domain slice in flight when the user zoomed was then misclassified isFullDomain=false, so the full-domain range was never cached and later zooms lost the stable color bar; a zoomed slice in flight when the user pressed reset was misclassified isFullDomain=true, so in 2-D the subregion's range was cached as the full-domain range and a follow-up zoom reused the poisoned entry. Classify from
result.request.visibleRegion == datasetSampleBounds(...) instead -- the request in hand -- for both the store and the cached-range reuse lookup.

(b) The deferred 3-D full-domain store (m_pendingRangeStore) could outlive its own sync -- e.g. its syncVisibleRanges early-returned because the mode was flipped to File -- and later be consumed by an unrelated Visible sync, storing that sync's union under the stale key and poisoning another field's cached range. Guard both ends: clear m_pendingRangeStore in the field, level, and range-mode combo handlers so a stale key cannot survive those changes, and in the sync completion re-derive the live (dataset, field, level, composition) key and store only when the pending key still equals it

No bespoke test: these are async interaction races (a slice in flight at th instant of a user action that does not bump the generation) and are not deterministically reproducible in the offscreen smoke harness without a way to pause slice completions. The fix removes the live-state dependency, the RangeKey guard reuses key semantics already covered by test_display_coordinator, and the full suite stays green including the qt_raster_zoom / qt_rubber_zoom / qt_range_cache / qt_pan_zoom smoke tests.