### PR TITLE
[client-server] define the remote wire schema

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,8 @@ project(
 
 option(AMREXPLORER_ENABLE_QT "Build the Qt 6 desktop application" ON)
 option(AMREXPLORER_ENABLE_VTK "Build the optional VTK volume module" OFF)
+option(AMREXPLORER_ENABLE_REMOTE
+    "Build production remote client/server support" ${AMREXPLORER_ENABLE_QT})
 option(AMREXPLORER_BUILD_TESTS "Build unit and integration tests" ON)
 option(AMREXPLORER_BUILD_MACOS_APP_BUNDLE
     "Build the Qt application as a macOS .app bundle" ${APPLE})
@@ -71,7 +73,22 @@ add_subdirectory(src/cache)
 add_subdirectory(src/io)
 add_subdirectory(src/query)
 add_subdirectory(src/data)
-add_subdirectory(src/remote)
+if(AMREXPLORER_ENABLE_REMOTE)
+    include(FetchContent)
+    set(FLATBUFFERS_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+    set(FLATBUFFERS_BUILD_GRPCTEST OFF CACHE BOOL "" FORCE)
+    set(FLATBUFFERS_BUILD_SHAREDLIB OFF CACHE BOOL "" FORCE)
+    set(FLATBUFFERS_BUILD_STATICLIB OFF CACHE BOOL "" FORCE)
+    set(FLATBUFFERS_BUILD_FLATC ON CACHE BOOL "" FORCE)
+    set(FLATBUFFERS_INSTALL OFF CACHE BOOL "" FORCE)
+    FetchContent_Declare(flatbuffers
+        GIT_REPOSITORY https://github.com/google/flatbuffers.git
+        GIT_TAG v25.12.19
+        GIT_SHALLOW TRUE
+    )
+    FetchContent_MakeAvailable(flatbuffers)
+    add_subdirectory(src/remote)
+endif()
 add_subdirectory(src/render2d)
 add_subdirectory(src/pipeline)
 

--- a/include/amrexplorer/remote/Protocol.hpp
+++ b/include/amrexplorer/remote/Protocol.hpp
@@ -1,0 +1,123 @@
+#pragma once
+
+#include <amrexplorer/cache/CacheMetrics.hpp>
+#include <amrexplorer/core/Metadata.hpp>
+#include <amrexplorer/core/Request.hpp>
+#include <amrexplorer/data/DatasetPage.hpp>
+#include <amrexplorer/data/DatasetSession.hpp>
+#include <amrexplorer/data/ViewData.hpp>
+#include <amrexplorer/io/ParticleReader.hpp>
+#include <amrexplorer/io/PlotfileMetadataReader.hpp>
+
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace amrvis::remote {
+
+inline constexpr std::uint16_t protocolMajor = 1;
+inline constexpr std::uint16_t protocolMinor = 0;
+
+enum class PayloadKind : std::uint8_t {
+    None,
+    HelloRequest,
+    HelloResponse,
+    OpenDatasetRequest,
+    DatasetOpened,
+    CloseDatasetRequest,
+    DatasetClosed,
+    SliceViewRequest,
+    SliceViewResponse,
+    LineViewRequest,
+    LineViewResponse,
+    DatasetPageRequest,
+    DatasetPageResponse,
+    ParticleSampleRequest,
+    ParticleSampleResponse,
+    RangeRequest,
+    RangeResponse,
+    ClearCacheRequest,
+    SetCacheBudgetRequest,
+    CacheResponse,
+    CancelRequest,
+    CancelAcknowledged,
+    PingRequest,
+    PongResponse,
+    ErrorResponse
+};
+
+enum class ErrorCode : std::uint16_t {
+    UnsupportedProtocol,
+    InvalidRequest,
+    UnknownDataset,
+    DatasetOpenFailure,
+    Cancelled,
+    CacheBudgetExceeded,
+    ResourceLimitExceeded,
+    OperationFailure,
+    InternalServerError,
+    Disconnected
+};
+
+struct EnvelopeInfo {
+    std::uint16_t protocolMajor = 0;
+    std::uint16_t protocolMinor = 0;
+    std::uint64_t requestId = 0;
+    PayloadKind payload = PayloadKind::None;
+};
+
+struct HelloRequestData {
+    std::string clientName;
+    std::string softwareVersion;
+    std::uint16_t minimumMinor = 0;
+    std::uint16_t maximumMinor = 0;
+    std::uint32_t maximumFrameBytes = 0;
+};
+
+struct HelloResponseData {
+    std::string serverName;
+    std::string softwareVersion;
+    std::uint16_t selectedMinor = 0;
+    std::uint32_t maximumFrameBytes = 0;
+    std::uint32_t maximumDatasets = 0;
+    std::uint32_t maximumOutstandingRequests = 0;
+    std::uint32_t workerCount = 0;
+};
+
+struct OpenDatasetData {
+    std::string path;
+    std::uint64_t cacheBudgetBytes = 0;
+};
+
+struct OpenedDataset {
+    DatasetId id;
+    DatasetMetadata catalog;
+    MetadataReadMetrics metadataMetrics;
+    std::string fileVersion;
+    std::vector<ParticleSpeciesMetadata> particleSpecies;
+    std::vector<std::uint8_t> fileRangeAvailable;
+    std::vector<std::uint8_t> levelRangeAvailable;
+    CacheMetrics cache;
+};
+
+struct ErrorData {
+    ErrorCode code = ErrorCode::OperationFailure;
+    std::string message;
+};
+
+class RemoteError : public std::runtime_error {
+public:
+    RemoteError(ErrorCode code, std::string message)
+        : std::runtime_error(std::move(message))
+        , m_code(code)
+    {
+    }
+
+    [[nodiscard]] ErrorCode code() const noexcept { return m_code; }
+
+private:
+    ErrorCode m_code;
+};
+
+} // namespace amrvis::remote

--- a/include/amrexplorer/remote/Protocol.hpp
+++ b/include/amrexplorer/remote/Protocol.hpp
@@ -17,7 +17,7 @@
 namespace amrvis::remote {
 
 inline constexpr std::uint16_t protocolMajor = 1;
-inline constexpr std::uint16_t protocolMinor = 0;
+inline constexpr std::uint16_t protocolMinorVersion = 0;
 
 enum class PayloadKind : std::uint8_t {
     None = 0,
@@ -63,7 +63,7 @@ enum class ErrorCode : std::uint16_t {
 
 struct EnvelopeInfo {
     std::uint16_t protocolMajor = 0;
-    std::uint16_t protocolMinor = 0;
+    std::uint16_t protocolMinorVersion = 0;
     std::uint64_t requestId = 0;
     PayloadKind payload = PayloadKind::None;
 };
@@ -71,8 +71,8 @@ struct EnvelopeInfo {
 struct HelloRequestData {
     std::string clientName;
     std::string softwareVersion;
-    std::uint16_t minimumMinor = 0;
-    std::uint16_t maximumMinor = 0;
+    std::uint16_t minimumMinorVersion = 0;
+    std::uint16_t maximumMinorVersion = 0;
     std::uint32_t maximumFrameBytes = 0;
     std::string sessionToken;
     std::vector<std::uint64_t> capabilities;
@@ -81,7 +81,7 @@ struct HelloRequestData {
 struct HelloResponseData {
     std::string serverName;
     std::string softwareVersion;
-    std::uint16_t selectedMinor = 0;
+    std::uint16_t selectedMinorVersion = 0;
     std::uint32_t maximumFrameBytes = 0;
     std::uint32_t maximumDatasets = 0;
     std::uint32_t maximumOutstandingRequests = 0;

--- a/include/amrexplorer/remote/Protocol.hpp
+++ b/include/amrexplorer/remote/Protocol.hpp
@@ -20,44 +20,45 @@ inline constexpr std::uint16_t protocolMajor = 1;
 inline constexpr std::uint16_t protocolMinor = 0;
 
 enum class PayloadKind : std::uint8_t {
-    None,
-    HelloRequest,
-    HelloResponse,
-    OpenDatasetRequest,
-    DatasetOpened,
-    CloseDatasetRequest,
-    DatasetClosed,
-    SliceViewRequest,
-    SliceViewResponse,
-    LineViewRequest,
-    LineViewResponse,
-    DatasetPageRequest,
-    DatasetPageResponse,
-    ParticleSampleRequest,
-    ParticleSampleResponse,
-    RangeRequest,
-    RangeResponse,
-    ClearCacheRequest,
-    SetCacheBudgetRequest,
-    CacheResponse,
-    CancelRequest,
-    CancelAcknowledged,
-    PingRequest,
-    PongResponse,
-    ErrorResponse
+    None = 0,
+    HelloRequest = 1,
+    HelloResponse = 2,
+    OpenDatasetRequest = 3,
+    DatasetOpened = 4,
+    CloseDatasetRequest = 5,
+    DatasetClosed = 6,
+    SliceViewRequest = 7,
+    SliceViewResponse = 8,
+    LineViewRequest = 9,
+    LineViewResponse = 10,
+    DatasetPageRequest = 11,
+    DatasetPageResponse = 12,
+    ParticleSampleRequest = 13,
+    ParticleSampleResponse = 14,
+    RangeRequest = 15,
+    RangeResponse = 16,
+    ClearCacheRequest = 17,
+    SetCacheBudgetRequest = 18,
+    CacheResponse = 19,
+    CancelRequest = 20,
+    CancelAcknowledged = 21,
+    PingRequest = 22,
+    PongResponse = 23,
+    ErrorResponse = 24
 };
 
 enum class ErrorCode : std::uint16_t {
-    UnsupportedProtocol,
-    InvalidRequest,
-    UnknownDataset,
-    DatasetOpenFailure,
-    Cancelled,
-    CacheBudgetExceeded,
-    ResourceLimitExceeded,
-    OperationFailure,
-    InternalServerError,
-    Disconnected
+    UnsupportedProtocol = 0,
+    InvalidRequest = 1,
+    UnknownDataset = 2,
+    DatasetOpenFailure = 3,
+    Cancelled = 4,
+    CacheBudgetExceeded = 5,
+    ResourceLimitExceeded = 6,
+    OperationFailure = 7,
+    InternalServerError = 8,
+    Disconnected = 9,
+    Unauthorized = 10
 };
 
 struct EnvelopeInfo {
@@ -73,6 +74,8 @@ struct HelloRequestData {
     std::uint16_t minimumMinor = 0;
     std::uint16_t maximumMinor = 0;
     std::uint32_t maximumFrameBytes = 0;
+    std::string sessionToken;
+    std::vector<std::uint64_t> capabilities;
 };
 
 struct HelloResponseData {
@@ -83,6 +86,7 @@ struct HelloResponseData {
     std::uint32_t maximumDatasets = 0;
     std::uint32_t maximumOutstandingRequests = 0;
     std::uint32_t workerCount = 0;
+    std::vector<std::uint64_t> capabilities;
 };
 
 struct OpenDatasetData {

--- a/schemas/amrexplorer_wire.fbs
+++ b/schemas/amrexplorer_wire.fbs
@@ -1,0 +1,339 @@
+namespace amrexplorer.wire;
+
+enum SamplingPolicy : ubyte {
+  Nearest,
+  PiecewiseConstant,
+  Linear
+}
+
+enum CompositionPolicy : ubyte {
+  FinestAvailable,
+  ExactLevel
+}
+
+enum Centering : ubyte {
+  Cell,
+  Node,
+  FaceX,
+  FaceY,
+  FaceZ,
+  EdgeX,
+  EdgeY,
+  EdgeZ,
+  Mixed
+}
+
+enum RangeScope : ubyte {
+  File,
+  Level
+}
+
+enum ErrorCode : ushort {
+  UnsupportedProtocol,
+  InvalidRequest,
+  UnknownDataset,
+  DatasetOpenFailure,
+  Cancelled,
+  CacheBudgetExceeded,
+  ResourceLimitExceeded,
+  OperationFailure,
+  InternalServerError,
+  Disconnected
+}
+
+table Int3 {
+  values:[int];
+}
+
+table Real3 {
+  values:[double];
+}
+
+table IntBox {
+  lower:Int3;
+  upper:Int3;
+  centering:Int3;
+}
+
+table RealBox {
+  lower:Real3;
+  upper:Real3;
+}
+
+table CacheState {
+  budget_bytes:ulong;
+  resident_bytes:ulong;
+  pinned_bytes:ulong;
+  hits:ulong;
+  misses:ulong;
+  evictions:ulong;
+  clears:ulong;
+}
+
+table HelloRequest {
+  client_name:string;
+  software_version:string;
+  minimum_minor:ushort;
+  maximum_minor:ushort;
+  maximum_frame_bytes:uint;
+}
+
+table HelloResponse {
+  server_name:string;
+  software_version:string;
+  selected_minor:ushort;
+  maximum_frame_bytes:uint;
+  maximum_datasets:uint;
+  maximum_outstanding_requests:uint;
+  worker_count:uint;
+}
+
+table OpenDatasetRequest {
+  path:string;
+  cache_budget_bytes:ulong;
+}
+
+table FieldCatalog {
+  name:string;
+  centering:Centering;
+  component_names:[string];
+}
+
+table LevelCatalog {
+  level:int;
+  step:int;
+  domain:IntBox;
+  cell_size:Real3;
+  index_origin:Real3;
+  boxes:[IntBox];
+}
+
+table ParticleSpeciesCatalog {
+  name:string;
+  dimension:int;
+  real_component_count:int;
+  int_component_count:int;
+  particle_count:ulong;
+  single_precision:bool;
+}
+
+table MetadataReadMetrics {
+  files_read:ulong;
+  bytes_read:ulong;
+  payload_files_read:ulong;
+  payload_bytes_read:ulong;
+}
+
+table DatasetOpened {
+  dataset_id:ulong;
+  dimension:int;
+  finest_level:int;
+  is_fab:bool;
+  has_physical_geometry:bool;
+  time:double;
+  coordinate_system:int;
+  physical_domain:RealBox;
+  fields:[FieldCatalog];
+  levels:[LevelCatalog];
+  particle_species:[ParticleSpeciesCatalog];
+  file_range_available:[ubyte];
+  level_range_available:[ubyte];
+  metadata_metrics:MetadataReadMetrics;
+  file_version:string;
+  cache:CacheState;
+}
+
+table CloseDatasetRequest {
+  dataset_id:ulong;
+}
+
+table DatasetClosed {
+  dataset_id:ulong;
+}
+
+table SliceViewRequest {
+  dataset_id:ulong;
+  field:uint;
+  component:int;
+  normal_direction:int;
+  physical_position:double;
+  visible_region:RealBox;
+  maximum_level:int;
+  width:int;
+  height:int;
+  sampling:SamplingPolicy;
+  composition:CompositionPolicy;
+}
+
+table SliceViewResponse {
+  width:int;
+  height:int;
+  physical_region:RealBox;
+  values:[float];
+  valid:[ubyte];
+  source_level:[short];
+  candidate_blocks:ulong;
+  blocks_read:ulong;
+  cache_hits:ulong;
+  payload_bytes_read:ulong;
+  cache:CacheState;
+}
+
+table LineViewRequest {
+  dataset_id:ulong;
+  field:uint;
+  component:int;
+  axis:int;
+  fixed_coordinates:Real3;
+  maximum_level:int;
+  composition:CompositionPolicy;
+  region:RealBox;
+  has_region:bool;
+  output_width:int;
+}
+
+table LineViewResponse {
+  axis:int;
+  positions_are_indices:bool;
+  positions:[double];
+  values:[float];
+  valid:[ubyte];
+  source_level:[short];
+  candidate_blocks:ulong;
+  blocks_read:ulong;
+  cache_hits:ulong;
+  payload_bytes_read:ulong;
+  cache:CacheState;
+}
+
+table DatasetPageRequest {
+  dataset_id:ulong;
+  field:uint;
+  level:int;
+  region:RealBox;
+  normal_axis:int;
+  slice_position:double;
+  maximum_extent:int;
+}
+
+table DatasetPageResponse {
+  lower:[int];
+  upper:[int];
+  nx:int;
+  ny:int;
+  slice_index:int;
+  values:[float];
+  covered:[ubyte];
+  minimum:double;
+  maximum:double;
+  has_finite_values:bool;
+  truncated_x:bool;
+  truncated_y:bool;
+  cache:CacheState;
+}
+
+table ParticleSampleRequest {
+  dataset_id:ulong;
+  species:string;
+  fraction:double;
+  seed:ulong;
+}
+
+table ParticleSampleResponse {
+  species:ParticleSpeciesCatalog;
+  ids:[ulong];
+  positions:[double];
+  integer_bytes_read:ulong;
+  real_bytes_read:ulong;
+  level_directories_scanned:ulong;
+  data_files_opened:ulong;
+  cache:CacheState;
+}
+
+table RangeRequest {
+  dataset_id:ulong;
+  field:uint;
+  maximum_level:int;
+  composition:CompositionPolicy;
+  scope:RangeScope;
+}
+
+table RangeResponse {
+  has_range:bool;
+  minimum:double;
+  maximum:double;
+  cache:CacheState;
+}
+
+table ClearCacheRequest {
+  dataset_id:ulong;
+}
+
+table SetCacheBudgetRequest {
+  dataset_id:ulong;
+  budget_bytes:ulong;
+}
+
+table CacheResponse {
+  dataset_id:ulong;
+  cache:CacheState;
+}
+
+table CancelRequest {
+  target_request_id:ulong;
+}
+
+table CancelAcknowledged {
+  target_request_id:ulong;
+  accepted:bool;
+}
+
+table PingRequest {
+  nonce:ulong;
+}
+
+table PongResponse {
+  nonce:ulong;
+}
+
+table ErrorResponse {
+  code:ErrorCode;
+  message:string;
+}
+
+union Payload {
+  HelloRequest,
+  HelloResponse,
+  OpenDatasetRequest,
+  DatasetOpened,
+  CloseDatasetRequest,
+  DatasetClosed,
+  SliceViewRequest,
+  SliceViewResponse,
+  LineViewRequest,
+  LineViewResponse,
+  DatasetPageRequest,
+  DatasetPageResponse,
+  ParticleSampleRequest,
+  ParticleSampleResponse,
+  RangeRequest,
+  RangeResponse,
+  ClearCacheRequest,
+  SetCacheBudgetRequest,
+  CacheResponse,
+  CancelRequest,
+  CancelAcknowledged,
+  PingRequest,
+  PongResponse,
+  ErrorResponse
+}
+
+table Envelope {
+  protocol_major:ushort = 1;
+  protocol_minor:ushort = 0;
+  request_id:ulong;
+  payload:Payload;
+}
+
+root_type Envelope;
+file_identifier "AVR2";

--- a/schemas/amrexplorer_wire.fbs
+++ b/schemas/amrexplorer_wire.fbs
@@ -74,8 +74,8 @@ table CacheState {
 table HelloRequest {
   client_name:string (id: 0);
   software_version:string (id: 1);
-  minimum_minor:ushort (id: 2);
-  maximum_minor:ushort (id: 3);
+  minimum_minor_version:ushort (id: 2);
+  maximum_minor_version:ushort (id: 3);
   maximum_frame_bytes:uint (id: 4);
   session_token:string (id: 5);
   capabilities:[ulong] (id: 6);
@@ -84,7 +84,7 @@ table HelloRequest {
 table HelloResponse {
   server_name:string (id: 0);
   software_version:string (id: 1);
-  selected_minor:ushort (id: 2);
+  selected_minor_version:ushort (id: 2);
   maximum_frame_bytes:uint (id: 3);
   maximum_datasets:uint (id: 4);
   maximum_outstanding_requests:uint (id: 5);
@@ -334,7 +334,7 @@ union Payload {
 
 table Envelope {
   protocol_major:ushort = 1 (id: 0);
-  protocol_minor:ushort = 0 (id: 1);
+  protocol_minor_version:ushort = 0 (id: 1);
   request_id:ulong (id: 2);
   payload:Payload (id: 4);
 }

--- a/schemas/amrexplorer_wire.fbs
+++ b/schemas/amrexplorer_wire.fbs
@@ -1,338 +1,342 @@
 namespace amrexplorer.wire;
 
 enum SamplingPolicy : ubyte {
-  Nearest,
-  PiecewiseConstant,
-  Linear
+  Nearest = 0,
+  PiecewiseConstant = 1,
+  Linear = 2
 }
 
 enum CompositionPolicy : ubyte {
-  FinestAvailable,
-  ExactLevel
+  FinestAvailable = 0,
+  ExactLevel = 1
 }
 
 enum Centering : ubyte {
-  Cell,
-  Node,
-  FaceX,
-  FaceY,
-  FaceZ,
-  EdgeX,
-  EdgeY,
-  EdgeZ,
-  Mixed
+  Cell = 0,
+  Node = 1,
+  FaceX = 2,
+  FaceY = 3,
+  FaceZ = 4,
+  EdgeX = 5,
+  EdgeY = 6,
+  EdgeZ = 7,
+  Mixed = 8
 }
 
 enum RangeScope : ubyte {
-  File,
-  Level
+  File = 0,
+  Level = 1
 }
 
 enum ErrorCode : ushort {
-  UnsupportedProtocol,
-  InvalidRequest,
-  UnknownDataset,
-  DatasetOpenFailure,
-  Cancelled,
-  CacheBudgetExceeded,
-  ResourceLimitExceeded,
-  OperationFailure,
-  InternalServerError,
-  Disconnected
+  UnsupportedProtocol = 0,
+  InvalidRequest = 1,
+  UnknownDataset = 2,
+  DatasetOpenFailure = 3,
+  Cancelled = 4,
+  CacheBudgetExceeded = 5,
+  ResourceLimitExceeded = 6,
+  OperationFailure = 7,
+  InternalServerError = 8,
+  Disconnected = 9,
+  Unauthorized = 10
 }
 
 table Int3 {
-  values:[int];
+  values:[int] (id: 0);
 }
 
 table Real3 {
-  values:[double];
+  values:[double] (id: 0);
 }
 
 table IntBox {
-  lower:Int3;
-  upper:Int3;
-  centering:Int3;
+  lower:Int3 (id: 0);
+  upper:Int3 (id: 1);
+  centering:Int3 (id: 2);
 }
 
 table RealBox {
-  lower:Real3;
-  upper:Real3;
+  lower:Real3 (id: 0);
+  upper:Real3 (id: 1);
 }
 
 table CacheState {
-  budget_bytes:ulong;
-  resident_bytes:ulong;
-  pinned_bytes:ulong;
-  hits:ulong;
-  misses:ulong;
-  evictions:ulong;
-  clears:ulong;
+  budget_bytes:ulong (id: 0);
+  resident_bytes:ulong (id: 1);
+  pinned_bytes:ulong (id: 2);
+  hits:ulong (id: 3);
+  misses:ulong (id: 4);
+  evictions:ulong (id: 5);
+  clears:ulong (id: 6);
 }
 
 table HelloRequest {
-  client_name:string;
-  software_version:string;
-  minimum_minor:ushort;
-  maximum_minor:ushort;
-  maximum_frame_bytes:uint;
+  client_name:string (id: 0);
+  software_version:string (id: 1);
+  minimum_minor:ushort (id: 2);
+  maximum_minor:ushort (id: 3);
+  maximum_frame_bytes:uint (id: 4);
+  session_token:string (id: 5);
+  capabilities:[ulong] (id: 6);
 }
 
 table HelloResponse {
-  server_name:string;
-  software_version:string;
-  selected_minor:ushort;
-  maximum_frame_bytes:uint;
-  maximum_datasets:uint;
-  maximum_outstanding_requests:uint;
-  worker_count:uint;
+  server_name:string (id: 0);
+  software_version:string (id: 1);
+  selected_minor:ushort (id: 2);
+  maximum_frame_bytes:uint (id: 3);
+  maximum_datasets:uint (id: 4);
+  maximum_outstanding_requests:uint (id: 5);
+  worker_count:uint (id: 6);
+  capabilities:[ulong] (id: 7);
 }
 
 table OpenDatasetRequest {
-  path:string;
-  cache_budget_bytes:ulong;
+  path:string (id: 0);
+  cache_budget_bytes:ulong (id: 1);
 }
 
 table FieldCatalog {
-  name:string;
-  centering:Centering;
-  component_names:[string];
+  name:string (id: 0);
+  centering:Centering (id: 1);
+  component_names:[string] (id: 2);
 }
 
 table LevelCatalog {
-  level:int;
-  step:int;
-  domain:IntBox;
-  cell_size:Real3;
-  index_origin:Real3;
-  boxes:[IntBox];
+  level:int (id: 0);
+  step:int (id: 1);
+  domain:IntBox (id: 2);
+  cell_size:Real3 (id: 3);
+  index_origin:Real3 (id: 4);
+  boxes:[IntBox] (id: 5);
 }
 
 table ParticleSpeciesCatalog {
-  name:string;
-  dimension:int;
-  real_component_count:int;
-  int_component_count:int;
-  particle_count:ulong;
-  single_precision:bool;
+  name:string (id: 0);
+  dimension:int (id: 1);
+  real_component_count:int (id: 2);
+  int_component_count:int (id: 3);
+  particle_count:ulong (id: 4);
+  single_precision:bool (id: 5);
 }
 
 table MetadataReadMetrics {
-  files_read:ulong;
-  bytes_read:ulong;
-  payload_files_read:ulong;
-  payload_bytes_read:ulong;
+  files_read:ulong (id: 0);
+  bytes_read:ulong (id: 1);
+  payload_files_read:ulong (id: 2);
+  payload_bytes_read:ulong (id: 3);
 }
 
 table DatasetOpened {
-  dataset_id:ulong;
-  dimension:int;
-  finest_level:int;
-  is_fab:bool;
-  has_physical_geometry:bool;
-  time:double;
-  coordinate_system:int;
-  physical_domain:RealBox;
-  fields:[FieldCatalog];
-  levels:[LevelCatalog];
-  particle_species:[ParticleSpeciesCatalog];
-  file_range_available:[ubyte];
-  level_range_available:[ubyte];
-  metadata_metrics:MetadataReadMetrics;
-  file_version:string;
-  cache:CacheState;
+  dataset_id:ulong (id: 0);
+  dimension:int (id: 1);
+  finest_level:int (id: 2);
+  is_fab:bool (id: 3);
+  has_physical_geometry:bool (id: 4);
+  time:double (id: 5);
+  coordinate_system:int (id: 6);
+  physical_domain:RealBox (id: 7);
+  fields:[FieldCatalog] (id: 8);
+  levels:[LevelCatalog] (id: 9);
+  particle_species:[ParticleSpeciesCatalog] (id: 10);
+  file_range_available:[ubyte] (id: 11);
+  level_range_available:[ubyte] (id: 12);
+  metadata_metrics:MetadataReadMetrics (id: 13);
+  file_version:string (id: 14);
+  cache:CacheState (id: 15);
 }
 
 table CloseDatasetRequest {
-  dataset_id:ulong;
+  dataset_id:ulong (id: 0);
 }
 
 table DatasetClosed {
-  dataset_id:ulong;
+  dataset_id:ulong (id: 0);
 }
 
 table SliceViewRequest {
-  dataset_id:ulong;
-  field:uint;
-  component:int;
-  normal_direction:int;
-  physical_position:double;
-  visible_region:RealBox;
-  maximum_level:int;
-  width:int;
-  height:int;
-  sampling:SamplingPolicy;
-  composition:CompositionPolicy;
+  dataset_id:ulong (id: 0);
+  field:uint (id: 1);
+  component:int (id: 2);
+  normal_direction:int (id: 3);
+  physical_position:double (id: 4);
+  visible_region:RealBox (id: 5);
+  maximum_level:int (id: 6);
+  width:int (id: 7);
+  height:int (id: 8);
+  sampling:SamplingPolicy (id: 9);
+  composition:CompositionPolicy (id: 10);
 }
 
 table SliceViewResponse {
-  width:int;
-  height:int;
-  physical_region:RealBox;
-  values:[float];
-  valid:[ubyte];
-  source_level:[short];
-  candidate_blocks:ulong;
-  blocks_read:ulong;
-  cache_hits:ulong;
-  payload_bytes_read:ulong;
-  cache:CacheState;
+  width:int (id: 0);
+  height:int (id: 1);
+  physical_region:RealBox (id: 2);
+  values:[float] (id: 3);
+  valid:[ubyte] (id: 4);
+  source_level:[short] (id: 5);
+  candidate_blocks:ulong (id: 6);
+  blocks_read:ulong (id: 7);
+  cache_hits:ulong (id: 8);
+  payload_bytes_read:ulong (id: 9);
+  cache:CacheState (id: 10);
 }
 
 table LineViewRequest {
-  dataset_id:ulong;
-  field:uint;
-  component:int;
-  axis:int;
-  fixed_coordinates:Real3;
-  maximum_level:int;
-  composition:CompositionPolicy;
-  region:RealBox;
-  has_region:bool;
-  output_width:int;
+  dataset_id:ulong (id: 0);
+  field:uint (id: 1);
+  component:int (id: 2);
+  axis:int (id: 3);
+  fixed_coordinates:Real3 (id: 4);
+  maximum_level:int (id: 5);
+  composition:CompositionPolicy (id: 6);
+  region:RealBox (id: 7);
+  has_region:bool (id: 8);
+  output_width:int (id: 9);
 }
 
 table LineViewResponse {
-  axis:int;
-  positions_are_indices:bool;
-  positions:[double];
-  values:[float];
-  valid:[ubyte];
-  source_level:[short];
-  candidate_blocks:ulong;
-  blocks_read:ulong;
-  cache_hits:ulong;
-  payload_bytes_read:ulong;
-  cache:CacheState;
+  axis:int (id: 0);
+  positions_are_indices:bool (id: 1);
+  positions:[double] (id: 2);
+  values:[float] (id: 3);
+  valid:[ubyte] (id: 4);
+  source_level:[short] (id: 5);
+  candidate_blocks:ulong (id: 6);
+  blocks_read:ulong (id: 7);
+  cache_hits:ulong (id: 8);
+  payload_bytes_read:ulong (id: 9);
+  cache:CacheState (id: 10);
 }
 
 table DatasetPageRequest {
-  dataset_id:ulong;
-  field:uint;
-  level:int;
-  region:RealBox;
-  normal_axis:int;
-  slice_position:double;
-  maximum_extent:int;
+  dataset_id:ulong (id: 0);
+  field:uint (id: 1);
+  level:int (id: 2);
+  region:RealBox (id: 3);
+  normal_axis:int (id: 4);
+  slice_position:double (id: 5);
+  maximum_extent:int (id: 6);
 }
 
 table DatasetPageResponse {
-  lower:[int];
-  upper:[int];
-  nx:int;
-  ny:int;
-  slice_index:int;
-  values:[float];
-  covered:[ubyte];
-  minimum:double;
-  maximum:double;
-  has_finite_values:bool;
-  truncated_x:bool;
-  truncated_y:bool;
-  cache:CacheState;
+  lower:[int] (id: 0);
+  upper:[int] (id: 1);
+  nx:int (id: 2);
+  ny:int (id: 3);
+  slice_index:int (id: 4);
+  values:[float] (id: 5);
+  covered:[ubyte] (id: 6);
+  minimum:double (id: 7);
+  maximum:double (id: 8);
+  has_finite_values:bool (id: 9);
+  truncated_x:bool (id: 10);
+  truncated_y:bool (id: 11);
+  cache:CacheState (id: 12);
 }
 
 table ParticleSampleRequest {
-  dataset_id:ulong;
-  species:string;
-  fraction:double;
-  seed:ulong;
+  dataset_id:ulong (id: 0);
+  species:string (id: 1);
+  fraction:double (id: 2);
+  seed:ulong (id: 3);
 }
 
 table ParticleSampleResponse {
-  species:ParticleSpeciesCatalog;
-  ids:[ulong];
-  positions:[double];
-  integer_bytes_read:ulong;
-  real_bytes_read:ulong;
-  level_directories_scanned:ulong;
-  data_files_opened:ulong;
-  cache:CacheState;
+  species:ParticleSpeciesCatalog (id: 0);
+  ids:[ulong] (id: 1);
+  positions:[double] (id: 2);
+  integer_bytes_read:ulong (id: 3);
+  real_bytes_read:ulong (id: 4);
+  level_directories_scanned:ulong (id: 5);
+  data_files_opened:ulong (id: 6);
+  cache:CacheState (id: 7);
 }
 
 table RangeRequest {
-  dataset_id:ulong;
-  field:uint;
-  maximum_level:int;
-  composition:CompositionPolicy;
-  scope:RangeScope;
+  dataset_id:ulong (id: 0);
+  field:uint (id: 1);
+  maximum_level:int (id: 2);
+  composition:CompositionPolicy (id: 3);
+  scope:RangeScope (id: 4);
 }
 
 table RangeResponse {
-  has_range:bool;
-  minimum:double;
-  maximum:double;
-  cache:CacheState;
+  has_range:bool (id: 0);
+  minimum:double (id: 1);
+  maximum:double (id: 2);
+  cache:CacheState (id: 3);
 }
 
 table ClearCacheRequest {
-  dataset_id:ulong;
+  dataset_id:ulong (id: 0);
 }
 
 table SetCacheBudgetRequest {
-  dataset_id:ulong;
-  budget_bytes:ulong;
+  dataset_id:ulong (id: 0);
+  budget_bytes:ulong (id: 1);
 }
 
 table CacheResponse {
-  dataset_id:ulong;
-  cache:CacheState;
+  dataset_id:ulong (id: 0);
+  cache:CacheState (id: 1);
 }
 
 table CancelRequest {
-  target_request_id:ulong;
+  target_request_id:ulong (id: 0);
 }
 
 table CancelAcknowledged {
-  target_request_id:ulong;
-  accepted:bool;
+  target_request_id:ulong (id: 0);
+  accepted:bool (id: 1);
 }
 
 table PingRequest {
-  nonce:ulong;
+  nonce:ulong (id: 0);
 }
 
 table PongResponse {
-  nonce:ulong;
+  nonce:ulong (id: 0);
 }
 
 table ErrorResponse {
-  code:ErrorCode;
-  message:string;
+  code:ErrorCode (id: 0);
+  message:string (id: 1);
 }
 
 union Payload {
-  HelloRequest,
-  HelloResponse,
-  OpenDatasetRequest,
-  DatasetOpened,
-  CloseDatasetRequest,
-  DatasetClosed,
-  SliceViewRequest,
-  SliceViewResponse,
-  LineViewRequest,
-  LineViewResponse,
-  DatasetPageRequest,
-  DatasetPageResponse,
-  ParticleSampleRequest,
-  ParticleSampleResponse,
-  RangeRequest,
-  RangeResponse,
-  ClearCacheRequest,
-  SetCacheBudgetRequest,
-  CacheResponse,
-  CancelRequest,
-  CancelAcknowledged,
-  PingRequest,
-  PongResponse,
-  ErrorResponse
+  HelloRequest = 1,
+  HelloResponse = 2,
+  OpenDatasetRequest = 3,
+  DatasetOpened = 4,
+  CloseDatasetRequest = 5,
+  DatasetClosed = 6,
+  SliceViewRequest = 7,
+  SliceViewResponse = 8,
+  LineViewRequest = 9,
+  LineViewResponse = 10,
+  DatasetPageRequest = 11,
+  DatasetPageResponse = 12,
+  ParticleSampleRequest = 13,
+  ParticleSampleResponse = 14,
+  RangeRequest = 15,
+  RangeResponse = 16,
+  ClearCacheRequest = 17,
+  SetCacheBudgetRequest = 18,
+  CacheResponse = 19,
+  CancelRequest = 20,
+  CancelAcknowledged = 21,
+  PingRequest = 22,
+  PongResponse = 23,
+  ErrorResponse = 24
 }
 
 table Envelope {
-  protocol_major:ushort = 1;
-  protocol_minor:ushort = 0;
-  request_id:ulong;
-  payload:Payload;
+  protocol_major:ushort = 1 (id: 0);
+  protocol_minor:ushort = 0 (id: 1);
+  request_id:ulong (id: 2);
+  payload:Payload (id: 4);
 }
 
 root_type Envelope;

--- a/src/remote/CMakeLists.txt
+++ b/src/remote/CMakeLists.txt
@@ -1,5 +1,29 @@
+set(amrexplorer_wire_schema
+    "${PROJECT_SOURCE_DIR}/schemas/amrexplorer_wire.fbs")
+set(amrexplorer_wire_generated_dir
+    "${CMAKE_CURRENT_BINARY_DIR}/generated")
+set(amrexplorer_wire_generated
+    "${amrexplorer_wire_generated_dir}/amrexplorer_wire_generated.h")
+
+add_custom_command(
+    OUTPUT "${amrexplorer_wire_generated}"
+    COMMAND "${CMAKE_COMMAND}" -E make_directory
+        "${amrexplorer_wire_generated_dir}"
+    COMMAND "$<TARGET_FILE:flatc>"
+        --cpp
+        --gen-object-api
+        --scoped-enums
+        --warnings-as-errors
+        -o "${amrexplorer_wire_generated_dir}"
+        "${amrexplorer_wire_schema}"
+    DEPENDS flatc "${amrexplorer_wire_schema}"
+    COMMENT "Generating production AMReXplorer wire bindings"
+    VERBATIM
+)
+
 add_library(amrexplorer_remote
     Frame.cpp
+    "${amrexplorer_wire_generated}"
 )
 add_library(amrexplorer::remote ALIAS amrexplorer_remote)
 
@@ -7,8 +31,12 @@ target_include_directories(amrexplorer_remote
     PUBLIC
         $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
         $<INSTALL_INTERFACE:include>
+    PRIVATE "${amrexplorer_wire_generated_dir}"
 )
-target_link_libraries(amrexplorer_remote PRIVATE amrexplorer::warnings)
+target_link_libraries(amrexplorer_remote
+    PUBLIC amrexplorer::data
+    PRIVATE amrexplorer::warnings
+)
 if(WIN32)
     target_link_libraries(amrexplorer_remote PRIVATE ws2_32)
 endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -91,12 +91,14 @@ target_link_libraries(
 )
 add_test(NAME slice_pipeline COMMAND test_slice_pipeline)
 
-add_executable(test_remote_frame unit/test_remote_frame.cpp)
-target_link_libraries(
-    test_remote_frame
-    PRIVATE amrexplorer::remote amrexplorer::warnings Threads::Threads
-)
-add_test(NAME remote_frame COMMAND test_remote_frame)
+if(TARGET amrexplorer_remote)
+    add_executable(test_remote_frame unit/test_remote_frame.cpp)
+    target_link_libraries(
+        test_remote_frame
+        PRIVATE amrexplorer::remote amrexplorer::warnings Threads::Threads
+    )
+    add_test(NAME remote_frame COMMAND test_remote_frame)
+endif()
 
 add_executable(test_vismf_index unit/test_vismf_index.cpp)
 target_link_libraries(test_vismf_index PRIVATE amrexplorer::io amrexplorer::warnings)


### PR DESCRIPTION
Part 5 of 13 in the remote client/server stack.

## Purpose

Define the production protocol surface separately from its conversion code.

## Scope

- Checks in the FlatBuffers schema and native protocol types.
- Adds build-time `flatc` generation.
- Covers handshake, dataset lifecycle, bounded views/pages, particles, ranges, cache control, cancellation, ping, and structured errors.

## Review focus

Review the schema as a compatibility contract: IDs, limits, optional data, and additive evolution points.

## Validation

- Schema generation in both desktop and headless remote builds
- Warnings-as-errors build at the stack tip
