### PR TITLE
[client-server] refit views when dataset identity changes

### DIFF
--- a/include/amrexplorer/pipeline/DisplayCoordinator.hpp
+++ b/include/amrexplorer/pipeline/DisplayCoordinator.hpp
@@ -23,6 +23,21 @@ namespace amrvis {
 
 class DisplayCoordinator {
 public:
+    // Physical facts that determine whether an existing view transform still
+    // denotes the same data-space window after a raster replacement. Dataset
+    // ids are deliberately absent: sequence frames receive fresh ids even
+    // when their physical geometry is identical.
+    struct RasterGeometry {
+        RealBox physicalDomain;
+        int dimension = 0;
+        int coordinateSystem = 0;
+        int normalDirection = 0;
+        SphericalDisplay sphericalDisplay = SphericalDisplay::RZ;
+
+        friend bool operator==(const RasterGeometry&, const RasterGeometry&)
+            = default;
+    };
+
     // What the cached full-domain range is valid for. Sequence frames load
     // fresh datasets with new ids, so keying on the dataset invalidates the
     // cache across frames (see sequence-frame-range-cache-goes-stale).
@@ -59,14 +74,13 @@ public:
         std::span<const ScalarPlane* const> planes, bool logarithmic);
 
     // How the view should treat its transform when `incoming` replaces the
-    // raster produced by `cached`. A zoomed panel-local refresh (same
-    // dataset and orientation) preserves; a replacement from another dataset
-    // or orientation refits even if the dimensions coincide; everything else
-    // refits only on a dimension change. Moved verbatim from the GUI's
-    // showSlice (see the raster-colorbar and rubber-band issues).
+    // raster produced by `cached`. Compatible physical geometry preserves the
+    // ImageView mode across ordinary refreshes and sequence-frame ids. A
+    // physical-domain, coordinate-system, dimensional, normal-direction, or
+    // displayed-orientation change refits deterministically.
     [[nodiscard]] static ImageTransformPolicy rasterTransformPolicy(
-        bool hasCachedRequest, const SliceRequest& cached,
-        const SliceRequest& incoming, bool zoomed);
+        const std::optional<RasterGeometry>& cached,
+        const RasterGeometry& incoming);
 
     // Realigns an arrived result to a replacement display range (the reused
     // full-domain range): overwrites minimum/maximum and, when

--- a/include/amrexplorer/pipeline/DisplayCoordinator.hpp
+++ b/include/amrexplorer/pipeline/DisplayCoordinator.hpp
@@ -60,9 +60,9 @@ public:
 
     // How the view should treat its transform when `incoming` replaces the
     // raster produced by `cached`. A zoomed panel-local refresh (same
-    // dataset and orientation) preserves; a replacement whose region or
-    // orientation differs refits even if the dimensions coincide; everything
-    // else refits only on a dimension change. Moved verbatim from the GUI's
+    // dataset and orientation) preserves; a replacement from another dataset
+    // or orientation refits even if the dimensions coincide; everything else
+    // refits only on a dimension change. Moved verbatim from the GUI's
     // showSlice (see the raster-colorbar and rubber-band issues).
     [[nodiscard]] static ImageTransformPolicy rasterTransformPolicy(
         bool hasCachedRequest, const SliceRequest& cached,

--- a/src/pipeline/DisplayCoordinator.cpp
+++ b/src/pipeline/DisplayCoordinator.cpp
@@ -64,28 +64,21 @@ std::optional<std::pair<double, double>> DisplayCoordinator::sharedVisibleRange(
 }
 
 ImageTransformPolicy DisplayCoordinator::rasterTransformPolicy(
-    bool hasCachedRequest, const SliceRequest& cached,
-    const SliceRequest& incoming, bool zoomed)
+    const std::optional<RasterGeometry>& cached,
+    const RasterGeometry& incoming)
 {
-    // A zoomed visibleRegion is physical data state, not evidence that the
-    // old raster transform is compatible with the incoming image. Preserve
-    // the transform only for a panel-local refresh in the same dataset and
-    // orientation (rubber-band zoom or pan). If a dataset replacement
-    // overtakes such a refresh, explicitly refit when the cached and
-    // incoming rasters cover different regions: their dimensions can
-    // coincide even though their pixel-to-data mappings do not.
-    const bool samePanelRenderContext = hasCachedRequest
-        && cached.dataset == incoming.dataset
-        && cached.normalDirection == incoming.normalDirection;
-    const bool incompatibleRasterContext
-        = hasCachedRequest && !samePanelRenderContext;
-    if (incompatibleRasterContext) {
+    // Dataset ids are connection/session-local ownership, not display
+    // geometry. A sequence frame with a fresh id remains compatible when its
+    // physical domain and raster-to-data orientation are unchanged. Pixel
+    // density is also allowed to change: MainWindow remaps Custom mode's
+    // visible physical window through the old and new planes.
+    if (!cached.has_value()) {
+        return ImageTransformPolicy::GeometryAware;
+    }
+    if (*cached != incoming) {
         return ImageTransformPolicy::Refit;
     }
-    if (zoomed && samePanelRenderContext) {
-        return ImageTransformPolicy::Preserve;
-    }
-    return ImageTransformPolicy::GeometryAware;
+    return ImageTransformPolicy::Preserve;
 }
 
 void DisplayCoordinator::realignArrivalToRange(SliceDisplayResult& result,

--- a/src/pipeline/DisplayCoordinator.cpp
+++ b/src/pipeline/DisplayCoordinator.cpp
@@ -77,10 +77,8 @@ ImageTransformPolicy DisplayCoordinator::rasterTransformPolicy(
     const bool samePanelRenderContext = hasCachedRequest
         && cached.dataset == incoming.dataset
         && cached.normalDirection == incoming.normalDirection;
-    const bool incompatibleRasterContext = hasCachedRequest
-        && !samePanelRenderContext
-        && (cached.normalDirection != incoming.normalDirection
-            || cached.visibleRegion != incoming.visibleRegion);
+    const bool incompatibleRasterContext
+        = hasCachedRequest && !samePanelRenderContext;
     if (incompatibleRasterContext) {
         return ImageTransformPolicy::Refit;
     }

--- a/src/qt/ImageView.cpp
+++ b/src/qt/ImageView.cpp
@@ -99,15 +99,15 @@ ImageView::ImageView(QWidget* parent)
 void ImageView::setImage(
     const QImage& image, ImageTransformPolicy transformPolicy)
 {
-    // Refit only when the image changes size (initial open, a zoom into a new
-    // region, a differently-sized dataset). When only the colors are remapped
-    // at the same size -- toggling Log, or changing field, level, or range --
-    // keep the user's current zoom/pan. Compatible panel-local cropped-region
-    // refreshes explicitly preserve the transform even when the replacement
-    // raster dimensions differ.
-    const bool refit = transformPolicy == ImageTransformPolicy::Refit
-        || (transformPolicy == ImageTransformPolicy::GeometryAware
-            && (m_image.isNull() || m_image.size() != image.size()));
+    const bool sizeChanged = m_image.isNull() || m_image.size() != image.size();
+    // An explicitly incompatible raster resets Custom mode. Fixed scale is a
+    // user-selected persistent mode and therefore survives every replacement,
+    // including a delayed result whose policy was computed before the scale
+    // selection. Fit likewise remains a mode and refits every replacement.
+    if (transformPolicy == ImageTransformPolicy::Refit
+        && m_transformMode == TransformMode::Custom) {
+        m_transformMode = TransformMode::Fit;
+    }
     m_scene->clear();
     m_gridItems.clear();
     m_overlayItems.clear();
@@ -123,8 +123,13 @@ void ImageView::setImage(
     m_item = m_scene->addPixmap(QPixmap::fromImage(m_image));
     m_scene->setSceneRect(m_item->boundingRect());
     setBackgroundBrush(viewportBackground());
-    if (refit) {
-        m_fitOnResize = true;
+    if (m_transformMode == TransformMode::Fit) {
+        fitImage();
+    } else if (m_transformMode == TransformMode::FixedScale) {
+        applyFixedScale();
+    } else if (transformPolicy == ImageTransformPolicy::GeometryAware
+        && sizeChanged) {
+        m_transformMode = TransformMode::Fit;
         fitImage();
     }
     applyCrosshairs();
@@ -430,6 +435,8 @@ void ImageView::setPlaceholder(const QString& text)
     label->setDefaultTextColor(palette().windowText().color());
     m_scene->setSceneRect(label->boundingRect());
     resetTransform();
+    m_transformMode = TransformMode::Fit;
+    m_fixedScaleFactor = 1;
 }
 
 bool ImageView::hasImage() const noexcept
@@ -494,7 +501,7 @@ QImage ImageView::composedImage(qreal scaleFactor) const
 void ImageView::fitToWindow()
 {
     if (hasImage()) {
-        m_fitOnResize = true;
+        m_transformMode = TransformMode::Fit;
         fitImage();
     }
 }
@@ -504,10 +511,18 @@ void ImageView::setFixedScale(int factor)
     if (!hasImage() || factor < 1) {
         return;
     }
-    m_fitOnResize = false;
-    resetTransform();
-    const auto scaleFactor = static_cast<double>(factor);
-    scale(scaleFactor, scaleFactor);
+    m_transformMode = TransformMode::FixedScale;
+    m_fixedScaleFactor = factor;
+    applyFixedScale();
+}
+
+void ImageView::zoomBy(qreal factor)
+{
+    if (!hasImage() || !(factor > 0.0)) {
+        return;
+    }
+    scale(factor, factor);
+    m_transformMode = TransformMode::Custom;
 }
 
 void ImageView::zoomToRect(const QRectF& sceneRect)
@@ -515,7 +530,7 @@ void ImageView::zoomToRect(const QRectF& sceneRect)
     if (!hasImage() || sceneRect.isEmpty()) {
         return;
     }
-    m_fitOnResize = false;
+    m_transformMode = TransformMode::Custom;
     fitInView(sceneRect, Qt::KeepAspectRatio);
 }
 
@@ -524,7 +539,7 @@ void ImageView::panViewport(const QPoint& delta)
     if (!hasImage() || (delta.x() == 0 && delta.y() == 0)) {
         return;
     }
-    m_fitOnResize = false;
+    m_transformMode = TransformMode::Custom;
     auto* const hBar = horizontalScrollBar();
     auto* const vBar = verticalScrollBar();
     if (hBar->maximum() > hBar->minimum()
@@ -560,7 +575,7 @@ void ImageView::mousePressEvent(QMouseEvent* event)
             m_panActive = true;
             m_lastPanPosition = event->position().toPoint();
             m_panAccumulated = QPointF();
-            m_fitOnResize = false;
+            m_transformMode = TransformMode::Custom;
             setCursor(Qt::ClosedHandCursor);
             emit panDragBegan();
             event->accept();
@@ -699,7 +714,7 @@ void ImageView::mouseMoveEvent(QMouseEvent* event)
 void ImageView::resizeEvent(QResizeEvent* event)
 {
     QGraphicsView::resizeEvent(event);
-    if (m_fitOnResize) {
+    if (m_transformMode == TransformMode::Fit) {
         fitImage();
     }
 }
@@ -717,8 +732,7 @@ void ImageView::wheelEvent(QWheelEvent* event)
     }
     constexpr double zoomStep = 1.15;
     const auto factor = vertical > 0 ? zoomStep : 1.0 / zoomStep;
-    scale(factor, factor);
-    m_fitOnResize = false;
+    zoomBy(factor);
     event->accept();
 }
 
@@ -798,6 +812,15 @@ void ImageView::fitImage()
     if (m_item != nullptr) {
         resetTransform();
         fitInView(m_item, Qt::KeepAspectRatio);
+    }
+}
+
+void ImageView::applyFixedScale()
+{
+    if (m_item != nullptr) {
+        resetTransform();
+        const auto factor = static_cast<qreal>(m_fixedScaleFactor);
+        scale(factor, factor);
     }
 }
 

--- a/src/qt/ImageView.cpp
+++ b/src/qt/ImageView.cpp
@@ -97,7 +97,8 @@ ImageView::ImageView(QWidget* parent)
 }
 
 void ImageView::setImage(
-    const QImage& image, ImageTransformPolicy transformPolicy)
+    const QImage& image, ImageTransformPolicy transformPolicy,
+    QSize logicalSize)
 {
     const bool sizeChanged = m_image.isNull() || m_image.size() != image.size();
     // An explicitly incompatible raster resets Custom mode. Fixed scale is a
@@ -120,6 +121,7 @@ void ImageView::setImage(
     m_lineGuide = nullptr;
     m_lineDragButton = Qt::NoButton;
     m_image = image;
+    m_logicalSize = logicalSize.isValid() ? logicalSize : image.size();
     m_item = m_scene->addPixmap(QPixmap::fromImage(m_image));
     m_scene->setSceneRect(m_item->boundingRect());
     setBackgroundBrush(viewportBackground());
@@ -430,6 +432,7 @@ void ImageView::setPlaceholder(const QString& text)
     m_lineDragButton = Qt::NoButton;
     m_item = nullptr;
     m_image = {};
+    m_logicalSize = {};
     setBackgroundBrush(palette().window());
     auto* label = m_scene->addText(text);
     label->setDefaultTextColor(palette().windowText().color());
@@ -820,7 +823,10 @@ void ImageView::applyFixedScale()
     if (m_item != nullptr) {
         resetTransform();
         const auto factor = static_cast<qreal>(m_fixedScaleFactor);
-        scale(factor, factor);
+        const auto logicalWidth = std::max(1, m_logicalSize.width());
+        const auto logicalHeight = std::max(1, m_logicalSize.height());
+        scale(factor * logicalWidth / m_image.width(),
+            factor * logicalHeight / m_image.height());
     }
 }
 

--- a/src/qt/ImageView.hpp
+++ b/src/qt/ImageView.hpp
@@ -10,6 +10,7 @@
 #include <QPoint>
 #include <QPointF>
 #include <QRectF>
+#include <QSize>
 
 #include <optional>
 #include <vector>
@@ -74,7 +75,8 @@ public:
     // rasters whose data regions are incompatible.
     void setImage(const QImage& image,
         ImageTransformPolicy transformPolicy =
-            ImageTransformPolicy::GeometryAware);
+            ImageTransformPolicy::GeometryAware,
+        QSize logicalSize = {});
     void setGridBoxes(const std::vector<GridBoxOverlay>& boxes);
     void setOverlaySegments(const std::vector<OverlaySegment>& segments);
     // Smooth contour polylines, rendered as cosmetic-pen path items at the
@@ -181,6 +183,10 @@ private:
     QGraphicsScene* m_scene = nullptr;
     QGraphicsPixmapItem* m_item = nullptr;
     QImage m_image;
+    // Raster dimensions at local/native density. Remote Fit rasters may have
+    // a different sampled size; fixed scales use this logical size so 1x
+    // remains one native output pixel per screen pixel.
+    QSize m_logicalSize;
     // Rect items (Cartesian) or path items (spherical sectors); QGraphicsItem*
     // so both kinds share the list.
     std::vector<QGraphicsItem*> m_gridItems;

--- a/src/qt/ImageView.hpp
+++ b/src/qt/ImageView.hpp
@@ -60,6 +60,12 @@ class ImageView final : public QGraphicsView {
     Q_OBJECT
 
 public:
+    enum class TransformMode {
+        Fit,
+        FixedScale,
+        Custom
+    };
+
     explicit ImageView(QWidget* parent = nullptr);
 
     // Preserve keeps the current panel-local transform when replacing a raster
@@ -98,9 +104,20 @@ public:
     void setCellHighlightPath(const std::optional<QPainterPath>& scenePath);
     void setPlaceholder(const QString& text);
     [[nodiscard]] bool hasImage() const noexcept;
-    // True while the view auto-fits the whole image to the window (i.e. the
-    // user has not zoomed or set a fixed scale). Cleared by zoom/pan/scale.
-    [[nodiscard]] bool isFitToWindow() const noexcept { return m_fitOnResize; }
+    // Fit, fixed integer scale, and custom zoom/pan are durable display modes,
+    // not incidental properties of the current QTransform.
+    [[nodiscard]] TransformMode transformMode() const noexcept
+    {
+        return m_transformMode;
+    }
+    [[nodiscard]] bool isFitToWindow() const noexcept
+    {
+        return m_transformMode == TransformMode::Fit;
+    }
+    [[nodiscard]] int fixedScaleFactor() const noexcept
+    {
+        return m_fixedScaleFactor;
+    }
     [[nodiscard]] const QImage& image() const noexcept;
     [[nodiscard]] std::size_t pointOverlayCount() const noexcept;
     [[nodiscard]] const std::vector<QColor>& pointOverlayColors() const noexcept;
@@ -111,6 +128,7 @@ public:
     [[nodiscard]] QImage composedImage(qreal scaleFactor = 1.0) const;
     void fitToWindow();
     void setFixedScale(int factor);
+    void zoomBy(qreal factor);
     void zoomToRect(const QRectF& sceneRect);
     // Shift+left-drag pans the viewport (scroll bars, or the view transform
     // when the scene fits the window). When zoomed into a subregion, the
@@ -155,6 +173,7 @@ protected:
 
 private:
     void fitImage();
+    void applyFixedScale();
     void showLineGuide(const QPoint& viewPosition);
     void updateLineGuide(const QPoint& viewPosition);
     void applyCrosshairs();
@@ -188,7 +207,8 @@ private:
     QGraphicsLineItem* m_lineGuide = nullptr;
     bool m_sliceMoveEnabled = false;
     bool m_lineToolEnabled = true;
-    bool m_fitOnResize = true;
+    TransformMode m_transformMode = TransformMode::Fit;
+    int m_fixedScaleFactor = 1;
 };
 
 } // namespace amrvis::qt

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -1766,6 +1766,78 @@ void MainWindow::setActiveViewScaleForTest(int factor)
     }
 }
 
+void MainWindow::selectFixedScaleForTest(int factor)
+{
+    if (m_scaleGroup == nullptr) {
+        return;
+    }
+    const auto label = tr("%1x").arg(factor);
+    for (auto* action : m_scaleGroup->actions()) {
+        auto text = action->text();
+        text.remove(QLatin1Char('&'));
+        if (text == label) {
+            action->trigger();
+            return;
+        }
+    }
+}
+
+bool MainWindow::fixedScaleStateMatchesForTest(int factor) const
+{
+    if (m_activeView == nullptr || m_scaleGroup == nullptr
+        || m_scaleButton == nullptr) {
+        return false;
+    }
+    const auto expected = tr("%1x").arg(factor);
+    auto* checked = m_scaleGroup->checkedAction();
+    auto checkedText = checked == nullptr ? QString() : checked->text();
+    checkedText.remove(QLatin1Char('&'));
+    const auto* view = m_activeView->view;
+    return view->transformMode() == ImageView::TransformMode::FixedScale
+        && view->fixedScaleFactor() == factor
+        && std::fabs(view->transform().m11() - factor) <= 1.0e-12
+        && m_scaleButton->text() == expected && checkedText == expected;
+}
+
+void MainWindow::wheelZoomAndPanActiveViewForTest()
+{
+    if (m_activeView == nullptr || !m_activeView->view->hasImage()) {
+        return;
+    }
+    m_activeView->view->zoomBy(1.5);
+    m_activeView->view->panViewport(QPoint(11, -7));
+}
+
+QRectF MainWindow::activeViewVisibleDataWindowForTest() const
+{
+    if (m_activeView == nullptr || !m_activeView->view->hasImage()) {
+        return {};
+    }
+    const auto* view = m_activeView->view;
+    const auto& plane = *m_activeView->plane;
+    if (plane.width < 1 || plane.height < 1) {
+        return {};
+    }
+    const auto visible = view->mapToScene(
+        view->viewport()->rect()).boundingRect().intersected(
+            QRectF(0.0, 0.0, plane.width, plane.height));
+    const auto axes = displayAxes(m_activeView->normal);
+    const auto xAxis = static_cast<std::size_t>(axes[0]);
+    const auto yAxis = static_cast<std::size_t>(axes[1]);
+    const auto& region = plane.physicalRegion;
+    const auto xExtent = region.upper[xAxis] - region.lower[xAxis];
+    const auto yExtent = region.upper[yAxis] - region.lower[yAxis];
+    const auto x0 = region.lower[xAxis]
+        + visible.left() / plane.width * xExtent;
+    const auto x1 = region.lower[xAxis]
+        + visible.right() / plane.width * xExtent;
+    const auto y0 = region.upper[yAxis]
+        - visible.bottom() / plane.height * yExtent;
+    const auto y1 = region.upper[yAxis]
+        - visible.top() / plane.height * yExtent;
+    return QRectF(QPointF(x0, y0), QPointF(x1, y1)).normalized();
+}
+
 void MainWindow::panActiveViewForTest(
     double sceneDeltaX, double sceneDeltaY)
 {
@@ -5184,12 +5256,6 @@ std::optional<QRectF> MainWindow::preservedDataWindow(
     }
     const auto& cached = *state.plane;
     const auto axes = displayAxes(state.normal);
-    // Equal densities (or degenerate geometry) mean the preserved scene
-    // transform already preserves the on-screen data, so leave it alone; the
-    // coordinator owns that decision.
-    if (!DisplayCoordinator::planeDensitiesDiffer(cached, incoming, axes)) {
-        return std::nullopt;
-    }
     const auto xAxis = static_cast<std::size_t>(axes[0]);
     const auto yAxis = static_cast<std::size_t>(axes[1]);
     const auto& oldRegion = cached.physicalRegion;
@@ -5275,22 +5341,29 @@ void MainWindow::showSlice(PlaneViewState& state, const SliceDisplayResult& disp
         } else {
             // Preserve/Refit/GeometryAware from the cached-vs-incoming request
             // pair; the rationale lives with the decision in the coordinator.
-            const auto transformPolicy = DisplayCoordinator::rasterTransformPolicy(
-                state.hasCachedRequest, state.cachedRequest, display.request,
-                state.visibleRegion.has_value());
-            // Preserve keeps the scene transform, which is only equivalent to
-            // keeping what the user sees while the raster's pixels-per-data
-            // density is unchanged. A zoomed re-slice can arrive denser: the
-            // full-domain raster is capped at maxSliceOutputDimension while a
-            // subregion fits under the cap, so preserving the scene transform
-            // would show the crop over-zoomed with part of it off screen
-            // (issue #45). When the density changes, preserve the visible *data*
-            // window instead: capture the viewport in physical coordinates
-            // through the old plane's geometry before the swap, then re-frame
-            // that window through the new plane's geometry after it. Equal
-            // densities (pan, uncapped zoom) keep the plain Preserve behavior.
+            const auto& metadata = m_dataset->metadata();
+            const DisplayCoordinator::RasterGeometry incomingGeometry{
+                metadata.physicalDomain, metadata.dimension,
+                metadata.coordinateSystem, display.request.normalDirection,
+                display.sphericalDisplay};
+            const auto transformPolicy
+                = DisplayCoordinator::rasterTransformPolicy(
+                    state.rasterGeometry, incomingGeometry);
+            // Preserve Custom mode by capturing the visible physical window
+            // through the old plane and re-framing it through the new one.
+            // This is required when pixel density changes (issue #45), and it
+            // also protects same-density sequence replacements from scene or
+            // scrollbar recentering while the pixmap item is replaced.
             std::optional<QRectF> dataWindowInNewScene;
-            if (transformPolicy == ImageTransformPolicy::Preserve) {
+            const auto axes = displayAxes(state.normal);
+            const bool ownerChanged = state.hasCachedRequest
+                && state.cachedRequest.dataset != display.request.dataset;
+            const bool densityChanged = DisplayCoordinator::planeDensitiesDiffer(
+                *state.plane, display.slice.plane, axes);
+            if (transformPolicy == ImageTransformPolicy::Preserve
+                && state.view->transformMode()
+                    == ImageView::TransformMode::Custom
+                && (ownerChanged || densityChanged)) {
                 dataWindowInNewScene = preservedDataWindow(
                     state, display.slice.plane);
             }
@@ -5299,6 +5372,7 @@ void MainWindow::showSlice(PlaneViewState& state, const SliceDisplayResult& disp
             if (dataWindowInNewScene) {
                 state.view->zoomToRect(*dataWindowInNewScene);
             }
+            state.rasterGeometry = incomingGeometry;
         }
     }
     // Fresh immutable snapshots: replace the pointers, never mutate the

--- a/src/qt/MainWindow.hpp
+++ b/src/qt/MainWindow.hpp
@@ -154,6 +154,10 @@ public:
     // Test-only: apply a panel-local scale, drive the exact data-region pan
     // handlers used by Shift+left drag, and inspect the resulting transform.
     void setActiveViewScaleForTest(int factor);
+    void selectFixedScaleForTest(int factor);
+    [[nodiscard]] bool fixedScaleStateMatchesForTest(int factor) const;
+    void wheelZoomAndPanActiveViewForTest();
+    [[nodiscard]] QRectF activeViewVisibleDataWindowForTest() const;
     void panActiveViewForTest(double sceneDeltaX, double sceneDeltaY);
     [[nodiscard]] qreal activeViewScaleForTest() const;
     // Test-only: compare the current transform with ImageView's own fitted
@@ -262,6 +266,7 @@ private:
         int coordinateSystem = 0;
         SphericalDisplay sphericalDisplay = SphericalDisplay::RZ;
         RealBox displayRegion;
+        std::optional<DisplayCoordinator::RasterGeometry> rasterGeometry;
         double displayMinimum = 0.0;
         double displayMaximum = 1.0;
         bool displayLogarithmic = false;

--- a/src/qt/main.cpp
+++ b/src/qt/main.cpp
@@ -1091,10 +1091,87 @@ int main(int argc, char* argv[])
             window.openSequence({first, second});
         });
     } else if (argc == 4
-        && std::string_view(argv[1]) == "--sequence-zoom-refit-smoke-test") {
+        && std::string_view(argv[1])
+            == "--fixed-scale-arrival-smoke-test") {
+        const std::filesystem::path path(argv[2]);
+        const int factor = std::stoi(argv[3]);
+        QObject::connect(&window, &amrvis::qt::MainWindow::initialSliceFinished,
+            &application, [&window, &application, factor](bool success) {
+                if (!success) {
+                    application.exit(2);
+                    return;
+                }
+                window.selectFixedScaleForTest(factor);
+                QObject::connect(&window,
+                    &amrvis::qt::MainWindow::interactiveSlicesSettled,
+                    &application, [&window, &application, factor] {
+                        application.exit(
+                            window.fixedScaleStateMatchesForTest(factor)
+                                ? 0 : 1);
+                    }, Qt::SingleShotConnection);
+                // Force an asynchronous replacement raster after selecting the
+                // scale, reproducing the delayed-arrival race.
+                window.enableVisibleRasterForTest();
+            }, Qt::SingleShotConnection);
+        QTimer::singleShot(15000, &application,
+            [&application] { application.exit(3); });
+        QTimer::singleShot(0, &window,
+            [&window, path] { window.openDataset(path); });
+    } else if (argc == 4
+        && std::string_view(argv[1])
+            == "--sequence-transform-preserve-smoke-test") {
+        const std::filesystem::path first(argv[2]);
+        const std::filesystem::path second(argv[3]);
+        auto before = std::make_shared<QRectF>();
+        QObject::connect(&window,
+            &amrvis::qt::MainWindow::sequenceFrameDisplayed,
+            &application, [&window, &application, before](int index) {
+                if (index == 0) {
+                    window.wheelZoomAndPanActiveViewForTest();
+                    *before = window.activeViewVisibleDataWindowForTest();
+                    window.stepSequence(1);
+                    return;
+                }
+                if (index != 1) {
+                    return;
+                }
+                const auto after
+                    = window.activeViewVisibleDataWindowForTest();
+                const auto close = [](double lhs, double rhs) {
+                    return std::fabs(lhs - rhs) <= 3.0e-2
+                        * std::max({1.0, std::fabs(lhs), std::fabs(rhs)});
+                };
+                const bool preserved = !window.activeViewFitsWindowForTest()
+                        && close(before->left(), after.left())
+                        && close(before->top(), after.top())
+                        && close(before->width(), after.width())
+                        && close(before->height(), after.height());
+                if (!preserved) {
+                    std::fprintf(stderr,
+                        "transform preservation mismatch: fit=%d "
+                        "before=(%.17g,%.17g %.17gx%.17g) "
+                        "after=(%.17g,%.17g %.17gx%.17g)\n",
+                        window.activeViewFitsWindowForTest() ? 1 : 0,
+                        before->x(), before->y(), before->width(),
+                        before->height(), after.x(), after.y(), after.width(),
+                        after.height());
+                }
+                application.exit(preserved ? 0 : 1);
+            });
+        QObject::connect(&window,
+            &amrvis::qt::MainWindow::sequenceFrameFailed,
+            &application, [&application] { application.exit(2); });
+        QTimer::singleShot(15000, &application,
+            [&application] { application.exit(3); });
+        QTimer::singleShot(0, &window, [&window, first, second] {
+            window.openSequence({first, second});
+        });
+    } else if (argc == 4
+        && std::string_view(argv[1])
+            == "--sequence-density-preserve-smoke-test") {
         // Preserve a physical crop while moving from an 8x8 frame to an 8x12
-        // frame. The incoming raster has a different geometry and must be
-        // fitted instead of inheriting the first raster's pixel transform.
+        // frame. Pixel density changes, but the physical geometry is
+        // compatible, so Custom mode must preserve the data window.
         const std::filesystem::path first(argv[2]);
         const std::filesystem::path second(argv[3]);
         auto zoomSettled = std::make_shared<bool>(false);
@@ -1114,7 +1191,7 @@ int main(int argc, char* argv[])
                     application.exit(
                         *zoomSettled
                             && window.activeViewIsZoomedForTest()
-                            && window.activeViewIsFitToWindowForTest()
+                            && !window.activeViewIsFitToWindowForTest()
                         ? 0 : 1);
                 }
             });
@@ -1125,13 +1202,13 @@ int main(int argc, char* argv[])
         });
     } else if (argc == 4
         && std::string_view(argv[1])
-            == "--sequence-equal-size-zoom-refit-smoke-test") {
+            == "--sequence-equal-size-transform-preserve-smoke-test") {
         // Exercise the timing edge directly: the first frame's full-domain
         // raster is 8x8. Rubber-band zoom changes the view transform and queues
         // a 4x4 crop, but stepping immediately cancels that work. The second
         // frame is 16x16, so its central-half crop is also 8x8. A size-only
-        // transform policy mistakes that cropped raster for the cached full
-        // raster and leaves only part of the new image visible.
+        // transform policy must use physical compatibility rather than the
+        // fresh dataset id or equal raster dimensions.
         const std::filesystem::path first(argv[2]);
         const std::filesystem::path second(argv[3]);
         QObject::connect(&window, &amrvis::qt::MainWindow::sequenceFrameDisplayed,
@@ -1142,12 +1219,36 @@ int main(int argc, char* argv[])
                 } else if (index == 1) {
                     application.exit(
                         window.activeViewIsZoomedForTest()
-                            && window.activeViewIsFitToWindowForTest()
+                            && !window.activeViewIsFitToWindowForTest()
                         ? 0 : 1);
                 }
             });
         QObject::connect(&window, &amrvis::qt::MainWindow::sequenceFrameFailed,
             &application, [&application] { application.exit(1); });
+        QTimer::singleShot(0, &window, [&window, first, second] {
+            window.openSequence({first, second});
+        });
+    } else if (argc == 4
+        && std::string_view(argv[1])
+            == "--sequence-geometry-refit-smoke-test") {
+        const std::filesystem::path first(argv[2]);
+        const std::filesystem::path second(argv[3]);
+        QObject::connect(&window,
+            &amrvis::qt::MainWindow::sequenceFrameDisplayed,
+            &application, [&window, &application](int index) {
+                if (index == 0) {
+                    window.wheelZoomAndPanActiveViewForTest();
+                    window.stepSequence(1);
+                } else if (index == 1) {
+                    application.exit(
+                        window.activeViewIsFitToWindowForTest() ? 0 : 1);
+                }
+            });
+        QObject::connect(&window,
+            &amrvis::qt::MainWindow::sequenceFrameFailed,
+            &application, [&application] { application.exit(2); });
+        QTimer::singleShot(15000, &application,
+            [&application] { application.exit(3); });
         QTimer::singleShot(0, &window, [&window, first, second] {
             window.openSequence({first, second});
         });

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -621,35 +621,74 @@ if(TARGET amrexplorer_qt)
             -P "${CMAKE_CURRENT_SOURCE_DIR}/qt_smoke_driver.cmake"
     )
     set_tests_properties(qt_sequence_spec_change_smoke PROPERTIES TIMEOUT 30)
-    # A preserved physical crop rendered at a different raster resolution in
-    # the next sequence frame must refit instead of retaining a stale transform.
+    foreach(factor IN ITEMS 1 4)
+        add_test(
+            NAME qt_fixed_scale_${factor}x_arrival_smoke
+            COMMAND "${CMAKE_COMMAND}"
+                "-DMATERIALIZER=$<TARGET_FILE:fixture_materializer>"
+                "-DAMREXPLORER_QT=$<TARGET_FILE:amrexplorer_qt>"
+                "-DSOURCE=${CMAKE_CURRENT_SOURCE_DIR}/data/plotfile_2d"
+                "-DWORK=${CMAKE_CURRENT_BINARY_DIR}/fixtures_fixed_scale_${factor}x"
+                "-DMODE=fixed-scale-${factor}"
+                -P "${CMAKE_CURRENT_SOURCE_DIR}/qt_smoke_driver.cmake"
+        )
+        set_tests_properties(
+            qt_fixed_scale_${factor}x_arrival_smoke PROPERTIES TIMEOUT 30)
+    endforeach()
     add_test(
-        NAME qt_sequence_zoom_refit_smoke
+        NAME qt_sequence_transform_preserve_smoke
+        COMMAND "${CMAKE_COMMAND}"
+            "-DMATERIALIZER=$<TARGET_FILE:fixture_materializer>"
+            "-DAMREXPLORER_QT=$<TARGET_FILE:amrexplorer_qt>"
+            "-DSOURCE=${CMAKE_CURRENT_SOURCE_DIR}/data/plotfile_2d"
+            "-DWORK=${CMAKE_CURRENT_BINARY_DIR}/fixtures_sequence_transform_preserve"
+            -DMODE=sequence-transform-preserve
+            -P "${CMAKE_CURRENT_SOURCE_DIR}/qt_smoke_driver.cmake"
+    )
+    set_tests_properties(
+        qt_sequence_transform_preserve_smoke PROPERTIES TIMEOUT 30)
+    # A compatible physical crop rendered at a different raster resolution in
+    # the next sequence frame preserves its visible data window.
+    add_test(
+        NAME qt_sequence_density_preserve_smoke
         COMMAND "${CMAKE_COMMAND}"
             "-DMATERIALIZER=$<TARGET_FILE:fixture_materializer>"
             "-DAMREXPLORER_QT=$<TARGET_FILE:amrexplorer_qt>"
             "-DSOURCE=${CMAKE_CURRENT_SOURCE_DIR}/data/plotfile_2d"
             "-DSECOND_SOURCE=${CMAKE_CURRENT_SOURCE_DIR}/data/plotfile_nonuniform"
-            "-DWORK=${CMAKE_CURRENT_BINARY_DIR}/fixtures_sequence_zoom_refit"
-            -DMODE=sequence-zoom-refit
+            "-DWORK=${CMAKE_CURRENT_BINARY_DIR}/fixtures_sequence_density_preserve"
+            -DMODE=sequence-density-preserve
             -P "${CMAKE_CURRENT_SOURCE_DIR}/qt_smoke_driver.cmake"
     )
-    set_tests_properties(qt_sequence_zoom_refit_smoke PROPERTIES TIMEOUT 30)
+    set_tests_properties(
+        qt_sequence_density_preserve_smoke PROPERTIES TIMEOUT 30)
     # Regression test for the sequence timing edge: if frame stepping cancels
     # a rubber-band crop before its raster lands, the next frame's cropped
     # raster can have the same pixel dimensions as the cached full-domain
     # raster. The incompatible full-domain transform must still be discarded.
     add_test(
-        NAME qt_sequence_equal_size_zoom_refit_smoke
+        NAME qt_sequence_equal_size_transform_preserve_smoke
         COMMAND "${CMAKE_COMMAND}"
             "-DMATERIALIZER=$<TARGET_FILE:fixture_materializer>"
             "-DAMREXPLORER_QT=$<TARGET_FILE:amrexplorer_qt>"
             "-DSOURCE=${CMAKE_CURRENT_SOURCE_DIR}/data/plotfile_2d"
             "-DSECOND_SOURCE=${CMAKE_CURRENT_SOURCE_DIR}/data/plotfile_refined_2d"
-            "-DWORK=${CMAKE_CURRENT_BINARY_DIR}/fixtures_sequence_equal_size_zoom_refit"
-            -DMODE=sequence-equal-size-zoom-refit
+            "-DWORK=${CMAKE_CURRENT_BINARY_DIR}/fixtures_sequence_equal_size_transform_preserve"
+            -DMODE=sequence-equal-size-transform-preserve
             -P "${CMAKE_CURRENT_SOURCE_DIR}/qt_smoke_driver.cmake"
     )
     set_tests_properties(
-        qt_sequence_equal_size_zoom_refit_smoke PROPERTIES TIMEOUT 30)
+        qt_sequence_equal_size_transform_preserve_smoke PROPERTIES TIMEOUT 30)
+    add_test(
+        NAME qt_sequence_geometry_refit_smoke
+        COMMAND "${CMAKE_COMMAND}"
+            "-DMATERIALIZER=$<TARGET_FILE:fixture_materializer>"
+            "-DAMREXPLORER_QT=$<TARGET_FILE:amrexplorer_qt>"
+            "-DSOURCE=${CMAKE_CURRENT_SOURCE_DIR}/data/plotfile_2d"
+            "-DWORK=${CMAKE_CURRENT_BINARY_DIR}/fixtures_sequence_geometry_refit"
+            -DMODE=sequence-geometry-refit
+            -P "${CMAKE_CURRENT_SOURCE_DIR}/qt_smoke_driver.cmake"
+    )
+    set_tests_properties(
+        qt_sequence_geometry_refit_smoke PROPERTIES TIMEOUT 30)
 endif()

--- a/tests/fixture_materializer/main.cpp
+++ b/tests/fixture_materializer/main.cpp
@@ -18,6 +18,7 @@
 #include <cstdlib>
 #include <filesystem>
 #include <fstream>
+#include <iomanip>
 #include <iostream>
 #include <limits>
 #include <optional>
@@ -44,6 +45,7 @@ struct FixtureHeader {
     int fieldCount = 0;
     int dimension = 0;
     std::size_t timeLine = 0;
+    std::size_t physicalUpperLine = 0;
 };
 
 // Plotfile Header layout: version, field count, one line per field name,
@@ -67,6 +69,7 @@ FixtureHeader readHeader(const std::filesystem::path& path)
         "the fixture Header is missing its dimension/time lines");
     header.dimension = std::stoi(header.lines[dimensionLine]);
     header.timeLine = dimensionLine + 1;
+    header.physicalUpperLine = header.timeLine + 3;
     require(header.dimension == 2 || header.dimension == 3,
         "the fixture is neither 2-D nor 3-D");
     return header;
@@ -277,9 +280,10 @@ void writeHeaderWithoutStatistics(const std::filesystem::path& path,
 
 int main(int argc, char* argv[])
 {
-    require(argc >= 3 && argc <= 8,
+    require(argc >= 3 && argc <= 10,
         "usage: fixture_materializer <sourceFixtureDir> <destDir> "
-        "[newTime] [--no-statistics] [--non-finite] [--scale <factor>]");
+        "[newTime] [--no-statistics] [--non-finite] [--scale <factor>] "
+        "[--domain-upper-x <value>]");
     const std::filesystem::path source(argv[1]);
     const std::filesystem::path destination(argv[2]);
     std::optional<std::string> newTime;
@@ -288,6 +292,7 @@ int main(int argc, char* argv[])
     // Multiplies the synthesized field values so successive frames of a
     // sequence can carry different ranges (used by the range-cache test).
     double scale = 1.0;
+    std::optional<double> domainUpperX;
     for (int argument = 3; argument < argc; ++argument) {
         const std::string value(argv[argument]);
         if (value == "--no-statistics") {
@@ -305,6 +310,14 @@ int main(int argc, char* argv[])
                 scale = std::stod(factor);
             } catch (const std::exception&) {
                 require(false, "--scale factor is not a number");
+            }
+        } else if (value == "--domain-upper-x") {
+            require(argument + 1 < argc,
+                "--domain-upper-x requires a value");
+            try {
+                domainUpperX = std::stod(argv[++argument]);
+            } catch (const std::exception&) {
+                require(false, "--domain-upper-x value is not a number");
             }
         } else {
             require(!newTime.has_value(), "more than one new time was specified");
@@ -326,9 +339,31 @@ int main(int argc, char* argv[])
         source, destination, std::filesystem::copy_options::recursive, error);
     require(!error, "could not copy the fixture");
 
-    if (newTime.has_value()) {
+    if (newTime.has_value() || domainUpperX.has_value()) {
         auto lines = header.lines;
-        lines[header.timeLine] = *newTime;
+        if (newTime.has_value()) {
+            lines[header.timeLine] = *newTime;
+        }
+        if (domainUpperX.has_value()) {
+            std::istringstream input(lines[header.physicalUpperLine]);
+            std::vector<double> upper(
+                static_cast<std::size_t>(header.dimension));
+            for (auto& coordinate : upper) {
+                input >> coordinate;
+            }
+            require(static_cast<bool>(input),
+                "could not parse the Header physical upper bound");
+            upper[0] = *domainUpperX;
+            std::ostringstream output;
+            output << std::setprecision(17);
+            for (std::size_t axis = 0; axis < upper.size(); ++axis) {
+                if (axis != 0) {
+                    output << ' ';
+                }
+                output << upper[axis];
+            }
+            lines[header.physicalUpperLine] = output.str();
+        }
         std::ofstream output(destination / "Header", std::ios::trunc);
         require(static_cast<bool>(output), "could not rewrite the Header");
         for (const auto& line : lines) {

--- a/tests/qt_smoke_driver.cmake
+++ b/tests/qt_smoke_driver.cmake
@@ -13,7 +13,10 @@
 #                 particle-visible-range |
 #                 rubber-zoom-local | rubber-overzoom | pan-zoom |
 #                 range-cache | fab-zoom | cache-budget |
-#                 sequence-zoom-refit | sequence-equal-size-zoom-refit
+#                 fixed-scale-1 | fixed-scale-4 | sequence-transform-preserve |
+#                 sequence-density-preserve |
+#                 sequence-equal-size-transform-preserve |
+#                 sequence-geometry-refit
 foreach(argument MATERIALIZER AMREXPLORER_QT SOURCE WORK MODE)
     if(NOT DEFINED ${argument})
         message(FATAL_ERROR "qt_smoke_driver.cmake requires -D${argument}=...")
@@ -61,24 +64,44 @@ elseif(MODE STREQUAL "sequence-spec-change")
     run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt00010" "2.5")
     run_or_die("${AMREXPLORER_QT}" --sequence-spec-change-smoke-test
         "${WORK}/plt00000" "${WORK}/plt00010")
-elseif(MODE STREQUAL "sequence-zoom-refit")
+elseif(MODE STREQUAL "fixed-scale-1" OR MODE STREQUAL "fixed-scale-4")
+    run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt")
+    if(MODE STREQUAL "fixed-scale-1")
+        set(factor 1)
+    else()
+        set(factor 4)
+    endif()
+    run_or_die("${AMREXPLORER_QT}" --fixed-scale-arrival-smoke-test
+        "${WORK}/plt" "${factor}")
+elseif(MODE STREQUAL "sequence-transform-preserve")
+    run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt00000")
+    run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt00010" "2.5")
+    run_or_die("${AMREXPLORER_QT}" --sequence-transform-preserve-smoke-test
+        "${WORK}/plt00000" "${WORK}/plt00010")
+elseif(MODE STREQUAL "sequence-density-preserve")
     if(NOT DEFINED SECOND_SOURCE)
         message(FATAL_ERROR
-            "sequence-zoom-refit requires -DSECOND_SOURCE=...")
+            "sequence-density-preserve requires -DSECOND_SOURCE=...")
     endif()
     run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt00000")
     run_or_die("${MATERIALIZER}" "${SECOND_SOURCE}" "${WORK}/plt00010")
-    run_or_die("${AMREXPLORER_QT}" --sequence-zoom-refit-smoke-test
+    run_or_die("${AMREXPLORER_QT}" --sequence-density-preserve-smoke-test
         "${WORK}/plt00000" "${WORK}/plt00010")
-elseif(MODE STREQUAL "sequence-equal-size-zoom-refit")
+elseif(MODE STREQUAL "sequence-equal-size-transform-preserve")
     if(NOT DEFINED SECOND_SOURCE)
         message(FATAL_ERROR
-            "sequence-equal-size-zoom-refit requires -DSECOND_SOURCE=...")
+            "sequence-equal-size-transform-preserve requires -DSECOND_SOURCE=...")
     endif()
     run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt00000")
     run_or_die("${MATERIALIZER}" "${SECOND_SOURCE}" "${WORK}/plt00010")
     run_or_die("${AMREXPLORER_QT}"
-        --sequence-equal-size-zoom-refit-smoke-test
+        --sequence-equal-size-transform-preserve-smoke-test
+        "${WORK}/plt00000" "${WORK}/plt00010")
+elseif(MODE STREQUAL "sequence-geometry-refit")
+    run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt00000")
+    run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt00010" "2.5"
+        --domain-upper-x "2.0")
+    run_or_die("${AMREXPLORER_QT}" --sequence-geometry-refit-smoke-test
         "${WORK}/plt00000" "${WORK}/plt00010")
 elseif(MODE STREQUAL "missing-range")
     run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt" "--no-statistics")

--- a/tests/unit/test_display_coordinator.cpp
+++ b/tests/unit/test_display_coordinator.cpp
@@ -361,12 +361,12 @@ int main()
                 true, cached, makeRequest(1, 2, 0.0), true)
                 == ImageTransformPolicy::Refit,
             "an orientation change should refit");
-        // A different dataset with an identical region and normal keeps the
-        // geometry-aware default (same pixel-to-data mapping).
+        // A different dataset always refits: equal raster dimensions do not
+        // prove that its physical geometry is compatible.
         require(DisplayCoordinator::rasterTransformPolicy(
                 true, cached, makeRequest(2, 1, 0.0), true)
-                == ImageTransformPolicy::GeometryAware,
-            "a same-region dataset swap should stay geometry-aware");
+                == ImageTransformPolicy::Refit,
+            "a same-region dataset swap should refit");
     }
 
     return 0;

--- a/tests/unit/test_display_coordinator.cpp
+++ b/tests/unit/test_display_coordinator.cpp
@@ -332,41 +332,49 @@ int main()
 
     // --- rasterTransformPolicy ----------------------------------------------
     {
-        const auto cached = makeRequest(1, 1, 0.0);
+        const DisplayCoordinator::RasterGeometry geometry{
+            makeRequest(1, 1, 0.0).visibleRegion, 2, 0, 1,
+            amrvis::SphericalDisplay::RZ};
 
         require(DisplayCoordinator::rasterTransformPolicy(
-                false, cached, cached, true)
+                std::nullopt, geometry)
                 == ImageTransformPolicy::GeometryAware,
             "no cache should be geometry-aware");
 
-        // Zoomed panel-local refresh (same dataset + normal): preserve, even
-        // when the region moved (pan) or shrank (zoom).
+        // A fresh DatasetId is irrelevant when the physical raster geometry is
+        // compatible, so same-geometry sequence frames preserve the mode.
         require(DisplayCoordinator::rasterTransformPolicy(
-                true, cached, makeRequest(1, 1, 0.5), true)
+                geometry, geometry)
                 == ImageTransformPolicy::Preserve,
-            "a zoomed same-panel refresh should preserve");
-        require(DisplayCoordinator::rasterTransformPolicy(
-                true, cached, cached, false)
-                == ImageTransformPolicy::GeometryAware,
-            "an unzoomed same-panel refresh should be geometry-aware");
+            "compatible physical geometry should preserve");
 
-        // A different dataset whose region differs must refit even when the
-        // raster dimensions coincide (the equal-size frame-step trap).
+        auto incompatible = geometry;
+        incompatible.physicalDomain.upper[0] = 2.0;
         require(DisplayCoordinator::rasterTransformPolicy(
-                true, cached, makeRequest(2, 1, 0.5), true)
+                geometry, incompatible)
                 == ImageTransformPolicy::Refit,
-            "a cross-dataset region change should refit");
-        // A different normal must refit regardless of dataset.
+            "a physical-domain change should refit");
+
+        incompatible = geometry;
+        incompatible.coordinateSystem = 1;
         require(DisplayCoordinator::rasterTransformPolicy(
-                true, cached, makeRequest(1, 2, 0.0), true)
+                geometry, incompatible)
                 == ImageTransformPolicy::Refit,
-            "an orientation change should refit");
-        // A different dataset always refits: equal raster dimensions do not
-        // prove that its physical geometry is compatible.
+            "a coordinate-system change should refit");
+
+        incompatible = geometry;
+        incompatible.normalDirection = 2;
         require(DisplayCoordinator::rasterTransformPolicy(
-                true, cached, makeRequest(2, 1, 0.0), true)
+                geometry, incompatible)
                 == ImageTransformPolicy::Refit,
-            "a same-region dataset swap should refit");
+            "a normal-direction change should refit");
+
+        incompatible = geometry;
+        incompatible.sphericalDisplay = amrvis::SphericalDisplay::ThetaR;
+        require(DisplayCoordinator::rasterTransformPolicy(
+                geometry, incompatible)
+                == ImageTransformPolicy::Refit,
+            "a displayed-orientation change should refit");
     }
 
     return 0;


### PR DESCRIPTION
Part 2 of 13 in the remote client/server stack.

## Purpose

Make raster replacement safe when a later dataset or sequence frame has a different identity but happens to use the same pixel dimensions.

## Scope

- Includes dataset identity in display-transform decisions.
- Refits incompatible arrivals while preserving compatible zoom behavior.
- Adds the focused display-coordinator regression.

## Review focus

This is an independent prerequisite: it changes no remote APIs and should be judged as a local display-correctness fix.

## Validation

- `display_coordinator`
- Existing Qt sequence zoom/refit smokes at the stack tip
