### PR TITLE
[client-server] route local data access through DatasetSession

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,7 @@ add_subdirectory(src/core)
 add_subdirectory(src/cache)
 add_subdirectory(src/io)
 add_subdirectory(src/query)
+add_subdirectory(src/data)
 add_subdirectory(src/render2d)
 add_subdirectory(src/pipeline)
 

--- a/include/amrexplorer/core/StopToken.hpp
+++ b/include/amrexplorer/core/StopToken.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <stdexcept>
 #include <version>
 
 #if !defined(AMREXPLORER_TEST_FORCE_FALLBACK_STOP_TOKEN) \
@@ -89,3 +90,13 @@ private:
 } // namespace amrvis
 
 #endif
+
+namespace amrvis {
+
+// Common cancellation outcome for metadata, block, particle, and remote I/O.
+class ReadCancelled : public std::runtime_error {
+public:
+    ReadCancelled() : std::runtime_error("read cancelled") {}
+};
+
+} // namespace amrvis

--- a/include/amrexplorer/data/DatasetPage.hpp
+++ b/include/amrexplorer/data/DatasetPage.hpp
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <amrexplorer/core/Geometry.hpp>
+#include <amrexplorer/core/Request.hpp>
+#include <amrexplorer/core/StopToken.hpp>
+
+#include <array>
+#include <cstdint>
+#include <vector>
+
+namespace amrvis {
+
+class PlotfileDataset;
+
+inline constexpr int datasetPageMaxExtent = 512;
+
+struct DatasetPageRequest {
+    DatasetId dataset;
+    FieldId field;
+    int level = 0;
+    RealBox region;
+    int normalAxis = 2;
+    double slicePosition = 0.0;
+    int maximumExtent = datasetPageMaxExtent;
+};
+
+struct DatasetPage {
+    std::array<int, 2> lower{0, 0};
+    std::array<int, 2> upper{-1, -1};
+    int nx = 0;
+    int ny = 0;
+    int sliceIndex = 0;
+    std::vector<float> values;
+    std::vector<std::uint8_t> covered;
+    double minimum = 0.0;
+    double maximum = 0.0;
+    bool hasFiniteValues = false;
+    bool truncatedX = false;
+    bool truncatedY = false;
+};
+
+[[nodiscard]] DatasetPage extractDatasetPage(
+    PlotfileDataset& dataset, const DatasetPageRequest& request,
+    StopToken cancellation = {});
+
+} // namespace amrvis

--- a/include/amrexplorer/data/DatasetSession.hpp
+++ b/include/amrexplorer/data/DatasetSession.hpp
@@ -40,6 +40,14 @@ public:
     [[nodiscard]] virtual const std::string& fileVersion() const noexcept = 0;
     [[nodiscard]] virtual const std::vector<ParticleSpeciesMetadata>&
     particleSpecies() const noexcept = 0;
+    // The largest encoded response accepted by this session. Local sessions
+    // have no transport frame budget; remote sessions expose the negotiated
+    // value so request planning can stay below it.
+    [[nodiscard]] virtual std::optional<std::uint32_t> maximumResponseBytes()
+        const noexcept
+    {
+        return std::nullopt;
+    }
 
     [[nodiscard]] virtual ViewDataResult requestView(
         const ViewDataRequest& request, StopToken cancellation = {}) = 0;

--- a/include/amrexplorer/data/DatasetSession.hpp
+++ b/include/amrexplorer/data/DatasetSession.hpp
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <amrexplorer/cache/CacheMetrics.hpp>
+#include <amrexplorer/core/Metadata.hpp>
+#include <amrexplorer/core/Request.hpp>
+#include <amrexplorer/core/Statistics.hpp>
+#include <amrexplorer/core/StopToken.hpp>
+#include <amrexplorer/data/DatasetPage.hpp>
+#include <amrexplorer/data/ViewData.hpp>
+#include <amrexplorer/io/ParticleReader.hpp>
+#include <amrexplorer/io/PlotfileMetadataReader.hpp>
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace amrvis {
+
+enum class RangeScope : std::uint8_t {
+    File,
+    Level
+};
+
+struct RangeRequest {
+    FieldId field;
+    int maximumLevel = 0;
+    CompositionPolicy composition = CompositionPolicy::FinestAvailable;
+    RangeScope scope = RangeScope::File;
+};
+
+class DatasetSession {
+public:
+    virtual ~DatasetSession() = default;
+
+    [[nodiscard]] virtual DatasetId id() const noexcept = 0;
+    [[nodiscard]] virtual const DatasetMetadata& metadata() const noexcept = 0;
+    [[nodiscard]] virtual const MetadataReadMetrics& metadataReadMetrics()
+        const noexcept = 0;
+    [[nodiscard]] virtual const std::string& fileVersion() const noexcept = 0;
+    [[nodiscard]] virtual const std::vector<ParticleSpeciesMetadata>&
+    particleSpecies() const noexcept = 0;
+
+    [[nodiscard]] virtual ViewDataResult requestView(
+        const ViewDataRequest& request, StopToken cancellation = {}) = 0;
+    [[nodiscard]] virtual DatasetPage requestDatasetPage(
+        const DatasetPageRequest& request, StopToken cancellation = {}) = 0;
+    [[nodiscard]] virtual std::optional<ValueRange> requestRange(
+        const RangeRequest& request, StopToken cancellation = {}) = 0;
+    [[nodiscard]] virtual bool rangeAvailable(
+        const RangeRequest& request) const noexcept = 0;
+    [[nodiscard]] virtual ParticleSample requestParticleSample(
+        const std::string& species, double fraction, std::uint64_t seed,
+        StopToken cancellation = {}) = 0;
+
+    [[nodiscard]] virtual CacheMetrics cacheMetrics() const = 0;
+    [[nodiscard]] virtual bool setCacheBudget(std::uint64_t bytes) = 0;
+    virtual void clearUnpinnedCache() = 0;
+    virtual void close() noexcept = 0;
+};
+
+} // namespace amrvis

--- a/include/amrexplorer/data/LocalDatasetSession.hpp
+++ b/include/amrexplorer/data/LocalDatasetSession.hpp
@@ -1,0 +1,59 @@
+#pragma once
+
+#include <amrexplorer/data/DatasetSession.hpp>
+
+#include <filesystem>
+#include <memory>
+#include <mutex>
+
+namespace amrvis {
+
+class PlotfileDataset;
+
+class LocalDatasetSession final : public DatasetSession {
+public:
+    explicit LocalDatasetSession(
+        std::shared_ptr<PlotfileDataset> dataset, std::string fileVersion = {});
+    LocalDatasetSession(const std::filesystem::path& path, DatasetId id,
+        std::uint64_t cacheBudgetBytes);
+    LocalDatasetSession(std::filesystem::path dataRoot, DatasetId id,
+        std::uint64_t cacheBudgetBytes, PlotfileMetadataResult metadata);
+
+    [[nodiscard]] DatasetId id() const noexcept override;
+    [[nodiscard]] const DatasetMetadata& metadata() const noexcept override;
+    [[nodiscard]] const MetadataReadMetrics& metadataReadMetrics()
+        const noexcept override;
+    [[nodiscard]] const std::string& fileVersion() const noexcept override;
+    [[nodiscard]] const std::vector<ParticleSpeciesMetadata>& particleSpecies()
+        const noexcept override;
+
+    [[nodiscard]] ViewDataResult requestView(
+        const ViewDataRequest& request, StopToken cancellation = {}) override;
+    [[nodiscard]] DatasetPage requestDatasetPage(
+        const DatasetPageRequest& request, StopToken cancellation = {}) override;
+    [[nodiscard]] std::optional<ValueRange> requestRange(
+        const RangeRequest& request, StopToken cancellation = {}) override;
+    [[nodiscard]] bool rangeAvailable(
+        const RangeRequest& request) const noexcept override;
+    [[nodiscard]] ParticleSample requestParticleSample(
+        const std::string& species, double fraction, std::uint64_t seed,
+        StopToken cancellation = {}) override;
+
+    [[nodiscard]] CacheMetrics cacheMetrics() const override;
+    [[nodiscard]] bool setCacheBudget(std::uint64_t bytes) override;
+    void clearUnpinnedCache() override;
+    void close() noexcept override;
+
+private:
+    [[nodiscard]] std::shared_ptr<PlotfileDataset> requireDataset() const;
+
+    DatasetId m_id;
+    DatasetMetadata m_metadata;
+    MetadataReadMetrics m_metadataMetrics;
+    std::string m_fileVersion;
+    std::vector<ParticleSpeciesMetadata> m_particleSpecies;
+    mutable std::mutex m_mutex;
+    std::shared_ptr<PlotfileDataset> m_dataset;
+};
+
+} // namespace amrvis

--- a/include/amrexplorer/data/LocalDatasetSession.hpp
+++ b/include/amrexplorer/data/LocalDatasetSession.hpp
@@ -15,9 +15,10 @@ public:
     explicit LocalDatasetSession(
         std::shared_ptr<PlotfileDataset> dataset, std::string fileVersion = {});
     LocalDatasetSession(const std::filesystem::path& path, DatasetId id,
-        std::uint64_t cacheBudgetBytes);
+        std::uint64_t cacheBudgetBytes, StopToken cancellation = {});
     LocalDatasetSession(std::filesystem::path dataRoot, DatasetId id,
-        std::uint64_t cacheBudgetBytes, PlotfileMetadataResult metadata);
+        std::uint64_t cacheBudgetBytes, PlotfileMetadataResult metadata,
+        StopToken cancellation = {});
 
     [[nodiscard]] DatasetId id() const noexcept override;
     [[nodiscard]] const DatasetMetadata& metadata() const noexcept override;

--- a/include/amrexplorer/data/ViewData.hpp
+++ b/include/amrexplorer/data/ViewData.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <amrexplorer/core/Request.hpp>
+#include <amrexplorer/query/LineQuery.hpp>
+#include <amrexplorer/query/SliceQuery.hpp>
+
+#include <variant>
+
+namespace amrvis {
+
+struct LineViewRequest {
+    LineRequest query;
+    int outputWidth = 0;
+};
+
+using ViewDataRequest = std::variant<SliceRequest, LineViewRequest>;
+using ViewDataResult = std::variant<SliceQueryResult, LineQueryResult>;
+
+[[nodiscard]] LineQueryResult boundLineToViewport(
+    LineQueryResult result, int outputWidth);
+
+} // namespace amrvis

--- a/include/amrexplorer/io/ParticleReader.hpp
+++ b/include/amrexplorer/io/ParticleReader.hpp
@@ -51,7 +51,7 @@ public:
 };
 
 [[nodiscard]] std::vector<ParticleSpeciesMetadata> discoverParticleSpecies(
-    const std::filesystem::path& plotfile);
+    const std::filesystem::path& plotfile, StopToken cancellation = {});
 
 // Selection is a stable hash of the complete AMReX idcpu. File order, grid,
 // level, and current file ownership do not affect it; lower fractions are

--- a/include/amrexplorer/io/PlotfileBlockReader.hpp
+++ b/include/amrexplorer/io/PlotfileBlockReader.hpp
@@ -62,11 +62,6 @@ public:
     using std::runtime_error::runtime_error;
 };
 
-class ReadCancelled : public std::runtime_error {
-public:
-    ReadCancelled() : std::runtime_error("block read cancelled") {}
-};
-
 class PlotfileBlockReader {
 public:
     PlotfileBlockReader(

--- a/include/amrexplorer/io/PlotfileDataset.hpp
+++ b/include/amrexplorer/io/PlotfileDataset.hpp
@@ -24,9 +24,11 @@ public:
     };
 
     PlotfileDataset(
-        std::filesystem::path plotfile, DatasetId id, std::uint64_t cacheBudgetBytes);
+        std::filesystem::path plotfile, DatasetId id,
+        std::uint64_t cacheBudgetBytes, StopToken cancellation = {});
     PlotfileDataset(std::filesystem::path dataRoot, DatasetId id,
-        std::uint64_t cacheBudgetBytes, PlotfileMetadataResult metadata);
+        std::uint64_t cacheBudgetBytes, PlotfileMetadataResult metadata,
+        StopToken cancellation = {});
 
     [[nodiscard]] const DatasetMetadata& metadata() const noexcept;
     [[nodiscard]] const MetadataReadMetrics& metadataReadMetrics() const noexcept;

--- a/include/amrexplorer/pipeline/SlicePipeline.hpp
+++ b/include/amrexplorer/pipeline/SlicePipeline.hpp
@@ -4,6 +4,7 @@
 #include <amrexplorer/core/Request.hpp>
 #include <amrexplorer/core/Result.hpp>
 #include <amrexplorer/core/StopToken.hpp>
+#include <amrexplorer/data/DatasetSession.hpp>
 #include <amrexplorer/io/ParticleReader.hpp>
 #include <amrexplorer/io/PlotfileMetadataReader.hpp>
 #include <amrexplorer/pipeline/DisplayMode.hpp>
@@ -30,8 +31,6 @@
 // orchestrates these from its request/completion handlers.
 
 namespace amrvis {
-
-class PlotfileDataset;
 
 struct SliceDisplayResult {
     // The request that produced everything below; the GUI keeps it as the
@@ -82,7 +81,7 @@ struct SliceDisplayResult {
 };
 
 struct InitialSliceResult {
-    std::shared_ptr<PlotfileDataset> dataset;
+    std::shared_ptr<DatasetSession> dataset;
     // One entry per displayed view, ordered by normal axis (2-D: one entry).
     std::vector<SliceDisplayResult> displays;
     std::vector<ParticleSample> particles;
@@ -184,7 +183,7 @@ inline constexpr int maxSliceOutputDimension = 4096;
 
 // Executes the display slice and resolves its range, rendering the raster.
 [[nodiscard]] SliceDisplayResult executeSlice(
-    const std::shared_ptr<PlotfileDataset>& dataset, const SliceRequest& request,
+    const std::shared_ptr<DatasetSession>& dataset, const SliceRequest& request,
     RangeMode rangeMode,
     const std::optional<std::pair<double, double>>& userRange,
     bool logarithmic, const Palette& palette, StopToken cancellation);
@@ -192,7 +191,7 @@ inline constexpr int maxSliceOutputDimension = 4096;
 // Vector mode queries the U- and V-component planes independently and
 // derives arrow glyphs from them. Both slices share the raster request's
 // region, level, and output size so the planes line up sample for sample.
-void appendVectorGlyphs(const std::shared_ptr<PlotfileDataset>& dataset,
+void appendVectorGlyphs(const std::shared_ptr<DatasetSession>& dataset,
     SliceRequest request, FieldId uField, FieldId vField, int count,
     StopToken cancellation, SliceDisplayResult& result);
 
@@ -205,7 +204,7 @@ void appendVectorGlyphs(const std::shared_ptr<PlotfileDataset>& dataset,
 // error instead (plain untranslated text; the GUI wraps failures in its own
 // translated message).
 [[nodiscard]] SliceDisplayResult executeSliceWithFallback(
-    const std::shared_ptr<PlotfileDataset>& dataset, SliceRequest request,
+    const std::shared_ptr<DatasetSession>& dataset, SliceRequest request,
     RangeMode rangeMode,
     const std::optional<std::pair<double, double>>& userRange,
     bool logarithmic, const Palette& palette, DisplayMode displayMode,
@@ -215,7 +214,7 @@ void appendVectorGlyphs(const std::shared_ptr<PlotfileDataset>& dataset,
 // Extracts contour polylines for the request at data resolution and maps
 // them to display-plane pixel space; caches the fine plane on the result so
 // range and contour-count changes can re-extract without a new SliceQuery.
-void appendContours(const std::shared_ptr<PlotfileDataset>& dataset,
+void appendContours(const std::shared_ptr<DatasetSession>& dataset,
     const SliceRequest& request, int contourCount, double minimum,
     double maximum, bool logarithmic, StopToken cancellation,
     SliceDisplayResult& result);
@@ -228,7 +227,7 @@ void appendContours(const std::shared_ptr<PlotfileDataset>& dataset,
 // the view's pixmap. Vector glyphs are reused from the cache: they do not
 // depend on palette/log/range.
 [[nodiscard]] SliceDisplayResult refreshCachedSlice(
-    const std::shared_ptr<PlotfileDataset>& dataset,
+    const std::shared_ptr<DatasetSession>& dataset,
     const SliceRequest& request, ScalarPlane displayPlane,
     ScalarPlane contourPlane, ScalarPlane contourFinePlane,
     int contourFineFactor, std::vector<VectorSegment> vectors,
@@ -258,7 +257,7 @@ void recomputeContourPolylines(SliceDisplayResult& result);
 // names are ignored, matching the behavior needed when a plotfile sequence
 // frame does not contain every species selected on another frame.
 [[nodiscard]] std::vector<ParticleSample> loadParticleSamples(
-    const PlotfileDataset& dataset,
+    DatasetSession& dataset,
     std::span<const std::string> selectedSpecies, double fraction,
     std::uint64_t seed, StopToken cancellation = {});
 
@@ -275,5 +274,10 @@ void recomputeContourPolylines(SliceDisplayResult& result);
     StopToken cancellation,
     std::optional<PlotfileMetadataResult> preparedMetadata = std::nullopt,
     std::filesystem::path dataRoot = {});
+
+// Renders an already-open session using the same initial/frame pipeline.
+[[nodiscard]] InitialSliceResult executeSessionFrameLoad(
+    std::shared_ptr<DatasetSession> dataset, const FrameSliceSpec& spec,
+    StopToken cancellation);
 
 } // namespace amrvis

--- a/include/amrexplorer/pipeline/SliceRangeResolver.hpp
+++ b/include/amrexplorer/pipeline/SliceRangeResolver.hpp
@@ -4,14 +4,13 @@
 #include <amrexplorer/core/Request.hpp>
 #include <amrexplorer/core/Result.hpp>
 #include <amrexplorer/core/Statistics.hpp>
+#include <amrexplorer/data/DatasetSession.hpp>
 
 #include <memory>
 #include <optional>
 #include <utility>
 
 namespace amrvis {
-
-class PlotfileDataset;
 
 // How a slice's color-mapping range is chosen. Values are persisted (combo data
 // and QSettings), so their order must stay stable.
@@ -46,11 +45,14 @@ struct ResolvedRange {
 [[nodiscard]] RangeMode effectiveRangeMode(
     const DatasetMetadata& metadata, FieldId field, int maximumLevel,
     CompositionPolicy composition, RangeMode requested);
+[[nodiscard]] RangeMode effectiveRangeMode(
+    const std::shared_ptr<DatasetSession>& dataset, FieldId field,
+    int maximumLevel, CompositionPolicy composition, RangeMode requested);
 
 // The finite extrema of a standalone FAB's payload, or nullopt for non-FAB
 // datasets / all-non-finite data.
 [[nodiscard]] std::optional<std::pair<double, double>> fabDataRange(
-    const std::shared_ptr<PlotfileDataset>& dataset, FieldId field);
+    const std::shared_ptr<DatasetSession>& dataset, FieldId field);
 
 // The display range for a slice: the user's explicit range, the level/file
 // metadata range, or the finite extrema of the plane itself, padded so
@@ -58,7 +60,7 @@ struct ResolvedRange {
 // strictly positive throws, so the caller can fall back to linear. Shared by
 // executeSlice and the re-render-from-cache path, which must agree exactly.
 [[nodiscard]] std::pair<double, double> resolveRange(
-    const std::shared_ptr<PlotfileDataset>& dataset, FieldId field,
+    const std::shared_ptr<DatasetSession>& dataset, FieldId field,
     int maximumLevel, CompositionPolicy composition, RangeMode rangeMode,
     const std::optional<std::pair<double, double>>& userRange,
     bool logarithmic, const ScalarPlane& plane);
@@ -69,7 +71,7 @@ struct ResolvedRange {
 // whole slice. A slice with no finite values uses a neutral positive range and
 // can therefore remain logarithmic.
 [[nodiscard]] ResolvedRange resolveDisplayRange(
-    const std::shared_ptr<PlotfileDataset>& dataset, FieldId field,
+    const std::shared_ptr<DatasetSession>& dataset, FieldId field,
     int maximumLevel, CompositionPolicy composition, RangeMode rangeMode,
     const std::optional<std::pair<double, double>>& userRange,
     bool logarithmic, const ScalarPlane& plane);

--- a/src/data/CMakeLists.txt
+++ b/src/data/CMakeLists.txt
@@ -1,0 +1,21 @@
+add_library(amrexplorer_data
+    DatasetPage.cpp
+    LocalDatasetSession.cpp
+    ViewData.cpp
+)
+add_library(amrexplorer::data ALIAS amrexplorer_data)
+
+target_include_directories(amrexplorer_data
+    PUBLIC
+        $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+        $<INSTALL_INTERFACE:include>
+)
+target_link_libraries(amrexplorer_data
+    PUBLIC
+        amrexplorer::cache
+        amrexplorer::core
+        amrexplorer::io
+        amrexplorer::query
+    PRIVATE amrexplorer::warnings
+)
+target_compile_features(amrexplorer_data PUBLIC cxx_std_20)

--- a/src/data/DatasetPage.cpp
+++ b/src/data/DatasetPage.cpp
@@ -1,0 +1,197 @@
+#include <amrexplorer/data/DatasetPage.hpp>
+
+#include <amrexplorer/core/Metadata.hpp>
+#include <amrexplorer/io/PlotfileBlockReader.hpp>
+#include <amrexplorer/io/PlotfileDataset.hpp>
+#include <amrexplorer/query/detail/BlockLookup.hpp>
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <stdexcept>
+
+namespace amrvis {
+namespace {
+
+std::array<int, 2> inPlaneAxes(int dimension, int normalAxis) noexcept
+{
+    if (dimension != 3) {
+        return {0, 1};
+    }
+    std::array<int, 2> axes{0, 1};
+    std::size_t next = 0;
+    for (int axis = 0; axis < 3; ++axis) {
+        if (axis != normalAxis) {
+            axes[next++] = axis;
+        }
+    }
+    return axes;
+}
+
+} // namespace
+
+DatasetPage extractDatasetPage(PlotfileDataset& dataset,
+    const DatasetPageRequest& request, StopToken cancellation)
+{
+    const auto& metadata = dataset.metadata();
+    if (request.dataset != dataset.id()) {
+        throw std::invalid_argument("dataset page uses the wrong dataset");
+    }
+    if (metadata.dimension < 2 || metadata.dimension > 3) {
+        throw std::invalid_argument(
+            "dataset page requires a 2-D or 3-D dataset");
+    }
+    if (request.level < 0
+        || request.level >= static_cast<int>(metadata.levels.size())) {
+        throw std::invalid_argument("dataset page level is unavailable");
+    }
+    if (request.field.value >= metadata.fields.size()) {
+        throw std::invalid_argument("dataset page field is unavailable");
+    }
+    if (metadata.dimension == 3
+        && (request.normalAxis < 0 || request.normalAxis > 2)) {
+        throw std::invalid_argument("dataset page normal axis is invalid");
+    }
+    if (request.maximumExtent < 1
+        || request.maximumExtent > datasetPageMaxExtent) {
+        throw std::invalid_argument("dataset page extent is outside its limit");
+    }
+
+    const auto& level
+        = metadata.levels[static_cast<std::size_t>(request.level)];
+    const auto axes = inPlaneAxes(metadata.dimension, request.normalAxis);
+
+    DatasetPage page;
+    std::array<std::int64_t, 2> lower{};
+    std::array<std::int64_t, 2> upper{};
+    for (std::size_t entry = 0; entry < 2; ++entry) {
+        const auto axis = static_cast<std::size_t>(axes[entry]);
+        const auto domainLower
+            = static_cast<std::int64_t>(level.domain.lower[axis]);
+        const auto domainUpper
+            = static_cast<std::int64_t>(level.domain.upper[axis]);
+        const auto rawLower = static_cast<std::int64_t>(
+            sampleIndex(level, axes[entry], request.region.lower[axis]));
+        const auto rawUpper = static_cast<std::int64_t>(
+            sampleIndex(level, axes[entry],
+                std::nextafter(request.region.upper[axis],
+                    -std::numeric_limits<double>::infinity())));
+        if (rawUpper < domainLower || rawLower > domainUpper) {
+            return page;
+        }
+        lower[entry] = std::max(rawLower, domainLower);
+        upper[entry] = std::min(rawUpper, domainUpper);
+    }
+
+    for (std::size_t entry = 0; entry < 2; ++entry) {
+        if (upper[entry] - lower[entry] + 1
+            > static_cast<std::int64_t>(request.maximumExtent)) {
+            upper[entry] = lower[entry] + request.maximumExtent - 1;
+            if (entry == 0) {
+                page.truncatedX = true;
+            } else {
+                page.truncatedY = true;
+            }
+        }
+        page.lower[entry] = static_cast<int>(lower[entry]);
+        page.upper[entry] = static_cast<int>(upper[entry]);
+    }
+    page.nx = static_cast<int>(upper[0] - lower[0] + 1);
+    page.ny = static_cast<int>(upper[1] - lower[1] + 1);
+
+    if (metadata.dimension == 3) {
+        const auto normal = static_cast<std::size_t>(request.normalAxis);
+        const auto domainLower
+            = static_cast<std::int64_t>(level.domain.lower[normal]);
+        const auto domainUpper
+            = static_cast<std::int64_t>(level.domain.upper[normal]);
+        const auto raw = static_cast<std::int64_t>(
+            sampleIndex(level, request.normalAxis, request.slicePosition));
+        page.sliceIndex
+            = static_cast<int>(std::clamp(raw, domainLower, domainUpper));
+    }
+
+    auto query = level.domain;
+    for (std::size_t entry = 0; entry < 2; ++entry) {
+        const auto axis = static_cast<std::size_t>(axes[entry]);
+        query.lower[axis] = page.lower[entry];
+        query.upper[axis] = page.upper[entry];
+    }
+    if (metadata.dimension == 3) {
+        const auto normal = static_cast<std::size_t>(request.normalAxis);
+        query.lower[normal] = page.sliceIndex;
+        query.upper[normal] = page.sliceIndex;
+    }
+
+    const auto cellCount = static_cast<std::size_t>(page.nx)
+        * static_cast<std::size_t>(page.ny);
+    page.values.assign(cellCount, 0.0F);
+    page.covered.assign(cellCount, std::uint8_t{0});
+
+    const auto xAxis = static_cast<std::size_t>(axes[0]);
+    const auto yAxis = static_cast<std::size_t>(axes[1]);
+    auto minimum = std::numeric_limits<double>::infinity();
+    auto maximum = -std::numeric_limits<double>::infinity();
+    for (std::size_t grid = 0; grid < level.blocks.size(); ++grid) {
+        if (cancellation.stop_requested()) {
+            throw ReadCancelled();
+        }
+        const auto validBox = level.blocks[grid].box;
+        if (!detail::intersects(validBox, query, metadata.dimension)) {
+            continue;
+        }
+        BlockRequest blockRequest;
+        blockRequest.dataset = dataset.id();
+        blockRequest.level = request.level;
+        blockRequest.gridIndex = static_cast<int>(grid);
+        blockRequest.field = request.field;
+        blockRequest.firstComponent = 0;
+        blockRequest.componentCount = 1;
+        const auto access = dataset.requestBlock(blockRequest, cancellation);
+        const auto& fab = *access.handle;
+
+        const auto iLower = std::max(validBox.lower[xAxis], page.lower[0]);
+        const auto iUpper = std::min(validBox.upper[xAxis], page.upper[0]);
+        const auto jLower = std::max(validBox.lower[yAxis], page.lower[1]);
+        const auto jUpper = std::min(validBox.upper[yAxis], page.upper[1]);
+        for (auto j = jLower; j <= jUpper; ++j) {
+            if (cancellation.stop_requested()) {
+                throw ReadCancelled();
+            }
+            const auto valueY = static_cast<std::size_t>(
+                static_cast<std::int64_t>(j) - page.lower[1]);
+            for (auto i = iLower; i <= iUpper; ++i) {
+                Int3 cell{};
+                cell[xAxis] = i;
+                cell[yAxis] = j;
+                if (metadata.dimension == 3) {
+                    cell[static_cast<std::size_t>(request.normalAxis)]
+                        = page.sliceIndex;
+                }
+                const auto value = fab.values[detail::valueOffset(
+                    fab.box, cell, metadata.dimension)];
+                const auto valueX = static_cast<std::size_t>(
+                    static_cast<std::int64_t>(i) - page.lower[0]);
+                const auto offset = valueX
+                    + static_cast<std::size_t>(page.nx) * valueY;
+                page.values[offset] = static_cast<float>(value);
+                page.covered[offset] = std::uint8_t{1};
+                if (std::isfinite(value)) {
+                    minimum = std::min(minimum, value);
+                    maximum = std::max(maximum, value);
+                }
+            }
+        }
+    }
+    if (std::isfinite(minimum) && std::isfinite(maximum)) {
+        page.minimum = minimum;
+        page.maximum = maximum;
+        page.hasFiniteValues = true;
+    }
+    return page;
+}
+
+} // namespace amrvis

--- a/src/data/LocalDatasetSession.cpp
+++ b/src/data/LocalDatasetSession.cpp
@@ -17,8 +17,12 @@
 namespace amrvis {
 namespace {
 
-std::string readFileVersion(const std::filesystem::path& path)
+std::string readFileVersion(
+    const std::filesystem::path& path, StopToken cancellation)
 {
+    if (cancellation.stop_requested()) {
+        throw ReadCancelled();
+    }
     std::ifstream header(path / "Header");
     std::string version;
     std::getline(header, version);
@@ -74,17 +78,18 @@ LocalDatasetSession::LocalDatasetSession(
 }
 
 LocalDatasetSession::LocalDatasetSession(const std::filesystem::path& path,
-    DatasetId id, std::uint64_t cacheBudgetBytes)
+    DatasetId id, std::uint64_t cacheBudgetBytes, StopToken cancellation)
     : LocalDatasetSession(std::make_shared<PlotfileDataset>(
-          path, id, cacheBudgetBytes), readFileVersion(path))
+          path, id, cacheBudgetBytes, cancellation),
+          readFileVersion(path, cancellation))
 {
 }
 
 LocalDatasetSession::LocalDatasetSession(std::filesystem::path dataRoot,
     DatasetId id, std::uint64_t cacheBudgetBytes,
-    PlotfileMetadataResult metadata)
+    PlotfileMetadataResult metadata, StopToken cancellation)
     : LocalDatasetSession(std::make_shared<PlotfileDataset>(dataRoot, id,
-          cacheBudgetBytes, metadata),
+          cacheBudgetBytes, metadata, cancellation),
           metadata.fileVersion)
 {
 }

--- a/src/data/LocalDatasetSession.cpp
+++ b/src/data/LocalDatasetSession.cpp
@@ -1,0 +1,230 @@
+#include <amrexplorer/data/LocalDatasetSession.hpp>
+
+#include <amrexplorer/core/Statistics.hpp>
+#include <amrexplorer/io/PlotfileDataset.hpp>
+#include <amrexplorer/query/LineQuery.hpp>
+#include <amrexplorer/query/SliceQuery.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <fstream>
+#include <limits>
+#include <stdexcept>
+#include <type_traits>
+#include <utility>
+#include <variant>
+
+namespace amrvis {
+namespace {
+
+std::string readFileVersion(const std::filesystem::path& path)
+{
+    std::ifstream header(path / "Header");
+    std::string version;
+    std::getline(header, version);
+    while (!version.empty() && version.back() == '\r') {
+        version.pop_back();
+    }
+    return version;
+}
+
+std::optional<ValueRange> compositeMetadataRange(const DatasetMetadata& metadata,
+    const RangeRequest& request)
+{
+    if (request.scope == RangeScope::File) {
+        return metadataValueRange(metadata, request.field, std::nullopt);
+    }
+    if (request.composition == CompositionPolicy::ExactLevel) {
+        return metadataValueRange(
+            metadata, request.field, request.maximumLevel);
+    }
+    auto minimum = std::numeric_limits<double>::infinity();
+    auto maximum = -std::numeric_limits<double>::infinity();
+    for (int level = 0; level <= request.maximumLevel; ++level) {
+        const auto range = metadataValueRange(metadata, request.field, level);
+        if (!range) {
+            return std::nullopt;
+        }
+        minimum = std::min(minimum, range->minimum);
+        maximum = std::max(maximum, range->maximum);
+    }
+    if (!std::isfinite(minimum) || !std::isfinite(maximum)) {
+        return std::nullopt;
+    }
+    return ValueRange{minimum, maximum};
+}
+
+} // namespace
+
+LocalDatasetSession::LocalDatasetSession(
+    std::shared_ptr<PlotfileDataset> dataset, std::string fileVersion)
+    : m_id(dataset ? dataset->id() : DatasetId{})
+    , m_metadata(dataset ? dataset->metadata() : DatasetMetadata{})
+    , m_metadataMetrics(
+          dataset ? dataset->metadataReadMetrics() : MetadataReadMetrics{})
+    , m_fileVersion(std::move(fileVersion))
+    , m_particleSpecies(
+          dataset ? dataset->particleSpecies()
+                  : std::vector<ParticleSpeciesMetadata>{})
+    , m_dataset(std::move(dataset))
+{
+    if (!m_dataset) {
+        throw std::invalid_argument("local dataset session requires a dataset");
+    }
+}
+
+LocalDatasetSession::LocalDatasetSession(const std::filesystem::path& path,
+    DatasetId id, std::uint64_t cacheBudgetBytes)
+    : LocalDatasetSession(std::make_shared<PlotfileDataset>(
+          path, id, cacheBudgetBytes), readFileVersion(path))
+{
+}
+
+LocalDatasetSession::LocalDatasetSession(std::filesystem::path dataRoot,
+    DatasetId id, std::uint64_t cacheBudgetBytes,
+    PlotfileMetadataResult metadata)
+    : LocalDatasetSession(std::make_shared<PlotfileDataset>(dataRoot, id,
+          cacheBudgetBytes, metadata),
+          metadata.fileVersion)
+{
+}
+
+DatasetId LocalDatasetSession::id() const noexcept
+{
+    return m_id;
+}
+
+const DatasetMetadata& LocalDatasetSession::metadata() const noexcept
+{
+    return m_metadata;
+}
+
+const MetadataReadMetrics&
+LocalDatasetSession::metadataReadMetrics() const noexcept
+{
+    return m_metadataMetrics;
+}
+
+const std::string& LocalDatasetSession::fileVersion() const noexcept
+{
+    return m_fileVersion;
+}
+
+const std::vector<ParticleSpeciesMetadata>&
+LocalDatasetSession::particleSpecies() const noexcept
+{
+    return m_particleSpecies;
+}
+
+ViewDataResult LocalDatasetSession::requestView(
+    const ViewDataRequest& request, StopToken cancellation)
+{
+    const auto dataset = requireDataset();
+    return std::visit(
+        [&](const auto& typedRequest) -> ViewDataResult {
+            using Request = std::decay_t<decltype(typedRequest)>;
+            if constexpr (std::is_same_v<Request, SliceRequest>) {
+                return SliceQuery(*dataset).execute(
+                    typedRequest, cancellation);
+            } else {
+                auto result = LineQuery(*dataset).execute(
+                    typedRequest.query, cancellation);
+                return boundLineToViewport(
+                    std::move(result), typedRequest.outputWidth);
+            }
+        },
+        request);
+}
+
+DatasetPage LocalDatasetSession::requestDatasetPage(
+    const DatasetPageRequest& request, StopToken cancellation)
+{
+    const auto dataset = requireDataset();
+    return extractDatasetPage(*dataset, request, cancellation);
+}
+
+std::optional<ValueRange> LocalDatasetSession::requestRange(
+    const RangeRequest& request, StopToken cancellation)
+{
+    const auto dataset = requireDataset();
+    if (request.field.value >= m_metadata.fields.size()) {
+        throw std::invalid_argument("range field is unavailable");
+    }
+    if (request.maximumLevel < 0
+        || request.maximumLevel > m_metadata.finestLevel) {
+        throw std::invalid_argument("range level is unavailable");
+    }
+    if (m_metadata.isFab && request.scope == RangeScope::File) {
+        BlockRequest block;
+        block.dataset = m_id;
+        block.field = request.field;
+        const auto access = dataset->requestBlock(block, cancellation);
+        auto minimum = std::numeric_limits<double>::infinity();
+        auto maximum = -std::numeric_limits<double>::infinity();
+        for (std::size_t index = 0; index < access.handle->values.size();
+             ++index) {
+            const auto value = access.handle->values[index];
+            if (std::isfinite(value)) {
+                minimum = std::min(minimum, value);
+                maximum = std::max(maximum, value);
+            }
+        }
+        if (std::isfinite(minimum) && std::isfinite(maximum)) {
+            return ValueRange{minimum, maximum};
+        }
+        return std::nullopt;
+    }
+    return compositeMetadataRange(m_metadata, request);
+}
+
+bool LocalDatasetSession::rangeAvailable(
+    const RangeRequest& request) const noexcept
+{
+    if (request.field.value >= m_metadata.fields.size()
+        || request.maximumLevel < 0
+        || request.maximumLevel > m_metadata.finestLevel) {
+        return false;
+    }
+    return (m_metadata.isFab && request.scope == RangeScope::File)
+        || compositeMetadataRange(m_metadata, request).has_value();
+}
+
+ParticleSample LocalDatasetSession::requestParticleSample(
+    const std::string& species, double fraction, std::uint64_t seed,
+    StopToken cancellation)
+{
+    return requireDataset()->requestParticleSample(
+        species, fraction, seed, cancellation);
+}
+
+CacheMetrics LocalDatasetSession::cacheMetrics() const
+{
+    return requireDataset()->cacheMetrics();
+}
+
+bool LocalDatasetSession::setCacheBudget(std::uint64_t bytes)
+{
+    return requireDataset()->setCacheBudget(bytes);
+}
+
+void LocalDatasetSession::clearUnpinnedCache()
+{
+    requireDataset()->clearUnpinnedCache();
+}
+
+void LocalDatasetSession::close() noexcept
+{
+    std::scoped_lock lock(m_mutex);
+    m_dataset.reset();
+}
+
+std::shared_ptr<PlotfileDataset> LocalDatasetSession::requireDataset() const
+{
+    std::scoped_lock lock(m_mutex);
+    if (!m_dataset) {
+        throw std::runtime_error("dataset session is closed");
+    }
+    return m_dataset;
+}
+
+} // namespace amrvis

--- a/src/data/ViewData.cpp
+++ b/src/data/ViewData.cpp
@@ -1,0 +1,78 @@
+#include <amrexplorer/data/ViewData.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <stdexcept>
+#include <utility>
+
+namespace amrvis {
+
+LineQueryResult boundLineToViewport(LineQueryResult result, int outputWidth)
+{
+    if (outputWidth < 1) {
+        throw std::invalid_argument("line viewport width must be positive");
+    }
+    const auto size = result.line.values.size();
+    if (result.line.positions.size() != size
+        || result.line.valid.size() != size
+        || result.line.sourceLevel.size() != size) {
+        throw std::invalid_argument("line result vectors have inconsistent sizes");
+    }
+    const auto maximumSamples = static_cast<std::size_t>(outputWidth) * 2;
+    if (size <= maximumSamples) {
+        return result;
+    }
+
+    LineResult bounded;
+    bounded.axis = result.line.axis;
+    bounded.positionsAreIndices = result.line.positionsAreIndices;
+    bounded.positions.reserve(maximumSamples);
+    bounded.values.reserve(maximumSamples);
+    bounded.valid.reserve(maximumSamples);
+    bounded.sourceLevel.reserve(maximumSamples);
+
+    const auto append = [&](std::size_t index) {
+        bounded.positions.push_back(result.line.positions[index]);
+        bounded.values.push_back(result.line.values[index]);
+        bounded.valid.push_back(result.line.valid[index]);
+        bounded.sourceLevel.push_back(result.line.sourceLevel[index]);
+    };
+
+    for (int pixel = 0; pixel < outputWidth; ++pixel) {
+        const auto begin = size * static_cast<std::size_t>(pixel)
+            / static_cast<std::size_t>(outputWidth);
+        const auto end = size * static_cast<std::size_t>(pixel + 1)
+            / static_cast<std::size_t>(outputWidth);
+        if (begin >= end) {
+            continue;
+        }
+        auto minimum = begin;
+        auto maximum = begin;
+        for (auto index = begin + 1; index < end; ++index) {
+            if (result.line.valid[index] == 0) {
+                continue;
+            }
+            if (result.line.valid[minimum] == 0
+                || result.line.values[index] < result.line.values[minimum]) {
+                minimum = index;
+            }
+            if (result.line.valid[maximum] == 0
+                || result.line.values[index] > result.line.values[maximum]) {
+                maximum = index;
+            }
+        }
+        if (minimum == maximum) {
+            append(minimum);
+        } else if (minimum < maximum) {
+            append(minimum);
+            append(maximum);
+        } else {
+            append(maximum);
+            append(minimum);
+        }
+    }
+    result.line = std::move(bounded);
+    return result;
+}
+
+} // namespace amrvis

--- a/src/data/ViewData.cpp
+++ b/src/data/ViewData.cpp
@@ -51,8 +51,27 @@ LineQueryResult boundLineToViewport(LineQueryResult result, int outputWidth)
             result.line.valid.begin() + static_cast<std::ptrdiff_t>(end), 0);
         if (invalid != result.line.valid.begin()
                 + static_cast<std::ptrdiff_t>(end)) {
-            append(static_cast<std::size_t>(
-                std::distance(result.line.valid.begin(), invalid)));
+            const auto invalidIndex = static_cast<std::size_t>(
+                std::distance(result.line.valid.begin(), invalid));
+            const auto validSample = std::find_if(
+                result.line.valid.begin()
+                    + static_cast<std::ptrdiff_t>(begin),
+                result.line.valid.begin() + static_cast<std::ptrdiff_t>(end),
+                [](std::uint8_t valid) { return valid != 0; });
+            if (validSample == result.line.valid.begin()
+                    + static_cast<std::ptrdiff_t>(end)) {
+                append(invalidIndex);
+                continue;
+            }
+            const auto validIndex = static_cast<std::size_t>(
+                std::distance(result.line.valid.begin(), validSample));
+            if (invalidIndex < validIndex) {
+                append(invalidIndex);
+                append(validIndex);
+            } else {
+                append(validIndex);
+                append(invalidIndex);
+            }
             continue;
         }
         auto minimum = begin;

--- a/src/data/ViewData.cpp
+++ b/src/data/ViewData.cpp
@@ -46,18 +46,22 @@ LineQueryResult boundLineToViewport(LineQueryResult result, int outputWidth)
         if (begin >= end) {
             continue;
         }
+        const auto invalid = std::find(result.line.valid.begin()
+                + static_cast<std::ptrdiff_t>(begin),
+            result.line.valid.begin() + static_cast<std::ptrdiff_t>(end), 0);
+        if (invalid != result.line.valid.begin()
+                + static_cast<std::ptrdiff_t>(end)) {
+            append(static_cast<std::size_t>(
+                std::distance(result.line.valid.begin(), invalid)));
+            continue;
+        }
         auto minimum = begin;
         auto maximum = begin;
         for (auto index = begin + 1; index < end; ++index) {
-            if (result.line.valid[index] == 0) {
-                continue;
-            }
-            if (result.line.valid[minimum] == 0
-                || result.line.values[index] < result.line.values[minimum]) {
+            if (result.line.values[index] < result.line.values[minimum]) {
                 minimum = index;
             }
-            if (result.line.valid[maximum] == 0
-                || result.line.values[index] > result.line.values[maximum]) {
+            if (result.line.values[index] > result.line.values[maximum]) {
                 maximum = index;
             }
         }

--- a/src/io/plotfile/ParticleReader.cpp
+++ b/src/io/plotfile/ParticleReader.cpp
@@ -347,7 +347,7 @@ void readGrid(std::istream& input, const GridRecord& grid,
     std::array<std::int32_t, 2> idWords{};
     for (std::uint64_t firstIndex = 0; firstIndex < grid.count;) {
         if (cancellation.stop_requested()) {
-            throw ParticleReadError("particle read cancelled");
+            throw ReadCancelled();
         }
         const auto count = chunkRecordCount(
             grid.count - firstIndex, intRecordBytes);
@@ -357,7 +357,7 @@ void readGrid(std::istream& input, const GridRecord& grid,
         for (std::size_t relativeIndex = 0;
              relativeIndex < count; ++relativeIndex) {
             if (cancellation.stop_requested()) {
-                throw ParticleReadError("particle read cancelled");
+                throw ReadCancelled();
             }
             const auto recordOffset = static_cast<std::size_t>(
                 static_cast<std::uint64_t>(relativeIndex) * intRecordBytes);
@@ -377,7 +377,7 @@ void readGrid(std::istream& input, const GridRecord& grid,
     std::size_t selectedIndex = 0;
     for (std::uint64_t firstIndex = 0; firstIndex < grid.count;) {
         if (cancellation.stop_requested()) {
-            throw ParticleReadError("particle read cancelled");
+            throw ReadCancelled();
         }
         const auto count = chunkRecordCount(
             grid.count - firstIndex, realRecordBytes);
@@ -416,11 +416,14 @@ void readGrid(std::istream& input, const GridRecord& grid,
 } // namespace
 
 std::vector<ParticleSpeciesMetadata> discoverParticleSpecies(
-    const std::filesystem::path& plotfile)
+    const std::filesystem::path& plotfile, StopToken cancellation)
 {
     std::vector<ParticleSpeciesMetadata> result;
     std::error_code error;
     for (const auto& entry : std::filesystem::directory_iterator(plotfile, error)) {
+        if (cancellation.stop_requested()) {
+            throw ReadCancelled();
+        }
         if (!entry.is_directory()) {
             continue;
         }
@@ -437,6 +440,9 @@ std::vector<ParticleSpeciesMetadata> discoverParticleSpecies(
             continue;
         }
     }
+    if (cancellation.stop_requested()) {
+        throw ReadCancelled();
+    }
     std::ranges::sort(result, {}, &ParticleSpeciesMetadata::name);
     return result;
 }
@@ -447,6 +453,9 @@ ParticleSample readParticleSample(
 {
     if (!std::isfinite(fraction) || fraction < 0.0 || fraction > 1.0) {
         throw std::invalid_argument("particle sample fraction must be between 0 and 1");
+    }
+    if (cancellation.stop_requested()) {
+        throw ReadCancelled();
     }
     const auto speciesPath = plotfile / species;
     const auto header = parseHeader(speciesPath / "Header", species);

--- a/src/io/plotfile/PlotfileDataset.cpp
+++ b/src/io/plotfile/PlotfileDataset.cpp
@@ -33,11 +33,11 @@ std::filesystem::path sourceDataRoot(const std::filesystem::path& path)
 }
 
 std::vector<ParticleSpeciesMetadata> discoverParticlesForPlotfileRoot(
-    const std::filesystem::path& root)
+    const std::filesystem::path& root, StopToken cancellation)
 {
     if (std::filesystem::is_directory(root)
         && std::filesystem::is_regular_file(root / "Header")) {
-        return discoverParticleSpecies(root);
+        return discoverParticleSpecies(root, cancellation);
     }
     return {};
 }
@@ -45,12 +45,13 @@ std::vector<ParticleSpeciesMetadata> discoverParticlesForPlotfileRoot(
 } // namespace
 
 PlotfileDataset::PlotfileDataset(
-    std::filesystem::path plotfile, DatasetId id, std::uint64_t cacheBudgetBytes)
+    std::filesystem::path plotfile, DatasetId id,
+    std::uint64_t cacheBudgetBytes, StopToken cancellation)
     : m_plotfile(sourceDataRoot(plotfile))
     , m_id(id)
-    , m_metadataResult(readDatasetMetadata(plotfile))
+    , m_metadataResult(readDatasetMetadata(plotfile, cancellation))
     , m_particleSpecies(std::filesystem::is_directory(plotfile)
-            ? discoverParticleSpecies(m_plotfile)
+            ? discoverParticleSpecies(m_plotfile, cancellation)
             : std::vector<ParticleSpeciesMetadata>{})
     , m_blockReader(m_plotfile, m_metadataResult.metadata)
     , m_cache(cacheBudgetBytes)
@@ -61,11 +62,13 @@ PlotfileDataset::PlotfileDataset(
 }
 
 PlotfileDataset::PlotfileDataset(std::filesystem::path root, DatasetId id,
-    std::uint64_t cacheBudgetBytes, PlotfileMetadataResult metadata)
+    std::uint64_t cacheBudgetBytes, PlotfileMetadataResult metadata,
+    StopToken cancellation)
     : m_plotfile(std::move(root))
     , m_id(id)
     , m_metadataResult(std::move(metadata))
-    , m_particleSpecies(discoverParticlesForPlotfileRoot(m_plotfile))
+    , m_particleSpecies(
+          discoverParticlesForPlotfileRoot(m_plotfile, cancellation))
     , m_blockReader(m_plotfile, m_metadataResult.metadata)
     , m_cache(cacheBudgetBytes)
 {

--- a/src/pipeline/CMakeLists.txt
+++ b/src/pipeline/CMakeLists.txt
@@ -14,6 +14,7 @@ target_include_directories(amrexplorer_pipeline
 target_link_libraries(amrexplorer_pipeline
     PUBLIC
         amrexplorer::core
+        amrexplorer::data
         amrexplorer::io
         amrexplorer::query
         amrexplorer::render2d

--- a/src/pipeline/SlicePipeline.cpp
+++ b/src/pipeline/SlicePipeline.cpp
@@ -1,8 +1,8 @@
 #include <amrexplorer/pipeline/SlicePipeline.hpp>
 
 #include <amrexplorer/cache/ByteLruCache.hpp>
+#include <amrexplorer/data/LocalDatasetSession.hpp>
 #include <amrexplorer/core/CoordinateSystem.hpp>
-#include <amrexplorer/io/PlotfileDataset.hpp>
 #include <amrexplorer/pipeline/DisplayCoordinator.hpp>
 #include <amrexplorer/render2d/ScalarRenderer.hpp>
 #include <amrexplorer/render2d/SphericalWarp.hpp>
@@ -14,6 +14,16 @@
 #include <stdexcept>
 
 namespace amrvis {
+namespace {
+
+SliceQueryResult requestSlice(DatasetSession& dataset,
+    const SliceRequest& request, StopToken cancellation)
+{
+    return std::get<SliceQueryResult>(
+        dataset.requestView(ViewDataRequest{request}, cancellation));
+}
+
+} // namespace
 
 LevelSelection decodeLevelData(int data, int finestLevel)
 {
@@ -186,7 +196,7 @@ void applyDisplayCoordinates(
 
 } // namespace
 
-SliceDisplayResult executeSlice(const std::shared_ptr<PlotfileDataset>& dataset,
+SliceDisplayResult executeSlice(const std::shared_ptr<DatasetSession>& dataset,
     const SliceRequest& request,
     RangeMode rangeMode,
     const std::optional<std::pair<double, double>>& userRange,
@@ -194,7 +204,7 @@ SliceDisplayResult executeSlice(const std::shared_ptr<PlotfileDataset>& dataset,
 {
     SliceDisplayResult result;
     result.request = request;
-    result.slice = SliceQuery(*dataset).execute(request, cancellation);
+    result.slice = requestSlice(*dataset, request, cancellation);
     const auto range = resolveDisplayRange(dataset, request.field,
         request.maximumLevel, request.composition, rangeMode, userRange,
         logarithmic, result.slice.plane);
@@ -213,14 +223,14 @@ SliceDisplayResult executeSlice(const std::shared_ptr<PlotfileDataset>& dataset,
     return result;
 }
 
-void appendVectorGlyphs(const std::shared_ptr<PlotfileDataset>& dataset,
+void appendVectorGlyphs(const std::shared_ptr<DatasetSession>& dataset,
     SliceRequest request, FieldId uField, FieldId vField, int count,
     StopToken cancellation, SliceDisplayResult& result)
 {
     request.field = uField;
-    auto uSlice = SliceQuery(*dataset).execute(request, cancellation);
+    auto uSlice = requestSlice(*dataset, request, cancellation);
     request.field = vField;
-    auto vSlice = SliceQuery(*dataset).execute(request, cancellation);
+    auto vSlice = requestSlice(*dataset, request, cancellation);
     // The warped R-Z spherical view anchors each glyph at its physical (R, Z)
     // position and rotates the components into display directions; the
     // executeSlice call preceding this one already populated
@@ -242,7 +252,7 @@ void appendVectorGlyphs(const std::shared_ptr<PlotfileDataset>& dataset,
 }
 
 SliceDisplayResult executeSliceWithFallback(
-    const std::shared_ptr<PlotfileDataset>& dataset, SliceRequest request,
+    const std::shared_ptr<DatasetSession>& dataset, SliceRequest request,
     RangeMode rangeMode,
     const std::optional<std::pair<double, double>>& userRange,
     bool logarithmic, const Palette& palette, DisplayMode displayMode,
@@ -306,7 +316,7 @@ SliceDisplayResult executeSliceWithFallback(
 // the GUI thread only converts the polylines to painter paths. The contour
 // plane is cached by the GUI, so range and contour-count changes re-run only
 // this cheap extraction (see refreshCachedSlice).
-void appendContours(const std::shared_ptr<PlotfileDataset>& dataset,
+void appendContours(const std::shared_ptr<DatasetSession>& dataset,
     const SliceRequest& request, int contourCount, double minimum, double maximum,
     bool logarithmic, StopToken cancellation, SliceDisplayResult& result)
 {
@@ -332,7 +342,7 @@ void appendContours(const std::shared_ptr<PlotfileDataset>& dataset,
         std::min(std::max(dataWidth, 512), 1024),
         std::min(std::max(dataHeight, 512), 1024)};
     contourRequest.sampling = SamplingPolicy::Linear;
-    auto contour = SliceQuery(*dataset).execute(contourRequest, cancellation);
+    auto contour = requestSlice(*dataset, contourRequest, cancellation);
     result.contourPlane = std::move(contour.plane);
     result.slice.metrics.candidateBlocks += contour.metrics.candidateBlocks;
     result.slice.metrics.blocksRead += contour.metrics.blocksRead;
@@ -352,7 +362,7 @@ void appendContours(const std::shared_ptr<PlotfileDataset>& dataset,
 }
 
 SliceDisplayResult refreshCachedSlice(
-    const std::shared_ptr<PlotfileDataset>& dataset,
+    const std::shared_ptr<DatasetSession>& dataset,
     const SliceRequest& request, ScalarPlane displayPlane,
     ScalarPlane contourPlane, ScalarPlane contourFinePlane, int contourFineFactor,
     std::vector<VectorSegment> vectors,
@@ -434,7 +444,7 @@ void recomputeContourPolylines(SliceDisplayResult& result)
 }
 
 std::vector<ParticleSample> loadParticleSamples(
-    const PlotfileDataset& dataset,
+    DatasetSession& dataset,
     std::span<const std::string> selectedSpecies, double fraction,
     std::uint64_t seed, StopToken cancellation)
 {
@@ -452,33 +462,23 @@ std::vector<ParticleSample> loadParticleSamples(
     return samples;
 }
 
-InitialSliceResult executeFrameLoad(const std::filesystem::path& path,
-    DatasetId datasetId, const FrameSliceSpec& spec,
-    std::uint64_t cacheBudgetBytes, StopToken cancellation,
-    std::optional<PlotfileMetadataResult> preparedMetadata,
-    std::filesystem::path dataRoot)
+InitialSliceResult executeSessionFrameLoad(
+    std::shared_ptr<DatasetSession> dataset, const FrameSliceSpec& spec,
+    StopToken cancellation)
 {
     InitialSliceResult result;
-    if (preparedMetadata) {
-        result.fileVersion = preparedMetadata->fileVersion;
-        result.dataset = std::make_shared<PlotfileDataset>(
-            std::move(dataRoot), datasetId, cacheBudgetBytes,
-            std::move(*preparedMetadata));
-    } else {
-        result.dataset = std::make_shared<PlotfileDataset>(
-            path, datasetId, cacheBudgetBytes);
+    result.dataset = std::move(dataset);
+    if (!result.dataset) {
+        throw std::invalid_argument("frame load requires a dataset session");
     }
+    const auto datasetId = result.dataset->id();
+    const auto cacheBudgetBytes
+        = result.dataset->cacheMetrics().budgetBytes;
     const auto& metadata = result.dataset->metadata();
     if (metadata.fields.empty()) {
         throw std::runtime_error("dataset has no scalar fields to display");
     }
-    if (result.fileVersion.empty()) {
-        std::ifstream header(path / "Header");
-        std::getline(header, result.fileVersion);
-        while (!result.fileVersion.empty() && result.fileVersion.back() == '\r') {
-            result.fileVersion.pop_back();
-        }
-    }
+    result.fileVersion = result.dataset->fileVersion();
 
     const auto fieldCount = static_cast<std::uint32_t>(metadata.fields.size());
     const auto field = std::min(spec.field, fieldCount - 1);
@@ -496,7 +496,7 @@ InitialSliceResult executeFrameLoad(const std::filesystem::path& path,
     const auto selectedLevel = decodeLevelData(
         levelSelection, metadata.finestLevel);
     auto attemptMaximumLevel = selectedLevel.maximumLevel;
-    const auto rangeMode = effectiveRangeMode(metadata, FieldId{field},
+    const auto rangeMode = effectiveRangeMode(result.dataset, FieldId{field},
         attemptMaximumLevel, selectedLevel.composition, spec.rangeMode);
     std::array<double, 3> positions{0.0, 0.0, 0.0};
     const auto dataBounds = datasetSampleBounds(metadata);
@@ -648,6 +648,25 @@ InitialSliceResult executeFrameLoad(const std::filesystem::path& path,
         spec.particleSpecies, spec.particleFraction, spec.particleSeed,
         cancellation);
     return result;
+}
+
+InitialSliceResult executeFrameLoad(const std::filesystem::path& path,
+    DatasetId datasetId, const FrameSliceSpec& spec,
+    std::uint64_t cacheBudgetBytes, StopToken cancellation,
+    std::optional<PlotfileMetadataResult> preparedMetadata,
+    std::filesystem::path dataRoot)
+{
+    std::shared_ptr<DatasetSession> dataset;
+    if (preparedMetadata) {
+        dataset = std::make_shared<LocalDatasetSession>(
+            std::move(dataRoot), datasetId, cacheBudgetBytes,
+            std::move(*preparedMetadata));
+    } else {
+        dataset = std::make_shared<LocalDatasetSession>(
+            path, datasetId, cacheBudgetBytes);
+    }
+    return executeSessionFrameLoad(
+        std::move(dataset), spec, cancellation);
 }
 
 } // namespace amrvis

--- a/src/pipeline/SliceRangeResolver.cpp
+++ b/src/pipeline/SliceRangeResolver.cpp
@@ -1,7 +1,5 @@
 #include <amrexplorer/pipeline/SliceRangeResolver.hpp>
 
-#include <amrexplorer/io/PlotfileDataset.hpp>
-
 #include <algorithm>
 #include <cmath>
 #include <limits>
@@ -80,35 +78,39 @@ RangeMode effectiveRangeMode(
     return requested;
 }
 
+RangeMode effectiveRangeMode(
+    const std::shared_ptr<DatasetSession>& dataset, FieldId field,
+    int maximumLevel, CompositionPolicy composition, RangeMode requested)
+{
+    if (requested != RangeMode::File && requested != RangeMode::Level) {
+        return requested;
+    }
+    const auto scope = requested == RangeMode::File
+        ? RangeScope::File : RangeScope::Level;
+    return dataset->rangeAvailable(
+               RangeRequest{field, maximumLevel, composition, scope})
+        ? requested : RangeMode::Visible;
+}
+
 std::optional<std::pair<double, double>> fabDataRange(
-    const std::shared_ptr<PlotfileDataset>& dataset, FieldId field)
+    const std::shared_ptr<DatasetSession>& dataset, FieldId field)
 {
     if (!dataset->metadata().isFab) {
         return std::nullopt;
     }
-    BlockRequest request;
-    request.dataset = dataset->id();
-    request.field = field;
-    const auto access = dataset->requestBlock(request);
-    const auto& values = access.handle->values;
-    auto minimum = std::numeric_limits<double>::infinity();
-    auto maximum = -std::numeric_limits<double>::infinity();
-    for (std::size_t index = 0; index < values.size(); ++index) {
-        const auto value = values[index];
-        if (!std::isfinite(value)) {
-            continue;
-        }
-        minimum = std::min(minimum, value);
-        maximum = std::max(maximum, value);
-    }
-    if (!std::isfinite(minimum) || !std::isfinite(maximum)) {
+    const auto range = dataset->requestRange(RangeRequest{
+        .field = field,
+        .maximumLevel = 0,
+        .composition = CompositionPolicy::ExactLevel,
+        .scope = RangeScope::File});
+    if (!range) {
         return std::nullopt;
     }
-    return std::pair{minimum, maximum};
+    return std::pair{range->minimum, range->maximum};
 }
 
 std::pair<double, double> resolveRange(
-    const std::shared_ptr<PlotfileDataset>& dataset, FieldId field,
+    const std::shared_ptr<DatasetSession>& dataset, FieldId field,
     int maximumLevel, CompositionPolicy composition, RangeMode rangeMode,
     const std::optional<std::pair<double, double>>& userRange,
     bool logarithmic, const ScalarPlane& plane)
@@ -119,11 +121,16 @@ std::pair<double, double> resolveRange(
             selectedRange = fabDataRange(dataset, field);
         }
         if (!selectedRange) {
-            const auto statistics = selectedMetadataRange(dataset->metadata(),
-                field, maximumLevel, composition, rangeMode);
+            const auto statistics = dataset->requestRange(RangeRequest{
+                .field = field,
+                .maximumLevel = maximumLevel,
+                .composition = composition,
+                .scope = rangeMode == RangeMode::File
+                    ? RangeScope::File
+                    : RangeScope::Level});
             if (statistics) {
-                selectedRange = std::pair{
-                    statistics->minimum, statistics->maximum};
+                selectedRange
+                    = std::pair{statistics->minimum, statistics->maximum};
             }
         }
     }
@@ -152,7 +159,7 @@ std::pair<double, double> resolveRange(
 }
 
 ResolvedRange resolveDisplayRange(
-    const std::shared_ptr<PlotfileDataset>& dataset, FieldId field,
+    const std::shared_ptr<DatasetSession>& dataset, FieldId field,
     int maximumLevel, CompositionPolicy composition, RangeMode rangeMode,
     const std::optional<std::pair<double, double>>& userRange,
     bool logarithmic, const ScalarPlane& plane)

--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -57,6 +57,7 @@ endif()
 target_link_libraries(amrexplorer_qt
     PRIVATE
         amrexplorer::core
+        amrexplorer::data
         amrexplorer::io
         amrexplorer::query
         amrexplorer::render2d

--- a/src/qt/DatasetExtract.hpp
+++ b/src/qt/DatasetExtract.hpp
@@ -1,250 +1,31 @@
 #pragma once
 
-// Raw per-level cell-value extraction behind the dataset (spreadsheet)
-// window. Kept free of Qt types so it can be exercised without the GUI.
+// Compatibility adapter for the Qt Dataset window. The extraction itself is
+// owned by the Qt-free data layer so local and remote sessions share the same
+// page-bounded contract.
 
-#include <amrexplorer/core/Geometry.hpp>
-#include <amrexplorer/core/Metadata.hpp>
-#include <amrexplorer/core/Request.hpp>
-#include <amrexplorer/core/StopToken.hpp>
-#include <amrexplorer/io/PlotfileBlockReader.hpp>
+#include <amrexplorer/data/DatasetPage.hpp>
 #include <amrexplorer/io/PlotfileDataset.hpp>
-#include <amrexplorer/query/detail/BlockLookup.hpp>
-
-#include <algorithm>
-#include <array>
-#include <cmath>
-#include <cstddef>
-#include <cstdint>
-#include <limits>
-#include <stdexcept>
-#include <vector>
 
 namespace amrvis::qt {
 
-// Hard cap on the extracted in-plane extent per axis; the dataset window
-// truncates larger regions instead of building million-cell tables.
-constexpr int datasetExtractMaxExtent = 512;
+inline constexpr int datasetExtractMaxExtent = datasetPageMaxExtent;
+using DatasetLevelExtract = DatasetPage;
 
-// Raw values of one field at one AMR level over a region. values/covered
-// run over the in-plane index box with the first in-plane axis fastest; a
-// cell no grid covers at this level keeps covered == 0 and value 0.
-struct DatasetLevelExtract {
-    std::array<int, 2> lower{0, 0};    // in-plane index box, level index space
-    std::array<int, 2> upper{-1, -1};
-    int nx = 0;                        // extent along in-plane axis 0
-    int ny = 0;                        // extent along in-plane axis 1
-    int sliceIndex = 0;                // normal-axis cell index (3-D)
-    std::vector<float> values;
-    std::vector<std::uint8_t> covered;
-    double minimum = 0.0;              // over finite covered cells only
-    double maximum = 0.0;
-    bool hasFiniteValues = false;       // minimum/maximum are meaningful
-    bool truncatedX = false;           // region exceeded maxExtent, axis 0
-    bool truncatedY = false;           // region exceeded maxExtent, axis 1
-};
-
-namespace dataset_extract_detail {
-
-// The two in-plane axes for a view normal, in ascending order (2-D: x, y).
-inline std::array<int, 2> inPlaneAxes(int dimension, int normalAxis) noexcept
-{
-    if (dimension != 3) {
-        return {0, 1};
-    }
-    std::array<int, 2> axes{0, 1};
-    std::size_t next = 0;
-    for (int axis = 0; axis < 3; ++axis) {
-        if (axis != normalAxis) {
-            axes[next++] = axis;
-        }
-    }
-    return axes;
-}
-
-// The shared overflow-checked helpers (this header previously carried its
-// own unchecked fabValueOffset variant — the drift the consolidation fixed).
-using amrvis::detail::intersects;
-using amrvis::detail::valueOffset;
-
-} // namespace dataset_extract_detail
-
-// Extracts the raw values of field at levelIndex over region (physical
-// coordinates). For 3-D the normal axis is clamped to the cell holding
-// slicePosition; for 2-D normalAxis/slicePosition are ignored. An in-plane
-// extent beyond maxExtent keeps only the first maxExtent cells of that axis
-// and sets the matching truncated flag. A region missing the level domain
-// entirely returns an extract with nx == ny == 0. Read errors (including
-// ReadCancelled) propagate to the caller.
 [[nodiscard]] inline DatasetLevelExtract extractDatasetLevel(
     PlotfileDataset& dataset, FieldId field, int levelIndex,
     const RealBox& region, int normalAxis, double slicePosition,
     int maxExtent, StopToken cancellation = {})
 {
-    const auto& metadata = dataset.metadata();
-    if (metadata.dimension < 2 || metadata.dimension > 3) {
-        throw std::invalid_argument(
-            "dataset extraction requires a 2-D or 3-D dataset");
-    }
-    if (levelIndex < 0
-        || levelIndex >= static_cast<int>(metadata.levels.size())) {
-        throw std::invalid_argument("dataset extraction level is unavailable");
-    }
-    if (field.value >= metadata.fields.size()) {
-        throw std::invalid_argument("dataset extraction field is unavailable");
-    }
-    if (metadata.dimension == 3 && (normalAxis < 0 || normalAxis > 2)) {
-        throw std::invalid_argument("dataset extraction normal axis is invalid");
-    }
-    if (maxExtent < 1) {
-        throw std::invalid_argument(
-            "dataset extraction extent cap must be positive");
-    }
-
-    const auto& level = metadata.levels[static_cast<std::size_t>(levelIndex)];
-    const auto axes = dataset_extract_detail::inPlaneAxes(
-        metadata.dimension, normalAxis);
-
-    DatasetLevelExtract extract;
-    // Map the physical region into this level's index space (SliceQuery's
-    // floor convention, nextafter on the half-open upper edge) and clip it
-    // against the level domain.
-    std::array<std::int64_t, 2> lower{};
-    std::array<std::int64_t, 2> upper{};
-    for (std::size_t entry = 0; entry < 2; ++entry) {
-        const auto axis = static_cast<std::size_t>(axes[entry]);
-        const auto domainLower
-            = static_cast<std::int64_t>(level.domain.lower[axis]);
-        const auto domainUpper
-            = static_cast<std::int64_t>(level.domain.upper[axis]);
-        const auto rawLower = static_cast<std::int64_t>(
-            sampleIndex(level, axes[entry], region.lower[axis]));
-        const auto rawUpper = static_cast<std::int64_t>(
-            sampleIndex(level, axes[entry],
-                std::nextafter(region.upper[axis],
-                    -std::numeric_limits<double>::infinity())));
-        if (rawUpper < domainLower || rawLower > domainUpper) {
-            return extract;  // region misses this level's domain entirely
-        }
-        lower[entry] = std::max(rawLower, domainLower);
-        upper[entry] = std::min(rawUpper, domainUpper);
-    }
-
-    // Over-long axes keep only their first maxExtent cells.
-    for (std::size_t entry = 0; entry < 2; ++entry) {
-        if (upper[entry] - lower[entry] + 1
-            > static_cast<std::int64_t>(maxExtent)) {
-            upper[entry] = lower[entry] + maxExtent - 1;
-            if (entry == 0) {
-                extract.truncatedX = true;
-            } else {
-                extract.truncatedY = true;
-            }
-        }
-        extract.lower[entry] = static_cast<int>(lower[entry]);
-        extract.upper[entry] = static_cast<int>(upper[entry]);
-    }
-    extract.nx = static_cast<int>(upper[0] - lower[0] + 1);
-    extract.ny = static_cast<int>(upper[1] - lower[1] + 1);
-
-    if (metadata.dimension == 3) {
-        const auto normal = static_cast<std::size_t>(normalAxis);
-        const auto domainLower
-            = static_cast<std::int64_t>(level.domain.lower[normal]);
-        const auto domainUpper
-            = static_cast<std::int64_t>(level.domain.upper[normal]);
-        const auto raw = static_cast<std::int64_t>(
-            sampleIndex(level, normalAxis, slicePosition));
-        extract.sliceIndex
-            = static_cast<int>(std::clamp(raw, domainLower, domainUpper));
-    }
-
-    auto query = level.domain;
-    for (std::size_t entry = 0; entry < 2; ++entry) {
-        const auto axis = static_cast<std::size_t>(axes[entry]);
-        query.lower[axis] = extract.lower[entry];
-        query.upper[axis] = extract.upper[entry];
-    }
-    if (metadata.dimension == 3) {
-        const auto normal = static_cast<std::size_t>(normalAxis);
-        query.lower[normal] = extract.sliceIndex;
-        query.upper[normal] = extract.sliceIndex;
-    }
-
-    const auto cellCount = static_cast<std::size_t>(extract.nx)
-        * static_cast<std::size_t>(extract.ny);
-    extract.values.assign(cellCount, 0.0F);
-    extract.covered.assign(cellCount, std::uint8_t{0});
-
-    const auto xAxis = static_cast<std::size_t>(axes[0]);
-    const auto yAxis = static_cast<std::size_t>(axes[1]);
-    auto minimum = std::numeric_limits<double>::infinity();
-    auto maximum = -std::numeric_limits<double>::infinity();
-    for (std::size_t grid = 0; grid < level.blocks.size(); ++grid) {
-        if (cancellation.stop_requested()) {
-            throw ReadCancelled();
-        }
-        // Coverage follows the grid's valid box; the FAB payload may carry
-        // ghost cells, so value offsets use the FAB's own box.
-        const auto validBox = level.blocks[grid].box;
-        if (!dataset_extract_detail::intersects(
-                validBox, query, metadata.dimension)) {
-            continue;
-        }
-        BlockRequest request;
-        request.dataset = dataset.id();
-        request.level = levelIndex;
-        request.gridIndex = static_cast<int>(grid);
-        request.field = field;
-        request.firstComponent = 0;
-        request.componentCount = 1;
-        const auto access = dataset.requestBlock(request, cancellation);
-        const auto& fab = *access.handle;
-
-        const auto iLower = std::max(validBox.lower[xAxis], extract.lower[0]);
-        const auto iUpper = std::min(validBox.upper[xAxis], extract.upper[0]);
-        const auto jLower = std::max(validBox.lower[yAxis], extract.lower[1]);
-        const auto jUpper = std::min(validBox.upper[yAxis], extract.upper[1]);
-        for (auto j = jLower; j <= jUpper; ++j) {
-            if (cancellation.stop_requested()) {
-                throw ReadCancelled();
-            }
-            const auto valueY = static_cast<std::size_t>(
-                static_cast<std::int64_t>(j) - extract.lower[1]);
-            for (auto i = iLower; i <= iUpper; ++i) {
-                // Place the in-plane indices (i, j) and, in 3-D, the slice
-                // index at their actual axes: the FAB is laid out in global
-                // index space and a grid box need not start at the origin
-                // (finer AMR levels especially), so a positional (i, j, k)
-                // lookup is only correct for a 2-D or xy slice.
-                Int3 cell{};
-                cell[xAxis] = i;
-                cell[yAxis] = j;
-                if (metadata.dimension == 3) {
-                    cell[static_cast<std::size_t>(normalAxis)]
-                        = extract.sliceIndex;
-                }
-                const auto value = fab.values[dataset_extract_detail::valueOffset(
-                    fab.box, cell, metadata.dimension)];
-                const auto valueX = static_cast<std::size_t>(
-                    static_cast<std::int64_t>(i) - extract.lower[0]);
-                const auto offset = valueX
-                    + static_cast<std::size_t>(extract.nx) * valueY;
-                extract.values[offset] = static_cast<float>(value);
-                extract.covered[offset] = std::uint8_t{1};
-                if (std::isfinite(value)) {
-                    minimum = std::min(minimum, value);
-                    maximum = std::max(maximum, value);
-                }
-            }
-        }
-    }
-    if (std::isfinite(minimum) && std::isfinite(maximum)) {
-        extract.minimum = minimum;
-        extract.maximum = maximum;
-        extract.hasFiniteValues = true;
-    }
-    return extract;
+    DatasetPageRequest request;
+    request.dataset = dataset.id();
+    request.field = field;
+    request.level = levelIndex;
+    request.region = region;
+    request.normalAxis = normalAxis;
+    request.slicePosition = slicePosition;
+    request.maximumExtent = maxExtent;
+    return extractDatasetPage(dataset, request, cancellation);
 }
 
 } // namespace amrvis::qt

--- a/src/qt/DatasetWindow.cpp
+++ b/src/qt/DatasetWindow.cpp
@@ -1,4 +1,6 @@
 #include "DatasetWindow.hpp"
+
+#include <amrexplorer/pipeline/SlicePipeline.hpp>
 #include "NumberFormat.hpp"
 
 #include <amrexplorer/io/PlotfileBlockReader.hpp>
@@ -199,9 +201,16 @@ std::vector<DatasetWindow::LevelData> DatasetWindow::extractLevels(
         if (cancellation.stop_requested()) {
             throw ReadCancelled();
         }
-        auto extract = extractDatasetLevel(*request.dataset, request.field,
-            level, request.region, request.normalAxis, request.slicePosition,
-            datasetExtractMaxExtent, cancellation);
+        DatasetPageRequest pageRequest;
+        pageRequest.dataset = request.dataset->id();
+        pageRequest.field = request.field;
+        pageRequest.level = level;
+        pageRequest.region = request.region;
+        pageRequest.normalAxis = request.normalAxis;
+        pageRequest.slicePosition = request.slicePosition;
+        pageRequest.maximumExtent = datasetExtractMaxExtent;
+        auto extract = request.dataset->requestDatasetPage(
+            pageRequest, cancellation);
         // Levels the region misses geometrically get no tab.
         if (extract.nx > 0 && extract.ny > 0) {
             levels.push_back(LevelData{level, std::move(extract)});
@@ -317,7 +326,7 @@ void DatasetWindow::cellClicked(std::size_t levelEntry, int row, int column)
 
     const auto& metadata = m_request.dataset->metadata();
     const auto& level = metadata.levels[static_cast<std::size_t>(levelData.level)];
-    const auto axes = dataset_extract_detail::inPlaneAxes(
+    const auto axes = slicePlaneAxes(
         metadata.dimension, m_request.normalAxis);
     // The sample's physical bin at this level's resolution. On nodal axes
     // this is centered on the node rather than shifted to the next cell.

--- a/src/qt/DatasetWindow.hpp
+++ b/src/qt/DatasetWindow.hpp
@@ -5,6 +5,7 @@
 #include <amrexplorer/core/Geometry.hpp>
 #include <amrexplorer/core/Request.hpp>
 #include <amrexplorer/core/StopToken.hpp>
+#include <amrexplorer/data/DatasetSession.hpp>
 
 #include <QString>
 #include <QWidget>
@@ -18,17 +19,13 @@ class QCloseEvent;
 class QLabel;
 class QTabWidget;
 
-namespace amrvis {
-class PlotfileDataset;
-}
-
 namespace amrvis::qt {
 
 // Everything one read of the dataset window needs: the dataset and field,
 // the physical region of the source view, and for 3-D the view normal plus
 // the current slice position.
 struct DatasetRequest {
-    std::shared_ptr<PlotfileDataset> dataset;
+    std::shared_ptr<DatasetSession> dataset;
     FieldId field;
     QString fieldName;
     RealBox region;

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -16,7 +16,6 @@
 #include "Theme.hpp"
 #include "UserGuideDialog.hpp"
 
-#include <amrexplorer/io/PlotfileDataset.hpp>
 #include <amrexplorer/io/FabCatalog.hpp>
 #include <amrexplorer/io/FitsWriter.hpp>
 #include <amrexplorer/io/detail/FabHeaderParsing.hpp>
@@ -25,8 +24,6 @@
 #include <amrexplorer/core/Statistics.hpp>
 #include <amrexplorer/pipeline/ParticleProjection.hpp>
 #include <amrexplorer/pipeline/SliceRangeResolver.hpp>
-#include <amrexplorer/query/LineQuery.hpp>
-#include <amrexplorer/query/SliceQuery.hpp>
 #include <amrexplorer/render2d/Contours.hpp>
 #include <amrexplorer/render2d/Palette.hpp>
 #include <amrexplorer/render2d/ScalarRenderer.hpp>
@@ -306,7 +303,7 @@ QString cacheBudgetDescription(std::uint64_t bytes)
 }
 
 QString cacheFallbackMessage(
-    const PlotfileDataset& dataset, int fromLevel, int toLevel)
+    const DatasetSession& dataset, int fromLevel, int toLevel)
 {
     const auto budget = cacheBudgetDescription(
         dataset.cacheMetrics().budgetBytes);
@@ -3152,6 +3149,8 @@ void MainWindow::linePlotRequested(PlaneViewState& state, int imageX, int imageY
             metadata.dimension, state.normal, slicePosition,
             dataset->id(), FieldId{field}, maximumLevel, composition);
     }
+    const auto outputWidth = horizontal ? state.view->image().width()
+                                        : state.view->image().height();
     const auto fieldName = metadata.fields[field].name;
     const auto dimension = metadata.dimension;
     // The other in-plane axis carries the cursor's fixed coordinate.
@@ -3227,8 +3226,11 @@ void MainWindow::linePlotRequested(PlaneViewState& state, int imageX, int imageY
             watcher->deleteLater();
         });
     watcher->setFuture(QtConcurrent::run(
-        [dataset, request, cancellation] {
-            return LineQuery(*dataset).execute(request, cancellation);
+        [dataset, request, outputWidth, cancellation] {
+            auto result = dataset->requestView(
+                ViewDataRequest{LineViewRequest{request, outputWidth}},
+                cancellation);
+            return std::get<LineQueryResult>(std::move(result));
         }));
 }
 
@@ -4815,7 +4817,7 @@ void MainWindow::requestSlice(PlaneViewState& state, bool rasterDirty)
 
     const auto requestedRangeMode = static_cast<RangeMode>(
         m_rangeMode->currentData().toInt());
-    const auto rangeMode = effectiveRangeMode(metadata, request.field,
+    const auto rangeMode = effectiveRangeMode(dataset, request.field,
         maximumLevel, composition, requestedRangeMode);
     std::optional<std::pair<double, double>> userRange;
     if (rangeMode == RangeMode::User) {
@@ -5906,11 +5908,10 @@ void MainWindow::updateRangeModeAvailability()
     const FieldId field{m_fieldSelector->currentData().toUInt()};
     const auto [composition, maximumLevel] = decodeLevelData(
         m_levelSelector->currentData().toInt(), metadata.finestLevel);
-    const auto fileAvailable = metadata.isFab
-        || selectedMetadataRange(metadata, field,
-            maximumLevel, composition, RangeMode::File).has_value();
-    const auto levelAvailable = selectedMetadataRange(metadata, field,
-        maximumLevel, composition, RangeMode::Level).has_value();
+    const auto fileAvailable = m_dataset->rangeAvailable(
+        RangeRequest{field, maximumLevel, composition, RangeScope::File});
+    const auto levelAvailable = m_dataset->rangeAvailable(
+        RangeRequest{field, maximumLevel, composition, RangeScope::Level});
 
     auto* model = qobject_cast<QStandardItemModel*>(m_rangeMode->model());
     if (model == nullptr) {

--- a/src/qt/MainWindow.hpp
+++ b/src/qt/MainWindow.hpp
@@ -6,11 +6,11 @@
 
 #include <amrexplorer/core/Result.hpp>
 #include <amrexplorer/core/StopToken.hpp>
+#include <amrexplorer/data/DatasetSession.hpp>
 #include <amrexplorer/io/PlotfileMetadataReader.hpp>
 #include <amrexplorer/pipeline/DisplayCoordinator.hpp>
 #include <amrexplorer/pipeline/SlicePipeline.hpp>
 #include <amrexplorer/pipeline/SliceRangeResolver.hpp>
-#include <amrexplorer/query/SliceQuery.hpp>
 #include <amrexplorer/render2d/Contours.hpp>
 #include <amrexplorer/render2d/ImageBuffer.hpp>
 #include <amrexplorer/render2d/Palette.hpp>
@@ -54,7 +54,6 @@ class QRectF;
 class QWidget;
 
 namespace amrvis {
-class PlotfileDataset;
 struct DatasetMetadata;
 struct LineResult;
 enum class CompositionPolicy : std::uint8_t;
@@ -615,7 +614,7 @@ private:
     // (progress, cancellation, FFmpeg encoding). This window supplies frame
     // rendering and sequence navigation, and restores its UI on finished().
     AnimationExporter* m_animationExporter = nullptr;
-    std::shared_ptr<PlotfileDataset> m_dataset;
+    std::shared_ptr<DatasetSession> m_dataset;
     std::shared_ptr<const DatasetMetadata> m_openMetadata;
     std::string m_fileVersion;
     PlaneViewState m_view2d;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,6 +6,10 @@ add_executable(test_geometry unit/test_geometry.cpp)
 target_link_libraries(test_geometry PRIVATE amrexplorer::core amrexplorer::warnings)
 add_test(NAME geometry COMMAND test_geometry)
 
+add_executable(test_view_data unit/test_view_data.cpp)
+target_link_libraries(test_view_data PRIVATE amrexplorer::data amrexplorer::warnings)
+add_test(NAME view_data COMMAND test_view_data)
+
 add_executable(test_stop_token unit/test_stop_token.cpp)
 target_compile_definitions(
     test_stop_token PRIVATE AMREXPLORER_TEST_FORCE_FALLBACK_STOP_TOKEN

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -124,7 +124,9 @@ add_test(
 )
 
 add_executable(test_dataset_extract integration/test_dataset_extract.cpp)
-target_link_libraries(test_dataset_extract PRIVATE amrexplorer::io amrexplorer::warnings)
+target_link_libraries(
+    test_dataset_extract PRIVATE amrexplorer::data amrexplorer::warnings
+)
 add_test(NAME dataset_extract COMMAND test_dataset_extract)
 
 add_executable(test_dataset_concurrency integration/test_dataset_concurrency.cpp)

--- a/tests/integration/test_display_transitions.cpp
+++ b/tests/integration/test_display_transitions.cpp
@@ -11,7 +11,7 @@
 // logic is unit-tested in test_display_coordinator and its wiring by the
 // Qt zoom/pan smoke tests.)
 
-#include <amrexplorer/io/PlotfileDataset.hpp>
+#include <amrexplorer/data/LocalDatasetSession.hpp>
 #include <amrexplorer/pipeline/DisplayCoordinator.hpp>
 #include <amrexplorer/pipeline/ParticleProjection.hpp>
 #include <amrexplorer/pipeline/SlicePipeline.hpp>
@@ -548,7 +548,7 @@ int main()
         // Measure the two blocks' resident sizes on a fresh dataset with a
         // generous budget (a frame load would have populated the cache
         // already), then rerun with budgets sized to force each fallback.
-        auto measured = std::make_shared<amrvis::PlotfileDataset>(
+        auto measured = std::make_shared<amrvis::LocalDatasetSession>(
             root2d, amrvis::DatasetId{nextId++}, bigBudget);
         const auto metadata = measured->metadata();
         const auto bounds = amrvis::datasetSampleBounds(metadata);
@@ -573,7 +573,7 @@ int main()
         require(coarseBytes > 0 && fineBytes > 0,
             "block size measurement failed");
 
-        const auto freshRequest = [&](const amrvis::PlotfileDataset& dataset) {
+        const auto freshRequest = [&](const amrvis::DatasetSession& dataset) {
             auto fresh = request;
             fresh.dataset = dataset.id();
             return fresh;
@@ -581,7 +581,7 @@ int main()
 
         // Composite finest under pressure: falls back to level 0 and records
         // the fallback; the result is still internally consistent.
-        auto tight = std::make_shared<amrvis::PlotfileDataset>(root2d,
+        auto tight = std::make_shared<amrvis::LocalDatasetSession>(root2d,
             amrvis::DatasetId{nextId++}, coarseBytes + fineBytes / 2);
         const auto fallback = amrvis::executeSliceWithFallback(tight,
             freshRequest(*tight), amrvis::RangeMode::Visible, std::nullopt,
@@ -594,7 +594,7 @@ int main()
             "budget fallback");
 
         // A generous budget records no fallback.
-        auto roomy = std::make_shared<amrvis::PlotfileDataset>(root2d,
+        auto roomy = std::make_shared<amrvis::LocalDatasetSession>(root2d,
             amrvis::DatasetId{nextId++}, bigBudget);
         const auto normal = amrvis::executeSliceWithFallback(roomy,
             freshRequest(*roomy), amrvis::RangeMode::Visible, std::nullopt,
@@ -604,7 +604,7 @@ int main()
             "an unpressured slice recorded a fallback");
 
         // An exact level cannot shed resolution: actionable error.
-        auto exact = std::make_shared<amrvis::PlotfileDataset>(root2d,
+        auto exact = std::make_shared<amrvis::LocalDatasetSession>(root2d,
             amrvis::DatasetId{nextId++}, std::min(coarseBytes, fineBytes) / 2);
         bool threw = false;
         try {
@@ -623,7 +623,7 @@ int main()
         require(threw, "an oversized exact level did not report an error");
 
         // Even level 0 cannot fit: the actionable dead-end error.
-        auto hopeless = std::make_shared<amrvis::PlotfileDataset>(root2d,
+        auto hopeless = std::make_shared<amrvis::LocalDatasetSession>(root2d,
             amrvis::DatasetId{nextId++}, coarseBytes / 2);
         threw = false;
         try {

--- a/tests/integration/test_particle_reader.cpp
+++ b/tests/integration/test_particle_reader.cpp
@@ -1,5 +1,5 @@
 #include <amrexplorer/io/ParticleReader.hpp>
-#include <amrexplorer/io/PlotfileDataset.hpp>
+#include <amrexplorer/data/LocalDatasetSession.hpp>
 #include <amrexplorer/io/PlotfileMetadataReader.hpp>
 #include <amrexplorer/pipeline/SlicePipeline.hpp>
 
@@ -313,7 +313,7 @@ int main(int argc, char* argv[])
         }
         auto preparedMetadata
             = amrvis::PlotfileMetadataReader{}.read(preparedRoot);
-        amrvis::PlotfileDataset preparedDataset(
+        amrvis::LocalDatasetSession preparedDataset(
             preparedRoot, amrvis::DatasetId{1}, 1024 * 1024,
             std::move(preparedMetadata));
         require(preparedDataset.particleSpecies().size() == 2,

--- a/tests/integration/test_particle_reader.cpp
+++ b/tests/integration/test_particle_reader.cpp
@@ -176,6 +176,18 @@ int main(int argc, char* argv[])
         require(rejectedNonCheckpoint,
             "non-checkpoint particle data was not rejected explicitly");
 
+        amrvis::StopSource stoppedDiscovery;
+        stoppedDiscovery.request_stop();
+        bool discoveryCancellationObserved = false;
+        try {
+            static_cast<void>(amrvis::discoverParticleSpecies(
+                root, stoppedDiscovery.get_token()));
+        } catch (const amrvis::ReadCancelled&) {
+            discoveryCancellationObserved = true;
+        }
+        require(discoveryCancellationObserved,
+            "particle discovery ignored cancellation");
+
         writeFixture(root, identities, 0.0, true);
         const auto expanded = amrvis::readParticleSample(root, "Tracer", 1.0);
         require(expanded.points.size() == all.points.size()
@@ -350,10 +362,8 @@ int main(int argc, char* argv[])
         try {
             static_cast<void>(amrvis::loadParticleSamples(preparedDataset,
                 selectedSpecies, 1.0, 0, stopped.get_token()));
-        } catch (const amrvis::ParticleReadError& error) {
-            batchCancellationObserved
-                = std::string(error.what()).find("cancelled")
-                != std::string::npos;
+        } catch (const amrvis::ReadCancelled&) {
+            batchCancellationObserved = true;
         }
         require(batchCancellationObserved,
             "batch sampling did not forward cancellation");

--- a/tests/unit/test_slice_pipeline.cpp
+++ b/tests/unit/test_slice_pipeline.cpp
@@ -117,7 +117,6 @@ int main()
         other.composition = amrvis::CompositionPolicy::ExactLevel;
         require(!amrvis::sameSliceSpec(base, other), "composition difference missed");
     }
-
     // --- coveredCells -----------------------------------------------------
     // A [0,9] cell-centered level with cell size 1 spans physical [0, 10].
     const auto grid = makeMetadata(2, 1.0);

--- a/tests/unit/test_slice_range_resolver.cpp
+++ b/tests/unit/test_slice_range_resolver.cpp
@@ -68,7 +68,7 @@ int main()
     // resolveRange/resolveDisplayRange only consult the dataset for the
     // Level/File statistics branch; the User and Visible paths are pure. The
     // null dataset below locks in that contract.
-    const std::shared_ptr<amrvis::PlotfileDataset> noDataset;
+    const std::shared_ptr<amrvis::DatasetSession> noDataset;
 
     // --- finiteRange -----------------------------------------------------
     {

--- a/tests/unit/test_view_data.cpp
+++ b/tests/unit/test_view_data.cpp
@@ -1,0 +1,49 @@
+#include <amrexplorer/data/ViewData.hpp>
+
+#include <algorithm>
+#include <cstdlib>
+#include <iostream>
+
+namespace {
+
+void require(bool condition, const char* message)
+{
+    if (!condition) {
+        std::cerr << "FAILED: " << message << '\n';
+        std::exit(1);
+    }
+}
+
+amrvis::LineQueryResult lineResult(std::vector<float> values,
+    std::vector<std::uint8_t> valid)
+{
+    amrvis::LineQueryResult result;
+    result.line.positions.reserve(values.size());
+    result.line.sourceLevel.reserve(values.size());
+    for (std::size_t index = 0; index < values.size(); ++index) {
+        result.line.positions.push_back(static_cast<double>(index));
+        result.line.sourceLevel.push_back(valid[index] != 0 ? 0 : -1);
+    }
+    result.line.values = std::move(values);
+    result.line.valid = std::move(valid);
+    return result;
+}
+
+} // namespace
+
+int main()
+{
+    auto gapped = amrvis::boundLineToViewport(
+        lineResult({1.0F, 0.0F, 3.0F, 2.0F}, {1, 0, 1, 1}), 1);
+    require(gapped.line.values.size() <= 2,
+        "gapped bucket exceeded the viewport sample bound");
+    require(std::ranges::any_of(gapped.line.valid,
+                [](std::uint8_t valid) { return valid == 0; }),
+        "downsampling discarded an AMR coverage gap");
+
+    const auto extrema = amrvis::boundLineToViewport(
+        lineResult({2.0F, -4.0F, 7.0F, 1.0F}, {1, 1, 1, 1}), 1);
+    require(extrema.line.values == std::vector<float>({-4.0F, 7.0F}),
+        "valid bucket did not preserve its ordered extrema");
+    return 0;
+}

--- a/tests/unit/test_view_data.cpp
+++ b/tests/unit/test_view_data.cpp
@@ -40,6 +40,9 @@ int main()
     require(std::ranges::any_of(gapped.line.valid,
                 [](std::uint8_t valid) { return valid == 0; }),
         "downsampling discarded an AMR coverage gap");
+    require(std::ranges::any_of(gapped.line.valid,
+                [](std::uint8_t valid) { return valid != 0; }),
+        "downsampling discarded every valid sample in a mixed bucket");
 
     const auto extrema = amrvis::boundLineToViewport(
         lineResult({2.0F, -4.0F, 7.0F, 1.0F}, {1, 1, 1, 1}), 1);


### PR DESCRIPTION
Part 3 of 13 in the remote client/server stack.

## Purpose

Route existing local data access through one `DatasetSession` interface before introducing networking.

## Scope

- Adds the Qt-free data/session layer and `LocalDatasetSession`.
- Moves bounded view and Dataset-window page requests behind the session API.
- Migrates the pipeline and Qt application while preserving the public local workflow.
- Makes line requests viewport-bounded, so sufficiently dense lines are decimated to the current display width instead of always returning every native sample.

## Review focus

Check ownership, close semantics, cache access, viewport-bounded line decimation, and preservation of the surrounding local behavior. There is no socket or wire code in this layer.

## Validation

- Headless data/query/pipeline tests
- Existing local Qt slice, FAB/MultiFab, sequence, range, particle, and shutdown smokes at the stack tip
