### PR TITLE
[client-server] serve bounded dataset requests

### DIFF
--- a/include/amrexplorer/data/LocalDatasetSession.hpp
+++ b/include/amrexplorer/data/LocalDatasetSession.hpp
@@ -39,6 +39,9 @@ public:
     [[nodiscard]] ParticleSample requestParticleSample(
         const std::string& species, double fraction, std::uint64_t seed,
         StopToken cancellation = {}) override;
+    [[nodiscard]] ParticleSample requestParticleSample(
+        const std::string& species, double fraction, std::uint64_t seed,
+        std::size_t maximumPoints, StopToken cancellation = {});
 
     [[nodiscard]] CacheMetrics cacheMetrics() const override;
     [[nodiscard]] bool setCacheBudget(std::uint64_t bytes) override;

--- a/include/amrexplorer/data/ViewData.hpp
+++ b/include/amrexplorer/data/ViewData.hpp
@@ -8,6 +8,8 @@
 
 namespace amrvis {
 
+inline constexpr int maxViewOutputDimension = 4096;
+
 struct LineViewRequest {
     LineRequest query;
     int outputWidth = 0;

--- a/include/amrexplorer/data/ViewData.hpp
+++ b/include/amrexplorer/data/ViewData.hpp
@@ -4,11 +4,15 @@
 #include <amrexplorer/query/LineQuery.hpp>
 #include <amrexplorer/query/SliceQuery.hpp>
 
+#include <cstdint>
 #include <variant>
 
 namespace amrvis {
 
 inline constexpr int maxViewOutputDimension = 4096;
+inline constexpr std::uint64_t sliceResponseOverheadBytes = 512;
+inline constexpr std::uint64_t sliceResponseBytesPerCell
+    = sizeof(float) + sizeof(std::uint8_t) + sizeof(std::int16_t);
 
 struct LineViewRequest {
     LineRequest query;

--- a/include/amrexplorer/io/ParticleReader.hpp
+++ b/include/amrexplorer/io/ParticleReader.hpp
@@ -3,8 +3,10 @@
 #include <amrexplorer/core/Geometry.hpp>
 #include <amrexplorer/core/StopToken.hpp>
 
+#include <cstddef>
 #include <cstdint>
 #include <filesystem>
+#include <limits>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -50,6 +52,11 @@ public:
     using std::runtime_error::runtime_error;
 };
 
+class ParticleSampleLimitExceeded : public std::runtime_error {
+public:
+    using std::runtime_error::runtime_error;
+};
+
 [[nodiscard]] std::vector<ParticleSpeciesMetadata> discoverParticleSpecies(
     const std::filesystem::path& plotfile, StopToken cancellation = {});
 
@@ -59,6 +66,7 @@ public:
 [[nodiscard]] ParticleSample readParticleSample(
     const std::filesystem::path& plotfile, const std::string& species,
     double fraction, std::uint64_t seed = 0,
-    StopToken cancellation = {});
+    StopToken cancellation = {},
+    std::size_t maximumPoints = std::numeric_limits<std::size_t>::max());
 
 } // namespace amrvis

--- a/include/amrexplorer/io/PlotfileDataset.hpp
+++ b/include/amrexplorer/io/PlotfileDataset.hpp
@@ -37,7 +37,8 @@ public:
         const noexcept;
     [[nodiscard]] ParticleSample requestParticleSample(
         const std::string& species, double fraction, std::uint64_t seed = 0,
-        StopToken cancellation = {}) const;
+        StopToken cancellation = {},
+        std::size_t maximumPoints = std::numeric_limits<std::size_t>::max()) const;
     [[nodiscard]] const std::filesystem::path& dataRoot() const noexcept;
 
     [[nodiscard]] BlockAccess requestBlock(

--- a/include/amrexplorer/pipeline/SlicePipeline.hpp
+++ b/include/amrexplorer/pipeline/SlicePipeline.hpp
@@ -146,7 +146,7 @@ struct LevelSelection {
 // of the cell size, so when this cap does engage the sampling pitch only
 // ever exceeds the cell size — honest downsampling — and never produces
 // duplicated or skipped cells.
-inline constexpr int maxSliceOutputDimension = 4096;
+inline constexpr int maxSliceOutputDimension = maxViewOutputDimension;
 
 // Native render resolution for a slice: the count of finest-level cells the
 // visible region spans along each in-plane axis. At the 1x fixed scale this is

--- a/include/amrexplorer/remote/Server.hpp
+++ b/include/amrexplorer/remote/Server.hpp
@@ -14,6 +14,7 @@ struct ServerOptions {
     std::uint32_t maximumFrameBytes = defaultMaximumFrameBytes;
     std::uint32_t maximumDatasets = 8;
     std::uint32_t maximumOutstandingRequests = 64;
+    std::uint32_t maximumConnections = 32;
     std::string softwareVersion = "unknown";
 };
 
@@ -26,6 +27,7 @@ public:
     Server& operator=(const Server&) = delete;
 
     [[nodiscard]] std::uint16_t port() const noexcept;
+    [[nodiscard]] std::string lastError() const;
     void run();
     void requestStop() noexcept;
 

--- a/include/amrexplorer/remote/Server.hpp
+++ b/include/amrexplorer/remote/Server.hpp
@@ -2,6 +2,7 @@
 
 #include <amrexplorer/remote/Frame.hpp>
 
+#include <chrono>
 #include <cstdint>
 #include <memory>
 #include <string>
@@ -15,6 +16,10 @@ struct ServerOptions {
     std::uint32_t maximumDatasets = 8;
     std::uint32_t maximumOutstandingRequests = 64;
     std::uint32_t maximumConnections = 32;
+    // Bounds the unauthenticated hello read with one absolute deadline and a
+    // small frame cap. Both limits are removed after a valid hello.
+    std::chrono::milliseconds handshakeTimeout{5000};
+    std::uint32_t maximumHandshakeFrameBytes = 64U * 1024U;
     std::string softwareVersion = "unknown";
 };
 

--- a/include/amrexplorer/remote/Server.hpp
+++ b/include/amrexplorer/remote/Server.hpp
@@ -20,10 +20,10 @@ struct ServerOptions {
     // small frame cap. Both limits are removed after a valid hello.
     std::chrono::milliseconds handshakeTimeout{5000};
     std::uint32_t maximumHandshakeFrameBytes = 64U * 1024U;
-    // Bounds each response write. A peer that stops reading is disconnected
-    // when this deadline expires so it cannot retain a worker or serialize
-    // later responses behind the session write mutex.
-    std::chrono::milliseconds responseWriteTimeout{5000};
+    // A response may take arbitrarily long while bytes continue moving. A peer
+    // that makes no write progress for this interval is disconnected so it
+    // cannot retain a worker or the session write mutex indefinitely.
+    std::chrono::milliseconds responseWriteStallTimeout{30000};
     std::string softwareVersion = "unknown";
 };
 

--- a/include/amrexplorer/remote/Server.hpp
+++ b/include/amrexplorer/remote/Server.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <amrexplorer/remote/Frame.hpp>
+
+#include <cstdint>
+#include <memory>
+#include <string>
+
+namespace amrvis::remote {
+
+struct ServerOptions {
+    std::uint16_t port = 0;
+    unsigned int workerCount = 0;
+    std::uint32_t maximumFrameBytes = defaultMaximumFrameBytes;
+    std::uint32_t maximumDatasets = 8;
+    std::uint32_t maximumOutstandingRequests = 64;
+    std::string softwareVersion = "unknown";
+};
+
+class Server {
+public:
+    explicit Server(ServerOptions options = {});
+    ~Server();
+
+    Server(const Server&) = delete;
+    Server& operator=(const Server&) = delete;
+
+    [[nodiscard]] std::uint16_t port() const noexcept;
+    void run();
+    void requestStop() noexcept;
+
+private:
+    class Impl;
+    std::unique_ptr<Impl> m_impl;
+};
+
+} // namespace amrvis::remote

--- a/include/amrexplorer/remote/Server.hpp
+++ b/include/amrexplorer/remote/Server.hpp
@@ -20,6 +20,10 @@ struct ServerOptions {
     // small frame cap. Both limits are removed after a valid hello.
     std::chrono::milliseconds handshakeTimeout{5000};
     std::uint32_t maximumHandshakeFrameBytes = 64U * 1024U;
+    // Bounds each response write. A peer that stops reading is disconnected
+    // when this deadline expires so it cannot retain a worker or serialize
+    // later responses behind the session write mutex.
+    std::chrono::milliseconds responseWriteTimeout{5000};
     std::string softwareVersion = "unknown";
 };
 

--- a/src/data/DatasetPage.cpp
+++ b/src/data/DatasetPage.cpp
@@ -63,6 +63,17 @@ DatasetPage extractDatasetPage(PlotfileDataset& dataset,
     const auto& level
         = metadata.levels[static_cast<std::size_t>(request.level)];
     const auto axes = inPlaneAxes(metadata.dimension, request.normalAxis);
+    for (const auto axis : axes) {
+        const auto entry = static_cast<std::size_t>(axis);
+        const auto lower = request.region.lower[entry];
+        const auto upper = request.region.upper[entry];
+        if (!std::isfinite(lower) || !std::isfinite(upper)
+            || !(lower < upper)) {
+            throw std::invalid_argument(
+                "dataset page region must have positive finite in-plane "
+                "extent");
+        }
+    }
 
     DatasetPage page;
     std::array<std::int64_t, 2> lower{};

--- a/src/data/LocalDatasetSession.cpp
+++ b/src/data/LocalDatasetSession.cpp
@@ -202,6 +202,14 @@ ParticleSample LocalDatasetSession::requestParticleSample(
         species, fraction, seed, cancellation);
 }
 
+ParticleSample LocalDatasetSession::requestParticleSample(
+    const std::string& species, double fraction, std::uint64_t seed,
+    std::size_t maximumPoints, StopToken cancellation)
+{
+    return requireDataset()->requestParticleSample(
+        species, fraction, seed, cancellation, maximumPoints);
+}
+
 CacheMetrics LocalDatasetSession::cacheMetrics() const
 {
     return requireDataset()->cacheMetrics();

--- a/src/io/plotfile/ParticleReader.cpp
+++ b/src/io/plotfile/ParticleReader.cpp
@@ -315,7 +315,8 @@ template <typename Real>
 void readGrid(std::istream& input, const GridRecord& grid,
     std::uint64_t dataFileSize, const ParsedHeader& header, double fraction,
     std::uint64_t seed, StopToken cancellation,
-    std::vector<ParticlePoint>& output, ParticleReadMetrics& metrics)
+    std::size_t maximumPoints, std::vector<ParticlePoint>& output,
+    ParticleReadMetrics& metrics)
 {
     const auto intValues = static_cast<std::uint64_t>(
         2 + header.metadata.intComponentCount);
@@ -366,6 +367,12 @@ void readGrid(std::istream& input, const GridRecord& grid,
             const auto idcpu = decodeIdCpu(
                 idWords[0], idWords[1], header.expandedIds);
             if (idcpu.has_value() && selected(*idcpu, fraction, seed)) {
+                if (output.size() >= maximumPoints
+                    || selectedParticles.size()
+                        >= maximumPoints - output.size()) {
+                    throw ParticleSampleLimitExceeded(
+                        "particle sample exceeds its point limit");
+                }
                 selectedParticles.push_back(
                     {firstIndex + relativeIndex, *idcpu});
             }
@@ -449,7 +456,8 @@ std::vector<ParticleSpeciesMetadata> discoverParticleSpecies(
 
 ParticleSample readParticleSample(
     const std::filesystem::path& plotfile, const std::string& species,
-    double fraction, std::uint64_t seed, StopToken cancellation)
+    double fraction, std::uint64_t seed, StopToken cancellation,
+    std::size_t maximumPoints)
 {
     if (!std::isfinite(fraction) || fraction < 0.0 || fraction > 1.0) {
         throw std::invalid_argument("particle sample fraction must be between 0 and 1");
@@ -473,7 +481,7 @@ ParticleSample readParticleSample(
         * static_cast<long double>(fraction);
     result.points.reserve(static_cast<std::size_t>(std::min<long double>(
         expected + 16.0L,
-        static_cast<long double>(std::numeric_limits<std::size_t>::max()))));
+        static_cast<long double>(maximumPoints))));
     const auto dataPaths
         = particleDataPaths(speciesPath, header.grids, result.io);
     std::map<DataFileKey, std::vector<const GridRecord*>> gridsByFile;
@@ -502,11 +510,11 @@ ParticleSample readParticleSample(
             if (header.metadata.precision == ParticleRealPrecision::Single) {
                 readGrid<float>(input, *grid,
                     static_cast<std::uint64_t>(dataFileSize), header, fraction,
-                    seed, cancellation, result.points, result.io);
+                    seed, cancellation, maximumPoints, result.points, result.io);
             } else {
                 readGrid<double>(input, *grid,
                     static_cast<std::uint64_t>(dataFileSize), header, fraction,
-                    seed, cancellation, result.points, result.io);
+                    seed, cancellation, maximumPoints, result.points, result.io);
             }
         }
     }

--- a/src/io/plotfile/PlotfileDataset.cpp
+++ b/src/io/plotfile/PlotfileDataset.cpp
@@ -100,10 +100,10 @@ const std::vector<ParticleSpeciesMetadata>& PlotfileDataset::particleSpecies()
 
 ParticleSample PlotfileDataset::requestParticleSample(
     const std::string& species, double fraction, std::uint64_t seed,
-    StopToken cancellation) const
+    StopToken cancellation, std::size_t maximumPoints) const
 {
     return readParticleSample(
-        m_plotfile, species, fraction, seed, cancellation);
+        m_plotfile, species, fraction, seed, cancellation, maximumPoints);
 }
 
 const std::filesystem::path& PlotfileDataset::dataRoot() const noexcept

--- a/src/remote/CMakeLists.txt
+++ b/src/remote/CMakeLists.txt
@@ -25,6 +25,7 @@ add_library(amrexplorer_remote
     Codec.cpp
     Codec.hpp
     Frame.cpp
+    Server.cpp
     "${amrexplorer_wire_generated}"
 )
 add_library(amrexplorer::remote ALIAS amrexplorer_remote)
@@ -37,7 +38,10 @@ target_include_directories(amrexplorer_remote
 )
 target_link_libraries(amrexplorer_remote
     PUBLIC amrexplorer::data
-    PRIVATE FlatBuffers::FlatBuffers amrexplorer::warnings
+    PRIVATE
+        FlatBuffers::FlatBuffers
+        Threads::Threads
+        amrexplorer::warnings
 )
 if(WIN32)
     target_link_libraries(amrexplorer_remote PRIVATE ws2_32)

--- a/src/remote/Frame.cpp
+++ b/src/remote/Frame.cpp
@@ -64,6 +64,11 @@ bool wouldBlock(int error)
 {
     return error == WSAEWOULDBLOCK;
 }
+
+bool transientAcceptFailure(int error)
+{
+    return interrupted(error) || error == WSAECONNABORTED;
+}
 void closeNative(NativeSocket socket)
 {
     ::closesocket(socket);
@@ -88,6 +93,11 @@ bool interrupted(int error)
 bool wouldBlock(int error)
 {
     return error == EAGAIN || error == EWOULDBLOCK;
+}
+
+bool transientAcceptFailure(int error)
+{
+    return interrupted(error) || error == ECONNABORTED;
 }
 void closeNative(NativeSocket socket)
 {
@@ -464,7 +474,7 @@ Socket acceptConnection(const Socket& listener, StopToken cancellation)
             return socket;
         }
         const auto error = lastSocketError();
-        if (!interrupted(error) && !wouldBlock(error)) {
+        if (!transientAcceptFailure(error) && !wouldBlock(error)) {
             throwSocketError("accept", error);
         }
     }

--- a/src/remote/Server.cpp
+++ b/src/remote/Server.cpp
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <atomic>
 #include <chrono>
+#include <cmath>
 #include <condition_variable>
 #include <cstdint>
 #include <deque>
@@ -133,6 +134,9 @@ ErrorData classifyError(const std::exception& error)
     if (dynamic_cast<const CacheBudgetExceeded*>(&error) != nullptr) {
         return {ErrorCode::CacheBudgetExceeded, error.what()};
     }
+    if (dynamic_cast<const ParticleSampleLimitExceeded*>(&error) != nullptr) {
+        return {ErrorCode::ResourceLimitExceeded, error.what()};
+    }
     if (dynamic_cast<const std::invalid_argument*>(&error) != nullptr) {
         return {ErrorCode::InvalidRequest, error.what()};
     }
@@ -252,12 +256,14 @@ private:
         Rejection rejection = Rejection::None;
         {
             std::scoped_lock lock(m_stateMutex);
-            if (m_active.size() >= m_options.maximumOutstandingRequests) {
-                rejection = Rejection::OutstandingLimit;
-            } else if (!m_active.emplace(info.requestId,
-                           ActiveRequest{dataset, stopSource})
-                            .second) {
+            if (m_active.contains(info.requestId)) {
                 rejection = Rejection::Duplicate;
+            } else if (m_active.size()
+                >= m_options.maximumOutstandingRequests) {
+                rejection = Rejection::OutstandingLimit;
+            } else {
+                m_active.emplace(info.requestId,
+                    ActiveRequest{dataset, stopSource});
             }
         }
         if (rejection == Rejection::OutstandingLimit) {
@@ -622,10 +628,30 @@ private:
         }
         const auto request = codec::fromWire(*payload);
         const auto dataset = requireDataset(request.dataset);
-        const auto sample = dataset->requestParticleSample(request.species,
-            request.fraction, request.seed, cancellation);
         constexpr std::uint64_t bytesPerPoint
             = sizeof(std::uint64_t) + 3 * sizeof(double);
+        constexpr std::uint64_t particleResponseOverheadBytes = 512;
+        const auto frameBytes
+            = static_cast<std::uint64_t>(m_maximumFrameBytes.load());
+        const auto maximumPoints = static_cast<std::size_t>(
+            frameBytes > particleResponseOverheadBytes
+                ? (frameBytes - particleResponseOverheadBytes) / bytesPerPoint
+                : 0);
+        const auto& species = dataset->particleSpecies();
+        const auto metadata = std::find_if(species.begin(), species.end(),
+            [&](const auto& entry) { return entry.name == request.species; });
+        if (metadata == species.end()) {
+            throw std::invalid_argument("particle species is unavailable");
+        }
+        const auto requestedPoints = std::ceil(
+            static_cast<long double>(metadata->particleCount)
+            * static_cast<long double>(request.fraction));
+        if (requestedPoints > static_cast<long double>(maximumPoints)) {
+            throw RemoteError(ErrorCode::ResourceLimitExceeded,
+                "particle sample cannot fit in one negotiated frame");
+        }
+        const auto sample = dataset->requestParticleSample(request.species,
+            request.fraction, request.seed, maximumPoints, cancellation);
         if (!fitsResponse(static_cast<std::uint64_t>(sample.points.size())
                 * bytesPerPoint)) {
             throw RemoteError(ErrorCode::ResourceLimitExceeded,

--- a/src/remote/Server.cpp
+++ b/src/remote/Server.cpp
@@ -794,7 +794,9 @@ private:
             }
             std::scoped_lock lock(m_writeMutex);
             if (!m_stopping.load()) {
-                writeFrame(m_socket, bytes, m_maximumFrameBytes.load());
+                writeFrame(m_socket, bytes, m_maximumFrameBytes.load(),
+                    std::chrono::steady_clock::now()
+                        + m_options.responseWriteTimeout);
             }
         } catch (...) {
             stop();
@@ -812,7 +814,9 @@ private:
             }
             std::scoped_lock lock(m_writeMutex);
             if (!m_stopping.load()) {
-                writeFrame(m_socket, bytes, m_maximumFrameBytes.load());
+                writeFrame(m_socket, bytes, m_maximumFrameBytes.load(),
+                    std::chrono::steady_clock::now()
+                        + m_options.responseWriteTimeout);
             }
         } catch (...) {
             stop();
@@ -851,6 +855,8 @@ public:
             || m_options.maximumFrameBytes == 0
             || m_options.maximumHandshakeFrameBytes == 0
             || m_options.handshakeTimeout
+                <= std::chrono::milliseconds::zero()
+            || m_options.responseWriteTimeout
                 <= std::chrono::milliseconds::zero()) {
             throw std::invalid_argument(
                 "server resource limits must be greater than zero");

--- a/src/remote/Server.cpp
+++ b/src/remote/Server.cpp
@@ -1,0 +1,794 @@
+#include <amrexplorer/remote/Server.hpp>
+
+#include "Codec.hpp"
+
+#include <amrexplorer/data/LocalDatasetSession.hpp>
+
+#include <algorithm>
+#include <atomic>
+#include <condition_variable>
+#include <cstdint>
+#include <deque>
+#include <exception>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <stdexcept>
+#include <thread>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace amrvis::remote {
+namespace {
+
+class JoiningThread {
+public:
+    template <typename Function>
+    explicit JoiningThread(Function&& function)
+        : m_thread(std::forward<Function>(function))
+    {
+    }
+
+    ~JoiningThread()
+    {
+        join();
+    }
+
+    JoiningThread(const JoiningThread&) = delete;
+    JoiningThread& operator=(const JoiningThread&) = delete;
+
+    JoiningThread(JoiningThread&&) noexcept = default;
+
+    JoiningThread& operator=(JoiningThread&& other) noexcept
+    {
+        if (this != &other) {
+            join();
+            m_thread = std::move(other.m_thread);
+        }
+        return *this;
+    }
+
+private:
+    void join() noexcept
+    {
+        if (m_thread.joinable()) {
+            m_thread.join();
+        }
+    }
+
+    std::thread m_thread;
+};
+
+class ThreadPool {
+public:
+    explicit ThreadPool(unsigned int count)
+    {
+        count = std::max(1U, count);
+        m_threads.reserve(count);
+        for (unsigned int index = 0; index < count; ++index) {
+            m_threads.emplace_back([this] { worker(); });
+        }
+    }
+
+    ~ThreadPool()
+    {
+        {
+            std::scoped_lock lock(m_mutex);
+            m_stopping = true;
+        }
+        m_ready.notify_all();
+    }
+
+    void submit(std::function<void()> task)
+    {
+        {
+            std::scoped_lock lock(m_mutex);
+            if (m_stopping) {
+                throw std::runtime_error("server worker pool is stopping");
+            }
+            m_tasks.push_back(std::move(task));
+        }
+        m_ready.notify_one();
+    }
+
+private:
+    void worker() noexcept
+    {
+        for (;;) {
+            std::function<void()> task;
+            {
+                std::unique_lock lock(m_mutex);
+                m_ready.wait(lock,
+                    [&] { return m_stopping || !m_tasks.empty(); });
+                if (m_stopping && m_tasks.empty()) {
+                    return;
+                }
+                task = std::move(m_tasks.front());
+                m_tasks.pop_front();
+            }
+            try {
+                task();
+            } catch (...) {
+            }
+        }
+    }
+
+    std::mutex m_mutex;
+    std::condition_variable m_ready;
+    std::deque<std::function<void()>> m_tasks;
+    bool m_stopping = false;
+    std::vector<JoiningThread> m_threads;
+};
+
+ErrorData classifyError(const std::exception& error)
+{
+    if (const auto* remote = dynamic_cast<const RemoteError*>(&error)) {
+        return {remote->code(), remote->what()};
+    }
+    if (dynamic_cast<const ReadCancelled*>(&error) != nullptr) {
+        return {ErrorCode::Cancelled, error.what()};
+    }
+    if (dynamic_cast<const CacheBudgetExceeded*>(&error) != nullptr) {
+        return {ErrorCode::CacheBudgetExceeded, error.what()};
+    }
+    if (dynamic_cast<const std::invalid_argument*>(&error) != nullptr) {
+        return {ErrorCode::InvalidRequest, error.what()};
+    }
+    return {ErrorCode::OperationFailure, error.what()};
+}
+
+class Session : public std::enable_shared_from_this<Session> {
+public:
+    Session(Socket socket, ThreadPool& workers, const ServerOptions& options)
+        : m_socket(std::move(socket))
+        , m_workers(workers)
+        , m_options(options)
+        , m_maximumFrameBytes(options.maximumFrameBytes)
+    {
+    }
+
+    void run() noexcept
+    {
+        try {
+            while (!m_stopping.load()) {
+                const auto frame
+                    = readFrame(m_socket, m_maximumFrameBytes.load());
+                if (!frame) {
+                    break;
+                }
+                auto envelope = codec::decode(*frame);
+                dispatch(std::move(envelope));
+            }
+        } catch (...) {
+        }
+        stop();
+    }
+
+    void stop() noexcept
+    {
+        if (m_stopping.exchange(true)) {
+            return;
+        }
+        std::vector<StopSource> stops;
+        {
+            std::scoped_lock lock(m_stateMutex);
+            for (const auto& [id, active] : m_active) {
+                static_cast<void>(id);
+                stops.push_back(active.stop);
+            }
+            m_datasets.clear();
+        }
+        for (auto& stop : stops) {
+            stop.request_stop();
+        }
+        m_socket.shutdown();
+    }
+
+    [[nodiscard]] bool stopped() const noexcept
+    {
+        return m_stopping.load();
+    }
+
+private:
+    struct ActiveRequest {
+        DatasetId dataset;
+        StopSource stop;
+    };
+
+    void dispatch(std::unique_ptr<codec::NativeEnvelope> envelope)
+    {
+        const auto info = codec::inspect(*envelope);
+        if (info.protocolMajor != protocolMajor) {
+            sendError(info.requestId, {ErrorCode::UnsupportedProtocol,
+                "unsupported protocol major version"});
+            stop();
+            return;
+        }
+        if (!m_handshakeComplete) {
+            if (info.payload != PayloadKind::HelloRequest) {
+                sendError(info.requestId, {ErrorCode::InvalidRequest,
+                    "hello must be the first request"});
+                stop();
+                return;
+            }
+            handleHello(*envelope);
+            return;
+        }
+        if (info.protocolMinor != m_selectedMinor) {
+            sendError(info.requestId, {ErrorCode::UnsupportedProtocol,
+                "message uses a non-negotiated protocol minor version"});
+            stop();
+            return;
+        }
+        if (info.payload == PayloadKind::CancelRequest) {
+            handleCancel(*envelope);
+            return;
+        }
+        if (info.payload == PayloadKind::PingRequest) {
+            const auto* request = envelope->payload.AsPingRequest();
+            codec::fb::PongResponseT response;
+            response.nonce = request == nullptr ? 0 : request->nonce;
+            send(info.requestId, std::move(response));
+            return;
+        }
+        const auto dataset = requestDataset(*envelope);
+        StopSource stopSource;
+        {
+            std::scoped_lock lock(m_stateMutex);
+            if (m_active.size() >= m_options.maximumOutstandingRequests) {
+                sendError(info.requestId,
+                    {ErrorCode::ResourceLimitExceeded,
+                        "too many outstanding requests"});
+                return;
+            }
+            if (!m_active.emplace(info.requestId,
+                    ActiveRequest{dataset, stopSource}).second) {
+                sendError(info.requestId, {ErrorCode::InvalidRequest,
+                    "duplicate live request ID"});
+                stop();
+                return;
+            }
+        }
+        auto self = shared_from_this();
+        auto sharedEnvelope
+            = std::shared_ptr<codec::NativeEnvelope>(std::move(envelope));
+        m_workers.submit([self, sharedEnvelope, stopSource]() {
+            self->handle(sharedEnvelope, stopSource.get_token());
+        });
+    }
+
+    void handleHello(const codec::NativeEnvelope& envelope)
+    {
+        const auto* request = envelope.payload.AsHelloRequest();
+        if (request == nullptr || request->maximum_frame_bytes == 0
+            || request->minimum_minor > protocolMinor
+            || request->maximum_minor < request->minimum_minor) {
+            sendError(envelope.request_id, {ErrorCode::UnsupportedProtocol,
+                "client protocol range is unsupported"});
+            stop();
+            return;
+        }
+        m_selectedMinor
+            = std::min<std::uint16_t>(protocolMinor, request->maximum_minor);
+        m_maximumFrameBytes = std::min(
+            m_options.maximumFrameBytes, request->maximum_frame_bytes);
+        HelloResponseData response;
+        response.serverName = "AMReXplorer server";
+        response.softwareVersion = m_options.softwareVersion;
+        response.selectedMinor = m_selectedMinor;
+        response.maximumFrameBytes = m_maximumFrameBytes.load();
+        response.maximumDatasets = m_options.maximumDatasets;
+        response.maximumOutstandingRequests
+            = m_options.maximumOutstandingRequests;
+        response.workerCount = m_options.workerCount;
+        send(envelope.request_id, codec::toWire(response));
+        m_handshakeComplete = true;
+    }
+
+    void handleCancel(const codec::NativeEnvelope& envelope)
+    {
+        const auto* request = envelope.payload.AsCancelRequest();
+        bool accepted = false;
+        if (request != nullptr) {
+            std::scoped_lock lock(m_stateMutex);
+            const auto found = m_active.find(request->target_request_id);
+            if (found != m_active.end()) {
+                found->second.stop.request_stop();
+                accepted = true;
+            }
+        }
+        codec::fb::CancelAcknowledgedT response;
+        response.target_request_id
+            = request == nullptr ? 0 : request->target_request_id;
+        response.accepted = accepted;
+        send(envelope.request_id, std::move(response));
+    }
+
+    void handle(std::shared_ptr<codec::NativeEnvelope> envelope,
+        StopToken cancellation) noexcept
+    {
+        const auto info = codec::inspect(*envelope);
+        try {
+            switch (info.payload) {
+            case PayloadKind::OpenDatasetRequest:
+                openDataset(*envelope, cancellation);
+                break;
+            case PayloadKind::CloseDatasetRequest:
+                closeDataset(*envelope);
+                break;
+            case PayloadKind::SliceViewRequest:
+                sliceView(*envelope, cancellation);
+                break;
+            case PayloadKind::LineViewRequest:
+                lineView(*envelope, cancellation);
+                break;
+            case PayloadKind::DatasetPageRequest:
+                datasetPage(*envelope, cancellation);
+                break;
+            case PayloadKind::ParticleSampleRequest:
+                particleSample(*envelope, cancellation);
+                break;
+            case PayloadKind::RangeRequest:
+                range(*envelope, cancellation);
+                break;
+            case PayloadKind::ClearCacheRequest:
+                clearCache(*envelope);
+                break;
+            case PayloadKind::SetCacheBudgetRequest:
+                setCacheBudget(*envelope);
+                break;
+            default:
+                throw std::invalid_argument(
+                    "payload is not a supported client request");
+            }
+        } catch (const std::exception& error) {
+            sendError(envelope->request_id, classifyError(error));
+        } catch (...) {
+            sendError(envelope->request_id,
+                {ErrorCode::InternalServerError,
+                    "unknown server operation failure"});
+        }
+        std::scoped_lock lock(m_stateMutex);
+        m_active.erase(envelope->request_id);
+    }
+
+    void openDataset(
+        const codec::NativeEnvelope& envelope, StopToken cancellation)
+    {
+        if (cancellation.stop_requested()) {
+            throw ReadCancelled();
+        }
+        const auto* request = envelope.payload.AsOpenDatasetRequest();
+        if (request == nullptr || request->path.empty()) {
+            throw std::invalid_argument("dataset path is empty");
+        }
+        const auto id = DatasetId{m_nextDatasetId.fetch_add(1)};
+        std::shared_ptr<LocalDatasetSession> dataset;
+        try {
+            dataset = std::make_shared<LocalDatasetSession>(
+                request->path, id, request->cache_budget_bytes);
+        } catch (const std::exception& error) {
+            throw RemoteError(ErrorCode::DatasetOpenFailure, error.what());
+        }
+        {
+            std::scoped_lock lock(m_stateMutex);
+            if (cancellation.stop_requested()) {
+                dataset->close();
+                throw ReadCancelled();
+            }
+            if (m_datasets.size() >= m_options.maximumDatasets) {
+                throw RemoteError(ErrorCode::ResourceLimitExceeded,
+                    "session dataset limit exceeded");
+            }
+            m_datasets.emplace(id.value, dataset);
+        }
+        OpenedDataset opened;
+        opened.id = id;
+        opened.catalog = dataset->metadata();
+        opened.metadataMetrics = dataset->metadataReadMetrics();
+        opened.fileVersion = dataset->fileVersion();
+        opened.particleSpecies = dataset->particleSpecies();
+        opened.fileRangeAvailable.reserve(
+            opened.catalog.fields.size());
+        opened.levelRangeAvailable.reserve(opened.catalog.fields.size()
+            * opened.catalog.levels.size());
+        for (std::size_t field = 0;
+             field < opened.catalog.fields.size(); ++field) {
+            const auto fieldId = FieldId{
+                static_cast<std::uint32_t>(field)};
+            opened.fileRangeAvailable.push_back(
+                dataset->rangeAvailable(RangeRequest{fieldId,
+                    opened.catalog.finestLevel,
+                    CompositionPolicy::FinestAvailable,
+                    RangeScope::File}));
+            for (int level = 0;
+                 level <= opened.catalog.finestLevel; ++level) {
+                opened.levelRangeAvailable.push_back(
+                    dataset->rangeAvailable(RangeRequest{fieldId, level,
+                        CompositionPolicy::ExactLevel,
+                        RangeScope::Level}));
+            }
+        }
+        opened.cache = dataset->cacheMetrics();
+        send(envelope.request_id, codec::toWire(opened));
+    }
+
+    void closeDataset(const codec::NativeEnvelope& envelope)
+    {
+        const auto* request = envelope.payload.AsCloseDatasetRequest();
+        if (request == nullptr) {
+            throw std::invalid_argument("close-dataset payload is missing");
+        }
+        std::shared_ptr<LocalDatasetSession> dataset;
+        std::vector<StopSource> stops;
+        {
+            std::scoped_lock lock(m_stateMutex);
+            const auto found = m_datasets.find(request->dataset_id);
+            if (found == m_datasets.end()) {
+                throw RemoteError(
+                    ErrorCode::UnknownDataset, "dataset handle is unknown");
+            }
+            dataset = std::move(found->second);
+            m_datasets.erase(found);
+            for (const auto& [id, active] : m_active) {
+                static_cast<void>(id);
+                if (active.dataset.value == request->dataset_id) {
+                    stops.push_back(active.stop);
+                }
+            }
+        }
+        for (auto& stop : stops) {
+            stop.request_stop();
+        }
+        dataset->close();
+        codec::fb::DatasetClosedT response;
+        response.dataset_id = request->dataset_id;
+        send(envelope.request_id, std::move(response));
+    }
+
+    void sliceView(
+        const codec::NativeEnvelope& envelope, StopToken cancellation)
+    {
+        const auto* payload = envelope.payload.AsSliceViewRequest();
+        if (payload == nullptr) {
+            throw std::invalid_argument("slice-view payload is missing");
+        }
+        const auto request = codec::fromWire(*payload);
+        validateSliceBound(request);
+        const auto dataset = requireDataset(request.dataset);
+        const auto result = std::get<SliceQueryResult>(
+            dataset->requestView(ViewDataRequest{request}, cancellation));
+        send(envelope.request_id,
+            codec::toWire(result, dataset->cacheMetrics()));
+    }
+
+    void lineView(
+        const codec::NativeEnvelope& envelope, StopToken cancellation)
+    {
+        const auto* payload = envelope.payload.AsLineViewRequest();
+        if (payload == nullptr) {
+            throw std::invalid_argument("line-view payload is missing");
+        }
+        const auto request = codec::fromWire(*payload);
+        if (request.outputWidth < 1 || request.outputWidth > 16384) {
+            throw RemoteError(ErrorCode::ResourceLimitExceeded,
+                "line viewport width is outside the server limit");
+        }
+        const auto dataset = requireDataset(request.query.dataset);
+        const auto result = std::get<LineQueryResult>(
+            dataset->requestView(ViewDataRequest{request}, cancellation));
+        if (result.line.values.size()
+            > static_cast<std::size_t>(request.outputWidth) * 2) {
+            throw std::logic_error(
+                "line planner exceeded its viewport response bound");
+        }
+        send(envelope.request_id,
+            codec::toWire(result, dataset->cacheMetrics()));
+    }
+
+    void datasetPage(
+        const codec::NativeEnvelope& envelope, StopToken cancellation)
+    {
+        const auto* payload = envelope.payload.AsDatasetPageRequest();
+        if (payload == nullptr) {
+            throw std::invalid_argument("dataset-page payload is missing");
+        }
+        const auto request = codec::fromWire(*payload);
+        if (request.maximumExtent < 1
+            || request.maximumExtent > datasetPageMaxExtent) {
+            throw RemoteError(ErrorCode::ResourceLimitExceeded,
+                "dataset page extent is outside the server limit");
+        }
+        const auto dataset = requireDataset(request.dataset);
+        const auto page
+            = dataset->requestDatasetPage(request, cancellation);
+        send(envelope.request_id,
+            codec::toWire(page, dataset->cacheMetrics()));
+    }
+
+    void range(
+        const codec::NativeEnvelope& envelope, StopToken cancellation)
+    {
+        const auto* payload = envelope.payload.AsRangeRequest();
+        if (payload == nullptr) {
+            throw std::invalid_argument("range payload is missing");
+        }
+        const auto [id, request] = codec::fromWire(*payload);
+        const auto dataset = requireDataset(id);
+        const auto result = dataset->requestRange(request, cancellation);
+        send(envelope.request_id,
+            codec::toWire(result, dataset->cacheMetrics()));
+    }
+
+    void particleSample(
+        const codec::NativeEnvelope& envelope, StopToken cancellation)
+    {
+        const auto* payload = envelope.payload.AsParticleSampleRequest();
+        if (payload == nullptr) {
+            throw std::invalid_argument(
+                "particle-sample payload is missing");
+        }
+        const auto request = codec::fromWire(*payload);
+        const auto dataset = requireDataset(request.dataset);
+        const auto sample = dataset->requestParticleSample(request.species,
+            request.fraction, request.seed, cancellation);
+        constexpr std::uint64_t bytesPerPoint
+            = sizeof(std::uint64_t) + 3 * sizeof(double);
+        if (sample.points.size()
+            > m_maximumFrameBytes.load() / bytesPerPoint) {
+            throw RemoteError(ErrorCode::ResourceLimitExceeded,
+                "particle sample cannot fit in one negotiated frame");
+        }
+        send(envelope.request_id,
+            codec::toWire(sample, dataset->cacheMetrics()));
+    }
+
+    void clearCache(const codec::NativeEnvelope& envelope)
+    {
+        const auto* request = envelope.payload.AsClearCacheRequest();
+        if (request == nullptr) {
+            throw std::invalid_argument("clear-cache payload is missing");
+        }
+        const auto dataset = requireDataset(DatasetId{request->dataset_id});
+        dataset->clearUnpinnedCache();
+        sendCache(envelope.request_id, *dataset);
+    }
+
+    void setCacheBudget(const codec::NativeEnvelope& envelope)
+    {
+        const auto* request = envelope.payload.AsSetCacheBudgetRequest();
+        if (request == nullptr) {
+            throw std::invalid_argument("cache-budget payload is missing");
+        }
+        const auto dataset = requireDataset(DatasetId{request->dataset_id});
+        static_cast<void>(dataset->setCacheBudget(request->budget_bytes));
+        sendCache(envelope.request_id, *dataset);
+    }
+
+    void sendCache(
+        std::uint64_t requestId, const LocalDatasetSession& dataset)
+    {
+        codec::fb::CacheResponseT response;
+        response.dataset_id = dataset.id().value;
+        response.cache = codec::toWire(dataset.cacheMetrics());
+        send(requestId, std::move(response));
+    }
+
+    void validateSliceBound(const SliceRequest& request) const
+    {
+        if (request.outputSize[0] < 1 || request.outputSize[1] < 1
+            || request.outputSize[0] > maxViewOutputDimension
+            || request.outputSize[1] > maxViewOutputDimension) {
+            throw RemoteError(ErrorCode::ResourceLimitExceeded,
+                "slice viewport dimensions are outside the server limit");
+        }
+        const auto cells = static_cast<std::uint64_t>(request.outputSize[0])
+            * static_cast<std::uint64_t>(request.outputSize[1]);
+        constexpr std::uint64_t bytesPerCell
+            = sizeof(float) + sizeof(std::uint8_t) + sizeof(std::int16_t);
+        if (cells > m_maximumFrameBytes.load() / bytesPerCell) {
+            throw RemoteError(ErrorCode::ResourceLimitExceeded,
+                "slice viewport cannot fit in one negotiated frame");
+        }
+    }
+
+    std::shared_ptr<LocalDatasetSession> requireDataset(DatasetId id)
+    {
+        std::scoped_lock lock(m_stateMutex);
+        const auto found = m_datasets.find(id.value);
+        if (found == m_datasets.end()) {
+            throw RemoteError(
+                ErrorCode::UnknownDataset, "dataset handle is unknown");
+        }
+        return found->second;
+    }
+
+    DatasetId requestDataset(const codec::NativeEnvelope& envelope) const
+    {
+        switch (codec::inspect(envelope).payload) {
+        case PayloadKind::CloseDatasetRequest: {
+            const auto* value
+                = envelope.payload.AsCloseDatasetRequest();
+            return DatasetId{value ? value->dataset_id : 0};
+        }
+        case PayloadKind::SliceViewRequest: {
+            const auto* value = envelope.payload.AsSliceViewRequest();
+            return DatasetId{value ? value->dataset_id : 0};
+        }
+        case PayloadKind::LineViewRequest: {
+            const auto* value = envelope.payload.AsLineViewRequest();
+            return DatasetId{value ? value->dataset_id : 0};
+        }
+        case PayloadKind::DatasetPageRequest: {
+            const auto* value
+                = envelope.payload.AsDatasetPageRequest();
+            return DatasetId{value ? value->dataset_id : 0};
+        }
+        case PayloadKind::ParticleSampleRequest: {
+            const auto* value
+                = envelope.payload.AsParticleSampleRequest();
+            return DatasetId{value ? value->dataset_id : 0};
+        }
+        case PayloadKind::RangeRequest: {
+            const auto* value = envelope.payload.AsRangeRequest();
+            return DatasetId{value ? value->dataset_id : 0};
+        }
+        case PayloadKind::ClearCacheRequest: {
+            const auto* value = envelope.payload.AsClearCacheRequest();
+            return DatasetId{value ? value->dataset_id : 0};
+        }
+        case PayloadKind::SetCacheBudgetRequest: {
+            const auto* value
+                = envelope.payload.AsSetCacheBudgetRequest();
+            return DatasetId{value ? value->dataset_id : 0};
+        }
+        default:
+            return {};
+        }
+    }
+
+    template <typename Payload>
+    void send(std::uint64_t requestId, Payload payload) noexcept
+    {
+        try {
+            const auto bytes
+                = codec::encode(requestId, std::move(payload), m_selectedMinor);
+            std::scoped_lock lock(m_writeMutex);
+            if (!m_stopping.load()) {
+                writeFrame(m_socket, bytes, m_maximumFrameBytes.load());
+            }
+        } catch (...) {
+            stop();
+        }
+    }
+
+    void sendError(std::uint64_t requestId, ErrorData error) noexcept
+    {
+        send(requestId, codec::toWire(error));
+    }
+
+    Socket m_socket;
+    ThreadPool& m_workers;
+    ServerOptions m_options;
+    std::atomic<std::uint32_t> m_maximumFrameBytes;
+    std::atomic_bool m_stopping{false};
+    std::uint16_t m_selectedMinor = 0;
+    bool m_handshakeComplete = false;
+    std::atomic<std::uint64_t> m_nextDatasetId{1};
+    std::mutex m_writeMutex;
+    mutable std::mutex m_stateMutex;
+    std::unordered_map<std::uint64_t,
+        std::shared_ptr<LocalDatasetSession>> m_datasets;
+    std::unordered_map<std::uint64_t, ActiveRequest> m_active;
+};
+
+} // namespace
+
+class Server::Impl {
+public:
+    explicit Impl(ServerOptions options)
+        : m_options(std::move(options))
+        , m_listener(listenOnLoopback(m_options.port))
+        , m_workers(resolveWorkerCount(m_options.workerCount))
+    {
+        m_options.workerCount = resolveWorkerCount(m_options.workerCount);
+    }
+
+    ~Impl()
+    {
+        requestStop();
+    }
+
+    std::uint16_t port() const noexcept
+    {
+        return m_listener.port;
+    }
+
+    void run()
+    {
+        while (!m_stopping.load()) {
+            try {
+                auto socket = acceptConnection(m_listener.socket);
+                auto session = std::make_shared<Session>(
+                    std::move(socket), m_workers, m_options);
+                std::scoped_lock lock(m_sessionsMutex);
+                std::erase_if(m_sessions,
+                    [](const auto& worker) {
+                        return worker.session->stopped();
+                    });
+                m_sessions.push_back(SessionWorker{
+                    session, JoiningThread(
+                        [session] { session->run(); })});
+            } catch (const std::exception&) {
+                if (!m_stopping.load()) {
+                    throw;
+                }
+            }
+        }
+    }
+
+    void requestStop() noexcept
+    {
+        if (m_stopping.exchange(true)) {
+            return;
+        }
+        m_listener.socket.shutdown();
+        m_listener.socket.close();
+        std::vector<std::shared_ptr<Session>> sessions;
+        {
+            std::scoped_lock lock(m_sessionsMutex);
+            sessions.reserve(m_sessions.size());
+            for (const auto& worker : m_sessions) {
+                sessions.push_back(worker.session);
+            }
+        }
+        for (const auto& session : sessions) {
+            session->stop();
+        }
+    }
+
+private:
+    static unsigned int resolveWorkerCount(unsigned int requested)
+    {
+        return requested == 0
+            ? std::max(1U, std::thread::hardware_concurrency())
+            : requested;
+    }
+
+    struct SessionWorker {
+        std::shared_ptr<Session> session;
+        JoiningThread thread;
+    };
+
+    ServerOptions m_options;
+    Listener m_listener;
+    ThreadPool m_workers;
+    std::atomic_bool m_stopping{false};
+    std::mutex m_sessionsMutex;
+    std::vector<SessionWorker> m_sessions;
+};
+
+Server::Server(ServerOptions options)
+    : m_impl(std::make_unique<Impl>(std::move(options)))
+{
+}
+
+Server::~Server() = default;
+
+std::uint16_t Server::port() const noexcept
+{
+    return m_impl->port();
+}
+
+void Server::run()
+{
+    m_impl->run();
+}
+
+void Server::requestStop() noexcept
+{
+    m_impl->requestStop();
+}
+
+} // namespace amrvis::remote

--- a/src/remote/Server.cpp
+++ b/src/remote/Server.cpp
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <atomic>
+#include <chrono>
 #include <condition_variable>
 #include <cstdint>
 #include <deque>
@@ -170,19 +171,28 @@ public:
         if (m_stopping.exchange(true)) {
             return;
         }
+        m_socket.shutdown();
         std::vector<StopSource> stops;
+        std::vector<std::shared_ptr<LocalDatasetSession>> datasets;
         {
             std::scoped_lock lock(m_stateMutex);
             for (const auto& [id, active] : m_active) {
                 static_cast<void>(id);
                 stops.push_back(active.stop);
             }
+            datasets.reserve(m_datasets.size());
+            for (auto& [id, dataset] : m_datasets) {
+                static_cast<void>(id);
+                datasets.push_back(std::move(dataset));
+            }
             m_datasets.clear();
         }
         for (auto& stop : stops) {
             stop.request_stop();
         }
-        m_socket.shutdown();
+        for (const auto& dataset : datasets) {
+            dataset->close();
+        }
     }
 
     [[nodiscard]] bool stopped() const noexcept
@@ -234,21 +244,32 @@ private:
         }
         const auto dataset = requestDataset(*envelope);
         StopSource stopSource;
+        enum class Rejection {
+            None,
+            OutstandingLimit,
+            Duplicate
+        };
+        Rejection rejection = Rejection::None;
         {
             std::scoped_lock lock(m_stateMutex);
             if (m_active.size() >= m_options.maximumOutstandingRequests) {
-                sendError(info.requestId,
-                    {ErrorCode::ResourceLimitExceeded,
-                        "too many outstanding requests"});
-                return;
+                rejection = Rejection::OutstandingLimit;
+            } else if (!m_active.emplace(info.requestId,
+                           ActiveRequest{dataset, stopSource})
+                            .second) {
+                rejection = Rejection::Duplicate;
             }
-            if (!m_active.emplace(info.requestId,
-                    ActiveRequest{dataset, stopSource}).second) {
-                sendError(info.requestId, {ErrorCode::InvalidRequest,
-                    "duplicate live request ID"});
-                stop();
-                return;
-            }
+        }
+        if (rejection == Rejection::OutstandingLimit) {
+            sendError(info.requestId, {ErrorCode::ResourceLimitExceeded,
+                "too many outstanding requests"});
+            return;
+        }
+        if (rejection == Rejection::Duplicate) {
+            sendError(info.requestId, {ErrorCode::InvalidRequest,
+                "duplicate live request ID"});
+            stop();
+            return;
         }
         auto self = shared_from_this();
         auto sharedEnvelope
@@ -290,13 +311,17 @@ private:
     {
         const auto* request = envelope.payload.AsCancelRequest();
         bool accepted = false;
+        StopSource activeStop;
         if (request != nullptr) {
             std::scoped_lock lock(m_stateMutex);
             const auto found = m_active.find(request->target_request_id);
             if (found != m_active.end()) {
-                found->second.stop.request_stop();
+                activeStop = found->second.stop;
                 accepted = true;
             }
+        }
+        if (accepted) {
+            activeStop.request_stop();
         }
         codec::fb::CancelAcknowledgedT response;
         response.target_request_id
@@ -363,55 +388,105 @@ private:
         if (request == nullptr || request->path.empty()) {
             throw std::invalid_argument("dataset path is empty");
         }
-        const auto id = DatasetId{m_nextDatasetId.fetch_add(1)};
-        std::shared_ptr<LocalDatasetSession> dataset;
-        try {
-            dataset = std::make_shared<LocalDatasetSession>(
-                request->path, id, request->cache_budget_bytes);
-        } catch (const std::exception& error) {
-            throw RemoteError(ErrorCode::DatasetOpenFailure, error.what());
-        }
         {
             std::scoped_lock lock(m_stateMutex);
-            if (cancellation.stop_requested()) {
-                dataset->close();
+            if (m_stopping.load() || cancellation.stop_requested()) {
                 throw ReadCancelled();
             }
-            if (m_datasets.size() >= m_options.maximumDatasets) {
+            if (m_datasets.size() + m_datasetReservations
+                >= m_options.maximumDatasets) {
                 throw RemoteError(ErrorCode::ResourceLimitExceeded,
                     "session dataset limit exceeded");
             }
-            m_datasets.emplace(id.value, dataset);
+            ++m_datasetReservations;
         }
-        OpenedDataset opened;
-        opened.id = id;
-        opened.catalog = dataset->metadata();
-        opened.metadataMetrics = dataset->metadataReadMetrics();
-        opened.fileVersion = dataset->fileVersion();
-        opened.particleSpecies = dataset->particleSpecies();
-        opened.fileRangeAvailable.reserve(
-            opened.catalog.fields.size());
-        opened.levelRangeAvailable.reserve(opened.catalog.fields.size()
-            * opened.catalog.levels.size());
-        for (std::size_t field = 0;
-             field < opened.catalog.fields.size(); ++field) {
-            const auto fieldId = FieldId{
-                static_cast<std::uint32_t>(field)};
-            opened.fileRangeAvailable.push_back(
-                dataset->rangeAvailable(RangeRequest{fieldId,
-                    opened.catalog.finestLevel,
-                    CompositionPolicy::FinestAvailable,
-                    RangeScope::File}));
-            for (int level = 0;
-                 level <= opened.catalog.finestLevel; ++level) {
-                opened.levelRangeAvailable.push_back(
-                    dataset->rangeAvailable(RangeRequest{fieldId, level,
-                        CompositionPolicy::ExactLevel,
-                        RangeScope::Level}));
+
+        const auto id = DatasetId{m_nextDatasetId.fetch_add(1)};
+        std::shared_ptr<LocalDatasetSession> dataset;
+        bool reservationActive = true;
+        try {
+            dataset = std::make_shared<LocalDatasetSession>(
+                request->path, id, request->cache_budget_bytes);
+            OpenedDataset opened;
+            opened.id = id;
+            opened.catalog = dataset->metadata();
+            opened.metadataMetrics = dataset->metadataReadMetrics();
+            opened.fileVersion = dataset->fileVersion();
+            opened.particleSpecies = dataset->particleSpecies();
+            opened.fileRangeAvailable.reserve(opened.catalog.fields.size());
+            opened.levelRangeAvailable.reserve(opened.catalog.fields.size()
+                * opened.catalog.levels.size());
+            for (std::size_t field = 0;
+                 field < opened.catalog.fields.size(); ++field) {
+                if (cancellation.stop_requested()) {
+                    throw ReadCancelled();
+                }
+                const auto fieldId
+                    = FieldId{static_cast<std::uint32_t>(field)};
+                opened.fileRangeAvailable.push_back(
+                    dataset->rangeAvailable(RangeRequest{fieldId,
+                        opened.catalog.finestLevel,
+                        CompositionPolicy::FinestAvailable,
+                        RangeScope::File}));
+                for (int level = 0;
+                     level <= opened.catalog.finestLevel; ++level) {
+                    opened.levelRangeAvailable.push_back(
+                        dataset->rangeAvailable(RangeRequest{fieldId, level,
+                            CompositionPolicy::ExactLevel,
+                            RangeScope::Level}));
+                }
             }
+            opened.cache = dataset->cacheMetrics();
+            if (codec::encode(envelope.request_id, codec::toWire(opened),
+                    m_selectedMinor)
+                    .size()
+                > m_maximumFrameBytes.load()) {
+                throw RemoteError(ErrorCode::ResourceLimitExceeded,
+                    "dataset catalog cannot fit in one negotiated frame");
+            }
+
+            bool published = false;
+            {
+                std::scoped_lock lock(m_stateMutex);
+                --m_datasetReservations;
+                reservationActive = false;
+                if (!m_stopping.load() && !cancellation.stop_requested()) {
+                    published = m_datasets.emplace(id.value, dataset).second;
+                }
+            }
+            if (!published) {
+                throw ReadCancelled();
+            }
+            send(envelope.request_id, codec::toWire(opened));
+            return;
+        } catch (const ReadCancelled&) {
+            if (reservationActive) {
+                std::scoped_lock lock(m_stateMutex);
+                --m_datasetReservations;
+            }
+            if (dataset) {
+                dataset->close();
+            }
+            throw;
+        } catch (const RemoteError&) {
+            if (reservationActive) {
+                std::scoped_lock lock(m_stateMutex);
+                --m_datasetReservations;
+            }
+            if (dataset) {
+                dataset->close();
+            }
+            throw;
+        } catch (const std::exception& error) {
+            if (reservationActive) {
+                std::scoped_lock lock(m_stateMutex);
+                --m_datasetReservations;
+            }
+            if (dataset) {
+                dataset->close();
+            }
+            throw RemoteError(ErrorCode::DatasetOpenFailure, error.what());
         }
-        opened.cache = dataset->cacheMetrics();
-        send(envelope.request_id, codec::toWire(opened));
     }
 
     void closeDataset(const codec::NativeEnvelope& envelope)
@@ -475,6 +550,13 @@ private:
             throw RemoteError(ErrorCode::ResourceLimitExceeded,
                 "line viewport width is outside the server limit");
         }
+        constexpr std::uint64_t bytesPerPoint = sizeof(double)
+            + sizeof(float) + sizeof(std::uint8_t) + sizeof(std::int16_t);
+        if (!fitsResponse(static_cast<std::uint64_t>(request.outputWidth)
+                * 2U * bytesPerPoint)) {
+            throw RemoteError(ErrorCode::ResourceLimitExceeded,
+                "line response cannot fit in one negotiated frame");
+        }
         const auto dataset = requireDataset(request.query.dataset);
         const auto result = std::get<LineQueryResult>(
             dataset->requestView(ViewDataRequest{request}, cancellation));
@@ -499,6 +581,15 @@ private:
             || request.maximumExtent > datasetPageMaxExtent) {
             throw RemoteError(ErrorCode::ResourceLimitExceeded,
                 "dataset page extent is outside the server limit");
+        }
+        constexpr std::uint64_t bytesPerCell
+            = sizeof(float) + sizeof(std::uint8_t);
+        const auto maximumCells
+            = static_cast<std::uint64_t>(request.maximumExtent)
+            * static_cast<std::uint64_t>(request.maximumExtent);
+        if (!fitsResponse(maximumCells * bytesPerCell)) {
+            throw RemoteError(ErrorCode::ResourceLimitExceeded,
+                "dataset page cannot fit in one negotiated frame");
         }
         const auto dataset = requireDataset(request.dataset);
         const auto page
@@ -535,8 +626,8 @@ private:
             request.fraction, request.seed, cancellation);
         constexpr std::uint64_t bytesPerPoint
             = sizeof(std::uint64_t) + 3 * sizeof(double);
-        if (sample.points.size()
-            > m_maximumFrameBytes.load() / bytesPerPoint) {
+        if (!fitsResponse(static_cast<std::uint64_t>(sample.points.size())
+                * bytesPerPoint)) {
             throw RemoteError(ErrorCode::ResourceLimitExceeded,
                 "particle sample cannot fit in one negotiated frame");
         }
@@ -587,10 +678,22 @@ private:
             * static_cast<std::uint64_t>(request.outputSize[1]);
         constexpr std::uint64_t bytesPerCell
             = sizeof(float) + sizeof(std::uint8_t) + sizeof(std::int16_t);
-        if (cells > m_maximumFrameBytes.load() / bytesPerCell) {
+        if (!fitsResponse(cells * bytesPerCell)) {
             throw RemoteError(ErrorCode::ResourceLimitExceeded,
                 "slice viewport cannot fit in one negotiated frame");
         }
+    }
+
+    [[nodiscard]] bool fitsResponse(std::uint64_t vectorBytes) const noexcept
+    {
+        // Reserve room for the envelope, tables, vector offsets, metrics, and
+        // FlatBuffers alignment. send() performs the final exact encoded-size
+        // check before touching the socket.
+        constexpr std::uint64_t responseOverheadReserveBytes = 512;
+        const auto frameBytes
+            = static_cast<std::uint64_t>(m_maximumFrameBytes.load());
+        return frameBytes >= responseOverheadReserveBytes
+            && vectorBytes <= frameBytes - responseOverheadReserveBytes;
     }
 
     std::shared_ptr<LocalDatasetSession> requireDataset(DatasetId id)
@@ -654,6 +757,11 @@ private:
         try {
             const auto bytes
                 = codec::encode(requestId, std::move(payload), m_selectedMinor);
+            if (bytes.size() > m_maximumFrameBytes.load()) {
+                sendError(requestId, {ErrorCode::ResourceLimitExceeded,
+                    "response cannot fit in one negotiated frame"});
+                return;
+            }
             std::scoped_lock lock(m_writeMutex);
             if (!m_stopping.load()) {
                 writeFrame(m_socket, bytes, m_maximumFrameBytes.load());
@@ -665,7 +773,20 @@ private:
 
     void sendError(std::uint64_t requestId, ErrorData error) noexcept
     {
-        send(requestId, codec::toWire(error));
+        try {
+            const auto bytes = codec::encode(
+                requestId, codec::toWire(error), m_selectedMinor);
+            if (bytes.size() > m_maximumFrameBytes.load()) {
+                stop();
+                return;
+            }
+            std::scoped_lock lock(m_writeMutex);
+            if (!m_stopping.load()) {
+                writeFrame(m_socket, bytes, m_maximumFrameBytes.load());
+            }
+        } catch (...) {
+            stop();
+        }
     }
 
     Socket m_socket;
@@ -680,6 +801,7 @@ private:
     mutable std::mutex m_stateMutex;
     std::unordered_map<std::uint64_t,
         std::shared_ptr<LocalDatasetSession>> m_datasets;
+    std::size_t m_datasetReservations = 0;
     std::unordered_map<std::uint64_t, ActiveRequest> m_active;
 };
 
@@ -692,6 +814,13 @@ public:
         , m_listener(listenOnLoopback(m_options.port))
         , m_workers(resolveWorkerCount(m_options.workerCount))
     {
+        if (m_options.maximumConnections == 0
+            || m_options.maximumDatasets == 0
+            || m_options.maximumOutstandingRequests == 0
+            || m_options.maximumFrameBytes == 0) {
+            throw std::invalid_argument(
+                "server resource limits must be greater than zero");
+        }
         m_options.workerCount = resolveWorkerCount(m_options.workerCount);
     }
 
@@ -705,8 +834,15 @@ public:
         return m_listener.port;
     }
 
+    std::string lastError() const
+    {
+        std::scoped_lock lock(m_errorMutex);
+        return m_lastError;
+    }
+
     void run()
     {
+        auto retryDelay = std::chrono::milliseconds{10};
         while (!m_stopping.load()) {
             try {
                 auto socket = acceptConnection(m_listener.socket);
@@ -717,13 +853,40 @@ public:
                     [](const auto& worker) {
                         return worker.session->stopped();
                     });
+                if (m_stopping.load()) {
+                    session->stop();
+                    break;
+                }
+                if (m_sessions.size() >= m_options.maximumConnections) {
+                    session->stop();
+                    continue;
+                }
                 m_sessions.push_back(SessionWorker{
                     session, JoiningThread(
                         [session] { session->run(); })});
-            } catch (const std::exception&) {
-                if (!m_stopping.load()) {
-                    throw;
+                retryDelay = std::chrono::milliseconds{10};
+            } catch (const std::exception& error) {
+                if (m_stopping.load()) {
+                    break;
                 }
+                {
+                    std::scoped_lock lock(m_errorMutex);
+                    m_lastError = error.what();
+                }
+                std::this_thread::sleep_for(retryDelay);
+                retryDelay = std::min(
+                    retryDelay * 2, std::chrono::milliseconds{250});
+            } catch (...) {
+                if (m_stopping.load()) {
+                    break;
+                }
+                {
+                    std::scoped_lock lock(m_errorMutex);
+                    m_lastError = "unknown server accept-loop failure";
+                }
+                std::this_thread::sleep_for(retryDelay);
+                retryDelay = std::min(
+                    retryDelay * 2, std::chrono::milliseconds{250});
             }
         }
     }
@@ -767,6 +930,8 @@ private:
     std::atomic_bool m_stopping{false};
     std::mutex m_sessionsMutex;
     std::vector<SessionWorker> m_sessions;
+    mutable std::mutex m_errorMutex;
+    std::string m_lastError;
 };
 
 Server::Server(ServerOptions options)
@@ -779,6 +944,11 @@ Server::~Server() = default;
 std::uint16_t Server::port() const noexcept
 {
     return m_impl->port();
+}
+
+std::string Server::lastError() const
+{
+    return m_impl->lastError();
 }
 
 void Server::run()

--- a/src/remote/Server.cpp
+++ b/src/remote/Server.cpp
@@ -172,11 +172,14 @@ public:
         try {
             while (!m_stopping.load()) {
                 const auto frame = m_handshakeComplete
-                    ? readFrame(m_socket, m_maximumFrameBytes.load())
+                    ? readFrame(m_socket, m_maximumFrameBytes.load(),
+                          std::chrono::steady_clock::time_point::max(),
+                          m_lifecycleStop.get_token())
                     : readFrame(m_socket,
                           std::min(m_options.maximumFrameBytes,
                               m_options.maximumHandshakeFrameBytes),
-                          m_handshakeDeadline);
+                          m_handshakeDeadline,
+                          m_lifecycleStop.get_token());
                 if (!frame) {
                     break;
                 }
@@ -186,6 +189,13 @@ public:
         } catch (...) {
         }
         stop();
+        // The reader has exited and lifecycle cancellation makes any
+        // in-flight writer leave its bounded readiness loop. Serialize with
+        // that writer before releasing the socket handle so closesocket never
+        // overlaps another Winsock operation.
+        std::scoped_lock lock(m_writeMutex);
+        m_socket.shutdown();
+        m_socket.close();
     }
 
     void stop() noexcept
@@ -193,7 +203,7 @@ public:
         if (m_stopping.exchange(true)) {
             return;
         }
-        m_socket.shutdown();
+        m_lifecycleStop.request_stop();
         std::vector<StopSource> stops;
         std::vector<std::shared_ptr<LocalDatasetSession>> datasets;
         {
@@ -808,7 +818,8 @@ private:
             if (!m_stopping.load()) {
                 writeFrameWithStallTimeout(m_socket, bytes,
                     m_maximumFrameBytes.load(),
-                    m_options.responseWriteStallTimeout);
+                    m_options.responseWriteStallTimeout, {},
+                    m_lifecycleStop.get_token());
             }
         } catch (...) {
             stop();
@@ -828,7 +839,8 @@ private:
             if (!m_stopping.load()) {
                 writeFrameWithStallTimeout(m_socket, bytes,
                     m_maximumFrameBytes.load(),
-                    m_options.responseWriteStallTimeout);
+                    m_options.responseWriteStallTimeout, {},
+                    m_lifecycleStop.get_token());
             }
         } catch (...) {
             stop();
@@ -841,6 +853,7 @@ private:
     std::chrono::steady_clock::time_point m_handshakeDeadline;
     std::atomic<std::uint32_t> m_maximumFrameBytes;
     std::atomic_bool m_stopping{false};
+    StopSource m_lifecycleStop;
     std::uint16_t m_selectedMinorVersion = 0;
     bool m_handshakeComplete = false;
     std::atomic<std::uint64_t> m_nextDatasetId{1};
@@ -897,7 +910,8 @@ public:
         auto retryDelay = std::chrono::milliseconds{10};
         while (!m_stopping.load()) {
             try {
-                auto socket = acceptConnection(m_listener.socket);
+                auto socket = acceptConnection(
+                    m_listener.socket, m_acceptStop.get_token());
                 auto session = std::make_shared<Session>(
                     std::move(socket), m_workers, m_options);
                 std::scoped_lock lock(m_sessionsMutex);
@@ -941,6 +955,7 @@ public:
                     retryDelay * 2, std::chrono::milliseconds{250});
             }
         }
+        m_listener.socket.close();
     }
 
     void requestStop() noexcept
@@ -948,8 +963,7 @@ public:
         if (m_stopping.exchange(true)) {
             return;
         }
-        m_listener.socket.shutdown();
-        m_listener.socket.close();
+        m_acceptStop.request_stop();
         std::vector<std::shared_ptr<Session>> sessions;
         {
             std::scoped_lock lock(m_sessionsMutex);
@@ -980,6 +994,7 @@ private:
     Listener m_listener;
     ThreadPool m_workers;
     std::atomic_bool m_stopping{false};
+    StopSource m_acceptStop;
     std::mutex m_sessionsMutex;
     std::vector<SessionWorker> m_sessions;
     mutable std::mutex m_errorMutex;

--- a/src/remote/Server.cpp
+++ b/src/remote/Server.cpp
@@ -149,6 +149,8 @@ public:
         : m_socket(std::move(socket))
         , m_workers(workers)
         , m_options(options)
+        , m_handshakeDeadline(
+              std::chrono::steady_clock::now() + options.handshakeTimeout)
         , m_maximumFrameBytes(options.maximumFrameBytes)
     {
     }
@@ -157,8 +159,12 @@ public:
     {
         try {
             while (!m_stopping.load()) {
-                const auto frame
-                    = readFrame(m_socket, m_maximumFrameBytes.load());
+                const auto frame = m_handshakeComplete
+                    ? readFrame(m_socket, m_maximumFrameBytes.load())
+                    : readFrame(m_socket,
+                          std::min(m_options.maximumFrameBytes,
+                              m_options.maximumHandshakeFrameBytes),
+                          m_handshakeDeadline);
                 if (!frame) {
                     break;
                 }
@@ -412,7 +418,7 @@ private:
         bool reservationActive = true;
         try {
             dataset = std::make_shared<LocalDatasetSession>(
-                request->path, id, request->cache_budget_bytes);
+                request->path, id, request->cache_budget_bytes, cancellation);
             OpenedDataset opened;
             opened.id = id;
             opened.catalog = dataset->metadata();
@@ -702,9 +708,7 @@ private:
         }
         const auto cells = static_cast<std::uint64_t>(request.outputSize[0])
             * static_cast<std::uint64_t>(request.outputSize[1]);
-        constexpr std::uint64_t bytesPerCell
-            = sizeof(float) + sizeof(std::uint8_t) + sizeof(std::int16_t);
-        if (!fitsResponse(cells * bytesPerCell)) {
+        if (!fitsResponse(cells * sliceResponseBytesPerCell)) {
             throw RemoteError(ErrorCode::ResourceLimitExceeded,
                 "slice viewport cannot fit in one negotiated frame");
         }
@@ -818,6 +822,7 @@ private:
     Socket m_socket;
     ThreadPool& m_workers;
     ServerOptions m_options;
+    std::chrono::steady_clock::time_point m_handshakeDeadline;
     std::atomic<std::uint32_t> m_maximumFrameBytes;
     std::atomic_bool m_stopping{false};
     std::uint16_t m_selectedMinor = 0;
@@ -843,7 +848,10 @@ public:
         if (m_options.maximumConnections == 0
             || m_options.maximumDatasets == 0
             || m_options.maximumOutstandingRequests == 0
-            || m_options.maximumFrameBytes == 0) {
+            || m_options.maximumFrameBytes == 0
+            || m_options.maximumHandshakeFrameBytes == 0
+            || m_options.handshakeTimeout
+                <= std::chrono::milliseconds::zero()) {
             throw std::invalid_argument(
                 "server resource limits must be greater than zero");
         }

--- a/src/remote/Server.cpp
+++ b/src/remote/Server.cpp
@@ -806,9 +806,9 @@ private:
             }
             std::scoped_lock lock(m_writeMutex);
             if (!m_stopping.load()) {
-                writeFrame(m_socket, bytes, m_maximumFrameBytes.load(),
-                    std::chrono::steady_clock::now()
-                        + m_options.responseWriteTimeout);
+                writeFrameWithStallTimeout(m_socket, bytes,
+                    m_maximumFrameBytes.load(),
+                    m_options.responseWriteStallTimeout);
             }
         } catch (...) {
             stop();
@@ -826,9 +826,9 @@ private:
             }
             std::scoped_lock lock(m_writeMutex);
             if (!m_stopping.load()) {
-                writeFrame(m_socket, bytes, m_maximumFrameBytes.load(),
-                    std::chrono::steady_clock::now()
-                        + m_options.responseWriteTimeout);
+                writeFrameWithStallTimeout(m_socket, bytes,
+                    m_maximumFrameBytes.load(),
+                    m_options.responseWriteStallTimeout);
             }
         } catch (...) {
             stop();
@@ -868,7 +868,7 @@ public:
             || m_options.maximumHandshakeFrameBytes == 0
             || m_options.handshakeTimeout
                 <= std::chrono::milliseconds::zero()
-            || m_options.responseWriteTimeout
+            || m_options.responseWriteStallTimeout
                 <= std::chrono::milliseconds::zero()) {
             throw std::invalid_argument(
                 "server resource limits must be greater than zero");

--- a/src/remote/Server.cpp
+++ b/src/remote/Server.cpp
@@ -68,8 +68,20 @@ public:
     {
         count = std::max(1U, count);
         m_threads.reserve(count);
-        for (unsigned int index = 0; index < count; ++index) {
-            m_threads.emplace_back([this] { worker(); });
+        try {
+            for (unsigned int index = 0; index < count; ++index) {
+                m_threads.emplace_back([this] { worker(); });
+            }
+        } catch (...) {
+            // A later std::thread construction can fail after earlier workers
+            // have started waiting. Wake those workers before constructor
+            // unwinding destroys and joins their JoiningThread wrappers.
+            {
+                std::scoped_lock lock(m_mutex);
+                m_stopping = true;
+            }
+            m_ready.notify_all();
+            throw;
         }
     }
 

--- a/src/remote/Server.cpp
+++ b/src/remote/Server.cpp
@@ -247,7 +247,7 @@ private:
             handleHello(*envelope);
             return;
         }
-        if (info.protocolMinor != m_selectedMinor) {
+        if (info.protocolMinorVersion != m_selectedMinorVersion) {
             sendError(info.requestId, {ErrorCode::UnsupportedProtocol,
                 "message uses a non-negotiated protocol minor version"});
             stop();
@@ -307,21 +307,22 @@ private:
     {
         const auto* request = envelope.payload.AsHelloRequest();
         if (request == nullptr || request->maximum_frame_bytes == 0
-            || request->minimum_minor > protocolMinor
-            || request->maximum_minor < request->minimum_minor) {
+            || request->minimum_minor_version > protocolMinorVersion
+            || request->maximum_minor_version
+                < request->minimum_minor_version) {
             sendError(envelope.request_id, {ErrorCode::UnsupportedProtocol,
                 "client protocol range is unsupported"});
             stop();
             return;
         }
-        m_selectedMinor
-            = std::min<std::uint16_t>(protocolMinor, request->maximum_minor);
+        m_selectedMinorVersion = std::min<std::uint16_t>(
+            protocolMinorVersion, request->maximum_minor_version);
         m_maximumFrameBytes = std::min(
             m_options.maximumFrameBytes, request->maximum_frame_bytes);
         HelloResponseData response;
         response.serverName = "AMReXplorer server";
         response.softwareVersion = m_options.softwareVersion;
-        response.selectedMinor = m_selectedMinor;
+        response.selectedMinorVersion = m_selectedMinorVersion;
         response.maximumFrameBytes = m_maximumFrameBytes.load();
         response.maximumDatasets = m_options.maximumDatasets;
         response.maximumOutstandingRequests
@@ -462,7 +463,7 @@ private:
             }
             opened.cache = dataset->cacheMetrics();
             if (codec::encode(envelope.request_id, codec::toWire(opened),
-                    m_selectedMinor)
+                    m_selectedMinorVersion)
                     .size()
                 > m_maximumFrameBytes.load()) {
                 throw RemoteError(ErrorCode::ResourceLimitExceeded,
@@ -796,8 +797,8 @@ private:
     void send(std::uint64_t requestId, Payload payload) noexcept
     {
         try {
-            const auto bytes
-                = codec::encode(requestId, std::move(payload), m_selectedMinor);
+            const auto bytes = codec::encode(
+                requestId, std::move(payload), m_selectedMinorVersion);
             if (bytes.size() > m_maximumFrameBytes.load()) {
                 sendError(requestId, {ErrorCode::ResourceLimitExceeded,
                     "response cannot fit in one negotiated frame"});
@@ -818,7 +819,7 @@ private:
     {
         try {
             const auto bytes = codec::encode(
-                requestId, codec::toWire(error), m_selectedMinor);
+                requestId, codec::toWire(error), m_selectedMinorVersion);
             if (bytes.size() > m_maximumFrameBytes.load()) {
                 stop();
                 return;
@@ -840,7 +841,7 @@ private:
     std::chrono::steady_clock::time_point m_handshakeDeadline;
     std::atomic<std::uint32_t> m_maximumFrameBytes;
     std::atomic_bool m_stopping{false};
-    std::uint16_t m_selectedMinor = 0;
+    std::uint16_t m_selectedMinorVersion = 0;
     bool m_handshakeComplete = false;
     std::atomic<std::uint64_t> m_nextDatasetId{1};
     std::mutex m_writeMutex;

--- a/src/remote/Server.cpp
+++ b/src/remote/Server.cpp
@@ -594,18 +594,17 @@ private:
             throw RemoteError(ErrorCode::ResourceLimitExceeded,
                 "dataset page extent is outside the server limit");
         }
-        constexpr std::uint64_t bytesPerCell
-            = sizeof(float) + sizeof(std::uint8_t);
-        const auto maximumCells
-            = static_cast<std::uint64_t>(request.maximumExtent)
-            * static_cast<std::uint64_t>(request.maximumExtent);
-        if (!fitsResponse(maximumCells * bytesPerCell)) {
-            throw RemoteError(ErrorCode::ResourceLimitExceeded,
-                "dataset page cannot fit in one negotiated frame");
-        }
         const auto dataset = requireDataset(request.dataset);
         const auto page
             = dataset->requestDatasetPage(request, cancellation);
+        const auto vectorBytes
+            = static_cast<std::uint64_t>(page.values.size()) * sizeof(float)
+            + static_cast<std::uint64_t>(page.covered.size())
+                * sizeof(std::uint8_t);
+        if (!fitsResponse(vectorBytes)) {
+            throw RemoteError(ErrorCode::ResourceLimitExceeded,
+                "dataset page cannot fit in one negotiated frame");
+        }
         send(envelope.request_id,
             codec::toWire(page, dataset->cacheMetrics()));
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -130,10 +130,18 @@ if(TARGET amrexplorer_remote)
             "${remote_server_fixture_dir}")
     set_tests_properties(remote_server_fixture PROPERTIES
         FIXTURES_SETUP remote_server_materialized)
+    set(remote_server_private_fixture_dir
+        "${CMAKE_CURRENT_BINARY_DIR}/fixtures_remote_server_private")
+    add_test(NAME remote_server_private_fixture
+        COMMAND "$<TARGET_FILE:fixture_materializer>"
+            "${CMAKE_CURRENT_SOURCE_DIR}/data/plotfile_2d"
+            "${remote_server_private_fixture_dir}")
+    set_tests_properties(remote_server_private_fixture PROPERTIES
+        FIXTURES_SETUP remote_server_private_materialized)
     add_test(NAME remote_server
-        COMMAND test_remote_server "${remote_server_fixture_dir}")
+        COMMAND test_remote_server "${remote_server_private_fixture_dir}")
     set_tests_properties(remote_server PROPERTIES
-        FIXTURES_REQUIRED remote_server_materialized
+        FIXTURES_REQUIRED remote_server_private_materialized
         TIMEOUT 30)
 endif()
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -110,6 +110,31 @@ if(TARGET amrexplorer_remote)
             amrexplorer::warnings
     )
     add_test(NAME remote_codec COMMAND test_remote_codec)
+
+    add_executable(test_remote_server
+        integration/test_remote_server.cpp)
+    target_include_directories(test_remote_server PRIVATE
+        "${PROJECT_BINARY_DIR}/src/remote/generated")
+    target_link_libraries(test_remote_server
+        PRIVATE
+            amrexplorer::remote
+            FlatBuffers::FlatBuffers
+            amrexplorer::warnings
+            Threads::Threads
+    )
+    set(remote_server_fixture_dir
+        "${CMAKE_CURRENT_BINARY_DIR}/fixtures_remote_server")
+    add_test(NAME remote_server_fixture
+        COMMAND "$<TARGET_FILE:fixture_materializer>"
+            "${CMAKE_CURRENT_SOURCE_DIR}/data/plotfile_2d"
+            "${remote_server_fixture_dir}")
+    set_tests_properties(remote_server_fixture PROPERTIES
+        FIXTURES_SETUP remote_server_materialized)
+    add_test(NAME remote_server
+        COMMAND test_remote_server "${remote_server_fixture_dir}")
+    set_tests_properties(remote_server PROPERTIES
+        FIXTURES_REQUIRED remote_server_materialized
+        TIMEOUT 30)
 endif()
 
 add_executable(test_vismf_index unit/test_vismf_index.cpp)

--- a/tests/integration/test_particle_reader.cpp
+++ b/tests/integration/test_particle_reader.cpp
@@ -158,6 +158,15 @@ int main(int argc, char* argv[])
         require(all.points[2].position[0] == 3.0
                 && all.points[2].position[1] == 6.0,
             "particle position was decoded incorrectly");
+        bool sampleLimitRejected = false;
+        try {
+            static_cast<void>(amrvis::readParticleSample(
+                root, "Tracer", 1.0, 0, {}, 1));
+        } catch (const amrvis::ParticleSampleLimitExceeded&) {
+            sampleLimitRejected = true;
+        }
+        require(sampleLimitRejected,
+            "particle reader exceeded its caller-provided point limit");
 
         writeFixture(root, identities, 0.0, false, 0, false);
         const auto nonCheckpointSpecies

--- a/tests/integration/test_remote_server.cpp
+++ b/tests/integration/test_remote_server.cpp
@@ -191,6 +191,20 @@ int main(int argc, char* argv[])
             && opened.catalog.levels.size() == 2,
         "server returned an incomplete dataset catalog");
 
+    DatasetPageRequest reversedPage;
+    reversedPage.dataset = opened.id;
+    reversedPage.field = FieldId{0};
+    reversedPage.level = 0;
+    reversedPage.region = opened.catalog.physicalDomain;
+    std::swap(reversedPage.region.lower[0], reversedPage.region.upper[0]);
+    reversedPage.normalAxis = 1;
+    envelope = exchange(socket, 10, codec::toWire(reversedPage),
+        hello.maximumFrameBytes);
+    require(codec::inspect(*envelope).payload == PayloadKind::ErrorResponse
+            && codec::fromWire(*envelope->payload.AsErrorResponse()).code
+                == ErrorCode::InvalidRequest,
+        "server did not reject a reversed dataset-page region");
+
     envelope = exchange(socket, 8,
         codec::toWire(opened.id, "Oversized", 1.0, 0),
         hello.maximumFrameBytes);
@@ -358,6 +372,84 @@ int main(int argc, char* argv[])
         "server did not enforce the configured connection limit");
     require(connectionLimitedRunning.stopWithin(std::chrono::seconds{2}),
         "connection-limited server shutdown exceeded its deadline");
+
+    ServerOptions handshakeTimeoutOptions;
+    handshakeTimeoutOptions.workerCount = 1;
+    handshakeTimeoutOptions.maximumConnections = 1;
+    handshakeTimeoutOptions.handshakeTimeout
+        = std::chrono::milliseconds{100};
+    Server handshakeTimeoutServer(handshakeTimeoutOptions);
+    RunningServer handshakeTimeoutRunning(handshakeTimeoutServer);
+    auto silentSocket
+        = connectTo("127.0.0.1", handshakeTimeoutServer.port());
+    const auto silentStart = std::chrono::steady_clock::now();
+    require(readWithDeadline(silentSocket, defaultMaximumFrameBytes,
+                std::chrono::seconds{2})
+            == nullptr,
+        "silent unauthenticated connection did not time out");
+    require(std::chrono::steady_clock::now() - silentStart
+            < std::chrono::seconds{1},
+        "silent unauthenticated connection exceeded its handshake deadline");
+    auto recoveredSocket
+        = connectTo("127.0.0.1", handshakeTimeoutServer.port());
+    envelope = exchange(recoveredSocket, 1,
+        codec::toWire(helloRequest(handshakeTimeoutServer.token())),
+        defaultMaximumFrameBytes);
+    require(codec::inspect(*envelope).payload == PayloadKind::HelloResponse,
+        "authorized client could not reclaim a timed-out connection slot");
+    std::this_thread::sleep_for(std::chrono::milliseconds{200});
+    codec::fb::PingRequestT delayedPing;
+    delayedPing.nonce = 17;
+    envelope = exchange(recoveredSocket, 2, std::move(delayedPing),
+        defaultMaximumFrameBytes);
+    require(codec::inspect(*envelope).payload == PayloadKind::PongResponse,
+        "server retained the handshake deadline after authentication");
+    require(handshakeTimeoutRunning.stopWithin(std::chrono::seconds{2}),
+        "handshake-timeout server shutdown exceeded its deadline");
+
+    ServerOptions handshakeFrameOptions;
+    handshakeFrameOptions.workerCount = 1;
+    handshakeFrameOptions.maximumConnections = 1;
+    handshakeFrameOptions.sessionToken = "bounded-handshake-token";
+    const auto normalHelloBytes = codec::encode(
+        1, codec::toWire(helloRequest(handshakeFrameOptions.sessionToken)));
+    handshakeFrameOptions.maximumHandshakeFrameBytes
+        = static_cast<std::uint32_t>(normalHelloBytes.size() + 16);
+    Server handshakeFrameServer(handshakeFrameOptions);
+    RunningServer handshakeFrameRunning(handshakeFrameServer);
+    auto oversizedHello = helloRequest(handshakeFrameServer.token());
+    oversizedHello.clientName.assign(
+        handshakeFrameOptions.maximumHandshakeFrameBytes, 'x');
+    auto oversizedHelloBytes
+        = codec::encode(1, codec::toWire(std::move(oversizedHello)));
+    require(oversizedHelloBytes.size()
+            > handshakeFrameOptions.maximumHandshakeFrameBytes,
+        "oversized hello fixture did not exceed the handshake frame cap");
+    auto oversizedHelloSocket
+        = connectTo("127.0.0.1", handshakeFrameServer.port());
+    writeFrame(oversizedHelloSocket, oversizedHelloBytes,
+        defaultMaximumFrameBytes);
+    require(readWithDeadline(oversizedHelloSocket,
+                defaultMaximumFrameBytes, std::chrono::seconds{2})
+            == nullptr,
+        "server accepted a hello above the pre-authentication frame cap");
+    auto boundedHandshakeSocket
+        = connectTo("127.0.0.1", handshakeFrameServer.port());
+    envelope = exchange(boundedHandshakeSocket, 1,
+        codec::toWire(helloRequest(handshakeFrameServer.token())),
+        defaultMaximumFrameBytes);
+    require(codec::inspect(*envelope).payload == PayloadKind::HelloResponse,
+        "server rejected a hello within the pre-authentication frame cap");
+    envelope = exchange(boundedHandshakeSocket, 2,
+        codec::toWire(OpenDatasetData{
+            std::string(
+                handshakeFrameOptions.maximumHandshakeFrameBytes * 2U, 'x'),
+            16ULL * 1024ULL * 1024ULL}),
+        defaultMaximumFrameBytes);
+    require(codec::inspect(*envelope).payload == PayloadKind::ErrorResponse,
+        "server retained the handshake frame cap after authentication");
+    require(handshakeFrameRunning.stopWithin(std::chrono::seconds{2}),
+        "handshake-frame server shutdown exceeded its deadline");
 
     ServerOptions boundedOptions;
     boundedOptions.workerCount = 1;

--- a/tests/integration/test_remote_server.cpp
+++ b/tests/integration/test_remote_server.cpp
@@ -506,49 +506,73 @@ int main(int argc, char* argv[])
         "handshake-timeout server shutdown exceeded its deadline");
     reportStage("handshake-timeout server stopped");
 
-    ServerOptions handshakeFrameOptions;
-    handshakeFrameOptions.workerCount = 1;
-    handshakeFrameOptions.maximumConnections = 1;
-    const auto normalHelloBytes = codec::encode(
-        1, codec::toWire(helloRequest()));
-    handshakeFrameOptions.maximumHandshakeFrameBytes
-        = static_cast<std::uint32_t>(normalHelloBytes.size() + 16);
-    Server handshakeFrameServer(handshakeFrameOptions);
-    RunningServer handshakeFrameRunning(handshakeFrameServer);
-    auto oversizedHello = helloRequest();
-    oversizedHello.clientName.assign(
-        handshakeFrameOptions.maximumHandshakeFrameBytes, 'x');
-    auto oversizedHelloBytes
-        = codec::encode(1, codec::toWire(std::move(oversizedHello)));
-    require(oversizedHelloBytes.size()
-            > handshakeFrameOptions.maximumHandshakeFrameBytes,
-        "oversized hello fixture did not exceed the handshake frame cap");
-    auto oversizedHelloSocket
-        = connectTo("127.0.0.1", handshakeFrameServer.port());
-    writeFrame(oversizedHelloSocket, oversizedHelloBytes,
-        defaultMaximumFrameBytes);
-    require(readWithDeadline(oversizedHelloSocket,
-                defaultMaximumFrameBytes, std::chrono::seconds{2})
-            == nullptr,
-        "server accepted a hello above the pre-authentication frame cap");
-    auto boundedHandshakeSocket
-        = connectTo("127.0.0.1", handshakeFrameServer.port());
-    envelope = exchange(boundedHandshakeSocket, 1,
-        codec::toWire(helloRequest()),
-        defaultMaximumFrameBytes);
-    require(codec::inspect(*envelope).payload == PayloadKind::HelloResponse,
-        "server rejected a hello within the pre-authentication frame cap");
-    envelope = exchange(boundedHandshakeSocket, 2,
-        codec::toWire(OpenDatasetData{
-            std::string(
-                handshakeFrameOptions.maximumHandshakeFrameBytes * 2U, 'x'),
-            16ULL * 1024ULL * 1024ULL}),
-        defaultMaximumFrameBytes);
-    require(codec::inspect(*envelope).payload == PayloadKind::ErrorResponse,
-        "server retained the handshake frame cap after authentication");
-    require(handshakeFrameRunning.stopWithin(std::chrono::seconds{2}),
-        "handshake-frame server shutdown exceeded its deadline");
-    reportStage("handshake-frame server stopped");
+    try {
+        reportStage("handshake-frame options setup");
+        ServerOptions handshakeFrameOptions;
+        handshakeFrameOptions.workerCount = 1;
+        handshakeFrameOptions.maximumConnections = 1;
+        const auto normalHelloBytes = codec::encode(
+            1, codec::toWire(helloRequest()));
+        handshakeFrameOptions.maximumHandshakeFrameBytes
+            = static_cast<std::uint32_t>(normalHelloBytes.size() + 16);
+        reportStage("handshake-frame server construction");
+        Server handshakeFrameServer(handshakeFrameOptions);
+        RunningServer handshakeFrameRunning(handshakeFrameServer);
+        reportStage("handshake-frame oversized hello encoding");
+        auto oversizedHello = helloRequest();
+        oversizedHello.clientName.assign(
+            handshakeFrameOptions.maximumHandshakeFrameBytes, 'x');
+        auto oversizedHelloBytes
+            = codec::encode(1, codec::toWire(std::move(oversizedHello)));
+        require(oversizedHelloBytes.size()
+                > handshakeFrameOptions.maximumHandshakeFrameBytes,
+            "oversized hello fixture did not exceed the handshake frame cap");
+        reportStage("handshake-frame oversized hello connection");
+        auto oversizedHelloSocket
+            = connectTo("127.0.0.1", handshakeFrameServer.port());
+        writeFrame(oversizedHelloSocket, oversizedHelloBytes,
+            defaultMaximumFrameBytes);
+        reportStage("handshake-frame oversized hello rejection");
+        require(readWithDeadline(oversizedHelloSocket,
+                    defaultMaximumFrameBytes, std::chrono::seconds{2})
+                == nullptr,
+            "server accepted a hello above the pre-authentication frame cap");
+        reportStage("handshake-frame bounded hello connection");
+        auto boundedHandshakeSocket
+            = connectTo("127.0.0.1", handshakeFrameServer.port());
+        envelope = exchange(boundedHandshakeSocket, 1,
+            codec::toWire(helloRequest()),
+            defaultMaximumFrameBytes);
+        require(codec::inspect(*envelope).payload
+                == PayloadKind::HelloResponse,
+            "server rejected a hello within the pre-authentication frame cap");
+        reportStage("handshake-frame authenticated request");
+        envelope = exchange(boundedHandshakeSocket, 2,
+            codec::toWire(OpenDatasetData{
+                std::string(handshakeFrameOptions.maximumHandshakeFrameBytes
+                        * 2U,
+                    'x'),
+                16ULL * 1024ULL * 1024ULL}),
+            defaultMaximumFrameBytes);
+        require(codec::inspect(*envelope).payload
+                == PayloadKind::ErrorResponse,
+            "server retained the handshake frame cap after authentication");
+        reportStage("handshake-frame server shutdown");
+        require(handshakeFrameRunning.stopWithin(std::chrono::seconds{2}),
+            "handshake-frame server shutdown exceeded its deadline");
+        reportStage("handshake-frame server stopped");
+    } catch (const std::exception& error) {
+        std::cerr << "[remote_server exception] during: "
+                  << activeStage.load(std::memory_order_relaxed) << ": "
+                  << error.what() << '\n';
+        std::cerr.flush();
+        return 3;
+    } catch (...) {
+        std::cerr << "[remote_server exception] unknown exception during: "
+                  << activeStage.load(std::memory_order_relaxed) << '\n';
+        std::cerr.flush();
+        return 3;
+    }
 
     ServerOptions boundedOptions;
     boundedOptions.workerCount = 1;

--- a/tests/integration/test_remote_server.cpp
+++ b/tests/integration/test_remote_server.cpp
@@ -363,7 +363,8 @@ int main(int argc, char* argv[])
     stalledOptions.workerCount = 1;
     stalledOptions.maximumDatasets = 1;
     stalledOptions.maximumConnections = 2;
-    stalledOptions.responseWriteTimeout = std::chrono::milliseconds{100};
+    stalledOptions.responseWriteStallTimeout
+        = std::chrono::milliseconds{100};
     Server stalledServer(stalledOptions);
     RunningServer stalledRunning(stalledServer);
     auto stalledSocket = connectTo("127.0.0.1", stalledServer.port());

--- a/tests/integration/test_remote_server.cpp
+++ b/tests/integration/test_remote_server.cpp
@@ -4,9 +4,11 @@
 #include <amrexplorer/remote/Frame.hpp>
 #include <amrexplorer/remote/Server.hpp>
 
+#include <chrono>
 #include <cstdlib>
 #include <exception>
 #include <filesystem>
+#include <future>
 #include <iostream>
 #include <memory>
 #include <thread>
@@ -26,12 +28,14 @@ class RunningServer {
 public:
     explicit RunningServer(amrvis::remote::Server& server)
         : m_server(server)
+        , m_done(m_donePromise.get_future())
         , m_thread([this] {
             try {
                 m_server.run();
             } catch (...) {
                 m_failure = std::current_exception();
             }
+            m_donePromise.set_value();
         })
     {
     }
@@ -39,7 +43,9 @@ public:
     ~RunningServer()
     {
         m_server.requestStop();
-        m_thread.join();
+        if (m_thread.joinable()) {
+            m_thread.join();
+        }
         if (m_failure) {
             try {
                 std::rethrow_exception(m_failure);
@@ -53,8 +59,22 @@ public:
     RunningServer(const RunningServer&) = delete;
     RunningServer& operator=(const RunningServer&) = delete;
 
+    bool stopWithin(std::chrono::milliseconds timeout)
+    {
+        m_server.requestStop();
+        if (m_done.wait_for(timeout) != std::future_status::ready) {
+            return false;
+        }
+        if (m_thread.joinable()) {
+            m_thread.join();
+        }
+        return true;
+    }
+
 private:
     amrvis::remote::Server& m_server;
+    std::promise<void> m_donePromise;
+    std::future<void> m_done;
     std::thread m_thread;
     std::exception_ptr m_failure;
 };
@@ -75,6 +95,34 @@ std::unique_ptr<amrvis::remote::codec::NativeEnvelope> exchange(
     return envelope;
 }
 
+std::unique_ptr<amrvis::remote::codec::NativeEnvelope> readWithDeadline(
+    amrvis::remote::Socket& socket, std::uint32_t maximumFrameBytes,
+    std::chrono::milliseconds timeout)
+{
+    auto pending = std::async(std::launch::async,
+        [&socket, maximumFrameBytes] {
+            const auto response
+                = amrvis::remote::readFrame(socket, maximumFrameBytes);
+            return response
+                ? amrvis::remote::codec::decode(*response)
+                : std::unique_ptr<
+                      amrvis::remote::codec::NativeEnvelope>{};
+        });
+    if (pending.wait_for(timeout) != std::future_status::ready) {
+        socket.shutdown();
+        pending.wait();
+        return {};
+    }
+    return pending.get();
+}
+
+amrvis::remote::HelloRequestData helloRequest()
+{
+    using namespace amrvis::remote;
+    return {"server integration test", "test", 0, protocolMinor,
+        defaultMaximumFrameBytes, {}, {}};
+}
+
 } // namespace
 
 int main(int argc, char* argv[])
@@ -91,14 +139,13 @@ int main(int argc, char* argv[])
     options.workerCount = 2;
     options.maximumDatasets = 2;
     options.maximumOutstandingRequests = 8;
+    options.maximumConnections = 4;
     Server server(options);
     RunningServer running(server);
 
     auto socket = connectTo("127.0.0.1", server.port());
     auto envelope = exchange(socket, 1,
-        codec::toWire(HelloRequestData{
-            "server integration test", "test", 0, protocolMinor,
-            defaultMaximumFrameBytes}),
+        codec::toWire(helloRequest()),
         defaultMaximumFrameBytes);
     require(codec::inspect(*envelope).payload == PayloadKind::HelloResponse,
         "server rejected a compatible handshake");
@@ -151,11 +198,127 @@ int main(int argc, char* argv[])
     require(error.code == ErrorCode::ResourceLimitExceeded,
         "oversized slice returned the wrong error");
 
+    envelope = exchange(socket, 5,
+        codec::toWire(OpenDatasetData{
+            std::filesystem::path(argv[1]).string(),
+            16ULL * 1024ULL * 1024ULL}),
+        hello.maximumFrameBytes);
+    require(codec::inspect(*envelope).payload == PayloadKind::DatasetOpened,
+        "server rejected the second allowed dataset");
+    const auto secondOpened
+        = codec::fromWire(*envelope->payload.AsDatasetOpened());
+
+    envelope = exchange(socket, 6,
+        codec::toWire(OpenDatasetData{
+            std::filesystem::path(argv[1]).string(),
+            16ULL * 1024ULL * 1024ULL}),
+        hello.maximumFrameBytes);
+    require(codec::inspect(*envelope).payload == PayloadKind::ErrorResponse
+            && codec::fromWire(*envelope->payload.AsErrorResponse()).code
+                == ErrorCode::ResourceLimitExceeded,
+        "server did not enforce the configured dataset limit");
+
+    codec::fb::CloseDatasetRequestT closeSecond;
+    closeSecond.dataset_id = secondOpened.id.value;
+    envelope = exchange(socket, 7, std::move(closeSecond),
+        hello.maximumFrameBytes);
+    require(codec::inspect(*envelope).payload == PayloadKind::DatasetClosed,
+        "server did not close the second dataset");
+
+    auto duplicateSocket = connectTo("127.0.0.1", server.port());
+    envelope = exchange(duplicateSocket, 1, codec::toWire(helloRequest()),
+        defaultMaximumFrameBytes);
+    require(codec::inspect(*envelope).payload == PayloadKind::HelloResponse,
+        "server rejected the duplicate-ID test connection");
+    const OpenDatasetData duplicateOpen{
+        std::filesystem::path(argv[1]).string(),
+        16ULL * 1024ULL * 1024ULL};
+    writeFrame(duplicateSocket, codec::encode(2, codec::toWire(duplicateOpen)),
+        hello.maximumFrameBytes);
+    writeFrame(duplicateSocket, codec::encode(2, codec::toWire(duplicateOpen)),
+        hello.maximumFrameBytes);
+    bool duplicateRejected = false;
+    for (int response = 0; response < 2 && !duplicateRejected; ++response) {
+        auto duplicateResponse = readWithDeadline(duplicateSocket,
+            hello.maximumFrameBytes, std::chrono::seconds{2});
+        require(duplicateResponse != nullptr,
+            "duplicate request ID caused an unbounded disconnect");
+        if (codec::inspect(*duplicateResponse).payload
+            == PayloadKind::ErrorResponse) {
+            duplicateRejected
+                = codec::fromWire(
+                      *duplicateResponse->payload.AsErrorResponse())
+                      .code
+                == ErrorCode::InvalidRequest;
+        }
+    }
+    require(duplicateRejected,
+        "duplicate live request ID did not receive a bounded error");
+
     codec::fb::CloseDatasetRequestT close;
     close.dataset_id = opened.id.value;
-    envelope = exchange(socket, 5, std::move(close),
+    envelope = exchange(socket, 8, std::move(close),
         hello.maximumFrameBytes);
     require(codec::inspect(*envelope).payload == PayloadKind::DatasetClosed,
         "server did not close the dataset");
+    require(running.stopWithin(std::chrono::seconds{2}),
+        "server shutdown exceeded its deadline");
+
+    ServerOptions connectionOptions;
+    connectionOptions.workerCount = 1;
+    connectionOptions.maximumConnections = 1;
+    Server connectionLimitedServer(connectionOptions);
+    RunningServer connectionLimitedRunning(connectionLimitedServer);
+    auto allowedSocket
+        = connectTo("127.0.0.1", connectionLimitedServer.port());
+    envelope = exchange(allowedSocket, 1, codec::toWire(helloRequest()),
+        defaultMaximumFrameBytes);
+    require(codec::inspect(*envelope).payload == PayloadKind::HelloResponse,
+        "server rejected the allowed connection");
+    auto excessSocket
+        = connectTo("127.0.0.1", connectionLimitedServer.port());
+    bool excessDisconnected = false;
+    try {
+        excessDisconnected = readWithDeadline(excessSocket,
+            defaultMaximumFrameBytes, std::chrono::seconds{2})
+            == nullptr;
+    } catch (const std::exception&) {
+        excessDisconnected = true;
+    }
+    require(excessDisconnected,
+        "server did not enforce the configured connection limit");
+    require(connectionLimitedRunning.stopWithin(std::chrono::seconds{2}),
+        "connection-limited server shutdown exceeded its deadline");
+
+    ServerOptions boundedOptions;
+    boundedOptions.workerCount = 1;
+    boundedOptions.maximumDatasets = 1;
+    boundedOptions.maximumFrameBytes = 1024;
+    Server boundedServer(boundedOptions);
+    RunningServer boundedRunning(boundedServer);
+    auto boundedSocket = connectTo("127.0.0.1", boundedServer.port());
+    auto boundedHello = helloRequest();
+    boundedHello.maximumFrameBytes = boundedOptions.maximumFrameBytes;
+    envelope = exchange(boundedSocket, 1, codec::toWire(boundedHello),
+        boundedOptions.maximumFrameBytes);
+    require(codec::inspect(*envelope).payload == PayloadKind::HelloResponse,
+        "small-frame server rejected a fitting hello response");
+    for (std::uint64_t requestId : {2ULL, 3ULL}) {
+        envelope = exchange(boundedSocket, requestId,
+            codec::toWire(OpenDatasetData{
+                std::filesystem::path(argv[1]).string(),
+                16ULL * 1024ULL * 1024ULL}),
+            boundedOptions.maximumFrameBytes);
+        require(codec::inspect(*envelope).payload
+                    == PayloadKind::ErrorResponse
+                && codec::fromWire(*envelope->payload.AsErrorResponse()).code
+                    == ErrorCode::ResourceLimitExceeded
+                && codec::fromWire(*envelope->payload.AsErrorResponse())
+                       .message.find("catalog")
+                    != std::string::npos,
+            "oversized dataset catalog was not rejected before publication");
+    }
+    require(boundedRunning.stopWithin(std::chrono::seconds{2}),
+        "small-frame server shutdown exceeded its deadline");
     return 0;
 }

--- a/tests/integration/test_remote_server.cpp
+++ b/tests/integration/test_remote_server.cpp
@@ -338,6 +338,53 @@ int main(int argc, char* argv[])
     require(duplicateRunning.stopWithin(std::chrono::seconds{2}),
         "duplicate-ID server shutdown exceeded its deadline");
 
+    // A large response to a peer that stops reading must time out, retire that
+    // session, and release the shared worker for another connection.
+    ServerOptions stalledOptions;
+    stalledOptions.workerCount = 1;
+    stalledOptions.maximumDatasets = 1;
+    stalledOptions.maximumConnections = 2;
+    stalledOptions.responseWriteTimeout = std::chrono::milliseconds{100};
+    Server stalledServer(stalledOptions);
+    RunningServer stalledRunning(stalledServer);
+    auto stalledSocket = connectTo("127.0.0.1", stalledServer.port());
+    envelope = exchange(stalledSocket, 1, codec::toWire(helloRequest()),
+        defaultMaximumFrameBytes);
+    const auto stalledHello
+        = codec::fromWire(*envelope->payload.AsHelloResponse());
+    envelope = exchange(stalledSocket, 2, codec::toWire(duplicateOpen),
+        stalledHello.maximumFrameBytes);
+    const auto stalledOpened
+        = codec::fromWire(*envelope->payload.AsDatasetOpened());
+    SliceRequest stalledSlice = duplicateSlice;
+    stalledSlice.dataset = stalledOpened.id;
+    stalledSlice.outputSize = {2048, 2048};
+    writeFrame(stalledSocket,
+        codec::encode(3, codec::toWire(stalledSlice)),
+        stalledHello.maximumFrameBytes);
+
+    auto healthySocket = connectTo("127.0.0.1", stalledServer.port());
+    envelope = exchange(healthySocket, 1, codec::toWire(helloRequest()),
+        defaultMaximumFrameBytes);
+    const auto healthyHello
+        = codec::fromWire(*envelope->payload.AsHelloResponse());
+    envelope = exchange(healthySocket, 2, codec::toWire(duplicateOpen),
+        healthyHello.maximumFrameBytes);
+    require(codec::inspect(*envelope).payload == PayloadKind::DatasetOpened,
+        "stalled response retained the shared server worker");
+    bool stalledRetired = false;
+    try {
+        stalledRetired = readWithDeadline(stalledSocket,
+            stalledHello.maximumFrameBytes, std::chrono::seconds{2})
+            == nullptr;
+    } catch (const std::exception&) {
+        stalledRetired = true;
+    }
+    require(stalledRetired,
+        "server did not retire the stalled response session");
+    require(stalledRunning.stopWithin(std::chrono::seconds{2}),
+        "stalled-response server shutdown exceeded its deadline");
+
     codec::fb::CloseDatasetRequestT close;
     close.dataset_id = opened.id.value;
     envelope = exchange(socket, 9, std::move(close),
@@ -393,7 +440,7 @@ int main(int argc, char* argv[])
     auto recoveredSocket
         = connectTo("127.0.0.1", handshakeTimeoutServer.port());
     envelope = exchange(recoveredSocket, 1,
-        codec::toWire(helloRequest(handshakeTimeoutServer.token())),
+        codec::toWire(helloRequest()),
         defaultMaximumFrameBytes);
     require(codec::inspect(*envelope).payload == PayloadKind::HelloResponse,
         "authorized client could not reclaim a timed-out connection slot");
@@ -410,14 +457,13 @@ int main(int argc, char* argv[])
     ServerOptions handshakeFrameOptions;
     handshakeFrameOptions.workerCount = 1;
     handshakeFrameOptions.maximumConnections = 1;
-    handshakeFrameOptions.sessionToken = "bounded-handshake-token";
     const auto normalHelloBytes = codec::encode(
-        1, codec::toWire(helloRequest(handshakeFrameOptions.sessionToken)));
+        1, codec::toWire(helloRequest()));
     handshakeFrameOptions.maximumHandshakeFrameBytes
         = static_cast<std::uint32_t>(normalHelloBytes.size() + 16);
     Server handshakeFrameServer(handshakeFrameOptions);
     RunningServer handshakeFrameRunning(handshakeFrameServer);
-    auto oversizedHello = helloRequest(handshakeFrameServer.token());
+    auto oversizedHello = helloRequest();
     oversizedHello.clientName.assign(
         handshakeFrameOptions.maximumHandshakeFrameBytes, 'x');
     auto oversizedHelloBytes
@@ -436,7 +482,7 @@ int main(int argc, char* argv[])
     auto boundedHandshakeSocket
         = connectTo("127.0.0.1", handshakeFrameServer.port());
     envelope = exchange(boundedHandshakeSocket, 1,
-        codec::toWire(helloRequest(handshakeFrameServer.token())),
+        codec::toWire(helloRequest()),
         defaultMaximumFrameBytes);
     require(codec::inspect(*envelope).payload == PayloadKind::HelloResponse,
         "server rejected a hello within the pre-authentication frame cap");

--- a/tests/integration/test_remote_server.cpp
+++ b/tests/integration/test_remote_server.cpp
@@ -4,7 +4,9 @@
 #include <amrexplorer/remote/Frame.hpp>
 #include <amrexplorer/remote/Server.hpp>
 
+#include <atomic>
 #include <chrono>
+#include <cstdio>
 #include <cstdlib>
 #include <exception>
 #include <filesystem>
@@ -16,6 +18,24 @@
 #include <utility>
 
 namespace {
+
+std::atomic<const char*> activeStage{"before main"};
+
+void reportStage(const char* stage)
+{
+    activeStage.store(stage, std::memory_order_relaxed);
+    std::cerr << "[remote_server stage] " << stage << '\n';
+    std::cerr.flush();
+}
+
+[[noreturn]] void reportTerminate() noexcept
+{
+    std::fprintf(stderr,
+        "[remote_server terminate] std::terminate invoked during: %s\n",
+        activeStage.load(std::memory_order_relaxed));
+    std::fflush(stderr);
+    std::_Exit(134);
+}
 
 void require(bool condition, const char* message)
 {
@@ -151,6 +171,9 @@ int main(int argc, char* argv[])
 {
     using namespace amrvis;
     using namespace amrvis::remote;
+
+    std::set_terminate(reportTerminate);
+    reportStage("test setup");
 
     if (argc != 2) {
         std::cerr << "usage: test_remote_server MATERIALIZED_PLOTFILE\n";
@@ -356,9 +379,11 @@ int main(int argc, char* argv[])
         "duplicate live request ID did not receive a bounded error");
     require(duplicateRunning.stopWithin(std::chrono::seconds{2}),
         "duplicate-ID server shutdown exceeded its deadline");
+    reportStage("duplicate-ID server stopped");
 
     // A large response to a peer that stops reading must time out, retire that
     // session, and release the shared worker for another connection.
+    reportStage("stalled-response server setup");
     ServerOptions stalledOptions;
     stalledOptions.workerCount = 1;
     stalledOptions.maximumDatasets = 1;
@@ -382,6 +407,7 @@ int main(int argc, char* argv[])
     writeFrame(stalledSocket,
         codec::encode(3, codec::toWire(stalledSlice)),
         stalledHello.maximumFrameBytes);
+    reportStage("stalled response requested");
 
     auto healthySocket = connectTo("127.0.0.1", stalledServer.port());
     envelope = exchange(healthySocket, 1, codec::toWire(helloRequest()),
@@ -392,6 +418,7 @@ int main(int argc, char* argv[])
         healthyHello.maximumFrameBytes);
     require(codec::inspect(*envelope).payload == PayloadKind::DatasetOpened,
         "stalled response retained the shared server worker");
+    reportStage("healthy client reclaimed worker");
     bool stalledRetired = false;
     try {
         stalledRetired = readWithDeadline(stalledSocket,
@@ -402,8 +429,10 @@ int main(int argc, char* argv[])
     }
     require(stalledRetired,
         "server did not retire the stalled response session");
+    reportStage("stalled session retired");
     require(stalledRunning.stopWithin(std::chrono::seconds{2}),
         "stalled-response server shutdown exceeded its deadline");
+    reportStage("stalled-response server stopped");
 
     codec::fb::CloseDatasetRequestT close;
     close.dataset_id = opened.id.value;
@@ -413,6 +442,7 @@ int main(int argc, char* argv[])
         "server did not close the dataset");
     require(running.stopWithin(std::chrono::seconds{2}),
         "server shutdown exceeded its deadline");
+    reportStage("primary server stopped");
 
     ServerOptions connectionOptions;
     connectionOptions.workerCount = 1;
@@ -439,6 +469,7 @@ int main(int argc, char* argv[])
         "server did not enforce the configured connection limit");
     require(connectionLimitedRunning.stopWithin(std::chrono::seconds{2}),
         "connection-limited server shutdown exceeded its deadline");
+    reportStage("connection-limited server stopped");
 
     ServerOptions handshakeTimeoutOptions;
     handshakeTimeoutOptions.workerCount = 1;
@@ -473,6 +504,7 @@ int main(int argc, char* argv[])
         "server retained the handshake deadline after authentication");
     require(handshakeTimeoutRunning.stopWithin(std::chrono::seconds{2}),
         "handshake-timeout server shutdown exceeded its deadline");
+    reportStage("handshake-timeout server stopped");
 
     ServerOptions handshakeFrameOptions;
     handshakeFrameOptions.workerCount = 1;
@@ -516,6 +548,7 @@ int main(int argc, char* argv[])
         "server retained the handshake frame cap after authentication");
     require(handshakeFrameRunning.stopWithin(std::chrono::seconds{2}),
         "handshake-frame server shutdown exceeded its deadline");
+    reportStage("handshake-frame server stopped");
 
     ServerOptions boundedOptions;
     boundedOptions.workerCount = 1;
@@ -547,7 +580,9 @@ int main(int argc, char* argv[])
     }
     require(boundedRunning.stopWithin(std::chrono::seconds{2}),
         "small-frame server shutdown exceeded its deadline");
+    reportStage("small-frame server stopped");
     std::filesystem::remove_all(
         std::filesystem::path(argv[1]) / "Oversized");
+    reportStage("test complete");
     return 0;
 }

--- a/tests/integration/test_remote_server.cpp
+++ b/tests/integration/test_remote_server.cpp
@@ -120,7 +120,7 @@ std::unique_ptr<amrvis::remote::codec::NativeEnvelope> readWithDeadline(
 amrvis::remote::HelloRequestData helloRequest()
 {
     using namespace amrvis::remote;
-    return {"server integration test", "test", 0, protocolMinor,
+    return {"server integration test", "test", 0, protocolMinorVersion,
         defaultMaximumFrameBytes, {}, {}};
 }
 
@@ -176,7 +176,7 @@ int main(int argc, char* argv[])
         "server rejected a compatible handshake");
     const auto hello = codec::fromWire(
         *envelope->payload.AsHelloResponse());
-    require(hello.selectedMinor == protocolMinor
+    require(hello.selectedMinorVersion == protocolMinorVersion
             && hello.workerCount == options.workerCount,
         "server handshake reported the wrong limits");
 

--- a/tests/integration/test_remote_server.cpp
+++ b/tests/integration/test_remote_server.cpp
@@ -4,9 +4,7 @@
 #include <amrexplorer/remote/Frame.hpp>
 #include <amrexplorer/remote/Server.hpp>
 
-#include <atomic>
 #include <chrono>
-#include <cstdio>
 #include <cstdlib>
 #include <exception>
 #include <filesystem>
@@ -18,24 +16,6 @@
 #include <utility>
 
 namespace {
-
-std::atomic<const char*> activeStage{"before main"};
-
-void reportStage(const char* stage)
-{
-    activeStage.store(stage, std::memory_order_relaxed);
-    std::cerr << "[remote_server stage] " << stage << '\n';
-    std::cerr.flush();
-}
-
-[[noreturn]] void reportTerminate() noexcept
-{
-    std::fprintf(stderr,
-        "[remote_server terminate] std::terminate invoked during: %s\n",
-        activeStage.load(std::memory_order_relaxed));
-    std::fflush(stderr);
-    std::_Exit(134);
-}
 
 void require(bool condition, const char* message)
 {
@@ -171,9 +151,6 @@ int main(int argc, char* argv[])
 {
     using namespace amrvis;
     using namespace amrvis::remote;
-
-    std::set_terminate(reportTerminate);
-    reportStage("test setup");
 
     if (argc != 2) {
         std::cerr << "usage: test_remote_server MATERIALIZED_PLOTFILE\n";
@@ -379,11 +356,9 @@ int main(int argc, char* argv[])
         "duplicate live request ID did not receive a bounded error");
     require(duplicateRunning.stopWithin(std::chrono::seconds{2}),
         "duplicate-ID server shutdown exceeded its deadline");
-    reportStage("duplicate-ID server stopped");
 
     // A large response to a peer that stops reading must time out, retire that
     // session, and release the shared worker for another connection.
-    reportStage("stalled-response server setup");
     ServerOptions stalledOptions;
     stalledOptions.workerCount = 1;
     stalledOptions.maximumDatasets = 1;
@@ -407,7 +382,6 @@ int main(int argc, char* argv[])
     writeFrame(stalledSocket,
         codec::encode(3, codec::toWire(stalledSlice)),
         stalledHello.maximumFrameBytes);
-    reportStage("stalled response requested");
 
     auto healthySocket = connectTo("127.0.0.1", stalledServer.port());
     envelope = exchange(healthySocket, 1, codec::toWire(helloRequest()),
@@ -418,7 +392,6 @@ int main(int argc, char* argv[])
         healthyHello.maximumFrameBytes);
     require(codec::inspect(*envelope).payload == PayloadKind::DatasetOpened,
         "stalled response retained the shared server worker");
-    reportStage("healthy client reclaimed worker");
     bool stalledRetired = false;
     try {
         stalledRetired = readWithDeadline(stalledSocket,
@@ -429,10 +402,8 @@ int main(int argc, char* argv[])
     }
     require(stalledRetired,
         "server did not retire the stalled response session");
-    reportStage("stalled session retired");
     require(stalledRunning.stopWithin(std::chrono::seconds{2}),
         "stalled-response server shutdown exceeded its deadline");
-    reportStage("stalled-response server stopped");
 
     codec::fb::CloseDatasetRequestT close;
     close.dataset_id = opened.id.value;
@@ -442,7 +413,6 @@ int main(int argc, char* argv[])
         "server did not close the dataset");
     require(running.stopWithin(std::chrono::seconds{2}),
         "server shutdown exceeded its deadline");
-    reportStage("primary server stopped");
 
     ServerOptions connectionOptions;
     connectionOptions.workerCount = 1;
@@ -469,7 +439,6 @@ int main(int argc, char* argv[])
         "server did not enforce the configured connection limit");
     require(connectionLimitedRunning.stopWithin(std::chrono::seconds{2}),
         "connection-limited server shutdown exceeded its deadline");
-    reportStage("connection-limited server stopped");
 
     ServerOptions handshakeTimeoutOptions;
     handshakeTimeoutOptions.workerCount = 1;
@@ -504,75 +473,56 @@ int main(int argc, char* argv[])
         "server retained the handshake deadline after authentication");
     require(handshakeTimeoutRunning.stopWithin(std::chrono::seconds{2}),
         "handshake-timeout server shutdown exceeded its deadline");
-    reportStage("handshake-timeout server stopped");
 
+    ServerOptions handshakeFrameOptions;
+    handshakeFrameOptions.workerCount = 1;
+    handshakeFrameOptions.maximumConnections = 1;
+    const auto normalHelloBytes = codec::encode(
+        1, codec::toWire(helloRequest()));
+    handshakeFrameOptions.maximumHandshakeFrameBytes
+        = static_cast<std::uint32_t>(normalHelloBytes.size() + 16);
+    Server handshakeFrameServer(handshakeFrameOptions);
+    RunningServer handshakeFrameRunning(handshakeFrameServer);
+    auto oversizedHello = helloRequest();
+    oversizedHello.clientName.assign(
+        handshakeFrameOptions.maximumHandshakeFrameBytes, 'x');
+    auto oversizedHelloBytes
+        = codec::encode(1, codec::toWire(std::move(oversizedHello)));
+    require(oversizedHelloBytes.size()
+            > handshakeFrameOptions.maximumHandshakeFrameBytes,
+        "oversized hello fixture did not exceed the handshake frame cap");
+    auto oversizedHelloSocket
+        = connectTo("127.0.0.1", handshakeFrameServer.port());
+    writeFrame(oversizedHelloSocket, oversizedHelloBytes,
+        defaultMaximumFrameBytes);
+    bool oversizedHelloRejected = false;
     try {
-        reportStage("handshake-frame options setup");
-        ServerOptions handshakeFrameOptions;
-        handshakeFrameOptions.workerCount = 1;
-        handshakeFrameOptions.maximumConnections = 1;
-        const auto normalHelloBytes = codec::encode(
-            1, codec::toWire(helloRequest()));
-        handshakeFrameOptions.maximumHandshakeFrameBytes
-            = static_cast<std::uint32_t>(normalHelloBytes.size() + 16);
-        reportStage("handshake-frame server construction");
-        Server handshakeFrameServer(handshakeFrameOptions);
-        RunningServer handshakeFrameRunning(handshakeFrameServer);
-        reportStage("handshake-frame oversized hello encoding");
-        auto oversizedHello = helloRequest();
-        oversizedHello.clientName.assign(
-            handshakeFrameOptions.maximumHandshakeFrameBytes, 'x');
-        auto oversizedHelloBytes
-            = codec::encode(1, codec::toWire(std::move(oversizedHello)));
-        require(oversizedHelloBytes.size()
-                > handshakeFrameOptions.maximumHandshakeFrameBytes,
-            "oversized hello fixture did not exceed the handshake frame cap");
-        reportStage("handshake-frame oversized hello connection");
-        auto oversizedHelloSocket
-            = connectTo("127.0.0.1", handshakeFrameServer.port());
-        writeFrame(oversizedHelloSocket, oversizedHelloBytes,
-            defaultMaximumFrameBytes);
-        reportStage("handshake-frame oversized hello rejection");
-        require(readWithDeadline(oversizedHelloSocket,
-                    defaultMaximumFrameBytes, std::chrono::seconds{2})
-                == nullptr,
-            "server accepted a hello above the pre-authentication frame cap");
-        reportStage("handshake-frame bounded hello connection");
-        auto boundedHandshakeSocket
-            = connectTo("127.0.0.1", handshakeFrameServer.port());
-        envelope = exchange(boundedHandshakeSocket, 1,
-            codec::toWire(helloRequest()),
-            defaultMaximumFrameBytes);
-        require(codec::inspect(*envelope).payload
-                == PayloadKind::HelloResponse,
-            "server rejected a hello within the pre-authentication frame cap");
-        reportStage("handshake-frame authenticated request");
-        envelope = exchange(boundedHandshakeSocket, 2,
-            codec::toWire(OpenDatasetData{
-                std::string(handshakeFrameOptions.maximumHandshakeFrameBytes
-                        * 2U,
-                    'x'),
-                16ULL * 1024ULL * 1024ULL}),
-            defaultMaximumFrameBytes);
-        require(codec::inspect(*envelope).payload
-                == PayloadKind::ErrorResponse,
-            "server retained the handshake frame cap after authentication");
-        reportStage("handshake-frame server shutdown");
-        require(handshakeFrameRunning.stopWithin(std::chrono::seconds{2}),
-            "handshake-frame server shutdown exceeded its deadline");
-        reportStage("handshake-frame server stopped");
-    } catch (const std::exception& error) {
-        std::cerr << "[remote_server exception] during: "
-                  << activeStage.load(std::memory_order_relaxed) << ": "
-                  << error.what() << '\n';
-        std::cerr.flush();
-        return 3;
-    } catch (...) {
-        std::cerr << "[remote_server exception] unknown exception during: "
-                  << activeStage.load(std::memory_order_relaxed) << '\n';
-        std::cerr.flush();
-        return 3;
+        oversizedHelloRejected = readWithDeadline(oversizedHelloSocket,
+                                     defaultMaximumFrameBytes,
+                                     std::chrono::seconds{2})
+            == nullptr;
+    } catch (const std::exception&) {
+        oversizedHelloRejected = true;
     }
+    require(oversizedHelloRejected,
+        "server accepted a hello above the pre-authentication frame cap");
+    auto boundedHandshakeSocket
+        = connectTo("127.0.0.1", handshakeFrameServer.port());
+    envelope = exchange(boundedHandshakeSocket, 1,
+        codec::toWire(helloRequest()),
+        defaultMaximumFrameBytes);
+    require(codec::inspect(*envelope).payload == PayloadKind::HelloResponse,
+        "server rejected a hello within the pre-authentication frame cap");
+    envelope = exchange(boundedHandshakeSocket, 2,
+        codec::toWire(OpenDatasetData{
+            std::string(
+                handshakeFrameOptions.maximumHandshakeFrameBytes * 2U, 'x'),
+            16ULL * 1024ULL * 1024ULL}),
+        defaultMaximumFrameBytes);
+    require(codec::inspect(*envelope).payload == PayloadKind::ErrorResponse,
+        "server retained the handshake frame cap after authentication");
+    require(handshakeFrameRunning.stopWithin(std::chrono::seconds{2}),
+        "handshake-frame server shutdown exceeded its deadline");
 
     ServerOptions boundedOptions;
     boundedOptions.workerCount = 1;
@@ -604,9 +554,7 @@ int main(int argc, char* argv[])
     }
     require(boundedRunning.stopWithin(std::chrono::seconds{2}),
         "small-frame server shutdown exceeded its deadline");
-    reportStage("small-frame server stopped");
     std::filesystem::remove_all(
         std::filesystem::path(argv[1]) / "Oversized");
-    reportStage("test complete");
     return 0;
 }

--- a/tests/integration/test_remote_server.cpp
+++ b/tests/integration/test_remote_server.cpp
@@ -1,0 +1,161 @@
+#include "../../src/remote/Codec.hpp"
+
+#include <amrexplorer/data/ViewData.hpp>
+#include <amrexplorer/remote/Frame.hpp>
+#include <amrexplorer/remote/Server.hpp>
+
+#include <cstdlib>
+#include <exception>
+#include <filesystem>
+#include <iostream>
+#include <memory>
+#include <thread>
+#include <utility>
+
+namespace {
+
+void require(bool condition, const char* message)
+{
+    if (!condition) {
+        std::cerr << "FAILED: " << message << '\n';
+        std::exit(1);
+    }
+}
+
+class RunningServer {
+public:
+    explicit RunningServer(amrvis::remote::Server& server)
+        : m_server(server)
+        , m_thread([this] {
+            try {
+                m_server.run();
+            } catch (...) {
+                m_failure = std::current_exception();
+            }
+        })
+    {
+    }
+
+    ~RunningServer()
+    {
+        m_server.requestStop();
+        m_thread.join();
+        if (m_failure) {
+            try {
+                std::rethrow_exception(m_failure);
+            } catch (const std::exception& error) {
+                std::cerr << "server thread failed: " << error.what() << '\n';
+                std::terminate();
+            }
+        }
+    }
+
+    RunningServer(const RunningServer&) = delete;
+    RunningServer& operator=(const RunningServer&) = delete;
+
+private:
+    amrvis::remote::Server& m_server;
+    std::thread m_thread;
+    std::exception_ptr m_failure;
+};
+
+template <typename Payload>
+std::unique_ptr<amrvis::remote::codec::NativeEnvelope> exchange(
+    const amrvis::remote::Socket& socket, std::uint64_t requestId,
+    Payload payload, std::uint32_t maximumFrameBytes)
+{
+    using namespace amrvis::remote;
+    writeFrame(socket,
+        codec::encode(requestId, std::move(payload)), maximumFrameBytes);
+    const auto response = readFrame(socket, maximumFrameBytes);
+    require(response.has_value(), "server closed before sending a response");
+    auto envelope = codec::decode(*response);
+    require(envelope->request_id == requestId,
+        "server response used the wrong request ID");
+    return envelope;
+}
+
+} // namespace
+
+int main(int argc, char* argv[])
+{
+    using namespace amrvis;
+    using namespace amrvis::remote;
+
+    if (argc != 2) {
+        std::cerr << "usage: test_remote_server MATERIALIZED_PLOTFILE\n";
+        return 2;
+    }
+
+    ServerOptions options;
+    options.workerCount = 2;
+    options.maximumDatasets = 2;
+    options.maximumOutstandingRequests = 8;
+    Server server(options);
+    RunningServer running(server);
+
+    auto socket = connectTo("127.0.0.1", server.port());
+    auto envelope = exchange(socket, 1,
+        codec::toWire(HelloRequestData{
+            "server integration test", "test", 0, protocolMinor,
+            defaultMaximumFrameBytes}),
+        defaultMaximumFrameBytes);
+    require(codec::inspect(*envelope).payload == PayloadKind::HelloResponse,
+        "server rejected a compatible handshake");
+    const auto hello = codec::fromWire(
+        *envelope->payload.AsHelloResponse());
+    require(hello.selectedMinor == protocolMinor
+            && hello.workerCount == options.workerCount,
+        "server handshake reported the wrong limits");
+
+    envelope = exchange(socket, 2,
+        codec::toWire(OpenDatasetData{
+            std::filesystem::path(argv[1]).string(),
+            16ULL * 1024ULL * 1024ULL}),
+        hello.maximumFrameBytes);
+    require(codec::inspect(*envelope).payload == PayloadKind::DatasetOpened,
+        "server did not open the materialized plotfile");
+    const auto opened = codec::fromWire(
+        *envelope->payload.AsDatasetOpened());
+    require(opened.catalog.dimension == 2
+            && opened.catalog.levels.size() == 2,
+        "server returned an incomplete dataset catalog");
+
+    SliceRequest request;
+    request.dataset = opened.id;
+    request.field = FieldId{0};
+    request.normalDirection = 1;
+    request.visibleRegion = opened.catalog.physicalDomain;
+    request.physicalPosition = 0.5
+        * (request.visibleRegion.lower[1] + request.visibleRegion.upper[1]);
+    request.maximumLevel = opened.catalog.finestLevel;
+    request.outputSize = {8, 6};
+    envelope = exchange(socket, 3, codec::toWire(request),
+        hello.maximumFrameBytes);
+    require(codec::inspect(*envelope).payload
+            == PayloadKind::SliceViewResponse,
+        "server did not return a slice response");
+    const auto slice = codec::fromWire(
+        *envelope->payload.AsSliceViewResponse());
+    require(slice.plane.width == 8 && slice.plane.height == 6
+            && slice.plane.values.size() == 48,
+        "server did not honor the bounded slice extent");
+
+    request.outputSize = {maxViewOutputDimension + 1, 1};
+    envelope = exchange(socket, 4, codec::toWire(request),
+        hello.maximumFrameBytes);
+    require(codec::inspect(*envelope).payload == PayloadKind::ErrorResponse,
+        "server accepted an oversized slice");
+    const auto error = codec::fromWire(
+        *envelope->payload.AsErrorResponse());
+    require(error.code == ErrorCode::ResourceLimitExceeded,
+        "oversized slice returned the wrong error");
+
+    codec::fb::CloseDatasetRequestT close;
+    close.dataset_id = opened.id.value;
+    envelope = exchange(socket, 5, std::move(close),
+        hello.maximumFrameBytes);
+    require(codec::inspect(*envelope).payload == PayloadKind::DatasetClosed,
+        "server did not close the dataset");
+    return 0;
+}

--- a/tests/integration/test_remote_server.cpp
+++ b/tests/integration/test_remote_server.cpp
@@ -167,9 +167,11 @@ int main(int argc, char* argv[])
     RunningServer running(server);
 
     auto socket = connectTo("127.0.0.1", server.port());
+    constexpr std::uint32_t reducedFrameBytes = 1U * 1024U * 1024U;
+    auto reducedFrameHello = helloRequest();
+    reducedFrameHello.maximumFrameBytes = reducedFrameBytes;
     auto envelope = exchange(socket, 1,
-        codec::toWire(helloRequest()),
-        defaultMaximumFrameBytes);
+        codec::toWire(reducedFrameHello), reducedFrameBytes);
     require(codec::inspect(*envelope).payload == PayloadKind::HelloResponse,
         "server rejected a compatible handshake");
     const auto hello = codec::fromWire(
@@ -190,6 +192,23 @@ int main(int argc, char* argv[])
     require(opened.catalog.dimension == 2
             && opened.catalog.levels.size() == 2,
         "server returned an incomplete dataset catalog");
+
+    DatasetPageRequest smallPage;
+    smallPage.dataset = opened.id;
+    smallPage.field = FieldId{0};
+    smallPage.level = 0;
+    smallPage.region = opened.catalog.physicalDomain;
+    smallPage.normalAxis = 1;
+    smallPage.maximumExtent = datasetPageMaxExtent;
+    envelope = exchange(socket, 9, codec::toWire(smallPage),
+        hello.maximumFrameBytes);
+    require(codec::inspect(*envelope).payload
+                == PayloadKind::DatasetPageResponse,
+        "server rejected a small dataset page under a reduced frame limit");
+    const auto page
+        = codec::fromWire(*envelope->payload.AsDatasetPageResponse());
+    require(page.nx == 4 && page.ny == 4 && page.values.size() == 16,
+        "server returned the wrong reduced-frame dataset page");
 
     DatasetPageRequest reversedPage;
     reversedPage.dataset = opened.id;

--- a/tests/integration/test_remote_server.cpp
+++ b/tests/integration/test_remote_server.cpp
@@ -8,6 +8,7 @@
 #include <cstdlib>
 #include <exception>
 #include <filesystem>
+#include <fstream>
 #include <future>
 #include <iostream>
 #include <memory>
@@ -123,6 +124,27 @@ amrvis::remote::HelloRequestData helloRequest()
         defaultMaximumFrameBytes, {}, {}};
 }
 
+void writeOversizedParticleHeader(const std::filesystem::path& root)
+{
+    using namespace amrvis::remote;
+    constexpr std::uint64_t bytesPerPoint
+        = sizeof(std::uint64_t) + 3 * sizeof(double);
+    constexpr std::uint64_t particleCount
+        = defaultMaximumFrameBytes / bytesPerPoint + 1;
+    const auto species = root / "Oversized";
+    std::filesystem::create_directories(species);
+    std::ofstream header(species / "Header");
+    require(static_cast<bool>(header),
+        "could not create oversized particle Header");
+    header << "Version_Two_Dot_Zero_double\n"
+           << "2\n0\n0\n1\n"
+           << particleCount << '\n'
+           << particleCount + 1 << "\n0\n1\n"
+           << "0 " << particleCount << " 0\n";
+    require(static_cast<bool>(header),
+        "could not write oversized particle Header");
+}
+
 } // namespace
 
 int main(int argc, char* argv[])
@@ -134,6 +156,7 @@ int main(int argc, char* argv[])
         std::cerr << "usage: test_remote_server MATERIALIZED_PLOTFILE\n";
         return 2;
     }
+    writeOversizedParticleHeader(argv[1]);
 
     ServerOptions options;
     options.workerCount = 2;
@@ -167,6 +190,14 @@ int main(int argc, char* argv[])
     require(opened.catalog.dimension == 2
             && opened.catalog.levels.size() == 2,
         "server returned an incomplete dataset catalog");
+
+    envelope = exchange(socket, 8,
+        codec::toWire(opened.id, "Oversized", 1.0, 0),
+        hello.maximumFrameBytes);
+    require(codec::inspect(*envelope).payload == PayloadKind::ErrorResponse
+            && codec::fromWire(*envelope->payload.AsErrorResponse()).code
+                == ErrorCode::ResourceLimitExceeded,
+        "oversized particle request reached the particle reader");
 
     SliceRequest request;
     request.dataset = opened.id;
@@ -225,20 +256,31 @@ int main(int argc, char* argv[])
     require(codec::inspect(*envelope).payload == PayloadKind::DatasetClosed,
         "server did not close the second dataset");
 
-    auto duplicateSocket = connectTo("127.0.0.1", server.port());
+    ServerOptions duplicateOptions;
+    duplicateOptions.workerCount = 2;
+    duplicateOptions.maximumDatasets = 1;
+    duplicateOptions.maximumOutstandingRequests = 2;
+    duplicateOptions.maximumConnections = 1;
+    Server duplicateServer(duplicateOptions);
+    RunningServer duplicateRunning(duplicateServer);
+    auto duplicateSocket
+        = connectTo("127.0.0.1", duplicateServer.port());
     envelope = exchange(duplicateSocket, 1, codec::toWire(helloRequest()),
         defaultMaximumFrameBytes);
     require(codec::inspect(*envelope).payload == PayloadKind::HelloResponse,
         "server rejected the duplicate-ID test connection");
+    const auto duplicateHello = codec::fromWire(
+        *envelope->payload.AsHelloResponse());
     const OpenDatasetData duplicateOpen{
         std::filesystem::path(argv[1]).string(),
         16ULL * 1024ULL * 1024ULL};
     envelope = exchange(duplicateSocket, 2, codec::toWire(duplicateOpen),
-        hello.maximumFrameBytes);
+        duplicateHello.maximumFrameBytes);
     require(codec::inspect(*envelope).payload == PayloadKind::DatasetOpened,
         "server did not open the duplicate-ID test dataset");
     const auto duplicateOpened = codec::fromWire(
         *envelope->payload.AsDatasetOpened());
+    std::this_thread::sleep_for(std::chrono::milliseconds{10});
 
     SliceRequest duplicateSlice;
     duplicateSlice.dataset = duplicateOpened.id;
@@ -255,14 +297,17 @@ int main(int argc, char* argv[])
     duplicateSlice.outputSize = {1536, 1536};
     writeFrame(duplicateSocket,
         codec::encode(3, codec::toWire(duplicateSlice)),
-        hello.maximumFrameBytes);
+        duplicateHello.maximumFrameBytes);
+    writeFrame(duplicateSocket,
+        codec::encode(4, codec::toWire(duplicateSlice)),
+        duplicateHello.maximumFrameBytes);
     writeFrame(duplicateSocket,
         codec::encode(3, codec::toWire(duplicateSlice)),
-        hello.maximumFrameBytes);
+        duplicateHello.maximumFrameBytes);
     bool duplicateRejected = false;
-    for (int response = 0; response < 2 && !duplicateRejected; ++response) {
+    for (int response = 0; response < 3 && !duplicateRejected; ++response) {
         auto duplicateResponse = readWithDeadline(duplicateSocket,
-            hello.maximumFrameBytes, std::chrono::seconds{10});
+            duplicateHello.maximumFrameBytes, std::chrono::seconds{10});
         require(duplicateResponse != nullptr,
             "duplicate request ID caused an unbounded disconnect");
         if (codec::inspect(*duplicateResponse).payload
@@ -276,10 +321,12 @@ int main(int argc, char* argv[])
     }
     require(duplicateRejected,
         "duplicate live request ID did not receive a bounded error");
+    require(duplicateRunning.stopWithin(std::chrono::seconds{2}),
+        "duplicate-ID server shutdown exceeded its deadline");
 
     codec::fb::CloseDatasetRequestT close;
     close.dataset_id = opened.id.value;
-    envelope = exchange(socket, 8, std::move(close),
+    envelope = exchange(socket, 9, std::move(close),
         hello.maximumFrameBytes);
     require(codec::inspect(*envelope).payload == PayloadKind::DatasetClosed,
         "server did not close the dataset");
@@ -342,5 +389,7 @@ int main(int argc, char* argv[])
     }
     require(boundedRunning.stopWithin(std::chrono::seconds{2}),
         "small-frame server shutdown exceeded its deadline");
+    std::filesystem::remove_all(
+        std::filesystem::path(argv[1]) / "Oversized");
     return 0;
 }

--- a/tests/integration/test_remote_server.cpp
+++ b/tests/integration/test_remote_server.cpp
@@ -233,14 +233,36 @@ int main(int argc, char* argv[])
     const OpenDatasetData duplicateOpen{
         std::filesystem::path(argv[1]).string(),
         16ULL * 1024ULL * 1024ULL};
-    writeFrame(duplicateSocket, codec::encode(2, codec::toWire(duplicateOpen)),
+    envelope = exchange(duplicateSocket, 2, codec::toWire(duplicateOpen),
         hello.maximumFrameBytes);
-    writeFrame(duplicateSocket, codec::encode(2, codec::toWire(duplicateOpen)),
+    require(codec::inspect(*envelope).payload == PayloadKind::DatasetOpened,
+        "server did not open the duplicate-ID test dataset");
+    const auto duplicateOpened = codec::fromWire(
+        *envelope->payload.AsDatasetOpened());
+
+    SliceRequest duplicateSlice;
+    duplicateSlice.dataset = duplicateOpened.id;
+    duplicateSlice.field = FieldId{0};
+    duplicateSlice.normalDirection = 1;
+    duplicateSlice.visibleRegion = duplicateOpened.catalog.physicalDomain;
+    duplicateSlice.physicalPosition = 0.5
+        * (duplicateSlice.visibleRegion.lower[1]
+            + duplicateSlice.visibleRegion.upper[1]);
+    duplicateSlice.maximumLevel = duplicateOpened.catalog.finestLevel;
+    // Keep the first request live while the reader dispatches the duplicate:
+    // its response is larger than the socket's send buffer and cannot finish
+    // until this client starts reading below.
+    duplicateSlice.outputSize = {1536, 1536};
+    writeFrame(duplicateSocket,
+        codec::encode(3, codec::toWire(duplicateSlice)),
+        hello.maximumFrameBytes);
+    writeFrame(duplicateSocket,
+        codec::encode(3, codec::toWire(duplicateSlice)),
         hello.maximumFrameBytes);
     bool duplicateRejected = false;
     for (int response = 0; response < 2 && !duplicateRejected; ++response) {
         auto duplicateResponse = readWithDeadline(duplicateSocket,
-            hello.maximumFrameBytes, std::chrono::seconds{2});
+            hello.maximumFrameBytes, std::chrono::seconds{10});
         require(duplicateResponse != nullptr,
             "duplicate request ID caused an unbounded disconnect");
         if (codec::inspect(*duplicateResponse).payload


### PR DESCRIPTION
Part 7 of 13 in the remote client/server stack.

## Purpose

Serve bounded dataset operations over the framed protocol.

## Scope

- Adds the concurrent loopback server and per-connection dataset registry.
- Enforces dataset, outstanding-request, viewport, page, particle, and frame limits.
- Propagates cancellation and classifies failures into protocol errors.

## Review focus

Check lock boundaries, worker/session lifetime, cancellation, and that every response is bounded by a client request or negotiated limit.

## Validation

- `remote_server`
- Raw handshake/open/slice/oversize/close integration coverage
