### PR TITLE
[client-server] add bounded socket framing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,7 @@ add_subdirectory(src/cache)
 add_subdirectory(src/io)
 add_subdirectory(src/query)
 add_subdirectory(src/data)
+add_subdirectory(src/remote)
 add_subdirectory(src/render2d)
 add_subdirectory(src/pipeline)
 

--- a/include/amrexplorer/remote/Frame.hpp
+++ b/include/amrexplorer/remote/Frame.hpp
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <span>
+#include <string>
+#include <vector>
+
+namespace amrvis::remote {
+
+inline constexpr std::uint32_t defaultMaximumFrameBytes
+    = 128U * 1024U * 1024U;
+
+class Socket {
+public:
+    using Native = std::intptr_t;
+
+    Socket() = default;
+    explicit Socket(Native descriptor) noexcept;
+    ~Socket();
+
+    Socket(const Socket&) = delete;
+    Socket& operator=(const Socket&) = delete;
+    Socket(Socket&& other) noexcept;
+    Socket& operator=(Socket&& other) noexcept;
+
+    [[nodiscard]] Native descriptor() const noexcept;
+    [[nodiscard]] bool valid() const noexcept;
+    void shutdown() noexcept;
+    void close() noexcept;
+
+private:
+    Native m_descriptor = -1;
+};
+
+struct Listener {
+    Socket socket;
+    std::uint16_t port = 0;
+};
+
+[[nodiscard]] Listener listenOnLoopback(
+    std::uint16_t port, int backlog = 16);
+[[nodiscard]] Socket acceptConnection(const Socket& listener);
+[[nodiscard]] Socket connectTo(const std::string& host, std::uint16_t port);
+
+void writeFrame(const Socket& socket, std::span<const std::uint8_t> payload,
+    std::uint32_t maximumBytes = defaultMaximumFrameBytes);
+[[nodiscard]] std::optional<std::vector<std::uint8_t>> readFrame(
+    const Socket& socket,
+    std::uint32_t maximumBytes = defaultMaximumFrameBytes);
+
+} // namespace amrvis::remote

--- a/include/amrexplorer/remote/Frame.hpp
+++ b/include/amrexplorer/remote/Frame.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <amrexplorer/core/StopToken.hpp>
+
+#include <chrono>
 #include <cstdint>
 #include <optional>
 #include <span>
@@ -45,8 +48,15 @@ struct Listener {
 
 void writeFrame(const Socket& socket, std::span<const std::uint8_t> payload,
     std::uint32_t maximumBytes = defaultMaximumFrameBytes);
+void writeFrame(const Socket& socket, std::span<const std::uint8_t> payload,
+    std::uint32_t maximumBytes,
+    std::chrono::steady_clock::time_point deadline,
+    StopToken cancellation = {});
 [[nodiscard]] std::optional<std::vector<std::uint8_t>> readFrame(
     const Socket& socket,
     std::uint32_t maximumBytes = defaultMaximumFrameBytes);
+[[nodiscard]] std::optional<std::vector<std::uint8_t>> readFrame(
+    const Socket& socket, std::uint32_t maximumBytes,
+    std::chrono::steady_clock::time_point deadline);
 
 } // namespace amrvis::remote

--- a/include/amrexplorer/remote/Frame.hpp
+++ b/include/amrexplorer/remote/Frame.hpp
@@ -52,6 +52,12 @@ void writeFrame(const Socket& socket, std::span<const std::uint8_t> payload,
     std::uint32_t maximumBytes,
     std::chrono::steady_clock::time_point deadline,
     StopToken cancellation = {});
+// Writes may take arbitrarily long while the peer continues accepting bytes.
+// The operation fails only when no bytes can be written for stallTimeout.
+void writeFrameWithStallTimeout(const Socket& socket,
+    std::span<const std::uint8_t> payload, std::uint32_t maximumBytes,
+    std::chrono::milliseconds stallTimeout,
+    StopToken cancellation = {});
 [[nodiscard]] std::optional<std::vector<std::uint8_t>> readFrame(
     const Socket& socket,
     std::uint32_t maximumBytes = defaultMaximumFrameBytes);

--- a/include/amrexplorer/remote/Frame.hpp
+++ b/include/amrexplorer/remote/Frame.hpp
@@ -43,7 +43,8 @@ struct Listener {
 
 [[nodiscard]] Listener listenOnLoopback(
     std::uint16_t port, int backlog = 16);
-[[nodiscard]] Socket acceptConnection(const Socket& listener);
+[[nodiscard]] Socket acceptConnection(
+    const Socket& listener, StopToken cancellation = {});
 [[nodiscard]] Socket connectTo(const std::string& host, std::uint16_t port);
 
 void writeFrame(const Socket& socket, std::span<const std::uint8_t> payload,
@@ -51,18 +52,19 @@ void writeFrame(const Socket& socket, std::span<const std::uint8_t> payload,
 void writeFrame(const Socket& socket, std::span<const std::uint8_t> payload,
     std::uint32_t maximumBytes,
     std::chrono::steady_clock::time_point deadline,
-    StopToken cancellation = {});
+    StopToken cancellation = {}, StopToken lifecycle = {});
 // Writes may take arbitrarily long while the peer continues accepting bytes.
 // The operation fails only when no bytes can be written for stallTimeout.
 void writeFrameWithStallTimeout(const Socket& socket,
     std::span<const std::uint8_t> payload, std::uint32_t maximumBytes,
     std::chrono::milliseconds stallTimeout,
-    StopToken cancellation = {});
+    StopToken cancellation = {}, StopToken lifecycle = {});
 [[nodiscard]] std::optional<std::vector<std::uint8_t>> readFrame(
     const Socket& socket,
     std::uint32_t maximumBytes = defaultMaximumFrameBytes);
 [[nodiscard]] std::optional<std::vector<std::uint8_t>> readFrame(
     const Socket& socket, std::uint32_t maximumBytes,
-    std::chrono::steady_clock::time_point deadline);
+    std::chrono::steady_clock::time_point deadline,
+    StopToken cancellation = {});
 
 } // namespace amrvis::remote

--- a/src/remote/CMakeLists.txt
+++ b/src/remote/CMakeLists.txt
@@ -1,0 +1,15 @@
+add_library(amrexplorer_remote
+    Frame.cpp
+)
+add_library(amrexplorer::remote ALIAS amrexplorer_remote)
+
+target_include_directories(amrexplorer_remote
+    PUBLIC
+        $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+        $<INSTALL_INTERFACE:include>
+)
+target_link_libraries(amrexplorer_remote PRIVATE amrexplorer::warnings)
+if(WIN32)
+    target_link_libraries(amrexplorer_remote PRIVATE ws2_32)
+endif()
+target_compile_features(amrexplorer_remote PUBLIC cxx_std_20)

--- a/src/remote/Frame.cpp
+++ b/src/remote/Frame.cpp
@@ -160,10 +160,14 @@ void configureConnectedSocket(NativeSocket descriptor)
 }
 
 void waitForReadable(NativeSocket socket,
-    std::chrono::steady_clock::time_point deadline)
+    std::chrono::steady_clock::time_point deadline,
+    StopToken cancellation)
 {
     using namespace std::chrono_literals;
     for (;;) {
+        if (cancellation.stop_requested()) {
+            throw ReadCancelled();
+        }
         const auto now = std::chrono::steady_clock::now();
         if (deadline != std::chrono::steady_clock::time_point::max()
             && now >= deadline) {
@@ -205,11 +209,12 @@ void waitForReadable(NativeSocket socket,
 
 void waitForWritable(NativeSocket socket,
     std::chrono::steady_clock::time_point deadline,
-    StopToken cancellation, const char* timeoutMessage)
+    StopToken cancellation, StopToken lifecycle,
+    const char* timeoutMessage)
 {
     using namespace std::chrono_literals;
     for (;;) {
-        if (cancellation.stop_requested()) {
+        if (cancellation.stop_requested() || lifecycle.stop_requested()) {
             throw ReadCancelled();
         }
         const auto now = std::chrono::steady_clock::now();
@@ -252,11 +257,12 @@ void waitForWritable(NativeSocket socket,
 
 bool readExact(NativeSocket descriptor, std::span<std::uint8_t> destination,
     bool allowCleanEof,
-    std::chrono::steady_clock::time_point deadline)
+    std::chrono::steady_clock::time_point deadline,
+    StopToken cancellation)
 {
     std::size_t completed = 0;
     while (completed < destination.size()) {
-        waitForReadable(descriptor, deadline);
+        waitForReadable(descriptor, deadline, cancellation);
 #ifdef _WIN32
         const auto remaining = std::min<std::size_t>(
             destination.size() - completed,
@@ -292,7 +298,7 @@ void writeExact(
 void writeExact(NativeSocket descriptor,
     std::span<const std::uint8_t> source,
     std::chrono::steady_clock::time_point deadline,
-    StopToken cancellation,
+    StopToken cancellation, StopToken lifecycle,
     std::optional<std::chrono::milliseconds> stallTimeout = std::nullopt)
 {
     std::size_t completed = 0;
@@ -301,8 +307,9 @@ void writeExact(NativeSocket descriptor,
         : std::chrono::steady_clock::time_point::max();
     while (completed < source.size()) {
         waitForWritable(descriptor, std::min(deadline, progressDeadline),
-            cancellation, stallTimeout ? "wire frame write stalled"
-                                       : "wire frame write timed out");
+            cancellation, lifecycle,
+            stallTimeout ? "wire frame write stalled"
+                         : "wire frame write timed out");
 #ifdef _WIN32
         const auto remaining = std::min<std::size_t>(
             source.size() - completed, 64U * 1024U);
@@ -341,7 +348,7 @@ void writeExact(
     NativeSocket descriptor, std::span<const std::uint8_t> source)
 {
     writeExact(descriptor, source,
-        std::chrono::steady_clock::time_point::max(), {});
+        std::chrono::steady_clock::time_point::max(), {}, {});
 }
 
 } // namespace
@@ -429,6 +436,7 @@ Listener listenOnLoopback(std::uint16_t port, int backlog)
     if (::listen(native(socket.descriptor()), backlog) != 0) {
         throwSocketError("listen");
     }
+    setNonBlocking(native(socket.descriptor()), true);
 
     SocketLength size = static_cast<SocketLength>(sizeof(address));
     if (::getsockname(native(socket.descriptor()),
@@ -439,10 +447,15 @@ Listener listenOnLoopback(std::uint16_t port, int backlog)
     return {std::move(socket), ntohs(address.sin_port)};
 }
 
-Socket acceptConnection(const Socket& listener)
+Socket acceptConnection(const Socket& listener, StopToken cancellation)
 {
     ensureSockets();
     for (;;) {
+        waitForReadable(native(listener.descriptor()),
+            std::chrono::steady_clock::time_point::max(), cancellation);
+        if (cancellation.stop_requested()) {
+            throw ReadCancelled();
+        }
         const auto descriptor
             = ::accept(native(listener.descriptor()), nullptr, nullptr);
         if (descriptor != invalidSocket) {
@@ -451,7 +464,7 @@ Socket acceptConnection(const Socket& listener)
             return socket;
         }
         const auto error = lastSocketError();
-        if (!interrupted(error)) {
+        if (!interrupted(error) && !wouldBlock(error)) {
             throwSocketError("accept", error);
         }
     }
@@ -518,7 +531,7 @@ void writeFrame(const Socket& socket, std::span<const std::uint8_t> payload,
 void writeFrame(const Socket& socket, std::span<const std::uint8_t> payload,
     std::uint32_t maximumBytes,
     std::chrono::steady_clock::time_point deadline,
-    StopToken cancellation)
+    StopToken cancellation, StopToken lifecycle)
 {
     if (payload.empty() || payload.size() > maximumBytes
         || payload.size() > std::numeric_limits<std::uint32_t>::max()) {
@@ -529,13 +542,15 @@ void writeFrame(const Socket& socket, std::span<const std::uint8_t> payload,
         = reinterpret_cast<const std::uint8_t*>(&networkSize);
     writeExact(native(socket.descriptor()),
         std::span<const std::uint8_t>(sizeBytes, sizeof(networkSize)),
-        deadline, cancellation);
-    writeExact(native(socket.descriptor()), payload, deadline, cancellation);
+        deadline, cancellation, lifecycle);
+    writeExact(native(socket.descriptor()), payload, deadline, cancellation,
+        lifecycle);
 }
 
 void writeFrameWithStallTimeout(const Socket& socket,
     std::span<const std::uint8_t> payload, std::uint32_t maximumBytes,
-    std::chrono::milliseconds stallTimeout, StopToken cancellation)
+    std::chrono::milliseconds stallTimeout, StopToken cancellation,
+    StopToken lifecycle)
 {
     if (payload.empty() || payload.size() > maximumBytes
         || payload.size() > std::numeric_limits<std::uint32_t>::max()) {
@@ -550,10 +565,10 @@ void writeFrameWithStallTimeout(const Socket& socket,
         = reinterpret_cast<const std::uint8_t*>(&networkSize);
     writeExact(native(socket.descriptor()),
         std::span<const std::uint8_t>(sizeBytes, sizeof(networkSize)),
-        std::chrono::steady_clock::time_point::max(), cancellation,
+        std::chrono::steady_clock::time_point::max(), cancellation, lifecycle,
         stallTimeout);
     writeExact(native(socket.descriptor()), payload,
-        std::chrono::steady_clock::time_point::max(), cancellation,
+        std::chrono::steady_clock::time_point::max(), cancellation, lifecycle,
         stallTimeout);
 }
 
@@ -561,16 +576,18 @@ std::optional<std::vector<std::uint8_t>> readFrame(
     const Socket& socket, std::uint32_t maximumBytes)
 {
     return readFrame(socket, maximumBytes,
-        std::chrono::steady_clock::time_point::max());
+        std::chrono::steady_clock::time_point::max(), {});
 }
 
 std::optional<std::vector<std::uint8_t>> readFrame(const Socket& socket,
     std::uint32_t maximumBytes,
-    std::chrono::steady_clock::time_point deadline)
+    std::chrono::steady_clock::time_point deadline,
+    StopToken cancellation)
 {
     std::array<std::uint8_t, sizeof(std::uint32_t)> sizeBytes{};
     if (!readExact(
-            native(socket.descriptor()), sizeBytes, true, deadline)) {
+            native(socket.descriptor()), sizeBytes, true, deadline,
+            cancellation)) {
         return std::nullopt;
     }
     std::uint32_t networkSize = 0;
@@ -581,7 +598,7 @@ std::optional<std::vector<std::uint8_t>> readFrame(const Socket& socket,
     }
     std::vector<std::uint8_t> payload(size);
     static_cast<void>(readExact(
-        native(socket.descriptor()), payload, false, deadline));
+        native(socket.descriptor()), payload, false, deadline, cancellation));
     return payload;
 }
 

--- a/src/remote/Frame.cpp
+++ b/src/remote/Frame.cpp
@@ -18,6 +18,7 @@
 #include <arpa/inet.h>
 #include <netdb.h>
 #include <netinet/in.h>
+#include <netinet/tcp.h>
 #include <sys/socket.h>
 #include <unistd.h>
 #endif
@@ -90,7 +91,33 @@ NativeSocket native(Socket::Native descriptor)
 }
 
 [[noreturn]] void throwSocketError(
-    const std::string& operation, int error = lastSocketError())
+    const std::string& operation, int error = lastSocketError());
+
+void setIntegerSocketOption(NativeSocket descriptor, int level, int option,
+    int value, const char* name)
+{
+#ifdef _WIN32
+    const auto* bytes = reinterpret_cast<const char*>(&value);
+#else
+    const auto* bytes = &value;
+#endif
+    if (::setsockopt(descriptor, level, option, bytes, sizeof(value)) != 0) {
+        throwSocketError(std::string("setsockopt(") + name + ')');
+    }
+}
+
+void configureConnectedSocket(NativeSocket descriptor)
+{
+#ifdef SO_NOSIGPIPE
+    setIntegerSocketOption(
+        descriptor, SOL_SOCKET, SO_NOSIGPIPE, 1, "SO_NOSIGPIPE");
+#endif
+    setIntegerSocketOption(
+        descriptor, IPPROTO_TCP, TCP_NODELAY, 1, "TCP_NODELAY");
+}
+
+[[noreturn]] void throwSocketError(
+    const std::string& operation, int error)
 {
 #ifdef _WIN32
     throw std::runtime_error(
@@ -232,17 +259,13 @@ Listener listenOnLoopback(std::uint16_t port, int backlog)
         || native(socket.descriptor()) == invalidSocket) {
         throwSocketError("socket");
     }
-    const int reuse = 1;
 #ifdef _WIN32
-    const auto* reuseBytes = reinterpret_cast<const char*>(&reuse);
+    setIntegerSocketOption(native(socket.descriptor()), SOL_SOCKET,
+        SO_EXCLUSIVEADDRUSE, 1, "SO_EXCLUSIVEADDRUSE");
 #else
-    const auto* reuseBytes = &reuse;
+    setIntegerSocketOption(native(socket.descriptor()), SOL_SOCKET,
+        SO_REUSEADDR, 1, "SO_REUSEADDR");
 #endif
-    if (::setsockopt(native(socket.descriptor()), SOL_SOCKET, SO_REUSEADDR,
-            reuseBytes, sizeof(reuse))
-        != 0) {
-        throwSocketError("setsockopt");
-    }
 
     sockaddr_in address{};
     address.sin_family = AF_INET;
@@ -273,7 +296,9 @@ Socket acceptConnection(const Socket& listener)
         const auto descriptor
             = ::accept(native(listener.descriptor()), nullptr, nullptr);
         if (descriptor != invalidSocket) {
-            return Socket(static_cast<Socket::Native>(descriptor));
+            Socket socket(static_cast<Socket::Native>(descriptor));
+            configureConnectedSocket(descriptor);
+            return socket;
         }
         const auto error = lastSocketError();
         if (!interrupted(error)) {
@@ -297,6 +322,10 @@ Socket connectTo(const std::string& host, std::uint16_t port)
         throw std::runtime_error(
             "getaddrinfo: " + std::string(gai_strerror(status)));
     }
+    if (addresses == nullptr) {
+        throw std::runtime_error(
+            "getaddrinfo succeeded without returning a usable address");
+    }
 
     int lastError = 0;
     for (auto* address = addresses; address != nullptr;
@@ -312,6 +341,7 @@ Socket connectTo(const std::string& host, std::uint16_t port)
                 static_cast<SocketLength>(address->ai_addrlen))
             == 0) {
             ::freeaddrinfo(addresses);
+            configureConnectedSocket(native(socket.descriptor()));
             return socket;
         }
         lastError = lastSocketError();

--- a/src/remote/Frame.cpp
+++ b/src/remote/Frame.cpp
@@ -205,7 +205,7 @@ void waitForReadable(NativeSocket socket,
 
 void waitForWritable(NativeSocket socket,
     std::chrono::steady_clock::time_point deadline,
-    StopToken cancellation)
+    StopToken cancellation, const char* timeoutMessage)
 {
     using namespace std::chrono_literals;
     for (;;) {
@@ -214,7 +214,7 @@ void waitForWritable(NativeSocket socket,
         }
         const auto now = std::chrono::steady_clock::now();
         if (now >= deadline) {
-            throw std::runtime_error("wire frame write timed out");
+            throw std::runtime_error(timeoutMessage);
         }
         auto wait = 50ms;
         if (deadline != std::chrono::steady_clock::time_point::max()) {
@@ -292,11 +292,17 @@ void writeExact(
 void writeExact(NativeSocket descriptor,
     std::span<const std::uint8_t> source,
     std::chrono::steady_clock::time_point deadline,
-    StopToken cancellation)
+    StopToken cancellation,
+    std::optional<std::chrono::milliseconds> stallTimeout = std::nullopt)
 {
     std::size_t completed = 0;
+    auto progressDeadline = stallTimeout
+        ? std::chrono::steady_clock::now() + *stallTimeout
+        : std::chrono::steady_clock::time_point::max();
     while (completed < source.size()) {
-        waitForWritable(descriptor, deadline, cancellation);
+        waitForWritable(descriptor, std::min(deadline, progressDeadline),
+            cancellation, stallTimeout ? "wire frame write stalled"
+                                       : "wire frame write timed out");
 #ifdef _WIN32
         const auto remaining = std::min<std::size_t>(
             source.size() - completed, 64U * 1024U);
@@ -319,7 +325,15 @@ void writeExact(NativeSocket descriptor,
             }
             throwSocketError("send", error);
         }
+        if (count == 0) {
+            throw std::runtime_error(
+                "connection closed during wire frame write");
+        }
         completed += static_cast<std::size_t>(count);
+        if (stallTimeout) {
+            progressDeadline
+                = std::chrono::steady_clock::now() + *stallTimeout;
+        }
     }
 }
 
@@ -517,6 +531,30 @@ void writeFrame(const Socket& socket, std::span<const std::uint8_t> payload,
         std::span<const std::uint8_t>(sizeBytes, sizeof(networkSize)),
         deadline, cancellation);
     writeExact(native(socket.descriptor()), payload, deadline, cancellation);
+}
+
+void writeFrameWithStallTimeout(const Socket& socket,
+    std::span<const std::uint8_t> payload, std::uint32_t maximumBytes,
+    std::chrono::milliseconds stallTimeout, StopToken cancellation)
+{
+    if (payload.empty() || payload.size() > maximumBytes
+        || payload.size() > std::numeric_limits<std::uint32_t>::max()) {
+        throw std::runtime_error("wire frame size is outside the allowed range");
+    }
+    if (stallTimeout <= std::chrono::milliseconds::zero()) {
+        throw std::invalid_argument(
+            "wire frame write stall timeout must be greater than zero");
+    }
+    const auto networkSize = htonl(static_cast<std::uint32_t>(payload.size()));
+    const auto* sizeBytes
+        = reinterpret_cast<const std::uint8_t*>(&networkSize);
+    writeExact(native(socket.descriptor()),
+        std::span<const std::uint8_t>(sizeBytes, sizeof(networkSize)),
+        std::chrono::steady_clock::time_point::max(), cancellation,
+        stallTimeout);
+    writeExact(native(socket.descriptor()), payload,
+        std::chrono::steady_clock::time_point::max(), cancellation,
+        stallTimeout);
 }
 
 std::optional<std::vector<std::uint8_t>> readFrame(

--- a/src/remote/Frame.cpp
+++ b/src/remote/Frame.cpp
@@ -16,9 +16,11 @@
 #include <ws2tcpip.h>
 #else
 #include <arpa/inet.h>
+#include <fcntl.h>
 #include <netdb.h>
 #include <netinet/in.h>
 #include <netinet/tcp.h>
+#include <poll.h>
 #include <sys/socket.h>
 #include <unistd.h>
 #endif
@@ -58,6 +60,10 @@ bool interrupted(int error)
     return error == WSAEINTR;
 }
 
+bool wouldBlock(int error)
+{
+    return error == WSAEWOULDBLOCK;
+}
 void closeNative(NativeSocket socket)
 {
     ::closesocket(socket);
@@ -79,6 +85,10 @@ bool interrupted(int error)
     return error == EINTR;
 }
 
+bool wouldBlock(int error)
+{
+    return error == EAGAIN || error == EWOULDBLOCK;
+}
 void closeNative(NativeSocket socket)
 {
     ::close(socket);
@@ -93,6 +103,23 @@ NativeSocket native(Socket::Native descriptor)
 [[noreturn]] void throwSocketError(
     const std::string& operation, int error = lastSocketError());
 
+void setNonBlocking(NativeSocket socket, bool enabled)
+{
+#ifdef _WIN32
+    u_long mode = enabled ? 1UL : 0UL;
+    if (::ioctlsocket(socket, FIONBIO, &mode) != 0) {
+        throwSocketError("ioctlsocket(FIONBIO)");
+    }
+#else
+    const auto flags = ::fcntl(socket, F_GETFL, 0);
+    if (flags < 0
+        || ::fcntl(socket, F_SETFL,
+               enabled ? flags | O_NONBLOCK : flags & ~O_NONBLOCK)
+            != 0) {
+        throwSocketError("fcntl(O_NONBLOCK)");
+    }
+#endif
+}
 void setIntegerSocketOption(NativeSocket descriptor, int level, int option,
     int value, const char* name)
 {
@@ -114,6 +141,10 @@ void configureConnectedSocket(NativeSocket descriptor)
 #endif
     setIntegerSocketOption(
         descriptor, IPPROTO_TCP, TCP_NODELAY, 1, "TCP_NODELAY");
+    // Keep connected sockets nonblocking. All frame reads/writes wait through
+    // poll/select first, which makes their deadline and shutdown paths
+    // authoritative instead of allowing a kernel send/recv to block forever.
+    setNonBlocking(descriptor, true);
 }
 
 [[noreturn]] void throwSocketError(
@@ -128,11 +159,104 @@ void configureConnectedSocket(NativeSocket descriptor)
 #endif
 }
 
+void waitForReadable(NativeSocket socket,
+    std::chrono::steady_clock::time_point deadline)
+{
+    using namespace std::chrono_literals;
+    for (;;) {
+        const auto now = std::chrono::steady_clock::now();
+        if (deadline != std::chrono::steady_clock::time_point::max()
+            && now >= deadline) {
+            throw std::runtime_error("wire frame read timed out");
+        }
+        auto wait = 50ms;
+        if (deadline != std::chrono::steady_clock::time_point::max()) {
+            wait = std::min(wait,
+                std::chrono::duration_cast<std::chrono::milliseconds>(
+                    deadline - now));
+            wait = std::max(wait, 1ms);
+        }
+#ifdef _WIN32
+        timeval timeout{};
+        timeout.tv_sec = static_cast<long>(wait.count() / 1000);
+        timeout.tv_usec = static_cast<decltype(timeout.tv_usec)>(
+            (wait.count() % 1000) * 1000);
+        fd_set readable;
+        FD_ZERO(&readable);
+        FD_SET(socket, &readable);
+        const auto ready = ::select(0, &readable, nullptr, nullptr, &timeout);
+#else
+        pollfd descriptor{socket, POLLIN, 0};
+        const auto ready
+            = ::poll(&descriptor, 1, static_cast<int>(wait.count()));
+#endif
+        if (ready > 0) {
+            return;
+        }
+        if (ready == 0) {
+            continue;
+        }
+        const auto error = lastSocketError();
+        if (!interrupted(error)) {
+            throwSocketError("socket readiness wait", error);
+        }
+    }
+}
+
+void waitForWritable(NativeSocket socket,
+    std::chrono::steady_clock::time_point deadline,
+    StopToken cancellation)
+{
+    using namespace std::chrono_literals;
+    for (;;) {
+        if (cancellation.stop_requested()) {
+            throw ReadCancelled();
+        }
+        const auto now = std::chrono::steady_clock::now();
+        if (now >= deadline) {
+            throw std::runtime_error("wire frame write timed out");
+        }
+        auto wait = 50ms;
+        if (deadline != std::chrono::steady_clock::time_point::max()) {
+            wait = std::min(wait,
+                std::chrono::duration_cast<std::chrono::milliseconds>(
+                    deadline - now));
+            wait = std::max(wait, 1ms);
+        }
+#ifdef _WIN32
+        timeval timeout{};
+        timeout.tv_sec = static_cast<long>(wait.count() / 1000);
+        timeout.tv_usec = static_cast<decltype(timeout.tv_usec)>(
+            (wait.count() % 1000) * 1000);
+        fd_set writable;
+        FD_ZERO(&writable);
+        FD_SET(socket, &writable);
+        const auto ready = ::select(0, nullptr, &writable, nullptr, &timeout);
+#else
+        pollfd descriptor{socket, POLLOUT, 0};
+        const auto ready = ::poll(
+            &descriptor, 1, static_cast<int>(wait.count()));
+#endif
+        if (ready > 0) {
+            return;
+        }
+        if (ready == 0) {
+            continue;
+        }
+        const auto error = lastSocketError();
+        if (!interrupted(error)) {
+            throwSocketError("socket write readiness wait", error);
+        }
+    }
+}
+
 bool readExact(NativeSocket descriptor, std::span<std::uint8_t> destination,
-    bool allowCleanEof)
+    bool allowCleanEof,
+    std::chrono::steady_clock::time_point deadline)
 {
     std::size_t completed = 0;
     while (completed < destination.size()) {
+        waitForReadable(descriptor, deadline);
 #ifdef _WIN32
         const auto remaining = std::min<std::size_t>(
             destination.size() - completed,
@@ -152,7 +276,7 @@ bool readExact(NativeSocket descriptor, std::span<std::uint8_t> destination,
         }
         if (count < 0) {
             const auto error = lastSocketError();
-            if (interrupted(error)) {
+            if (interrupted(error) || wouldBlock(error)) {
                 continue;
             }
             throwSocketError("recv", error);
@@ -163,35 +287,47 @@ bool readExact(NativeSocket descriptor, std::span<std::uint8_t> destination,
 }
 
 void writeExact(
-    NativeSocket descriptor, std::span<const std::uint8_t> source)
+    NativeSocket descriptor, std::span<const std::uint8_t> source);
+
+void writeExact(NativeSocket descriptor,
+    std::span<const std::uint8_t> source,
+    std::chrono::steady_clock::time_point deadline,
+    StopToken cancellation)
 {
     std::size_t completed = 0;
     while (completed < source.size()) {
+        waitForWritable(descriptor, deadline, cancellation);
 #ifdef _WIN32
         const auto remaining = std::min<std::size_t>(
-            source.size() - completed,
-            static_cast<std::size_t>(std::numeric_limits<int>::max()));
+            source.size() - completed, 64U * 1024U);
         const auto count = ::send(descriptor,
             reinterpret_cast<const char*>(source.data() + completed),
             static_cast<int>(remaining), 0);
 #else
+        constexpr int noSignal =
 #ifdef MSG_NOSIGNAL
-        constexpr int flags = MSG_NOSIGNAL;
-#else
-        constexpr int flags = 0;
+            MSG_NOSIGNAL |
 #endif
+            MSG_DONTWAIT;
         const auto count = ::send(descriptor, source.data() + completed,
-            source.size() - completed, flags);
+            source.size() - completed, noSignal);
 #endif
         if (count < 0) {
             const auto error = lastSocketError();
-            if (interrupted(error)) {
+            if (interrupted(error) || wouldBlock(error)) {
                 continue;
             }
             throwSocketError("send", error);
         }
         completed += static_cast<std::size_t>(count);
     }
+}
+
+void writeExact(
+    NativeSocket descriptor, std::span<const std::uint8_t> source)
+{
+    writeExact(descriptor, source,
+        std::chrono::steady_clock::time_point::max(), {});
 }
 
 } // namespace
@@ -365,11 +501,38 @@ void writeFrame(const Socket& socket, std::span<const std::uint8_t> payload,
     writeExact(native(socket.descriptor()), payload);
 }
 
+void writeFrame(const Socket& socket, std::span<const std::uint8_t> payload,
+    std::uint32_t maximumBytes,
+    std::chrono::steady_clock::time_point deadline,
+    StopToken cancellation)
+{
+    if (payload.empty() || payload.size() > maximumBytes
+        || payload.size() > std::numeric_limits<std::uint32_t>::max()) {
+        throw std::runtime_error("wire frame size is outside the allowed range");
+    }
+    const auto networkSize = htonl(static_cast<std::uint32_t>(payload.size()));
+    const auto* sizeBytes
+        = reinterpret_cast<const std::uint8_t*>(&networkSize);
+    writeExact(native(socket.descriptor()),
+        std::span<const std::uint8_t>(sizeBytes, sizeof(networkSize)),
+        deadline, cancellation);
+    writeExact(native(socket.descriptor()), payload, deadline, cancellation);
+}
+
 std::optional<std::vector<std::uint8_t>> readFrame(
     const Socket& socket, std::uint32_t maximumBytes)
 {
+    return readFrame(socket, maximumBytes,
+        std::chrono::steady_clock::time_point::max());
+}
+
+std::optional<std::vector<std::uint8_t>> readFrame(const Socket& socket,
+    std::uint32_t maximumBytes,
+    std::chrono::steady_clock::time_point deadline)
+{
     std::array<std::uint8_t, sizeof(std::uint32_t)> sizeBytes{};
-    if (!readExact(native(socket.descriptor()), sizeBytes, true)) {
+    if (!readExact(
+            native(socket.descriptor()), sizeBytes, true, deadline)) {
         return std::nullopt;
     }
     std::uint32_t networkSize = 0;
@@ -379,8 +542,8 @@ std::optional<std::vector<std::uint8_t>> readFrame(
         throw std::runtime_error("wire frame size is outside the allowed range");
     }
     std::vector<std::uint8_t> payload(size);
-    static_cast<void>(
-        readExact(native(socket.descriptor()), payload, false));
+    static_cast<void>(readExact(
+        native(socket.descriptor()), payload, false, deadline));
     return payload;
 }
 

--- a/src/remote/Frame.cpp
+++ b/src/remote/Frame.cpp
@@ -1,0 +1,357 @@
+#include <amrexplorer/remote/Frame.hpp>
+
+#include <algorithm>
+#include <array>
+#include <cerrno>
+#include <cstring>
+#include <limits>
+#include <stdexcept>
+#include <utility>
+
+#ifdef _WIN32
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#else
+#include <arpa/inet.h>
+#include <netdb.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+#endif
+
+namespace amrvis::remote {
+namespace {
+
+#ifdef _WIN32
+using NativeSocket = SOCKET;
+using SocketLength = int;
+constexpr NativeSocket invalidSocket = INVALID_SOCKET;
+
+struct WinsockRuntime {
+    WinsockRuntime()
+    {
+        WSADATA data{};
+        if (::WSAStartup(MAKEWORD(2, 2), &data) != 0) {
+            throw std::runtime_error("WSAStartup failed");
+        }
+    }
+    ~WinsockRuntime() { ::WSACleanup(); }
+};
+
+void ensureSockets()
+{
+    static WinsockRuntime runtime;
+    static_cast<void>(runtime);
+}
+
+int lastSocketError()
+{
+    return ::WSAGetLastError();
+}
+
+bool interrupted(int error)
+{
+    return error == WSAEINTR;
+}
+
+void closeNative(NativeSocket socket)
+{
+    ::closesocket(socket);
+}
+#else
+using NativeSocket = int;
+using SocketLength = socklen_t;
+constexpr NativeSocket invalidSocket = -1;
+
+void ensureSockets() {}
+
+int lastSocketError()
+{
+    return errno;
+}
+
+bool interrupted(int error)
+{
+    return error == EINTR;
+}
+
+void closeNative(NativeSocket socket)
+{
+    ::close(socket);
+}
+#endif
+
+NativeSocket native(Socket::Native descriptor)
+{
+    return static_cast<NativeSocket>(descriptor);
+}
+
+[[noreturn]] void throwSocketError(
+    const std::string& operation, int error = lastSocketError())
+{
+#ifdef _WIN32
+    throw std::runtime_error(
+        operation + " failed with socket error " + std::to_string(error));
+#else
+    throw std::runtime_error(
+        operation + ": " + std::string(std::strerror(error)));
+#endif
+}
+
+bool readExact(NativeSocket descriptor, std::span<std::uint8_t> destination,
+    bool allowCleanEof)
+{
+    std::size_t completed = 0;
+    while (completed < destination.size()) {
+#ifdef _WIN32
+        const auto remaining = std::min<std::size_t>(
+            destination.size() - completed,
+            static_cast<std::size_t>(std::numeric_limits<int>::max()));
+        const auto count = ::recv(descriptor,
+            reinterpret_cast<char*>(destination.data() + completed),
+            static_cast<int>(remaining), 0);
+#else
+        const auto count = ::recv(descriptor, destination.data() + completed,
+            destination.size() - completed, 0);
+#endif
+        if (count == 0) {
+            if (completed == 0 && allowCleanEof) {
+                return false;
+            }
+            throw std::runtime_error("connection closed inside a wire frame");
+        }
+        if (count < 0) {
+            const auto error = lastSocketError();
+            if (interrupted(error)) {
+                continue;
+            }
+            throwSocketError("recv", error);
+        }
+        completed += static_cast<std::size_t>(count);
+    }
+    return true;
+}
+
+void writeExact(
+    NativeSocket descriptor, std::span<const std::uint8_t> source)
+{
+    std::size_t completed = 0;
+    while (completed < source.size()) {
+#ifdef _WIN32
+        const auto remaining = std::min<std::size_t>(
+            source.size() - completed,
+            static_cast<std::size_t>(std::numeric_limits<int>::max()));
+        const auto count = ::send(descriptor,
+            reinterpret_cast<const char*>(source.data() + completed),
+            static_cast<int>(remaining), 0);
+#else
+#ifdef MSG_NOSIGNAL
+        constexpr int flags = MSG_NOSIGNAL;
+#else
+        constexpr int flags = 0;
+#endif
+        const auto count = ::send(descriptor, source.data() + completed,
+            source.size() - completed, flags);
+#endif
+        if (count < 0) {
+            const auto error = lastSocketError();
+            if (interrupted(error)) {
+                continue;
+            }
+            throwSocketError("send", error);
+        }
+        completed += static_cast<std::size_t>(count);
+    }
+}
+
+} // namespace
+
+Socket::Socket(Native descriptor) noexcept
+    : m_descriptor(descriptor)
+{
+}
+
+Socket::~Socket()
+{
+    close();
+}
+
+Socket::Socket(Socket&& other) noexcept
+    : m_descriptor(std::exchange(other.m_descriptor, -1))
+{
+}
+
+Socket& Socket::operator=(Socket&& other) noexcept
+{
+    if (this != &other) {
+        close();
+        m_descriptor = std::exchange(other.m_descriptor, -1);
+    }
+    return *this;
+}
+
+Socket::Native Socket::descriptor() const noexcept
+{
+    return m_descriptor;
+}
+
+bool Socket::valid() const noexcept
+{
+    return m_descriptor != -1;
+}
+
+void Socket::shutdown() noexcept
+{
+    if (!valid()) {
+        return;
+    }
+#ifdef _WIN32
+    ::shutdown(native(m_descriptor), SD_BOTH);
+#else
+    ::shutdown(native(m_descriptor), SHUT_RDWR);
+#endif
+}
+
+void Socket::close() noexcept
+{
+    if (valid()) {
+        closeNative(native(m_descriptor));
+        m_descriptor = -1;
+    }
+}
+
+Listener listenOnLoopback(std::uint16_t port, int backlog)
+{
+    ensureSockets();
+    Socket socket(static_cast<Socket::Native>(
+        ::socket(AF_INET, SOCK_STREAM, IPPROTO_TCP)));
+    if (!socket.valid()
+        || native(socket.descriptor()) == invalidSocket) {
+        throwSocketError("socket");
+    }
+    const int reuse = 1;
+#ifdef _WIN32
+    const auto* reuseBytes = reinterpret_cast<const char*>(&reuse);
+#else
+    const auto* reuseBytes = &reuse;
+#endif
+    if (::setsockopt(native(socket.descriptor()), SOL_SOCKET, SO_REUSEADDR,
+            reuseBytes, sizeof(reuse))
+        != 0) {
+        throwSocketError("setsockopt");
+    }
+
+    sockaddr_in address{};
+    address.sin_family = AF_INET;
+    address.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    address.sin_port = htons(port);
+    if (::bind(native(socket.descriptor()),
+            reinterpret_cast<const sockaddr*>(&address), sizeof(address))
+        != 0) {
+        throwSocketError("bind");
+    }
+    if (::listen(native(socket.descriptor()), backlog) != 0) {
+        throwSocketError("listen");
+    }
+
+    SocketLength size = static_cast<SocketLength>(sizeof(address));
+    if (::getsockname(native(socket.descriptor()),
+            reinterpret_cast<sockaddr*>(&address), &size)
+        != 0) {
+        throwSocketError("getsockname");
+    }
+    return {std::move(socket), ntohs(address.sin_port)};
+}
+
+Socket acceptConnection(const Socket& listener)
+{
+    ensureSockets();
+    for (;;) {
+        const auto descriptor
+            = ::accept(native(listener.descriptor()), nullptr, nullptr);
+        if (descriptor != invalidSocket) {
+            return Socket(static_cast<Socket::Native>(descriptor));
+        }
+        const auto error = lastSocketError();
+        if (!interrupted(error)) {
+            throwSocketError("accept", error);
+        }
+    }
+}
+
+Socket connectTo(const std::string& host, std::uint16_t port)
+{
+    ensureSockets();
+    addrinfo hints{};
+    hints.ai_family = AF_UNSPEC;
+    hints.ai_socktype = SOCK_STREAM;
+    hints.ai_protocol = IPPROTO_TCP;
+    addrinfo* addresses = nullptr;
+    const auto service = std::to_string(port);
+    const auto status
+        = ::getaddrinfo(host.c_str(), service.c_str(), &hints, &addresses);
+    if (status != 0) {
+        throw std::runtime_error(
+            "getaddrinfo: " + std::string(gai_strerror(status)));
+    }
+
+    int lastError = 0;
+    for (auto* address = addresses; address != nullptr;
+         address = address->ai_next) {
+        Socket socket(static_cast<Socket::Native>(::socket(address->ai_family,
+            address->ai_socktype, address->ai_protocol)));
+        if (!socket.valid()
+            || native(socket.descriptor()) == invalidSocket) {
+            lastError = lastSocketError();
+            continue;
+        }
+        if (::connect(native(socket.descriptor()), address->ai_addr,
+                static_cast<SocketLength>(address->ai_addrlen))
+            == 0) {
+            ::freeaddrinfo(addresses);
+            return socket;
+        }
+        lastError = lastSocketError();
+    }
+    ::freeaddrinfo(addresses);
+    throwSocketError("connect", lastError);
+}
+
+void writeFrame(const Socket& socket, std::span<const std::uint8_t> payload,
+    std::uint32_t maximumBytes)
+{
+    if (payload.empty() || payload.size() > maximumBytes
+        || payload.size() > std::numeric_limits<std::uint32_t>::max()) {
+        throw std::runtime_error("wire frame size is outside the allowed range");
+    }
+    const auto networkSize = htonl(static_cast<std::uint32_t>(payload.size()));
+    const auto* sizeBytes
+        = reinterpret_cast<const std::uint8_t*>(&networkSize);
+    writeExact(native(socket.descriptor()),
+        std::span<const std::uint8_t>(sizeBytes, sizeof(networkSize)));
+    writeExact(native(socket.descriptor()), payload);
+}
+
+std::optional<std::vector<std::uint8_t>> readFrame(
+    const Socket& socket, std::uint32_t maximumBytes)
+{
+    std::array<std::uint8_t, sizeof(std::uint32_t)> sizeBytes{};
+    if (!readExact(native(socket.descriptor()), sizeBytes, true)) {
+        return std::nullopt;
+    }
+    std::uint32_t networkSize = 0;
+    std::memcpy(&networkSize, sizeBytes.data(), sizeof(networkSize));
+    const auto size = ntohl(networkSize);
+    if (size == 0 || size > maximumBytes) {
+        throw std::runtime_error("wire frame size is outside the allowed range");
+    }
+    std::vector<std::uint8_t> payload(size);
+    static_cast<void>(
+        readExact(native(socket.descriptor()), payload, false));
+    return payload;
+}
+
+} // namespace amrvis::remote

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -91,6 +91,13 @@ target_link_libraries(
 )
 add_test(NAME slice_pipeline COMMAND test_slice_pipeline)
 
+add_executable(test_remote_frame unit/test_remote_frame.cpp)
+target_link_libraries(
+    test_remote_frame
+    PRIVATE amrexplorer::remote amrexplorer::warnings Threads::Threads
+)
+add_test(NAME remote_frame COMMAND test_remote_frame)
+
 add_executable(test_vismf_index unit/test_vismf_index.cpp)
 target_link_libraries(test_vismf_index PRIVATE amrexplorer::io amrexplorer::warnings)
 add_test(NAME vismf_index COMMAND test_vismf_index)

--- a/tests/unit/test_remote_frame.cpp
+++ b/tests/unit/test_remote_frame.cpp
@@ -1,6 +1,7 @@
 #include <amrexplorer/remote/Frame.hpp>
 
 #include <array>
+#include <atomic>
 #include <chrono>
 #include <cstdint>
 #include <cstring>
@@ -185,6 +186,58 @@ int main()
             != std::string::npos;
     }
     require(timedOut, "a peer-blocked frame write ignored its deadline");
+
+    // A slow peer that keeps draining bytes must be allowed to take longer
+    // than one stall interval to receive the complete frame.
+    int slowDescriptors[2]{};
+    require(::socketpair(AF_UNIX, SOCK_STREAM, 0, slowDescriptors) == 0,
+        "could not create the slow-reader socket pair");
+    Socket slowWriter(slowDescriptors[0]);
+    Socket slowPeer(slowDescriptors[1]);
+    const auto slowWriterFlags = ::fcntl(slowDescriptors[0], F_GETFL, 0);
+    require(slowWriterFlags >= 0
+            && ::fcntl(slowDescriptors[0], F_SETFL,
+                   slowWriterFlags | O_NONBLOCK) == 0,
+        "could not make the slow writer nonblocking");
+    require(::setsockopt(slowDescriptors[0], SOL_SOCKET, SO_SNDBUF,
+                &sendBufferBytes, sizeof(sendBufferBytes)) == 0,
+        "could not reduce the slow-writer send buffer");
+    constexpr std::size_t slowPayloadBytes = 512U * 1024U;
+    constexpr auto writeStallTimeout = std::chrono::milliseconds{50};
+    std::atomic<std::size_t> slowBytesRead{0};
+    std::thread slowReader([&] {
+        std::array<std::uint8_t, 4096> bytes{};
+        while (slowBytesRead.load()
+            < slowPayloadBytes + sizeof(std::uint32_t)) {
+            std::this_thread::sleep_for(std::chrono::milliseconds{5});
+            const auto count = ::recv(slowDescriptors[1], bytes.data(),
+                bytes.size(), 0);
+            if (count <= 0) {
+                break;
+            }
+            slowBytesRead += static_cast<std::size_t>(count);
+        }
+    });
+    bool slowWriteCompleted = true;
+    const auto slowWriteStart = std::chrono::steady_clock::now();
+    try {
+        writeFrameWithStallTimeout(slowWriter,
+            std::vector<std::uint8_t>(slowPayloadBytes), slowPayloadBytes,
+            writeStallTimeout);
+    } catch (const std::exception&) {
+        slowWriteCompleted = false;
+    }
+    const auto slowWriteElapsed
+        = std::chrono::steady_clock::now() - slowWriteStart;
+    slowWriter.shutdown();
+    slowReader.join();
+    require(slowWriteCompleted,
+        "a progressing slow-reader frame write was timed out");
+    require(slowBytesRead.load()
+            == slowPayloadBytes + sizeof(std::uint32_t),
+        "the slow reader did not receive the complete frame");
+    require(slowWriteElapsed > writeStallTimeout,
+        "the slow-reader regression did not exceed one stall interval");
 #endif
 
     // A TCP-segment boundary may tear the four-byte header without making the

--- a/tests/unit/test_remote_frame.cpp
+++ b/tests/unit/test_remote_frame.cpp
@@ -1,11 +1,25 @@
 #include <amrexplorer/remote/Frame.hpp>
 
+#include <array>
+#include <chrono>
+#include <cstdint>
+#include <cstring>
 #include <cstdlib>
 #include <exception>
 #include <iostream>
 #include <stdexcept>
 #include <thread>
 #include <vector>
+
+#ifdef _WIN32
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <winsock2.h>
+#else
+#include <arpa/inet.h>
+#include <sys/socket.h>
+#endif
 
 namespace {
 
@@ -26,6 +40,66 @@ void requireRejected(Function&& function, const char* message)
         return;
     }
     require(false, message);
+}
+
+void writeRaw(const amrvis::remote::Socket& socket,
+    const std::vector<std::uint8_t>& bytes)
+{
+    std::size_t completed = 0;
+    while (completed < bytes.size()) {
+#ifdef _WIN32
+        const auto count = ::send(
+            static_cast<SOCKET>(socket.descriptor()),
+            reinterpret_cast<const char*>(bytes.data() + completed),
+            static_cast<int>(bytes.size() - completed), 0);
+        require(count > 0 && count != SOCKET_ERROR, "raw test send failed");
+#else
+        const auto count = ::send(static_cast<int>(socket.descriptor()),
+            bytes.data() + completed, bytes.size() - completed, 0);
+        require(count > 0, "raw test send failed");
+#endif
+        completed += static_cast<std::size_t>(count);
+    }
+}
+
+std::vector<std::uint8_t> header(std::uint32_t size)
+{
+    const auto network = htonl(size);
+    std::vector<std::uint8_t> bytes(sizeof(network));
+    std::memcpy(bytes.data(), &network, sizeof(network));
+    return bytes;
+}
+
+void closeAbortively(amrvis::remote::Socket& socket)
+{
+    linger option{};
+    option.l_onoff = 1;
+    option.l_linger = 0;
+#ifdef _WIN32
+    const auto result = ::setsockopt(
+        static_cast<SOCKET>(socket.descriptor()), SOL_SOCKET, SO_LINGER,
+        reinterpret_cast<const char*>(&option), sizeof(option));
+    require(result != SOCKET_ERROR, "could not configure abortive close");
+#else
+    const auto result = ::setsockopt(static_cast<int>(socket.descriptor()),
+        SOL_SOCKET, SO_LINGER, &option, sizeof(option));
+    require(result == 0, "could not configure abortive close");
+#endif
+    socket.close();
+}
+
+template <typename Writer, typename Reader>
+void loopbackExchange(Writer&& writer, Reader&& reader)
+{
+    using namespace amrvis::remote;
+    const auto listener = listenOnLoopback(0);
+    std::thread peerThread([&] {
+        auto peer = acceptConnection(listener.socket);
+        writer(peer);
+    });
+    auto client = connectTo("127.0.0.1", listener.port);
+    reader(client);
+    peerThread.join();
 }
 
 } // namespace
@@ -67,6 +141,61 @@ int main()
         [&] { writeFrame(client, std::vector<std::uint8_t>(65), 64); },
         "an oversized frame was accepted");
 
+    // A TCP-segment boundary may tear the four-byte header without making the
+    // frame malformed. readFrame must assemble it exactly.
+    loopbackExchange(
+        [](const Socket& peer) {
+            auto bytes = header(3);
+            writeRaw(peer, std::vector<std::uint8_t>(
+                bytes.begin(), bytes.begin() + 2));
+            std::this_thread::sleep_for(std::chrono::milliseconds(5));
+            std::vector<std::uint8_t> tail(bytes.begin() + 2, bytes.end());
+            tail.insert(tail.end(), {4, 5, 6});
+            writeRaw(peer, tail);
+        },
+        [](const Socket& peer) {
+            require(readFrame(peer, 64)
+                    == std::optional{
+                        std::vector<std::uint8_t>{4, 5, 6}},
+                "a torn header was not reassembled");
+        });
+
+    loopbackExchange(
+        [](const Socket& peer) {
+            const auto bytes = header(4);
+            writeRaw(peer, std::vector<std::uint8_t>(
+                bytes.begin(), bytes.begin() + 2));
+        },
+        [](const Socket& peer) {
+            requireRejected([&] { static_cast<void>(readFrame(peer, 64)); },
+                "EOF inside a short header was accepted");
+        });
+
+    loopbackExchange(
+        [](const Socket& peer) { writeRaw(peer, header(0)); },
+        [](const Socket& peer) {
+            requireRejected([&] { static_cast<void>(readFrame(peer, 64)); },
+                "a zero-length injected frame was accepted");
+        });
+
+    loopbackExchange(
+        [](const Socket& peer) { writeRaw(peer, header(65)); },
+        [](const Socket& peer) {
+            requireRejected([&] { static_cast<void>(readFrame(peer, 64)); },
+                "an injected oversized frame was accepted");
+        });
+
+    loopbackExchange(
+        [](const Socket& peer) {
+            auto bytes = header(4);
+            bytes.insert(bytes.end(), {1, 2});
+            writeRaw(peer, bytes);
+        },
+        [](const Socket& peer) {
+            requireRejected([&] { static_cast<void>(readFrame(peer, 64)); },
+                "EOF inside a short payload was accepted");
+        });
+
     const auto eofListener = listenOnLoopback(0);
     std::thread closer([&] {
         auto peer = acceptConnection(eofListener.socket);
@@ -76,5 +205,27 @@ int main()
     require(!readFrame(eofClient, 64).has_value(),
         "clean EOF was not distinguished from a partial frame");
     closer.join();
+
+    const auto resetListener = listenOnLoopback(0);
+    std::thread resetter([&] {
+        auto peer = acceptConnection(resetListener.socket);
+        closeAbortively(peer);
+    });
+    auto resetClient = connectTo("127.0.0.1", resetListener.port);
+    requireRejected(
+        [&] { static_cast<void>(readFrame(resetClient, 64)); },
+        "an abortive close was not observed by the client");
+    resetter.join();
+
+    // On Unix this reaches EPIPE after the reset. The connected-socket setup and
+    // per-send flags must convert it to an exception instead of SIGPIPE process
+    // termination; Windows has the equivalent socket-error behavior.
+    requireRejected(
+        [&] {
+            for (int attempt = 0; attempt < 4; ++attempt) {
+                writeFrame(resetClient, std::vector<std::uint8_t>{1}, 64);
+            }
+        },
+        "writing to a closed peer did not throw");
     return 0;
 }

--- a/tests/unit/test_remote_frame.cpp
+++ b/tests/unit/test_remote_frame.cpp
@@ -36,7 +36,7 @@ int main()
 
     const auto listener = listenOnLoopback(0);
     std::exception_ptr serverFailure;
-    std::jthread server([&] {
+    std::thread server([&] {
         try {
             auto peer = acceptConnection(listener.socket);
             const auto request = readFrame(peer, 64);
@@ -68,12 +68,13 @@ int main()
         "an oversized frame was accepted");
 
     const auto eofListener = listenOnLoopback(0);
-    std::jthread closer([&] {
+    std::thread closer([&] {
         auto peer = acceptConnection(eofListener.socket);
         peer.close();
     });
     auto eofClient = connectTo("127.0.0.1", eofListener.port);
     require(!readFrame(eofClient, 64).has_value(),
         "clean EOF was not distinguished from a partial frame");
+    closer.join();
     return 0;
 }

--- a/tests/unit/test_remote_frame.cpp
+++ b/tests/unit/test_remote_frame.cpp
@@ -9,6 +9,7 @@
 #include <future>
 #include <iostream>
 #include <stdexcept>
+#include <string>
 #include <thread>
 #include <vector>
 
@@ -19,6 +20,7 @@
 #include <winsock2.h>
 #else
 #include <arpa/inet.h>
+#include <fcntl.h>
 #include <sys/socket.h>
 #endif
 
@@ -141,6 +143,49 @@ int main()
     requireRejected(
         [&] { writeFrame(client, std::vector<std::uint8_t>(65), 64); },
         "an oversized frame was accepted");
+
+    amrvis::StopSource stoppedWrite;
+    stoppedWrite.request_stop();
+    bool writeCancellationObserved = false;
+    try {
+        writeFrame(client, std::vector<std::uint8_t>{1}, 64,
+            std::chrono::steady_clock::now() + std::chrono::seconds(1),
+            stoppedWrite.get_token());
+    } catch (const amrvis::ReadCancelled&) {
+        writeCancellationObserved = true;
+    }
+    require(writeCancellationObserved,
+        "a cancelled deadline-aware frame write was not interrupted");
+
+#ifndef _WIN32
+    // A peer that stops reading must not hold a writer forever. AF_UNIX keeps
+    // this deterministic without loopback TCP receive-window autotuning.
+    int blockedDescriptors[2]{};
+    require(::socketpair(AF_UNIX, SOCK_STREAM, 0, blockedDescriptors) == 0,
+        "could not create the blocked-write socket pair");
+    Socket blockedWriter(blockedDescriptors[0]);
+    Socket blockedPeer(blockedDescriptors[1]);
+    const auto writerFlags = ::fcntl(blockedDescriptors[0], F_GETFL, 0);
+    require(writerFlags >= 0
+            && ::fcntl(blockedDescriptors[0], F_SETFL,
+                   writerFlags | O_NONBLOCK) == 0,
+        "could not make the blocked writer nonblocking");
+    int sendBufferBytes = 4096;
+    require(::setsockopt(blockedDescriptors[0], SOL_SOCKET, SO_SNDBUF,
+                &sendBufferBytes, sizeof(sendBufferBytes)) == 0,
+        "could not reduce the test send buffer");
+    bool timedOut = false;
+    try {
+        writeFrame(blockedWriter,
+            std::vector<std::uint8_t>(4U * 1024U * 1024U),
+            4U * 1024U * 1024U,
+            std::chrono::steady_clock::now() + std::chrono::milliseconds(50));
+    } catch (const std::runtime_error& error) {
+        timedOut = std::string(error.what()).find("timed out")
+            != std::string::npos;
+    }
+    require(timedOut, "a peer-blocked frame write ignored its deadline");
+#endif
 
     // A TCP-segment boundary may tear the four-byte header without making the
     // frame malformed. readFrame must assemble it exactly.

--- a/tests/unit/test_remote_frame.cpp
+++ b/tests/unit/test_remote_frame.cpp
@@ -244,9 +244,12 @@ int main()
                 &sendBufferBytes, sizeof(sendBufferBytes)) == 0,
         "could not reduce the slow-writer send buffer");
     constexpr std::size_t slowPayloadBytes = 512U * 1024U;
-    constexpr auto writeStallTimeout = std::chrono::milliseconds{50};
+    constexpr auto writeStallTimeout = std::chrono::milliseconds{250};
     std::atomic<std::size_t> slowBytesRead{0};
+    std::promise<void> slowReaderReady;
+    auto slowReaderStarted = slowReaderReady.get_future();
     std::thread slowReader([&] {
+        slowReaderReady.set_value();
         std::array<std::uint8_t, 4096> bytes{};
         while (slowBytesRead.load()
             < slowPayloadBytes + sizeof(std::uint32_t)) {
@@ -259,19 +262,25 @@ int main()
             slowBytesRead += static_cast<std::size_t>(count);
         }
     });
+    slowReaderStarted.wait();
     bool slowWriteCompleted = true;
+    std::string slowWriteError;
     const auto slowWriteStart = std::chrono::steady_clock::now();
     try {
         writeFrameWithStallTimeout(slowWriter,
             std::vector<std::uint8_t>(slowPayloadBytes), slowPayloadBytes,
             writeStallTimeout);
-    } catch (const std::exception&) {
+    } catch (const std::exception& error) {
         slowWriteCompleted = false;
+        slowWriteError = error.what();
     }
     const auto slowWriteElapsed
         = std::chrono::steady_clock::now() - slowWriteStart;
     slowWriter.shutdown();
     slowReader.join();
+    if (!slowWriteCompleted) {
+        std::cerr << "slow-reader write failed: " << slowWriteError << '\n';
+    }
     require(slowWriteCompleted,
         "a progressing slow-reader frame write was timed out");
     require(slowBytesRead.load()

--- a/tests/unit/test_remote_frame.cpp
+++ b/tests/unit/test_remote_frame.cpp
@@ -6,6 +6,7 @@
 #include <cstring>
 #include <cstdlib>
 #include <exception>
+#include <future>
 #include <iostream>
 #include <stdexcept>
 #include <thread>
@@ -207,11 +208,15 @@ int main()
     closer.join();
 
     const auto resetListener = listenOnLoopback(0);
+    std::promise<void> resetConnected;
+    auto resetMayProceed = resetConnected.get_future();
     std::thread resetter([&] {
         auto peer = acceptConnection(resetListener.socket);
+        resetMayProceed.wait();
         closeAbortively(peer);
     });
     auto resetClient = connectTo("127.0.0.1", resetListener.port);
+    resetConnected.set_value();
     requireRejected(
         [&] { static_cast<void>(readFrame(resetClient, 64)); },
         "an abortive close was not observed by the client");

--- a/tests/unit/test_remote_frame.cpp
+++ b/tests/unit/test_remote_frame.cpp
@@ -1,0 +1,79 @@
+#include <amrexplorer/remote/Frame.hpp>
+
+#include <cstdlib>
+#include <exception>
+#include <iostream>
+#include <stdexcept>
+#include <thread>
+#include <vector>
+
+namespace {
+
+void require(bool condition, const char* message)
+{
+    if (!condition) {
+        std::cerr << "FAILED: " << message << '\n';
+        std::exit(1);
+    }
+}
+
+template <typename Function>
+void requireRejected(Function&& function, const char* message)
+{
+    try {
+        function();
+    } catch (const std::exception&) {
+        return;
+    }
+    require(false, message);
+}
+
+} // namespace
+
+int main()
+{
+    using namespace amrvis::remote;
+
+    const auto listener = listenOnLoopback(0);
+    std::exception_ptr serverFailure;
+    std::jthread server([&] {
+        try {
+            auto peer = acceptConnection(listener.socket);
+            const auto request = readFrame(peer, 64);
+            require(request == std::optional{
+                    std::vector<std::uint8_t>{1, 2, 3, 4}},
+                "server did not receive the framed request");
+            writeFrame(peer, std::vector<std::uint8_t>{9, 8, 7}, 64);
+        } catch (...) {
+            serverFailure = std::current_exception();
+        }
+    });
+
+    auto client = connectTo("127.0.0.1", listener.port);
+    writeFrame(client, std::vector<std::uint8_t>{1, 2, 3, 4}, 64);
+    const auto response = readFrame(client, 64);
+    require(response == std::optional{
+            std::vector<std::uint8_t>{9, 8, 7}},
+        "client did not receive the framed response");
+    server.join();
+    if (serverFailure) {
+        std::rethrow_exception(serverFailure);
+    }
+
+    requireRejected(
+        [&] { writeFrame(client, {}, 64); },
+        "an empty frame was accepted");
+    requireRejected(
+        [&] { writeFrame(client, std::vector<std::uint8_t>(65), 64); },
+        "an oversized frame was accepted");
+
+    const auto eofListener = listenOnLoopback(0);
+    std::jthread closer([&] {
+        auto peer = acceptConnection(eofListener.socket);
+        peer.close();
+    });
+    auto eofClient = connectTo("127.0.0.1", eofListener.port);
+    require(!readFrame(eofClient, 64).has_value(),
+        "clean EOF was not distinguished from a partial frame");
+    return 0;
+}

--- a/tests/unit/test_remote_frame.cpp
+++ b/tests/unit/test_remote_frame.cpp
@@ -158,6 +158,47 @@ int main()
     require(writeCancellationObserved,
         "a cancelled deadline-aware frame write was not interrupted");
 
+    const auto cancelledAcceptListener = listenOnLoopback(0);
+    amrvis::StopSource stoppedAccept;
+    auto cancelledAccept = std::async(std::launch::async, [&] {
+        try {
+            static_cast<void>(acceptConnection(
+                cancelledAcceptListener.socket, stoppedAccept.get_token()));
+        } catch (const amrvis::ReadCancelled&) {
+            return true;
+        }
+        return false;
+    });
+    stoppedAccept.request_stop();
+    require(cancelledAccept.wait_for(std::chrono::seconds(1))
+                == std::future_status::ready
+            && cancelledAccept.get(),
+        "a cancelled listener accept was not interrupted");
+
+    const auto cancelledReadListener = listenOnLoopback(0);
+    auto cancelledReadPeer = std::async(std::launch::async, [&] {
+        return acceptConnection(cancelledReadListener.socket);
+    });
+    auto cancelledReadClient
+        = connectTo("127.0.0.1", cancelledReadListener.port);
+    auto cancelledReadServer = cancelledReadPeer.get();
+    amrvis::StopSource stoppedRead;
+    auto cancelledRead = std::async(std::launch::async, [&] {
+        try {
+            static_cast<void>(readFrame(cancelledReadClient, 64,
+                std::chrono::steady_clock::time_point::max(),
+                stoppedRead.get_token()));
+        } catch (const amrvis::ReadCancelled&) {
+            return true;
+        }
+        return false;
+    });
+    stoppedRead.request_stop();
+    require(cancelledRead.wait_for(std::chrono::seconds(1))
+                == std::future_status::ready
+            && cancelledRead.get(),
+        "a cancelled frame read was not interrupted");
+
 #ifndef _WIN32
     // A peer that stops reading must not hold a writer forever. AF_UNIX keeps
     // this deterministic without loopback TCP receive-window autotuning.


### PR DESCRIPTION
Part 4 of 13 in the remote client/server stack.

## Purpose

Provide a portable, bounded transport primitive independent of the application protocol.

## Scope

- Loopback TCP socket/listener wrappers for supported platforms.
- A fixed 32-bit length-prefixed frame format.
- Exact reads/writes, orderly shutdown, and hard maximum-frame enforcement.

## Review focus

Review byte order, partial I/O handling, ownership, and rejection of oversized or truncated frames. There is intentionally no compression here.

## Validation

- `remote_frame`
