### PR TITLE
[client-server] add the remote client connection

### DIFF
--- a/include/amrexplorer/remote/Connection.hpp
+++ b/include/amrexplorer/remote/Connection.hpp
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <amrexplorer/core/StopToken.hpp>
+#include <amrexplorer/data/DatasetPage.hpp>
+#include <amrexplorer/data/DatasetSession.hpp>
+#include <amrexplorer/data/ViewData.hpp>
+#include <amrexplorer/remote/Frame.hpp>
+#include <amrexplorer/remote/Protocol.hpp>
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+
+namespace amrvis::remote {
+
+struct ConnectionOptions {
+    std::string clientName = "AMReXplorer";
+    std::string softwareVersion = "unknown";
+    std::uint32_t maximumFrameBytes = defaultMaximumFrameBytes;
+};
+
+class Connection {
+public:
+    Connection(std::string host, std::uint16_t port,
+        ConnectionOptions options = {});
+    ~Connection();
+
+    Connection(const Connection&) = delete;
+    Connection& operator=(const Connection&) = delete;
+
+    [[nodiscard]] const HelloResponseData& serverInfo() const noexcept;
+    [[nodiscard]] bool connected() const noexcept;
+    [[nodiscard]] std::string disconnectReason() const;
+
+    [[nodiscard]] OpenedDataset openDataset(const std::string& path,
+        std::uint64_t cacheBudgetBytes, StopToken cancellation = {});
+    void closeDataset(DatasetId dataset, StopToken cancellation = {});
+    [[nodiscard]] ViewDataResult requestView(
+        const ViewDataRequest& request, StopToken cancellation = {});
+    [[nodiscard]] DatasetPage requestDatasetPage(
+        const DatasetPageRequest& request, StopToken cancellation = {});
+    [[nodiscard]] std::optional<ValueRange> requestRange(DatasetId dataset,
+        const RangeRequest& request, StopToken cancellation = {});
+    [[nodiscard]] ParticleSample requestParticleSample(DatasetId dataset,
+        const std::string& species, double fraction, std::uint64_t seed,
+        StopToken cancellation = {});
+    [[nodiscard]] CacheMetrics clearCache(
+        DatasetId dataset, StopToken cancellation = {});
+    [[nodiscard]] CacheMetrics setCacheBudget(DatasetId dataset,
+        std::uint64_t bytes, StopToken cancellation = {});
+    [[nodiscard]] CacheMetrics latestCache(DatasetId dataset) const;
+    void ping(StopToken cancellation = {});
+
+    void close() noexcept;
+
+private:
+    class Impl;
+    std::unique_ptr<Impl> m_impl;
+};
+
+} // namespace amrvis::remote

--- a/include/amrexplorer/remote/Connection.hpp
+++ b/include/amrexplorer/remote/Connection.hpp
@@ -20,6 +20,9 @@ struct ConnectionOptions {
     std::string softwareVersion = "unknown";
     std::uint32_t maximumFrameBytes = defaultMaximumFrameBytes;
     std::chrono::milliseconds connectionTimeout{10000};
+    // Bounds request writes, lightweight control responses, and cancellation
+    // acknowledgement. Plotfile-operation responses have no wall-clock
+    // deadline and remain governed by cancellation or disconnect instead.
     std::chrono::milliseconds requestTimeout{30000};
 };
 

--- a/include/amrexplorer/remote/Connection.hpp
+++ b/include/amrexplorer/remote/Connection.hpp
@@ -7,6 +7,7 @@
 #include <amrexplorer/remote/Frame.hpp>
 #include <amrexplorer/remote/Protocol.hpp>
 
+#include <chrono>
 #include <cstdint>
 #include <memory>
 #include <optional>
@@ -18,19 +19,21 @@ struct ConnectionOptions {
     std::string clientName = "AMReXplorer";
     std::string softwareVersion = "unknown";
     std::uint32_t maximumFrameBytes = defaultMaximumFrameBytes;
+    std::chrono::milliseconds connectionTimeout{10000};
+    std::chrono::milliseconds requestTimeout{30000};
 };
 
 class Connection {
 public:
     Connection(std::string host, std::uint16_t port,
-        ConnectionOptions options = {});
+        ConnectionOptions options = {}, StopToken cancellation = {});
     ~Connection();
 
     Connection(const Connection&) = delete;
     Connection& operator=(const Connection&) = delete;
 
     [[nodiscard]] const HelloResponseData& serverInfo() const noexcept;
-    [[nodiscard]] bool connected() const noexcept;
+    [[nodiscard]] bool connected() const;
     [[nodiscard]] std::string disconnectReason() const;
 
     [[nodiscard]] OpenedDataset openDataset(const std::string& path,

--- a/include/amrexplorer/remote/Frame.hpp
+++ b/include/amrexplorer/remote/Frame.hpp
@@ -46,6 +46,9 @@ struct Listener {
 [[nodiscard]] Socket acceptConnection(
     const Socket& listener, StopToken cancellation = {});
 [[nodiscard]] Socket connectTo(const std::string& host, std::uint16_t port);
+[[nodiscard]] Socket connectTo(const std::string& host, std::uint16_t port,
+    std::chrono::steady_clock::time_point deadline,
+    StopToken cancellation = {});
 
 void writeFrame(const Socket& socket, std::span<const std::uint8_t> payload,
     std::uint32_t maximumBytes = defaultMaximumFrameBytes);

--- a/include/amrexplorer/remote/Frame.hpp
+++ b/include/amrexplorer/remote/Frame.hpp
@@ -45,6 +45,9 @@ struct Listener {
     std::uint16_t port, int backlog = 16);
 [[nodiscard]] Socket acceptConnection(
     const Socket& listener, StopToken cancellation = {});
+// Connections accept numeric IPv4/IPv6 addresses only. Remote deployments use
+// a loopback SSH tunnel, and avoiding hostname resolution keeps the deadline
+// and cancellation guarantees portable.
 [[nodiscard]] Socket connectTo(const std::string& host, std::uint16_t port);
 [[nodiscard]] Socket connectTo(const std::string& host, std::uint16_t port,
     std::chrono::steady_clock::time_point deadline,

--- a/src/remote/CMakeLists.txt
+++ b/src/remote/CMakeLists.txt
@@ -24,6 +24,7 @@ add_custom_command(
 add_library(amrexplorer_remote
     Codec.cpp
     Codec.hpp
+    Connection.cpp
     Frame.cpp
     Server.cpp
     "${amrexplorer_wire_generated}"

--- a/src/remote/Connection.cpp
+++ b/src/remote/Connection.cpp
@@ -461,6 +461,10 @@ private:
             send(bytes, deadline);
         } catch (...) {
             erasePending(cancelId);
+            // Like an ordinary transaction write, a failed cancellation write
+            // may have left a partial frame on the stream. No later request
+            // can safely reuse this connection.
+            close();
         }
     }
 

--- a/src/remote/Connection.cpp
+++ b/src/remote/Connection.cpp
@@ -1,0 +1,538 @@
+#include <amrexplorer/remote/Connection.hpp>
+
+#include "Codec.hpp"
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <exception>
+#include <future>
+#include <mutex>
+#include <stdexcept>
+#include <thread>
+#include <type_traits>
+#include <unordered_map>
+#include <utility>
+
+namespace amrvis::remote {
+namespace {
+
+using NativeEnvelope = codec::NativeEnvelope;
+
+std::runtime_error disconnectedError(const std::string& reason)
+{
+    return std::runtime_error(
+        reason.empty() ? "remote connection is closed" : reason);
+}
+
+} // namespace
+
+class Connection::Impl {
+public:
+    Impl(std::string host, std::uint16_t port, ConnectionOptions options)
+        : m_socket(connectTo(host, port))
+        , m_maximumFrameBytes(options.maximumFrameBytes)
+        , m_receiver([this] { receiveLoop(); })
+    {
+        try {
+            HelloRequestData hello;
+            hello.clientName = std::move(options.clientName);
+            hello.softwareVersion = std::move(options.softwareVersion);
+            hello.minimumMinor = 0;
+            hello.maximumMinor = protocolMinor;
+            hello.maximumFrameBytes = options.maximumFrameBytes;
+            const auto response = transact(codec::toWire(hello),
+                PayloadKind::HelloResponse, {});
+            const auto* payload = response->payload.AsHelloResponse();
+            if (payload == nullptr) {
+                throw std::runtime_error(
+                    "server returned the wrong hello payload");
+            }
+            m_serverInfo = codec::fromWire(*payload);
+            if (m_serverInfo.selectedMinor > protocolMinor
+                || m_serverInfo.maximumFrameBytes == 0) {
+                throw std::runtime_error(
+                    "server negotiated invalid capabilities");
+            }
+            m_maximumFrameBytes = std::min(
+                m_maximumFrameBytes.load(),
+                m_serverInfo.maximumFrameBytes);
+        } catch (...) {
+            close();
+            throw;
+        }
+    }
+
+    ~Impl()
+    {
+        close();
+    }
+
+    template <typename Payload>
+    std::unique_ptr<NativeEnvelope> transact(Payload payload,
+        PayloadKind expected, StopToken cancellation)
+    {
+        if (cancellation.stop_requested()) {
+            throw ReadCancelled();
+        }
+        const auto requestId = nextRequestId();
+        auto pending = std::make_shared<Pending>();
+        pending->expected = expected;
+        auto future = pending->promise.get_future();
+        {
+            std::scoped_lock lock(m_stateMutex);
+            ensureConnected();
+            if (m_pending.size() >= m_serverInfo.maximumOutstandingRequests
+                && m_serverInfo.maximumOutstandingRequests != 0) {
+                throw RemoteError(ErrorCode::ResourceLimitExceeded,
+                    "connection has too many outstanding requests");
+            }
+            m_pending.emplace(requestId, pending);
+        }
+        try {
+            auto bytes = codec::encode(requestId, std::move(payload));
+            send(bytes);
+        } catch (...) {
+            erasePending(requestId);
+            throw;
+        }
+
+        bool cancellationSent = false;
+        while (future.wait_for(std::chrono::milliseconds(10))
+            != std::future_status::ready) {
+            if (cancellation.stop_requested() && !cancellationSent) {
+                cancellationSent = true;
+                sendCancellation(requestId);
+            }
+        }
+        auto response = future.get();
+        if (const auto* error = response->payload.AsErrorResponse()) {
+            const auto decoded = codec::fromWire(*error);
+            if (decoded.code == ErrorCode::Cancelled) {
+                throw ReadCancelled();
+            }
+            if (decoded.code == ErrorCode::CacheBudgetExceeded) {
+                throw CacheBudgetExceeded(decoded.message);
+            }
+            throw RemoteError(decoded.code, decoded.message);
+        }
+        if (cancellation.stop_requested()) {
+            throw ReadCancelled();
+        }
+        return response;
+    }
+
+    OpenedDataset openDataset(const std::string& path,
+        std::uint64_t cacheBudgetBytes, StopToken cancellation)
+    {
+        const auto response = transact(codec::toWire(
+            OpenDatasetData{path, cacheBudgetBytes}),
+            PayloadKind::DatasetOpened, cancellation);
+        const auto* payload = response->payload.AsDatasetOpened();
+        if (payload == nullptr) {
+            throw std::runtime_error("server omitted dataset-open payload");
+        }
+        auto opened = codec::fromWire(*payload);
+        updateCache(opened.id, opened.cache);
+        return opened;
+    }
+
+    void closeDataset(DatasetId dataset, StopToken cancellation)
+    {
+        codec::fb::CloseDatasetRequestT request;
+        request.dataset_id = dataset.value;
+        static_cast<void>(transact(std::move(request),
+            PayloadKind::DatasetClosed, cancellation));
+        std::scoped_lock lock(m_cacheMutex);
+        m_cache.erase(dataset.value);
+    }
+
+    ViewDataResult requestView(
+        const ViewDataRequest& request, StopToken cancellation)
+    {
+        return std::visit(
+            [&](const auto& typed) -> ViewDataResult {
+                using Request = std::decay_t<decltype(typed)>;
+                if constexpr (std::is_same_v<Request, SliceRequest>) {
+                    const auto response = transact(codec::toWire(typed),
+                        PayloadKind::SliceViewResponse, cancellation);
+                    const auto* payload
+                        = response->payload.AsSliceViewResponse();
+                    if (payload == nullptr) {
+                        throw std::runtime_error(
+                            "server omitted slice-view payload");
+                    }
+                    updateCache(typed.dataset,
+                        codec::fromWire(payload->cache.get()));
+                    return codec::fromWire(*payload);
+                } else {
+                    const auto response = transact(codec::toWire(typed),
+                        PayloadKind::LineViewResponse, cancellation);
+                    const auto* payload
+                        = response->payload.AsLineViewResponse();
+                    if (payload == nullptr) {
+                        throw std::runtime_error(
+                            "server omitted line-view payload");
+                    }
+                    updateCache(typed.query.dataset,
+                        codec::fromWire(payload->cache.get()));
+                    return codec::fromWire(*payload);
+                }
+            },
+            request);
+    }
+
+    DatasetPage requestDatasetPage(
+        const DatasetPageRequest& request, StopToken cancellation)
+    {
+        const auto response = transact(codec::toWire(request),
+            PayloadKind::DatasetPageResponse, cancellation);
+        const auto* payload = response->payload.AsDatasetPageResponse();
+        if (payload == nullptr) {
+            throw std::runtime_error("server omitted dataset-page payload");
+        }
+        updateCache(
+            request.dataset, codec::fromWire(payload->cache.get()));
+        return codec::fromWire(*payload);
+    }
+
+    std::optional<ValueRange> requestRange(DatasetId dataset,
+        const RangeRequest& request, StopToken cancellation)
+    {
+        const auto response = transact(codec::toWire(dataset, request),
+            PayloadKind::RangeResponse, cancellation);
+        const auto* payload = response->payload.AsRangeResponse();
+        if (payload == nullptr) {
+            throw std::runtime_error("server omitted range payload");
+        }
+        updateCache(dataset, codec::fromWire(payload->cache.get()));
+        return codec::fromWire(*payload);
+    }
+
+    ParticleSample requestParticleSample(DatasetId dataset,
+        const std::string& species, double fraction, std::uint64_t seed,
+        StopToken cancellation)
+    {
+        const auto response = transact(
+            codec::toWire(dataset, species, fraction, seed),
+            PayloadKind::ParticleSampleResponse, cancellation);
+        const auto* payload = response->payload.AsParticleSampleResponse();
+        if (payload == nullptr) {
+            throw std::runtime_error(
+                "server omitted particle-sample payload");
+        }
+        updateCache(dataset, codec::fromWire(payload->cache.get()));
+        return codec::fromWire(*payload);
+    }
+
+    CacheMetrics clearCache(DatasetId dataset, StopToken cancellation)
+    {
+        codec::fb::ClearCacheRequestT request;
+        request.dataset_id = dataset.value;
+        return cacheRequest(
+            dataset, std::move(request), cancellation);
+    }
+
+    CacheMetrics setCacheBudget(DatasetId dataset,
+        std::uint64_t bytes, StopToken cancellation)
+    {
+        codec::fb::SetCacheBudgetRequestT request;
+        request.dataset_id = dataset.value;
+        request.budget_bytes = bytes;
+        return cacheRequest(
+            dataset, std::move(request), cancellation);
+    }
+
+    CacheMetrics latestCache(DatasetId dataset) const
+    {
+        std::scoped_lock lock(m_cacheMutex);
+        const auto found = m_cache.find(dataset.value);
+        return found == m_cache.end() ? CacheMetrics{} : found->second;
+    }
+
+    void ping(StopToken cancellation)
+    {
+        codec::fb::PingRequestT request;
+        request.nonce = nextRequestId();
+        static_cast<void>(transact(
+            std::move(request), PayloadKind::PongResponse, cancellation));
+    }
+
+    const HelloResponseData& serverInfo() const noexcept
+    {
+        return m_serverInfo;
+    }
+
+    bool connected() const noexcept
+    {
+        std::scoped_lock lock(m_stateMutex);
+        return m_connected;
+    }
+
+    std::string disconnectReason() const
+    {
+        std::scoped_lock lock(m_stateMutex);
+        return m_disconnectReason;
+    }
+
+    void close() noexcept
+    {
+        {
+            std::scoped_lock lock(m_stateMutex);
+            if (!m_connected && !m_socket.valid()) {
+                return;
+            }
+            m_connected = false;
+        }
+        m_socket.shutdown();
+        if (m_receiver.joinable()
+            && m_receiver.get_id() != std::this_thread::get_id()) {
+            m_receiver.join();
+        }
+        m_socket.close();
+        failPending("remote connection closed");
+    }
+
+private:
+    struct Pending {
+        PayloadKind expected = PayloadKind::None;
+        std::promise<std::unique_ptr<NativeEnvelope>> promise;
+    };
+
+    template <typename Payload>
+    CacheMetrics cacheRequest(
+        DatasetId dataset, Payload request, StopToken cancellation)
+    {
+        const auto response = transact(std::move(request),
+            PayloadKind::CacheResponse, cancellation);
+        const auto* payload = response->payload.AsCacheResponse();
+        if (payload == nullptr || payload->dataset_id != dataset.value) {
+            throw std::runtime_error("server returned invalid cache state");
+        }
+        const auto cache = codec::fromWire(payload->cache.get());
+        updateCache(dataset, cache);
+        return cache;
+    }
+
+    void receiveLoop() noexcept
+    {
+        try {
+            for (;;) {
+                const auto frame
+                    = readFrame(m_socket, m_maximumFrameBytes.load());
+                if (!frame) {
+                    throw std::runtime_error("remote server closed connection");
+                }
+                auto envelope = codec::decode(*frame);
+                const auto info = codec::inspect(*envelope);
+                if (info.protocolMajor != protocolMajor) {
+                    throw std::runtime_error(
+                        "remote server changed protocol major version");
+                }
+                std::shared_ptr<Pending> pending;
+                {
+                    std::scoped_lock lock(m_stateMutex);
+                    const auto found = m_pending.find(info.requestId);
+                    if (found == m_pending.end()) {
+                        throw std::runtime_error(
+                            "remote response has an unknown request ID");
+                    }
+                    pending = found->second;
+                    m_pending.erase(found);
+                }
+                if (info.payload != pending->expected
+                    && info.payload != PayloadKind::ErrorResponse) {
+                    throw std::runtime_error(
+                        "remote response has an unexpected payload type");
+                }
+                pending->promise.set_value(std::move(envelope));
+            }
+        } catch (const std::exception& error) {
+            {
+                std::scoped_lock lock(m_stateMutex);
+                m_connected = false;
+                if (m_disconnectReason.empty()) {
+                    m_disconnectReason = error.what();
+                }
+            }
+            m_socket.shutdown();
+            failPending(error.what());
+        }
+    }
+
+    void send(const codec::Bytes& bytes)
+    {
+        std::scoped_lock lock(m_sendMutex);
+        {
+            std::scoped_lock stateLock(m_stateMutex);
+            ensureConnected();
+        }
+        writeFrame(m_socket, bytes, m_maximumFrameBytes.load());
+    }
+
+    void sendCancellation(std::uint64_t target)
+    {
+        const auto cancelId = nextRequestId();
+        auto pending = std::make_shared<Pending>();
+        pending->expected = PayloadKind::CancelAcknowledged;
+        {
+            std::scoped_lock lock(m_stateMutex);
+            if (!m_connected) {
+                return;
+            }
+            m_pending.emplace(cancelId, pending);
+        }
+        codec::fb::CancelRequestT request;
+        request.target_request_id = target;
+        try {
+            auto bytes = codec::encode(cancelId, std::move(request));
+            send(bytes);
+        } catch (...) {
+            erasePending(cancelId);
+        }
+    }
+
+    void erasePending(std::uint64_t requestId)
+    {
+        std::scoped_lock lock(m_stateMutex);
+        m_pending.erase(requestId);
+    }
+
+    void failPending(const std::string& reason) noexcept
+    {
+        std::unordered_map<std::uint64_t, std::shared_ptr<Pending>> pending;
+        {
+            std::scoped_lock lock(m_stateMutex);
+            pending.swap(m_pending);
+        }
+        for (auto& [id, operation] : pending) {
+            static_cast<void>(id);
+            try {
+                operation->promise.set_exception(
+                    std::make_exception_ptr(disconnectedError(reason)));
+            } catch (...) {
+            }
+        }
+    }
+
+    void ensureConnected() const
+    {
+        if (!m_connected) {
+            throw disconnectedError(m_disconnectReason);
+        }
+    }
+
+    std::uint64_t nextRequestId()
+    {
+        return m_nextRequestId.fetch_add(1);
+    }
+
+    void updateCache(DatasetId dataset, const CacheMetrics& cache)
+    {
+        std::scoped_lock lock(m_cacheMutex);
+        m_cache[dataset.value] = cache;
+    }
+
+    Socket m_socket;
+    std::atomic<std::uint32_t> m_maximumFrameBytes;
+    std::atomic<std::uint64_t> m_nextRequestId{1};
+    mutable std::mutex m_stateMutex;
+    bool m_connected = true;
+    std::string m_disconnectReason;
+    std::unordered_map<std::uint64_t, std::shared_ptr<Pending>> m_pending;
+    std::mutex m_sendMutex;
+    mutable std::mutex m_cacheMutex;
+    std::unordered_map<std::uint64_t, CacheMetrics> m_cache;
+    HelloResponseData m_serverInfo;
+    std::thread m_receiver;
+};
+
+Connection::Connection(std::string host, std::uint16_t port,
+    ConnectionOptions options)
+    : m_impl(std::make_unique<Impl>(
+          std::move(host), port, std::move(options)))
+{
+}
+
+Connection::~Connection() = default;
+
+const HelloResponseData& Connection::serverInfo() const noexcept
+{
+    return m_impl->serverInfo();
+}
+
+bool Connection::connected() const noexcept
+{
+    return m_impl->connected();
+}
+
+std::string Connection::disconnectReason() const
+{
+    return m_impl->disconnectReason();
+}
+
+OpenedDataset Connection::openDataset(const std::string& path,
+    std::uint64_t cacheBudgetBytes, StopToken cancellation)
+{
+    return m_impl->openDataset(path, cacheBudgetBytes, cancellation);
+}
+
+void Connection::closeDataset(DatasetId dataset, StopToken cancellation)
+{
+    m_impl->closeDataset(dataset, cancellation);
+}
+
+ViewDataResult Connection::requestView(
+    const ViewDataRequest& request, StopToken cancellation)
+{
+    return m_impl->requestView(request, cancellation);
+}
+
+DatasetPage Connection::requestDatasetPage(
+    const DatasetPageRequest& request, StopToken cancellation)
+{
+    return m_impl->requestDatasetPage(request, cancellation);
+}
+
+std::optional<ValueRange> Connection::requestRange(DatasetId dataset,
+    const RangeRequest& request, StopToken cancellation)
+{
+    return m_impl->requestRange(dataset, request, cancellation);
+}
+
+ParticleSample Connection::requestParticleSample(DatasetId dataset,
+    const std::string& species, double fraction, std::uint64_t seed,
+    StopToken cancellation)
+{
+    return m_impl->requestParticleSample(
+        dataset, species, fraction, seed, cancellation);
+}
+
+CacheMetrics Connection::clearCache(
+    DatasetId dataset, StopToken cancellation)
+{
+    return m_impl->clearCache(dataset, cancellation);
+}
+
+CacheMetrics Connection::setCacheBudget(
+    DatasetId dataset, std::uint64_t bytes, StopToken cancellation)
+{
+    return m_impl->setCacheBudget(dataset, bytes, cancellation);
+}
+
+CacheMetrics Connection::latestCache(DatasetId dataset) const
+{
+    return m_impl->latestCache(dataset);
+}
+
+void Connection::ping(StopToken cancellation)
+{
+    m_impl->ping(cancellation);
+}
+
+void Connection::close() noexcept
+{
+    m_impl->close();
+}
+
+} // namespace amrvis::remote

--- a/src/remote/Connection.cpp
+++ b/src/remote/Connection.cpp
@@ -111,9 +111,13 @@ public:
         }
         try {
             auto bytes = codec::encode(requestId, std::move(payload));
-            send(bytes);
+            send(bytes, deadline, cancellation);
         } catch (...) {
             erasePending(requestId);
+            // A failed write may have emitted only part of the frame. Retire
+            // the connection rather than allowing a later request to append
+            // bytes to a corrupted stream.
+            close();
             throw;
         }
 
@@ -131,7 +135,7 @@ public:
                     throw ReadCancelled();
                 }
                 cancellationSent = true;
-                sendCancellation(requestId);
+                sendCancellation(requestId, deadline);
             }
             if (future.wait_for(std::chrono::milliseconds::zero())
                 == std::future_status::ready) {
@@ -316,14 +320,16 @@ public:
     void close() noexcept
     {
         {
-            std::scoped_lock sendLock(m_sendMutex);
             std::scoped_lock lock(m_stateMutex);
             if (!m_connected && !m_socket.valid()) {
                 return;
             }
             m_connected = false;
-            m_socket.shutdown();
         }
+        // shutdown() is safe concurrently with send() and is deliberately not
+        // serialized by m_sendMutex: it is what interrupts a peer-blocked
+        // writer so that cancellation and application shutdown can finish.
+        m_socket.shutdown();
         if (m_receiver.joinable()
             && m_receiver.get_id() != std::this_thread::get_id()) {
             m_receiver.join();
@@ -421,17 +427,21 @@ private:
         }
     }
 
-    void send(const codec::Bytes& bytes)
+    void send(const codec::Bytes& bytes,
+        std::chrono::steady_clock::time_point deadline,
+        StopToken cancellation = {})
     {
         std::scoped_lock lock(m_sendMutex);
         {
             std::scoped_lock stateLock(m_stateMutex);
             ensureConnected();
         }
-        writeFrame(m_socket, bytes, m_maximumFrameBytes.load());
+        writeFrame(m_socket, bytes, m_maximumFrameBytes.load(),
+            deadline, cancellation);
     }
 
-    void sendCancellation(std::uint64_t target)
+    void sendCancellation(std::uint64_t target,
+        std::chrono::steady_clock::time_point deadline)
     {
         const auto cancelId = nextRequestId();
         auto pending = std::make_shared<Pending>();
@@ -448,7 +458,7 @@ private:
         request.target_request_id = target;
         try {
             auto bytes = codec::encode(cancelId, std::move(request));
-            send(bytes);
+            send(bytes, deadline);
         } catch (...) {
             erasePending(cancelId);
         }

--- a/src/remote/Connection.cpp
+++ b/src/remote/Connection.cpp
@@ -391,6 +391,7 @@ private:
                         "remote server changed protocol major version");
                 }
                 std::shared_ptr<Pending> pending;
+                bool minorVersionMismatch = false;
                 bool payloadMismatch = false;
                 {
                     std::scoped_lock lock(m_stateMutex);
@@ -400,12 +401,23 @@ private:
                             "remote response has an unknown request ID");
                     }
                     pending = found->second;
+                    minorVersionMismatch
+                        = pending->expected != PayloadKind::HelloResponse
+                        && info.protocolMinorVersion
+                            != m_selectedMinorVersion;
                     payloadMismatch = info.payload != pending->expected
                         && info.payload != PayloadKind::ErrorResponse;
                     m_pending.erase(found);
                     if (pending->countsAgainstBudget) {
                         --m_outstandingRequests;
                     }
+                }
+                if (minorVersionMismatch) {
+                    pending->promise.set_exception(std::make_exception_ptr(
+                        std::runtime_error(
+                            "remote server changed protocol minor version")));
+                    throw std::runtime_error(
+                        "remote server changed protocol minor version");
                 }
                 if (payloadMismatch) {
                     pending->promise.set_exception(std::make_exception_ptr(

--- a/src/remote/Connection.cpp
+++ b/src/remote/Connection.cpp
@@ -360,16 +360,14 @@ public:
             }
             m_connected = false;
         }
-        // shutdown() is safe concurrently with send() and is deliberately not
-        // serialized by m_sendMutex: it is what interrupts a peer-blocked
-        // writer so that cancellation and application shutdown can finish.
-        m_socket.shutdown();
+        m_lifecycleStop.request_stop();
         if (m_receiver.joinable()
             && m_receiver.get_id() != std::this_thread::get_id()) {
             m_receiver.join();
         }
         {
             std::scoped_lock lock(m_sendMutex);
+            m_socket.shutdown();
             m_socket.close();
         }
         failPending("remote connection closed");
@@ -412,7 +410,9 @@ private:
         try {
             for (;;) {
                 const auto frame
-                    = readFrame(m_socket, m_maximumFrameBytes.load());
+                    = readFrame(m_socket, m_maximumFrameBytes.load(),
+                          std::chrono::steady_clock::time_point::max(),
+                          m_lifecycleStop.get_token());
                 if (!frame) {
                     throw std::runtime_error("remote server closed connection");
                 }
@@ -460,6 +460,9 @@ private:
                 }
                 pending->promise.set_value(std::move(envelope));
             }
+        } catch (const ReadCancelled&) {
+            // close() owns pending-request failure and socket teardown after
+            // the receiver has cooperatively left the readiness loop.
         } catch (const std::exception& error) {
             {
                 std::scoped_lock lock(m_stateMutex);
@@ -468,7 +471,7 @@ private:
                     m_disconnectReason = error.what();
                 }
             }
-            m_socket.shutdown();
+            m_lifecycleStop.request_stop();
             failPending(error.what());
         }
     }
@@ -483,7 +486,7 @@ private:
             ensureConnected();
         }
         writeFrame(m_socket, bytes, m_maximumFrameBytes.load(),
-            deadline, cancellation);
+            deadline, cancellation, m_lifecycleStop.get_token());
     }
 
     void sendCancellation(std::uint64_t target,
@@ -568,6 +571,7 @@ private:
     std::uint16_t m_selectedMinorVersion = protocolMinorVersion;
     std::atomic<std::uint32_t> m_maximumFrameBytes;
     std::chrono::milliseconds m_requestTimeout;
+    StopSource m_lifecycleStop;
     std::atomic<std::uint64_t> m_nextRequestId{1};
     std::atomic<std::uint64_t> m_nextPingNonce{1};
     mutable std::mutex m_stateMutex;

--- a/src/remote/Connection.cpp
+++ b/src/remote/Connection.cpp
@@ -46,8 +46,8 @@ public:
             HelloRequestData hello;
             hello.clientName = std::move(options.clientName);
             hello.softwareVersion = std::move(options.softwareVersion);
-            hello.minimumMinor = 0;
-            hello.maximumMinor = protocolMinor;
+            hello.minimumMinorVersion = 0;
+            hello.maximumMinorVersion = protocolMinorVersion;
             hello.maximumFrameBytes = options.maximumFrameBytes;
             const auto response = transact(codec::toWire(hello),
                 PayloadKind::HelloResponse, cancellation,
@@ -58,11 +58,12 @@ public:
                     "server returned the wrong hello payload");
             }
             m_serverInfo = codec::fromWire(*payload);
-            if (m_serverInfo.selectedMinor > protocolMinor
+            if (m_serverInfo.selectedMinorVersion > protocolMinorVersion
                 || m_serverInfo.maximumFrameBytes == 0) {
                 throw std::runtime_error(
                     "server negotiated invalid capabilities");
             }
+            m_selectedMinorVersion = m_serverInfo.selectedMinorVersion;
             m_maximumFrameBytes = std::min(
                 m_maximumFrameBytes.load(),
                 m_serverInfo.maximumFrameBytes);
@@ -110,7 +111,8 @@ public:
             ++m_outstandingRequests;
         }
         try {
-            auto bytes = codec::encode(requestId, std::move(payload));
+            auto bytes = codec::encode(
+                requestId, std::move(payload), m_selectedMinorVersion);
             send(bytes, deadline, cancellation);
         } catch (...) {
             erasePending(requestId);
@@ -457,7 +459,8 @@ private:
         codec::fb::CancelRequestT request;
         request.target_request_id = target;
         try {
-            auto bytes = codec::encode(cancelId, std::move(request));
+            auto bytes = codec::encode(
+                cancelId, std::move(request), m_selectedMinorVersion);
             send(bytes, deadline);
         } catch (...) {
             erasePending(cancelId);
@@ -518,6 +521,7 @@ private:
 
     std::chrono::steady_clock::time_point m_connectionDeadline;
     Socket m_socket;
+    std::uint16_t m_selectedMinorVersion = protocolMinorVersion;
     std::atomic<std::uint32_t> m_maximumFrameBytes;
     std::chrono::milliseconds m_requestTimeout;
     std::atomic<std::uint64_t> m_nextRequestId{1};

--- a/src/remote/Connection.cpp
+++ b/src/remote/Connection.cpp
@@ -29,12 +29,20 @@ std::runtime_error disconnectedError(const std::string& reason)
 
 class Connection::Impl {
 public:
-    Impl(std::string host, std::uint16_t port, ConnectionOptions options)
-        : m_socket(connectTo(host, port))
+    Impl(std::string host, std::uint16_t port, ConnectionOptions options,
+        StopToken cancellation)
+        : m_connectionDeadline(deadlineAfter(
+              options.connectionTimeout, "connection timeout"))
+        , m_socket(connectTo(host, port, m_connectionDeadline, cancellation))
         , m_maximumFrameBytes(options.maximumFrameBytes)
+        , m_requestTimeout(options.requestTimeout)
         , m_receiver([this] { receiveLoop(); })
     {
         try {
+            if (m_requestTimeout <= std::chrono::milliseconds::zero()) {
+                throw std::invalid_argument(
+                    "request timeout must be greater than zero");
+            }
             HelloRequestData hello;
             hello.clientName = std::move(options.clientName);
             hello.softwareVersion = std::move(options.softwareVersion);
@@ -42,7 +50,8 @@ public:
             hello.maximumMinor = protocolMinor;
             hello.maximumFrameBytes = options.maximumFrameBytes;
             const auto response = transact(codec::toWire(hello),
-                PayloadKind::HelloResponse, {});
+                PayloadKind::HelloResponse, cancellation,
+                m_connectionDeadline);
             const auto* payload = response->payload.AsHelloResponse();
             if (payload == nullptr) {
                 throw std::runtime_error(
@@ -72,6 +81,15 @@ public:
     std::unique_ptr<NativeEnvelope> transact(Payload payload,
         PayloadKind expected, StopToken cancellation)
     {
+        return transact(std::move(payload), expected, cancellation,
+            deadlineAfter(m_requestTimeout, "request timeout"));
+    }
+
+    template <typename Payload>
+    std::unique_ptr<NativeEnvelope> transact(Payload payload,
+        PayloadKind expected, StopToken cancellation,
+        std::chrono::steady_clock::time_point deadline)
+    {
         if (cancellation.stop_requested()) {
             throw ReadCancelled();
         }
@@ -82,12 +100,14 @@ public:
         {
             std::scoped_lock lock(m_stateMutex);
             ensureConnected();
-            if (m_pending.size() >= m_serverInfo.maximumOutstandingRequests
+            if (m_outstandingRequests
+                    >= m_serverInfo.maximumOutstandingRequests
                 && m_serverInfo.maximumOutstandingRequests != 0) {
                 throw RemoteError(ErrorCode::ResourceLimitExceeded,
                     "connection has too many outstanding requests");
             }
             m_pending.emplace(requestId, pending);
+            ++m_outstandingRequests;
         }
         try {
             auto bytes = codec::encode(requestId, std::move(payload));
@@ -100,9 +120,30 @@ public:
         bool cancellationSent = false;
         while (future.wait_for(std::chrono::milliseconds(10))
             != std::future_status::ready) {
+            if (future.wait_for(std::chrono::milliseconds::zero())
+                == std::future_status::ready) {
+                break;
+            }
             if (cancellation.stop_requested() && !cancellationSent) {
+                if (expected == PayloadKind::HelloResponse) {
+                    erasePending(requestId);
+                    close();
+                    throw ReadCancelled();
+                }
                 cancellationSent = true;
                 sendCancellation(requestId);
+            }
+            if (future.wait_for(std::chrono::milliseconds::zero())
+                == std::future_status::ready) {
+                break;
+            }
+            if (std::chrono::steady_clock::now() >= deadline) {
+                erasePending(requestId);
+                close();
+                throw std::runtime_error(
+                    expected == PayloadKind::HelloResponse
+                        ? "remote handshake timed out"
+                        : "remote request timed out");
             }
         }
         auto response = future.get();
@@ -115,9 +156,6 @@ public:
                 throw CacheBudgetExceeded(decoded.message);
             }
             throw RemoteError(decoded.code, decoded.message);
-        }
-        if (cancellation.stop_requested()) {
-            throw ReadCancelled();
         }
         return response;
     }
@@ -253,7 +291,7 @@ public:
     void ping(StopToken cancellation)
     {
         codec::fb::PingRequestT request;
-        request.nonce = nextRequestId();
+        request.nonce = m_nextPingNonce.fetch_add(1);
         static_cast<void>(transact(
             std::move(request), PayloadKind::PongResponse, cancellation));
     }
@@ -263,7 +301,7 @@ public:
         return m_serverInfo;
     }
 
-    bool connected() const noexcept
+    bool connected() const
     {
         std::scoped_lock lock(m_stateMutex);
         return m_connected;
@@ -278,26 +316,41 @@ public:
     void close() noexcept
     {
         {
+            std::scoped_lock sendLock(m_sendMutex);
             std::scoped_lock lock(m_stateMutex);
             if (!m_connected && !m_socket.valid()) {
                 return;
             }
             m_connected = false;
+            m_socket.shutdown();
         }
-        m_socket.shutdown();
         if (m_receiver.joinable()
             && m_receiver.get_id() != std::this_thread::get_id()) {
             m_receiver.join();
         }
-        m_socket.close();
+        {
+            std::scoped_lock lock(m_sendMutex);
+            m_socket.close();
+        }
         failPending("remote connection closed");
     }
 
 private:
     struct Pending {
         PayloadKind expected = PayloadKind::None;
+        bool countsAgainstBudget = true;
         std::promise<std::unique_ptr<NativeEnvelope>> promise;
     };
+
+    static std::chrono::steady_clock::time_point deadlineAfter(
+        std::chrono::milliseconds timeout, const char* description)
+    {
+        if (timeout <= std::chrono::milliseconds::zero()) {
+            throw std::invalid_argument(
+                std::string(description) + " must be greater than zero");
+        }
+        return std::chrono::steady_clock::now() + timeout;
+    }
 
     template <typename Payload>
     CacheMetrics cacheRequest(
@@ -330,6 +383,7 @@ private:
                         "remote server changed protocol major version");
                 }
                 std::shared_ptr<Pending> pending;
+                bool payloadMismatch = false;
                 {
                     std::scoped_lock lock(m_stateMutex);
                     const auto found = m_pending.find(info.requestId);
@@ -338,10 +392,17 @@ private:
                             "remote response has an unknown request ID");
                     }
                     pending = found->second;
+                    payloadMismatch = info.payload != pending->expected
+                        && info.payload != PayloadKind::ErrorResponse;
                     m_pending.erase(found);
+                    if (pending->countsAgainstBudget) {
+                        --m_outstandingRequests;
+                    }
                 }
-                if (info.payload != pending->expected
-                    && info.payload != PayloadKind::ErrorResponse) {
+                if (payloadMismatch) {
+                    pending->promise.set_exception(std::make_exception_ptr(
+                        std::runtime_error(
+                            "remote response has an unexpected payload type")));
                     throw std::runtime_error(
                         "remote response has an unexpected payload type");
                 }
@@ -375,6 +436,7 @@ private:
         const auto cancelId = nextRequestId();
         auto pending = std::make_shared<Pending>();
         pending->expected = PayloadKind::CancelAcknowledged;
+        pending->countsAgainstBudget = false;
         {
             std::scoped_lock lock(m_stateMutex);
             if (!m_connected) {
@@ -395,7 +457,13 @@ private:
     void erasePending(std::uint64_t requestId)
     {
         std::scoped_lock lock(m_stateMutex);
-        m_pending.erase(requestId);
+        const auto found = m_pending.find(requestId);
+        if (found != m_pending.end()) {
+            if (found->second->countsAgainstBudget) {
+                --m_outstandingRequests;
+            }
+            m_pending.erase(found);
+        }
     }
 
     void failPending(const std::string& reason) noexcept
@@ -404,6 +472,7 @@ private:
         {
             std::scoped_lock lock(m_stateMutex);
             pending.swap(m_pending);
+            m_outstandingRequests = 0;
         }
         for (auto& [id, operation] : pending) {
             static_cast<void>(id);
@@ -433,13 +502,17 @@ private:
         m_cache[dataset.value] = cache;
     }
 
+    std::chrono::steady_clock::time_point m_connectionDeadline;
     Socket m_socket;
     std::atomic<std::uint32_t> m_maximumFrameBytes;
+    std::chrono::milliseconds m_requestTimeout;
     std::atomic<std::uint64_t> m_nextRequestId{1};
+    std::atomic<std::uint64_t> m_nextPingNonce{1};
     mutable std::mutex m_stateMutex;
     bool m_connected = true;
     std::string m_disconnectReason;
     std::unordered_map<std::uint64_t, std::shared_ptr<Pending>> m_pending;
+    std::uint32_t m_outstandingRequests = 0;
     std::mutex m_sendMutex;
     mutable std::mutex m_cacheMutex;
     std::unordered_map<std::uint64_t, CacheMetrics> m_cache;
@@ -448,9 +521,9 @@ private:
 };
 
 Connection::Connection(std::string host, std::uint16_t port,
-    ConnectionOptions options)
+    ConnectionOptions options, StopToken cancellation)
     : m_impl(std::make_unique<Impl>(
-          std::move(host), port, std::move(options)))
+          std::move(host), port, std::move(options), cancellation))
 {
 }
 
@@ -461,7 +534,7 @@ const HelloResponseData& Connection::serverInfo() const noexcept
     return m_impl->serverInfo();
 }
 
-bool Connection::connected() const noexcept
+bool Connection::connected() const
 {
     return m_impl->connected();
 }

--- a/src/remote/Connection.cpp
+++ b/src/remote/Connection.cpp
@@ -25,6 +25,11 @@ std::runtime_error disconnectedError(const std::string& reason)
         reason.empty() ? "remote connection is closed" : reason);
 }
 
+enum class ResponseWait {
+    Bounded,
+    Indefinite
+};
+
 } // namespace
 
 class Connection::Impl {
@@ -80,16 +85,32 @@ public:
 
     template <typename Payload>
     std::unique_ptr<NativeEnvelope> transact(Payload payload,
-        PayloadKind expected, StopToken cancellation)
+        PayloadKind expected, StopToken cancellation,
+        ResponseWait responseWait = ResponseWait::Bounded)
     {
+        const auto writeDeadline
+            = deadlineAfter(m_requestTimeout, "request timeout");
         return transact(std::move(payload), expected, cancellation,
-            deadlineAfter(m_requestTimeout, "request timeout"));
+            writeDeadline,
+            responseWait == ResponseWait::Indefinite
+                ? std::chrono::steady_clock::time_point::max()
+                : writeDeadline);
     }
 
     template <typename Payload>
     std::unique_ptr<NativeEnvelope> transact(Payload payload,
         PayloadKind expected, StopToken cancellation,
         std::chrono::steady_clock::time_point deadline)
+    {
+        return transact(std::move(payload), expected, cancellation,
+            deadline, deadline);
+    }
+
+    template <typename Payload>
+    std::unique_ptr<NativeEnvelope> transact(Payload payload,
+        PayloadKind expected, StopToken cancellation,
+        std::chrono::steady_clock::time_point writeDeadline,
+        std::chrono::steady_clock::time_point responseDeadline)
     {
         if (cancellation.stop_requested()) {
             throw ReadCancelled();
@@ -113,7 +134,7 @@ public:
         try {
             auto bytes = codec::encode(
                 requestId, std::move(payload), m_selectedMinorVersion);
-            send(bytes, deadline, cancellation);
+            send(bytes, writeDeadline, cancellation);
         } catch (...) {
             erasePending(requestId);
             // A failed write may have emitted only part of the frame. Retire
@@ -137,15 +158,20 @@ public:
                     throw ReadCancelled();
                 }
                 cancellationSent = true;
-                sendCancellation(requestId, deadline);
+                responseDeadline
+                    = deadlineAfter(m_requestTimeout, "cancellation timeout");
+                sendCancellation(requestId, responseDeadline);
             }
             if (future.wait_for(std::chrono::milliseconds::zero())
                 == std::future_status::ready) {
                 break;
             }
-            if (std::chrono::steady_clock::now() >= deadline) {
+            if (std::chrono::steady_clock::now() >= responseDeadline) {
                 erasePending(requestId);
                 close();
+                if (cancellationSent) {
+                    throw ReadCancelled();
+                }
                 throw std::runtime_error(
                     expected == PayloadKind::HelloResponse
                         ? "remote handshake timed out"
@@ -171,7 +197,8 @@ public:
     {
         const auto response = transact(codec::toWire(
             OpenDatasetData{path, cacheBudgetBytes}),
-            PayloadKind::DatasetOpened, cancellation);
+            PayloadKind::DatasetOpened, cancellation,
+            ResponseWait::Indefinite);
         const auto* payload = response->payload.AsDatasetOpened();
         if (payload == nullptr) {
             throw std::runtime_error("server omitted dataset-open payload");
@@ -199,7 +226,8 @@ public:
                 using Request = std::decay_t<decltype(typed)>;
                 if constexpr (std::is_same_v<Request, SliceRequest>) {
                     const auto response = transact(codec::toWire(typed),
-                        PayloadKind::SliceViewResponse, cancellation);
+                        PayloadKind::SliceViewResponse, cancellation,
+                        ResponseWait::Indefinite);
                     const auto* payload
                         = response->payload.AsSliceViewResponse();
                     if (payload == nullptr) {
@@ -211,7 +239,8 @@ public:
                     return codec::fromWire(*payload);
                 } else {
                     const auto response = transact(codec::toWire(typed),
-                        PayloadKind::LineViewResponse, cancellation);
+                        PayloadKind::LineViewResponse, cancellation,
+                        ResponseWait::Indefinite);
                     const auto* payload
                         = response->payload.AsLineViewResponse();
                     if (payload == nullptr) {
@@ -230,7 +259,8 @@ public:
         const DatasetPageRequest& request, StopToken cancellation)
     {
         const auto response = transact(codec::toWire(request),
-            PayloadKind::DatasetPageResponse, cancellation);
+            PayloadKind::DatasetPageResponse, cancellation,
+            ResponseWait::Indefinite);
         const auto* payload = response->payload.AsDatasetPageResponse();
         if (payload == nullptr) {
             throw std::runtime_error("server omitted dataset-page payload");
@@ -244,7 +274,8 @@ public:
         const RangeRequest& request, StopToken cancellation)
     {
         const auto response = transact(codec::toWire(dataset, request),
-            PayloadKind::RangeResponse, cancellation);
+            PayloadKind::RangeResponse, cancellation,
+            ResponseWait::Indefinite);
         const auto* payload = response->payload.AsRangeResponse();
         if (payload == nullptr) {
             throw std::runtime_error("server omitted range payload");
@@ -259,7 +290,8 @@ public:
     {
         const auto response = transact(
             codec::toWire(dataset, species, fraction, seed),
-            PayloadKind::ParticleSampleResponse, cancellation);
+            PayloadKind::ParticleSampleResponse, cancellation,
+            ResponseWait::Indefinite);
         const auto* payload = response->payload.AsParticleSampleResponse();
         if (payload == nullptr) {
             throw std::runtime_error(

--- a/src/remote/Frame.cpp
+++ b/src/remote/Frame.cpp
@@ -1,10 +1,14 @@
 #include <amrexplorer/remote/Frame.hpp>
 
+#include <amrexplorer/io/PlotfileBlockReader.hpp>
+
 #include <algorithm>
 #include <array>
 #include <cerrno>
+#include <chrono>
 #include <cstring>
 #include <limits>
+#include <memory>
 #include <stdexcept>
 #include <utility>
 
@@ -69,6 +73,12 @@ bool transientAcceptFailure(int error)
 {
     return interrupted(error) || error == WSAECONNABORTED;
 }
+
+bool connectInProgress(int error)
+{
+    return error == WSAEWOULDBLOCK || error == WSAEINPROGRESS
+        || error == WSAEINVAL;
+}
 void closeNative(NativeSocket socket)
 {
     ::closesocket(socket);
@@ -98,6 +108,11 @@ bool wouldBlock(int error)
 bool transientAcceptFailure(int error)
 {
     return interrupted(error) || error == ECONNABORTED;
+}
+
+bool connectInProgress(int error)
+{
+    return error == EINPROGRESS || error == EWOULDBLOCK;
 }
 void closeNative(NativeSocket socket)
 {
@@ -129,6 +144,62 @@ void setNonBlocking(NativeSocket socket, bool enabled)
         throwSocketError("fcntl(O_NONBLOCK)");
     }
 #endif
+}
+
+int waitForConnect(NativeSocket socket,
+    std::chrono::steady_clock::time_point deadline,
+    StopToken cancellation)
+{
+    using namespace std::chrono_literals;
+    for (;;) {
+        if (cancellation.stop_requested()) {
+            throw ReadCancelled();
+        }
+        const auto now = std::chrono::steady_clock::now();
+        if (now >= deadline) {
+            throw std::runtime_error("connection attempt timed out");
+        }
+        auto wait = 50ms;
+        if (deadline != std::chrono::steady_clock::time_point::max()) {
+            wait = std::min(wait,
+                std::chrono::duration_cast<std::chrono::milliseconds>(
+                    deadline - now));
+        }
+#ifdef _WIN32
+        timeval timeout{};
+        timeout.tv_sec = static_cast<long>(wait.count() / 1000);
+        timeout.tv_usec = static_cast<decltype(timeout.tv_usec)>(
+            (wait.count() % 1000) * 1000);
+        fd_set writable;
+        FD_ZERO(&writable);
+        FD_SET(socket, &writable);
+        const auto ready = ::select(0, nullptr, &writable, nullptr, &timeout);
+#else
+        pollfd descriptor{socket, POLLOUT, 0};
+        const auto ready = ::poll(&descriptor, 1, static_cast<int>(wait.count()));
+#endif
+        if (ready == 0) {
+            continue;
+        }
+        if (ready < 0) {
+            const auto error = lastSocketError();
+            if (interrupted(error)) {
+                continue;
+            }
+            return error;
+        }
+        int error = 0;
+        SocketLength size = static_cast<SocketLength>(sizeof(error));
+#ifdef _WIN32
+        auto* bytes = reinterpret_cast<char*>(&error);
+#else
+        auto* bytes = &error;
+#endif
+        if (::getsockopt(socket, SOL_SOCKET, SO_ERROR, bytes, &size) != 0) {
+            return lastSocketError();
+        }
+        return error;
+    }
 }
 void setIntegerSocketOption(NativeSocket descriptor, int level, int option,
     int value, const char* name)
@@ -482,7 +553,18 @@ Socket acceptConnection(const Socket& listener, StopToken cancellation)
 
 Socket connectTo(const std::string& host, std::uint16_t port)
 {
+    return connectTo(host, port,
+        std::chrono::steady_clock::time_point::max(), {});
+}
+
+Socket connectTo(const std::string& host, std::uint16_t port,
+    std::chrono::steady_clock::time_point deadline,
+    StopToken cancellation)
+{
     ensureSockets();
+    if (cancellation.stop_requested()) {
+        throw ReadCancelled();
+    }
     addrinfo hints{};
     hints.ai_family = AF_UNSPEC;
     hints.ai_socktype = SOCK_STREAM;
@@ -499,6 +581,11 @@ Socket connectTo(const std::string& host, std::uint16_t port)
         throw std::runtime_error(
             "getaddrinfo succeeded without returning a usable address");
     }
+    std::unique_ptr<addrinfo, decltype(&::freeaddrinfo)> addressOwner(
+        addresses, &::freeaddrinfo);
+    if (std::chrono::steady_clock::now() >= deadline) {
+        throw std::runtime_error("connection attempt timed out");
+    }
 
     int lastError = 0;
     for (auto* address = addresses; address != nullptr;
@@ -510,16 +597,26 @@ Socket connectTo(const std::string& host, std::uint16_t port)
             lastError = lastSocketError();
             continue;
         }
-        if (::connect(native(socket.descriptor()), address->ai_addr,
+        const auto descriptor = native(socket.descriptor());
+        setNonBlocking(descriptor, true);
+        if (::connect(descriptor, address->ai_addr,
                 static_cast<SocketLength>(address->ai_addrlen))
             == 0) {
-            ::freeaddrinfo(addresses);
-            configureConnectedSocket(native(socket.descriptor()));
+            setNonBlocking(descriptor, false);
+            configureConnectedSocket(descriptor);
             return socket;
         }
         lastError = lastSocketError();
+        if (!connectInProgress(lastError)) {
+            continue;
+        }
+        lastError = waitForConnect(descriptor, deadline, cancellation);
+        if (lastError == 0) {
+            setNonBlocking(descriptor, false);
+            configureConnectedSocket(descriptor);
+            return socket;
+        }
     }
-    ::freeaddrinfo(addresses);
     throwSocketError("connect", lastError);
 }
 

--- a/src/remote/Frame.cpp
+++ b/src/remote/Frame.cpp
@@ -64,11 +64,6 @@ bool interrupted(int error)
     return error == WSAEINTR;
 }
 
-bool wouldBlock(int error)
-{
-    return error == WSAEWOULDBLOCK;
-}
-
 bool transientAcceptFailure(int error)
 {
     return interrupted(error) || error == WSAECONNABORTED;
@@ -79,6 +74,12 @@ bool connectInProgress(int error)
     return error == WSAEWOULDBLOCK || error == WSAEINPROGRESS
         || error == WSAEINVAL;
 }
+
+bool wouldBlock(int error)
+{
+    return error == WSAEWOULDBLOCK;
+}
+
 void closeNative(NativeSocket socket)
 {
     ::closesocket(socket);
@@ -100,11 +101,6 @@ bool interrupted(int error)
     return error == EINTR;
 }
 
-bool wouldBlock(int error)
-{
-    return error == EAGAIN || error == EWOULDBLOCK;
-}
-
 bool transientAcceptFailure(int error)
 {
     return interrupted(error) || error == ECONNABORTED;
@@ -114,6 +110,12 @@ bool connectInProgress(int error)
 {
     return error == EINPROGRESS || error == EWOULDBLOCK;
 }
+
+bool wouldBlock(int error)
+{
+    return error == EAGAIN || error == EWOULDBLOCK;
+}
+
 void closeNative(NativeSocket socket)
 {
     ::close(socket);
@@ -201,6 +203,7 @@ int waitForConnect(NativeSocket socket,
         return error;
     }
 }
+
 void setIntegerSocketOption(NativeSocket descriptor, int level, int option,
     int value, const char* name)
 {

--- a/src/remote/Frame.cpp
+++ b/src/remote/Frame.cpp
@@ -565,17 +565,22 @@ Socket connectTo(const std::string& host, std::uint16_t port,
     if (cancellation.stop_requested()) {
         throw ReadCancelled();
     }
+    if (std::chrono::steady_clock::now() >= deadline) {
+        throw std::runtime_error("connection attempt timed out");
+    }
     addrinfo hints{};
     hints.ai_family = AF_UNSPEC;
     hints.ai_socktype = SOCK_STREAM;
     hints.ai_protocol = IPPROTO_TCP;
+    hints.ai_flags = AI_NUMERICHOST;
     addrinfo* addresses = nullptr;
     const auto service = std::to_string(port);
     const auto status
         = ::getaddrinfo(host.c_str(), service.c_str(), &hints, &addresses);
     if (status != 0) {
-        throw std::runtime_error(
-            "getaddrinfo: " + std::string(gai_strerror(status)));
+        throw std::runtime_error("remote host must be a numeric IPv4 or IPv6 "
+                                 "address: "
+            + std::string(gai_strerror(status)));
     }
     if (addresses == nullptr) {
         throw std::runtime_error(
@@ -583,10 +588,6 @@ Socket connectTo(const std::string& host, std::uint16_t port,
     }
     std::unique_ptr<addrinfo, decltype(&::freeaddrinfo)> addressOwner(
         addresses, &::freeaddrinfo);
-    if (std::chrono::steady_clock::now() >= deadline) {
-        throw std::runtime_error("connection attempt timed out");
-    }
-
     int lastError = 0;
     for (auto* address = addresses; address != nullptr;
          address = address->ai_next) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -143,6 +143,20 @@ if(TARGET amrexplorer_remote)
     set_tests_properties(remote_server PROPERTIES
         FIXTURES_REQUIRED remote_server_private_materialized
         TIMEOUT 30)
+
+    add_executable(test_remote_connection
+        integration/test_remote_connection.cpp)
+    target_link_libraries(test_remote_connection
+        PRIVATE
+            amrexplorer::remote
+            amrexplorer::warnings
+            Threads::Threads
+    )
+    add_test(NAME remote_connection
+        COMMAND test_remote_connection "${remote_server_fixture_dir}")
+    set_tests_properties(remote_connection PROPERTIES
+        FIXTURES_REQUIRED remote_server_materialized
+        TIMEOUT 30)
 endif()
 
 add_executable(test_vismf_index unit/test_vismf_index.cpp)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -146,9 +146,13 @@ if(TARGET amrexplorer_remote)
 
     add_executable(test_remote_connection
         integration/test_remote_connection.cpp)
+    target_include_directories(test_remote_connection PRIVATE
+        "${PROJECT_SOURCE_DIR}/src/remote"
+        "${PROJECT_BINARY_DIR}/src/remote/generated")
     target_link_libraries(test_remote_connection
         PRIVATE
             amrexplorer::remote
+            FlatBuffers::FlatBuffers
             amrexplorer::warnings
             Threads::Threads
     )

--- a/tests/integration/test_remote_connection.cpp
+++ b/tests/integration/test_remote_connection.cpp
@@ -258,7 +258,7 @@ int main(int argc, char* argv[])
     auto fanoutPeer = std::async(std::launch::async, [&] {
         auto peer = acceptConnection(fanoutListener.socket);
         static_cast<void>(acceptHello(peer));
-        for (int request = 0; request < 2; ++request) {
+        for (int pendingRequest = 0; pendingRequest < 2; ++pendingRequest) {
             require(readFrame(peer, defaultMaximumFrameBytes).has_value(),
                 "client omitted a concurrent request");
         }

--- a/tests/integration/test_remote_connection.cpp
+++ b/tests/integration/test_remote_connection.cpp
@@ -191,6 +191,32 @@ int main(int argc, char* argv[])
     negotiatedMinorVersionConnection.close();
     negotiatedMinorVersionPeer.get();
 
+    auto wrongMinorVersionListener = listenOnLoopback(0);
+    auto wrongMinorVersionPeer = std::async(std::launch::async, [&] {
+        auto peer = acceptConnection(wrongMinorVersionListener.socket);
+        static_cast<void>(acceptHello(peer));
+        const auto frame = readFrame(peer, defaultMaximumFrameBytes);
+        require(frame.has_value(),
+            "client omitted wrong-minor-version test request");
+        const auto request = codec::decode(*frame);
+        const auto info = codec::inspect(*request);
+        codec::fb::PongResponseT pong;
+        pong.nonce = request->payload.AsPingRequest()->nonce;
+        writeFrame(peer,
+            codec::encode(info.requestId, std::move(pong),
+                static_cast<std::uint16_t>(protocolMinorVersion + 1)),
+            defaultMaximumFrameBytes);
+    });
+    Connection wrongMinorVersionConnection(
+        "127.0.0.1", wrongMinorVersionListener.port);
+    auto wrongMinorVersionCall = std::async(std::launch::async,
+        [&] { wrongMinorVersionConnection.ping(); });
+    require(throwsWithin(wrongMinorVersionCall, 1s),
+        "non-negotiated response minor version was accepted");
+    require(!wrongMinorVersionConnection.connected(),
+        "non-negotiated response minor version did not fail the connection");
+    wrongMinorVersionPeer.get();
+
     StopSource preCancelled;
     preCancelled.request_stop();
     try {

--- a/tests/integration/test_remote_connection.cpp
+++ b/tests/integration/test_remote_connection.cpp
@@ -71,7 +71,9 @@ amrvis::SliceRequest sliceRequest(
     return request;
 }
 
-std::uint64_t acceptHello(amrvis::remote::Socket& peer)
+std::uint64_t acceptHello(amrvis::remote::Socket& peer,
+    std::uint16_t selectedMinorVersion
+    = amrvis::remote::protocolMinorVersion)
 {
     using namespace amrvis::remote;
     const auto frame = readFrame(peer, defaultMaximumFrameBytes);
@@ -82,12 +84,13 @@ std::uint64_t acceptHello(amrvis::remote::Socket& peer)
     HelloResponseData hello;
     hello.serverName = "test peer";
     hello.softwareVersion = "test";
-    hello.selectedMinor = protocolMinor;
+    hello.selectedMinorVersion = selectedMinorVersion;
     hello.maximumFrameBytes = defaultMaximumFrameBytes;
     hello.maximumDatasets = 8;
     hello.maximumOutstandingRequests = 8;
     hello.workerCount = 1;
-    writeFrame(peer, codec::encode(request->request_id, codec::toWire(hello)),
+    writeFrame(peer, codec::encode(request->request_id,
+                         codec::toWire(hello), selectedMinorVersion),
         defaultMaximumFrameBytes);
     return request->request_id;
 }
@@ -159,6 +162,34 @@ int main(int argc, char* argv[])
     connection.close();
     require(!connection.connected(),
         "connection remained live after close");
+
+    auto negotiatedMinorVersionListener = listenOnLoopback(0);
+    constexpr auto selectedMinorVersion = protocolMinorVersion == 0
+        ? std::uint16_t{0}
+        : static_cast<std::uint16_t>(protocolMinorVersion - 1);
+    auto negotiatedMinorVersionPeer = std::async(std::launch::async, [&] {
+        auto peer = acceptConnection(negotiatedMinorVersionListener.socket);
+        static_cast<void>(acceptHello(peer, selectedMinorVersion));
+        const auto frame = readFrame(peer, defaultMaximumFrameBytes);
+        require(frame.has_value(),
+            "client omitted negotiated minor version ping request");
+        const auto request = codec::decode(*frame);
+        const auto info = codec::inspect(*request);
+        require(info.payload == PayloadKind::PingRequest
+                && info.protocolMinorVersion == selectedMinorVersion,
+            "client did not use the negotiated protocol minor version");
+        codec::fb::PongResponseT pong;
+        pong.nonce = request->payload.AsPingRequest()->nonce;
+        writeFrame(peer,
+            codec::encode(
+                info.requestId, std::move(pong), selectedMinorVersion),
+            defaultMaximumFrameBytes);
+    });
+    Connection negotiatedMinorVersionConnection(
+        "127.0.0.1", negotiatedMinorVersionListener.port);
+    negotiatedMinorVersionConnection.ping();
+    negotiatedMinorVersionConnection.close();
+    negotiatedMinorVersionPeer.get();
 
     StopSource preCancelled;
     preCancelled.request_stop();

--- a/tests/integration/test_remote_connection.cpp
+++ b/tests/integration/test_remote_connection.cpp
@@ -1,3 +1,5 @@
+#include "../../src/remote/Codec.hpp"
+
 #include <amrexplorer/data/ViewData.hpp>
 #include <amrexplorer/remote/Connection.hpp>
 #include <amrexplorer/remote/Server.hpp>
@@ -11,6 +13,8 @@
 #include <variant>
 
 namespace {
+
+using namespace std::chrono_literals;
 
 void require(bool condition, const char* message)
 {
@@ -67,6 +71,41 @@ amrvis::SliceRequest sliceRequest(
     return request;
 }
 
+std::uint64_t acceptHello(amrvis::remote::Socket& peer)
+{
+    using namespace amrvis::remote;
+    const auto frame = readFrame(peer, defaultMaximumFrameBytes);
+    require(frame.has_value(), "client closed before sending hello");
+    const auto request = codec::decode(*frame);
+    require(codec::inspect(*request).payload == PayloadKind::HelloRequest,
+        "client did not send hello first");
+    HelloResponseData hello;
+    hello.serverName = "test peer";
+    hello.softwareVersion = "test";
+    hello.selectedMinor = protocolMinor;
+    hello.maximumFrameBytes = defaultMaximumFrameBytes;
+    hello.maximumDatasets = 8;
+    hello.maximumOutstandingRequests = 8;
+    hello.workerCount = 1;
+    writeFrame(peer, codec::encode(request->request_id, codec::toWire(hello)),
+        defaultMaximumFrameBytes);
+    return request->request_id;
+}
+
+bool throwsWithin(std::future<void>& operation,
+    std::chrono::milliseconds timeout)
+{
+    if (operation.wait_for(timeout) != std::future_status::ready) {
+        return false;
+    }
+    try {
+        operation.get();
+    } catch (const std::exception&) {
+        return true;
+    }
+    return false;
+}
+
 } // namespace
 
 int main(int argc, char* argv[])
@@ -120,5 +159,138 @@ int main(int argc, char* argv[])
     connection.close();
     require(!connection.connected(),
         "connection remained live after close");
+
+    StopSource preCancelled;
+    preCancelled.request_stop();
+    try {
+        Connection cancelledBeforeConnect("127.0.0.1", server.port(), {},
+            preCancelled.get_token());
+        require(false, "pre-cancelled connection attempt succeeded");
+    } catch (const ReadCancelled&) {
+    }
+
+    auto silentListener = listenOnLoopback(0);
+    auto silentPeer = std::async(std::launch::async, [&] {
+        auto peer = acceptConnection(silentListener.socket);
+        std::this_thread::sleep_for(500ms);
+    });
+    ConnectionOptions shortHandshake;
+    shortHandshake.connectionTimeout = 100ms;
+    const auto handshakeStart = std::chrono::steady_clock::now();
+    bool handshakeTimedOut = false;
+    try {
+        Connection silentConnection(
+            "127.0.0.1", silentListener.port, shortHandshake);
+    } catch (const std::exception& error) {
+        handshakeTimedOut
+            = std::string(error.what()).find("handshake timed out")
+            != std::string::npos;
+    }
+    require(handshakeTimedOut
+            && std::chrono::steady_clock::now() - handshakeStart < 1s,
+        "silent hello did not honor the connection deadline");
+    silentPeer.get();
+
+    auto cancelListener = listenOnLoopback(0);
+    std::promise<void> cancelAcceptedPromise;
+    auto cancelAccepted = cancelAcceptedPromise.get_future();
+    std::promise<void> releaseCancelPeerPromise;
+    auto releaseCancelPeer = releaseCancelPeerPromise.get_future();
+    auto cancelPeer = std::async(std::launch::async, [&] {
+        auto peer = acceptConnection(cancelListener.socket);
+        cancelAcceptedPromise.set_value();
+        releaseCancelPeer.wait();
+    });
+    StopSource connectCancellation;
+    ConnectionOptions cancellableHandshake;
+    cancellableHandshake.connectionTimeout = 5s;
+    auto cancelledConnection = std::async(std::launch::async, [&] {
+        Connection pending("127.0.0.1", cancelListener.port,
+            cancellableHandshake, connectCancellation.get_token());
+    });
+    require(cancelAccepted.wait_for(1s) == std::future_status::ready,
+        "cancellation test peer did not accept the connection");
+    connectCancellation.request_stop();
+    require(cancelledConnection.wait_for(1s) == std::future_status::ready,
+        "hello cancellation did not complete within its deadline");
+    bool helloCancelled = false;
+    try {
+        cancelledConnection.get();
+    } catch (const ReadCancelled&) {
+        helloCancelled = true;
+    }
+    require(helloCancelled,
+        "hello cancellation returned the wrong exception");
+    releaseCancelPeerPromise.set_value();
+    cancelPeer.get();
+
+    auto wrongPayloadListener = listenOnLoopback(0);
+    auto wrongPayloadPeer = std::async(std::launch::async, [&] {
+        auto peer = acceptConnection(wrongPayloadListener.socket);
+        static_cast<void>(acceptHello(peer));
+        const auto frame = readFrame(peer, defaultMaximumFrameBytes);
+        require(frame.has_value(), "client omitted ping request");
+        const auto requestEnvelope = codec::decode(*frame);
+        const auto requestInfo = codec::inspect(*requestEnvelope);
+        const auto* ping = requestEnvelope->payload.AsPingRequest();
+        require(requestInfo.requestId == 2 && ping != nullptr
+                && ping->nonce == 1,
+            "ping consumed an extra request ID");
+        codec::fb::DatasetClosedT wrong;
+        wrong.dataset_id = 1;
+        writeFrame(peer,
+            codec::encode(requestInfo.requestId, std::move(wrong)),
+            defaultMaximumFrameBytes);
+    });
+    ConnectionOptions shortRequest;
+    shortRequest.requestTimeout = 1s;
+    Connection wrongPayloadConnection(
+        "127.0.0.1", wrongPayloadListener.port, shortRequest);
+    auto wrongPayloadCall = std::async(std::launch::async,
+        [&] { wrongPayloadConnection.ping(); });
+    require(throwsWithin(wrongPayloadCall, 1s),
+        "wrong response payload left its caller waiting");
+    require(!wrongPayloadConnection.connected(),
+        "wrong response payload did not fail the connection");
+    wrongPayloadPeer.get();
+
+    auto fanoutListener = listenOnLoopback(0);
+    auto fanoutPeer = std::async(std::launch::async, [&] {
+        auto peer = acceptConnection(fanoutListener.socket);
+        static_cast<void>(acceptHello(peer));
+        for (int request = 0; request < 2; ++request) {
+            require(readFrame(peer, defaultMaximumFrameBytes).has_value(),
+                "client omitted a concurrent request");
+        }
+    });
+    Connection fanoutConnection(
+        "127.0.0.1", fanoutListener.port, shortRequest);
+    auto fanoutFirst = std::async(std::launch::async,
+        [&] { fanoutConnection.ping(); });
+    auto fanoutSecond = std::async(std::launch::async,
+        [&] { fanoutConnection.ping(); });
+    require(throwsWithin(fanoutFirst, 2s)
+            && throwsWithin(fanoutSecond, 2s),
+        "disconnect did not fail every pending request");
+    fanoutPeer.get();
+
+    auto requestTimeoutListener = listenOnLoopback(0);
+    auto requestTimeoutPeer = std::async(std::launch::async, [&] {
+        auto peer = acceptConnection(requestTimeoutListener.socket);
+        static_cast<void>(acceptHello(peer));
+        require(readFrame(peer, defaultMaximumFrameBytes).has_value(),
+            "client omitted timeout test request");
+        std::this_thread::sleep_for(500ms);
+    });
+    ConnectionOptions requestDeadline;
+    requestDeadline.requestTimeout = 100ms;
+    Connection requestTimeoutConnection(
+        "127.0.0.1", requestTimeoutListener.port, requestDeadline);
+    auto timedRequest = std::async(std::launch::async,
+        [&] { requestTimeoutConnection.ping(); });
+    require(throwsWithin(timedRequest, 1s),
+        "silent request did not honor the request deadline");
+    requestTimeoutPeer.get();
     return 0;
 }
+#include <chrono>

--- a/tests/integration/test_remote_connection.cpp
+++ b/tests/integration/test_remote_connection.cpp
@@ -1,0 +1,124 @@
+#include <amrexplorer/data/ViewData.hpp>
+#include <amrexplorer/remote/Connection.hpp>
+#include <amrexplorer/remote/Server.hpp>
+
+#include <cstdlib>
+#include <exception>
+#include <filesystem>
+#include <future>
+#include <iostream>
+#include <thread>
+#include <variant>
+
+namespace {
+
+void require(bool condition, const char* message)
+{
+    if (!condition) {
+        std::cerr << "FAILED: " << message << '\n';
+        std::exit(1);
+    }
+}
+
+class RunningServer {
+public:
+    explicit RunningServer(amrvis::remote::Server& server)
+        : m_server(server)
+        , m_thread([this] {
+            try {
+                m_server.run();
+            } catch (...) {
+                m_failure = std::current_exception();
+            }
+        })
+    {
+    }
+
+    ~RunningServer()
+    {
+        m_server.requestStop();
+        m_thread.join();
+        if (m_failure) {
+            std::terminate();
+        }
+    }
+
+    RunningServer(const RunningServer&) = delete;
+    RunningServer& operator=(const RunningServer&) = delete;
+
+private:
+    amrvis::remote::Server& m_server;
+    std::thread m_thread;
+    std::exception_ptr m_failure;
+};
+
+amrvis::SliceRequest sliceRequest(
+    const amrvis::remote::OpenedDataset& opened, int width, int height)
+{
+    amrvis::SliceRequest request;
+    request.dataset = opened.id;
+    request.field = amrvis::FieldId{0};
+    request.normalDirection = 1;
+    request.visibleRegion = opened.catalog.physicalDomain;
+    request.physicalPosition = 0.5
+        * (request.visibleRegion.lower[1] + request.visibleRegion.upper[1]);
+    request.maximumLevel = opened.catalog.finestLevel;
+    request.outputSize = {width, height};
+    return request;
+}
+
+} // namespace
+
+int main(int argc, char* argv[])
+{
+    using namespace amrvis;
+    using namespace amrvis::remote;
+
+    if (argc != 2) {
+        std::cerr << "usage: test_remote_connection MATERIALIZED_PLOTFILE\n";
+        return 2;
+    }
+
+    ServerOptions options;
+    options.workerCount = 3;
+    Server server(options);
+    RunningServer running(server);
+
+    Connection connection("127.0.0.1", server.port());
+    require(connection.connected()
+            && connection.serverInfo().workerCount == options.workerCount,
+        "connection did not complete the protocol handshake");
+    connection.ping();
+
+    const auto opened = connection.openDataset(
+        std::filesystem::path(argv[1]).string(),
+        16ULL * 1024ULL * 1024ULL);
+    require(opened.catalog.dimension == 2,
+        "connection did not decode the dataset catalog");
+
+    const auto request = sliceRequest(opened, 7, 5);
+    auto first = std::async(std::launch::async,
+        [&] { return connection.requestView(request); });
+    auto second = std::async(std::launch::async,
+        [&] { return connection.requestView(request); });
+    require(std::get<SliceQueryResult>(first.get()).plane.values.size() == 35
+            && std::get<SliceQueryResult>(second.get())
+                    .plane.values.size()
+                == 35,
+        "connection did not match concurrent responses to their requests");
+
+    StopSource cancelled;
+    cancelled.request_stop();
+    try {
+        static_cast<void>(connection.requestView(
+            request, cancelled.get_token()));
+        require(false, "connection sent a pre-cancelled request");
+    } catch (const ReadCancelled&) {
+    }
+
+    connection.closeDataset(opened.id);
+    connection.close();
+    require(!connection.connected(),
+        "connection remained live after close");
+    return 0;
+}

--- a/tests/integration/test_remote_connection.cpp
+++ b/tests/integration/test_remote_connection.cpp
@@ -311,6 +311,92 @@ int main(int argc, char* argv[])
         "wrong response payload did not fail the connection");
     wrongPayloadPeer.get();
 
+    auto delayedRangeListener = listenOnLoopback(0);
+    auto delayedRangePeer = std::async(std::launch::async, [&] {
+        auto peer = acceptConnection(delayedRangeListener.socket);
+        static_cast<void>(acceptHello(peer));
+        const auto frame = readFrame(peer, defaultMaximumFrameBytes);
+        require(frame.has_value(), "client omitted delayed range request");
+        const auto requestEnvelope = codec::decode(*frame);
+        const auto requestInfo = codec::inspect(*requestEnvelope);
+        require(requestInfo.payload == PayloadKind::RangeRequest,
+            "client sent the wrong delayed plotfile request");
+        std::this_thread::sleep_for(250ms);
+        writeFrame(peer,
+            codec::encode(requestInfo.requestId,
+                codec::toWire(std::optional<ValueRange>{{1.0, 2.0}},
+                    CacheMetrics{})),
+            defaultMaximumFrameBytes);
+    });
+    ConnectionOptions shortPayloadWait;
+    shortPayloadWait.requestTimeout = 100ms;
+    Connection delayedRangeConnection(
+        "127.0.0.1", delayedRangeListener.port, shortPayloadWait);
+    const auto delayedRange = delayedRangeConnection.requestRange(
+        DatasetId{1}, RangeRequest{.field = FieldId{0}});
+    require(delayedRange && delayedRange->minimum == 1.0
+            && delayedRange->maximum == 2.0,
+        "plotfile response inherited the control-request deadline");
+    delayedRangePeer.get();
+
+    auto cancellableRangeListener = listenOnLoopback(0);
+    std::promise<void> rangeAcceptedPromise;
+    auto rangeAccepted = rangeAcceptedPromise.get_future();
+    auto cancellableRangePeer = std::async(std::launch::async, [&] {
+        auto peer = acceptConnection(cancellableRangeListener.socket);
+        static_cast<void>(acceptHello(peer));
+        const auto rangeFrame = readFrame(peer, defaultMaximumFrameBytes);
+        require(rangeFrame.has_value(),
+            "client omitted cancellable range request");
+        const auto rangeEnvelope = codec::decode(*rangeFrame);
+        const auto rangeInfo = codec::inspect(*rangeEnvelope);
+        require(rangeInfo.payload == PayloadKind::RangeRequest,
+            "client sent the wrong cancellable plotfile request");
+        rangeAcceptedPromise.set_value();
+
+        const auto cancelFrame = readFrame(peer, defaultMaximumFrameBytes);
+        require(cancelFrame.has_value(),
+            "client omitted cancellation for indefinite plotfile wait");
+        const auto cancelEnvelope = codec::decode(*cancelFrame);
+        const auto cancelInfo = codec::inspect(*cancelEnvelope);
+        const auto* cancel = cancelEnvelope->payload.AsCancelRequest();
+        require(cancelInfo.payload == PayloadKind::CancelRequest
+                && cancel != nullptr
+                && cancel->target_request_id == rangeInfo.requestId,
+            "client cancelled the wrong indefinite plotfile request");
+        codec::fb::CancelAcknowledgedT acknowledged;
+        acknowledged.target_request_id = rangeInfo.requestId;
+        writeFrame(peer,
+            codec::encode(cancelInfo.requestId, std::move(acknowledged)),
+            defaultMaximumFrameBytes);
+        writeFrame(peer,
+            codec::encode(rangeInfo.requestId,
+                codec::toWire(
+                    ErrorData{ErrorCode::Cancelled, "request cancelled"})),
+            defaultMaximumFrameBytes);
+    });
+    Connection cancellableRangeConnection(
+        "127.0.0.1", cancellableRangeListener.port, shortPayloadWait);
+    StopSource rangeCancellation;
+    auto cancelledRange = std::async(std::launch::async, [&] {
+        try {
+            static_cast<void>(cancellableRangeConnection.requestRange(
+                DatasetId{1}, RangeRequest{.field = FieldId{0}},
+                rangeCancellation.get_token()));
+        } catch (const ReadCancelled&) {
+            return true;
+        }
+        return false;
+    });
+    require(rangeAccepted.wait_for(1s) == std::future_status::ready,
+        "cancellable range request was not sent");
+    std::this_thread::sleep_for(250ms);
+    rangeCancellation.request_stop();
+    require(cancelledRange.wait_for(1s) == std::future_status::ready
+            && cancelledRange.get(),
+        "indefinite plotfile wait ignored explicit cancellation");
+    cancellableRangePeer.get();
+
     auto fanoutListener = listenOnLoopback(0);
     auto fanoutPeer = std::async(std::launch::async, [&] {
         auto peer = acceptConnection(fanoutListener.socket);

--- a/tests/integration/test_remote_connection.cpp
+++ b/tests/integration/test_remote_connection.cpp
@@ -173,13 +173,13 @@ int main(int argc, char* argv[])
         const auto frame = readFrame(peer, defaultMaximumFrameBytes);
         require(frame.has_value(),
             "client omitted negotiated minor version ping request");
-        const auto request = codec::decode(*frame);
-        const auto info = codec::inspect(*request);
+        const auto requestEnvelope = codec::decode(*frame);
+        const auto info = codec::inspect(*requestEnvelope);
         require(info.payload == PayloadKind::PingRequest
                 && info.protocolMinorVersion == selectedMinorVersion,
             "client did not use the negotiated protocol minor version");
         codec::fb::PongResponseT pong;
-        pong.nonce = request->payload.AsPingRequest()->nonce;
+        pong.nonce = requestEnvelope->payload.AsPingRequest()->nonce;
         writeFrame(peer,
             codec::encode(
                 info.requestId, std::move(pong), selectedMinorVersion),
@@ -198,10 +198,10 @@ int main(int argc, char* argv[])
         const auto frame = readFrame(peer, defaultMaximumFrameBytes);
         require(frame.has_value(),
             "client omitted wrong-minor-version test request");
-        const auto request = codec::decode(*frame);
-        const auto info = codec::inspect(*request);
+        const auto requestEnvelope = codec::decode(*frame);
+        const auto info = codec::inspect(*requestEnvelope);
         codec::fb::PongResponseT pong;
-        pong.nonce = request->payload.AsPingRequest()->nonce;
+        pong.nonce = requestEnvelope->payload.AsPingRequest()->nonce;
         writeFrame(peer,
             codec::encode(info.requestId, std::move(pong),
                 static_cast<std::uint16_t>(protocolMinorVersion + 1)),

--- a/tests/unit/test_remote_frame.cpp
+++ b/tests/unit/test_remote_frame.cpp
@@ -112,6 +112,15 @@ int main()
 {
     using namespace amrvis::remote;
 
+    const auto numericOnlyListener = listenOnLoopback(0);
+    requireRejected(
+        [&] {
+            static_cast<void>(connectTo("localhost",
+                numericOnlyListener.port,
+                std::chrono::steady_clock::now() + std::chrono::seconds(1)));
+        },
+        "hostname resolution remained in the deadline-bounded connect path");
+
     const auto listener = listenOnLoopback(0);
     std::exception_ptr serverFailure;
     std::thread server([&] {


### PR DESCRIPTION
Part 8 of 13 in the remote client/server stack.

## Purpose

Add the concurrent client connection with exactly one socket reader.

## Scope

- Negotiates protocol limits and correlates responses by request ID.
- Supports multiple outstanding requests without concurrent socket reads.
- Handles pre-cancellation, remote errors, disconnect fan-out, and orderly close.

## Review focus

Review request-map synchronization, cancellation races, reader shutdown, and promise completion on disconnect.

## Validation

- `remote_connection`
- Concurrent matching and pre-cancel regressions
