### PR TITLE
[client-server] adapt remote datasets to DatasetSession

### DIFF
--- a/include/amrexplorer/data/SessionValidation.hpp
+++ b/include/amrexplorer/data/SessionValidation.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <amrexplorer/data/DatasetPage.hpp>
+#include <amrexplorer/data/DatasetSession.hpp>
+
+#include <string>
+
+namespace amrvis {
+
+void validateSessionViewRequest(const DatasetMetadata& metadata,
+    DatasetId dataset, const ViewDataRequest& request);
+void validateSessionDatasetPageRequest(const DatasetMetadata& metadata,
+    DatasetId dataset, const DatasetPageRequest& request);
+void validateSessionRangeRequest(
+    const DatasetMetadata& metadata, const RangeRequest& request);
+void validateSessionParticleRequest(const DatasetMetadata& metadata,
+    const std::vector<ParticleSpeciesMetadata>& species,
+    const std::string& name, double fraction);
+
+} // namespace amrvis

--- a/include/amrexplorer/remote/Connection.hpp
+++ b/include/amrexplorer/remote/Connection.hpp
@@ -26,7 +26,7 @@ struct ConnectionOptions {
     std::chrono::milliseconds requestTimeout{30000};
 };
 
-class Connection {
+class Connection : public std::enable_shared_from_this<Connection> {
 public:
     Connection(std::string host, std::uint16_t port,
         ConnectionOptions options = {}, StopToken cancellation = {});
@@ -42,6 +42,7 @@ public:
     [[nodiscard]] OpenedDataset openDataset(const std::string& path,
         std::uint64_t cacheBudgetBytes, StopToken cancellation = {});
     void closeDataset(DatasetId dataset, StopToken cancellation = {});
+    void closeDatasetBestEffort(DatasetId dataset) noexcept;
     [[nodiscard]] ViewDataResult requestView(
         const ViewDataRequest& request, StopToken cancellation = {});
     [[nodiscard]] DatasetPage requestDatasetPage(

--- a/include/amrexplorer/remote/RemoteDatasetSession.hpp
+++ b/include/amrexplorer/remote/RemoteDatasetSession.hpp
@@ -1,0 +1,66 @@
+#pragma once
+
+#include <amrexplorer/data/DatasetSession.hpp>
+#include <amrexplorer/remote/Connection.hpp>
+
+#include <memory>
+#include <mutex>
+#include <string>
+
+namespace amrvis::remote {
+
+class RemoteDatasetSession final : public DatasetSession {
+public:
+    [[nodiscard]] static std::shared_ptr<RemoteDatasetSession> open(
+        std::shared_ptr<Connection> connection, const std::string& path,
+        std::uint64_t cacheBudgetBytes, StopToken cancellation = {});
+
+    ~RemoteDatasetSession() override;
+
+    [[nodiscard]] DatasetId id() const noexcept override;
+    [[nodiscard]] const DatasetMetadata& metadata() const noexcept override;
+    [[nodiscard]] const MetadataReadMetrics& metadataReadMetrics()
+        const noexcept override;
+    [[nodiscard]] const std::string& fileVersion() const noexcept override;
+    [[nodiscard]] const std::vector<ParticleSpeciesMetadata>& particleSpecies()
+        const noexcept override;
+
+    [[nodiscard]] ViewDataResult requestView(
+        const ViewDataRequest& request, StopToken cancellation = {}) override;
+    [[nodiscard]] DatasetPage requestDatasetPage(
+        const DatasetPageRequest& request, StopToken cancellation = {}) override;
+    [[nodiscard]] std::optional<ValueRange> requestRange(
+        const RangeRequest& request, StopToken cancellation = {}) override;
+    [[nodiscard]] bool rangeAvailable(
+        const RangeRequest& request) const noexcept override;
+    [[nodiscard]] ParticleSample requestParticleSample(
+        const std::string& species, double fraction, std::uint64_t seed,
+        StopToken cancellation = {}) override;
+
+    [[nodiscard]] CacheMetrics cacheMetrics() const override;
+    [[nodiscard]] bool setCacheBudget(std::uint64_t bytes) override;
+    void clearUnpinnedCache() override;
+    void close() noexcept override;
+
+    [[nodiscard]] std::shared_ptr<Connection> connection() const noexcept;
+    [[nodiscard]] const std::string& remotePath() const noexcept;
+
+private:
+    RemoteDatasetSession(std::shared_ptr<Connection> connection,
+        std::string path, OpenedDataset opened);
+    void requireOpen() const;
+
+    std::shared_ptr<Connection> m_connection;
+    std::string m_path;
+    DatasetId m_id;
+    DatasetMetadata m_metadata;
+    MetadataReadMetrics m_metadataMetrics;
+    std::string m_fileVersion;
+    std::vector<ParticleSpeciesMetadata> m_particleSpecies;
+    std::vector<std::uint8_t> m_fileRangeAvailable;
+    std::vector<std::uint8_t> m_levelRangeAvailable;
+    mutable std::mutex m_mutex;
+    bool m_open = true;
+};
+
+} // namespace amrvis::remote

--- a/include/amrexplorer/remote/RemoteDatasetSession.hpp
+++ b/include/amrexplorer/remote/RemoteDatasetSession.hpp
@@ -24,6 +24,8 @@ public:
     [[nodiscard]] const std::string& fileVersion() const noexcept override;
     [[nodiscard]] const std::vector<ParticleSpeciesMetadata>& particleSpecies()
         const noexcept override;
+    [[nodiscard]] std::optional<std::uint32_t> maximumResponseBytes()
+        const noexcept override;
 
     [[nodiscard]] ViewDataResult requestView(
         const ViewDataRequest& request, StopToken cancellation = {}) override;

--- a/src/data/CMakeLists.txt
+++ b/src/data/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(amrexplorer_data
     DatasetPage.cpp
     LocalDatasetSession.cpp
+    SessionValidation.cpp
     ViewData.cpp
 )
 add_library(amrexplorer::data ALIAS amrexplorer_data)

--- a/src/data/LocalDatasetSession.cpp
+++ b/src/data/LocalDatasetSession.cpp
@@ -1,6 +1,7 @@
 #include <amrexplorer/data/LocalDatasetSession.hpp>
 
 #include <amrexplorer/core/Statistics.hpp>
+#include <amrexplorer/data/SessionValidation.hpp>
 #include <amrexplorer/io/PlotfileDataset.hpp>
 #include <amrexplorer/query/LineQuery.hpp>
 #include <amrexplorer/query/SliceQuery.hpp>
@@ -125,6 +126,7 @@ ViewDataResult LocalDatasetSession::requestView(
     const ViewDataRequest& request, StopToken cancellation)
 {
     const auto dataset = requireDataset();
+    validateSessionViewRequest(m_metadata, m_id, request);
     return std::visit(
         [&](const auto& typedRequest) -> ViewDataResult {
             using Request = std::decay_t<decltype(typedRequest)>;
@@ -145,6 +147,7 @@ DatasetPage LocalDatasetSession::requestDatasetPage(
     const DatasetPageRequest& request, StopToken cancellation)
 {
     const auto dataset = requireDataset();
+    validateSessionDatasetPageRequest(m_metadata, m_id, request);
     return extractDatasetPage(*dataset, request, cancellation);
 }
 
@@ -152,13 +155,7 @@ std::optional<ValueRange> LocalDatasetSession::requestRange(
     const RangeRequest& request, StopToken cancellation)
 {
     const auto dataset = requireDataset();
-    if (request.field.value >= m_metadata.fields.size()) {
-        throw std::invalid_argument("range field is unavailable");
-    }
-    if (request.maximumLevel < 0
-        || request.maximumLevel > m_metadata.finestLevel) {
-        throw std::invalid_argument("range level is unavailable");
-    }
+    validateSessionRangeRequest(m_metadata, request);
     if (m_metadata.isFab && request.scope == RangeScope::File) {
         BlockRequest block;
         block.dataset = m_id;
@@ -198,6 +195,8 @@ ParticleSample LocalDatasetSession::requestParticleSample(
     const std::string& species, double fraction, std::uint64_t seed,
     StopToken cancellation)
 {
+    validateSessionParticleRequest(
+        m_metadata, m_particleSpecies, species, fraction);
     return requireDataset()->requestParticleSample(
         species, fraction, seed, cancellation);
 }

--- a/src/data/SessionValidation.cpp
+++ b/src/data/SessionValidation.cpp
@@ -1,0 +1,149 @@
+#include <amrexplorer/data/SessionValidation.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <stdexcept>
+#include <type_traits>
+#include <variant>
+
+namespace amrvis {
+namespace {
+
+void requireFieldAndLevel(const DatasetMetadata& metadata, FieldId field,
+    int maximumLevel, const char* operation)
+{
+    if (field.value >= metadata.fields.size()) {
+        throw std::invalid_argument(
+            std::string(operation) + " field is unavailable");
+    }
+    if (maximumLevel < 0 || maximumLevel > metadata.finestLevel) {
+        throw std::invalid_argument(
+            std::string(operation) + " level is unavailable");
+    }
+}
+
+void requireComponent(const DatasetMetadata& metadata, FieldId field,
+    int component, const char* operation)
+{
+    if (component < 0) {
+        throw std::invalid_argument(
+            std::string(operation) + " component is unavailable");
+    }
+    const auto& components
+        = metadata.fields[static_cast<std::size_t>(field.value)]
+              .componentNames;
+    const auto count = std::max<std::size_t>(1, components.size());
+    if (static_cast<std::size_t>(component) >= count) {
+        throw std::invalid_argument(
+            std::string(operation) + " component is unavailable");
+    }
+}
+
+} // namespace
+
+void validateSessionViewRequest(const DatasetMetadata& metadata,
+    DatasetId dataset, const ViewDataRequest& request)
+{
+    std::visit(
+        [&](const auto& typed) {
+            using Request = std::decay_t<decltype(typed)>;
+            const auto& query = [&]() -> const auto& {
+                if constexpr (std::is_same_v<Request, SliceRequest>) {
+                    return typed;
+                } else {
+                    return typed.query;
+                }
+            }();
+            if (query.dataset != dataset) {
+                throw std::invalid_argument(
+                    "view request uses the wrong dataset");
+            }
+            requireFieldAndLevel(
+                metadata, query.field, query.maximumLevel, "view");
+            requireComponent(
+                metadata, query.field, query.component, "view");
+            if constexpr (std::is_same_v<Request, SliceRequest>) {
+                const auto errors
+                    = validateSliceRequest(typed, metadata.dimension);
+                if (!errors.empty()) {
+                    throw std::invalid_argument(errors.front());
+                }
+            } else {
+                const auto errors
+                    = validateLineRequest(typed.query, metadata.dimension);
+                if (!errors.empty()) {
+                    throw std::invalid_argument(errors.front());
+                }
+                if (typed.outputWidth < 1) {
+                    throw std::invalid_argument(
+                        "line output width must be positive");
+                }
+            }
+        },
+        request);
+}
+
+void validateSessionDatasetPageRequest(const DatasetMetadata& metadata,
+    DatasetId dataset, const DatasetPageRequest& request)
+{
+    if (request.dataset != dataset) {
+        throw std::invalid_argument("dataset page uses the wrong dataset");
+    }
+    if (metadata.dimension < 2 || metadata.dimension > 3) {
+        throw std::invalid_argument(
+            "dataset page requires a 2-D or 3-D dataset");
+    }
+    if (request.level < 0
+        || request.level >= static_cast<int>(metadata.levels.size())) {
+        throw std::invalid_argument("dataset page level is unavailable");
+    }
+    if (request.field.value >= metadata.fields.size()) {
+        throw std::invalid_argument("dataset page field is unavailable");
+    }
+    if (metadata.dimension == 3
+        && (request.normalAxis < 0 || request.normalAxis > 2)) {
+        throw std::invalid_argument("dataset page normal axis is invalid");
+    }
+    if (request.maximumExtent < 1
+        || request.maximumExtent > datasetPageMaxExtent) {
+        throw std::invalid_argument(
+            "dataset page extent is outside its limit");
+    }
+    if (!std::isfinite(request.slicePosition)) {
+        throw std::invalid_argument(
+            "dataset page slice position must be finite");
+    }
+}
+
+void validateSessionRangeRequest(
+    const DatasetMetadata& metadata, const RangeRequest& request)
+{
+    requireFieldAndLevel(
+        metadata, request.field, request.maximumLevel, "range");
+    if (request.composition != CompositionPolicy::FinestAvailable
+        && request.composition != CompositionPolicy::ExactLevel) {
+        throw std::invalid_argument("range composition policy is invalid");
+    }
+    if (request.scope != RangeScope::File
+        && request.scope != RangeScope::Level) {
+        throw std::invalid_argument("range scope is invalid");
+    }
+}
+
+void validateSessionParticleRequest(const DatasetMetadata& metadata,
+    const std::vector<ParticleSpeciesMetadata>& species,
+    const std::string& name, double fraction)
+{
+    static_cast<void>(metadata);
+    if (name.empty()
+        || std::none_of(species.begin(), species.end(),
+            [&](const auto& entry) { return entry.name == name; })) {
+        throw std::invalid_argument("particle species is unavailable");
+    }
+    if (!std::isfinite(fraction) || !(fraction > 0.0) || fraction > 1.0) {
+        throw std::invalid_argument(
+            "particle sample fraction must be in (0, 1]");
+    }
+}
+
+} // namespace amrvis

--- a/src/remote/CMakeLists.txt
+++ b/src/remote/CMakeLists.txt
@@ -26,6 +26,7 @@ add_library(amrexplorer_remote
     Codec.hpp
     Connection.cpp
     Frame.cpp
+    RemoteDatasetSession.cpp
     Server.cpp
     "${amrexplorer_wire_generated}"
 )

--- a/src/remote/Connection.cpp
+++ b/src/remote/Connection.cpp
@@ -353,6 +353,7 @@ public:
 
     void close() noexcept
     {
+        std::scoped_lock closeLock(m_closeMutex);
         {
             std::scoped_lock lock(m_stateMutex);
             if (!m_connected && !m_socket.valid()) {
@@ -574,6 +575,7 @@ private:
     StopSource m_lifecycleStop;
     std::atomic<std::uint64_t> m_nextRequestId{1};
     std::atomic<std::uint64_t> m_nextPingNonce{1};
+    std::mutex m_closeMutex;
     mutable std::mutex m_stateMutex;
     bool m_connected = true;
     std::string m_disconnectReason;
@@ -619,6 +621,25 @@ OpenedDataset Connection::openDataset(const std::string& path,
 void Connection::closeDataset(DatasetId dataset, StopToken cancellation)
 {
     m_impl->closeDataset(dataset, cancellation);
+}
+
+void Connection::closeDatasetBestEffort(DatasetId dataset) noexcept
+{
+    try {
+        auto self = shared_from_this();
+        std::thread([self = std::move(self), dataset] {
+            try {
+                self->closeDataset(dataset);
+            } catch (...) {
+                // A failed close acknowledgement leaves the server handle's
+                // ownership uncertain. Closing the connection makes server
+                // session teardown the final cleanup authority.
+                self->close();
+            }
+        }).detach();
+    } catch (...) {
+        close();
+    }
 }
 
 ViewDataResult Connection::requestView(

--- a/src/remote/RemoteDatasetSession.cpp
+++ b/src/remote/RemoteDatasetSession.cpp
@@ -1,5 +1,7 @@
 #include <amrexplorer/remote/RemoteDatasetSession.hpp>
 
+#include <amrexplorer/data/SessionValidation.hpp>
+
 #include <stdexcept>
 #include <utility>
 #include <variant>
@@ -72,18 +74,7 @@ ViewDataResult RemoteDatasetSession::requestView(
     const ViewDataRequest& request, StopToken cancellation)
 {
     requireOpen();
-    const auto requestDataset = std::visit([](const auto& typed) {
-        using Request = std::decay_t<decltype(typed)>;
-        if constexpr (std::is_same_v<Request, SliceRequest>) {
-            return typed.dataset;
-        } else {
-            return typed.query.dataset;
-        }
-    }, request);
-    if (requestDataset != m_id) {
-        throw std::invalid_argument(
-            "view request uses the wrong remote dataset");
-    }
+    validateSessionViewRequest(m_metadata, m_id, request);
     return m_connection->requestView(request, cancellation);
 }
 
@@ -91,10 +82,7 @@ DatasetPage RemoteDatasetSession::requestDatasetPage(
     const DatasetPageRequest& request, StopToken cancellation)
 {
     requireOpen();
-    if (request.dataset != m_id) {
-        throw std::invalid_argument(
-            "page request uses the wrong remote dataset");
-    }
+    validateSessionDatasetPageRequest(m_metadata, m_id, request);
     return m_connection->requestDatasetPage(request, cancellation);
 }
 
@@ -102,6 +90,7 @@ std::optional<ValueRange> RemoteDatasetSession::requestRange(
     const RangeRequest& request, StopToken cancellation)
 {
     requireOpen();
+    validateSessionRangeRequest(m_metadata, request);
     return m_connection->requestRange(m_id, request, cancellation);
 }
 
@@ -141,6 +130,8 @@ ParticleSample RemoteDatasetSession::requestParticleSample(
     StopToken cancellation)
 {
     requireOpen();
+    validateSessionParticleRequest(
+        m_metadata, m_particleSpecies, species, fraction);
     return m_connection->requestParticleSample(
         m_id, species, fraction, seed, cancellation);
 }
@@ -154,7 +145,7 @@ CacheMetrics RemoteDatasetSession::cacheMetrics() const
 bool RemoteDatasetSession::setCacheBudget(std::uint64_t bytes)
 {
     requireOpen();
-    return m_connection->setCacheBudget(m_id, bytes).budgetBytes == bytes;
+    return m_connection->setCacheBudget(m_id, bytes).withinBudget();
 }
 
 void RemoteDatasetSession::clearUnpinnedCache()
@@ -172,11 +163,8 @@ void RemoteDatasetSession::close() noexcept
         }
         m_open = false;
     }
-    try {
-        if (m_connection->connected()) {
-            m_connection->closeDataset(m_id);
-        }
-    } catch (...) {
+    if (m_connection->connected()) {
+        m_connection->closeDatasetBestEffort(m_id);
     }
 }
 

--- a/src/remote/RemoteDatasetSession.cpp
+++ b/src/remote/RemoteDatasetSession.cpp
@@ -70,6 +70,12 @@ RemoteDatasetSession::particleSpecies() const noexcept
     return m_particleSpecies;
 }
 
+std::optional<std::uint32_t>
+RemoteDatasetSession::maximumResponseBytes() const noexcept
+{
+    return m_connection->serverInfo().maximumFrameBytes;
+}
+
 ViewDataResult RemoteDatasetSession::requestView(
     const ViewDataRequest& request, StopToken cancellation)
 {

--- a/src/remote/RemoteDatasetSession.cpp
+++ b/src/remote/RemoteDatasetSession.cpp
@@ -1,0 +1,201 @@
+#include <amrexplorer/remote/RemoteDatasetSession.hpp>
+
+#include <stdexcept>
+#include <utility>
+#include <variant>
+
+namespace amrvis::remote {
+
+std::shared_ptr<RemoteDatasetSession> RemoteDatasetSession::open(
+    std::shared_ptr<Connection> connection, const std::string& path,
+    std::uint64_t cacheBudgetBytes, StopToken cancellation)
+{
+    if (!connection) {
+        throw std::invalid_argument(
+            "remote dataset requires a connection");
+    }
+    auto opened
+        = connection->openDataset(path, cacheBudgetBytes, cancellation);
+    return std::shared_ptr<RemoteDatasetSession>(
+        new RemoteDatasetSession(
+            std::move(connection), path, std::move(opened)));
+}
+
+RemoteDatasetSession::RemoteDatasetSession(
+    std::shared_ptr<Connection> connection, std::string path,
+    OpenedDataset opened)
+    : m_connection(std::move(connection))
+    , m_path(std::move(path))
+    , m_id(opened.id)
+    , m_metadata(std::move(opened.catalog))
+    , m_metadataMetrics(opened.metadataMetrics)
+    , m_fileVersion(std::move(opened.fileVersion))
+    , m_particleSpecies(std::move(opened.particleSpecies))
+    , m_fileRangeAvailable(std::move(opened.fileRangeAvailable))
+    , m_levelRangeAvailable(std::move(opened.levelRangeAvailable))
+{
+}
+
+RemoteDatasetSession::~RemoteDatasetSession()
+{
+    close();
+}
+
+DatasetId RemoteDatasetSession::id() const noexcept
+{
+    return m_id;
+}
+
+const DatasetMetadata& RemoteDatasetSession::metadata() const noexcept
+{
+    return m_metadata;
+}
+
+const MetadataReadMetrics&
+RemoteDatasetSession::metadataReadMetrics() const noexcept
+{
+    return m_metadataMetrics;
+}
+
+const std::string& RemoteDatasetSession::fileVersion() const noexcept
+{
+    return m_fileVersion;
+}
+
+const std::vector<ParticleSpeciesMetadata>&
+RemoteDatasetSession::particleSpecies() const noexcept
+{
+    return m_particleSpecies;
+}
+
+ViewDataResult RemoteDatasetSession::requestView(
+    const ViewDataRequest& request, StopToken cancellation)
+{
+    requireOpen();
+    const auto requestDataset = std::visit([](const auto& typed) {
+        using Request = std::decay_t<decltype(typed)>;
+        if constexpr (std::is_same_v<Request, SliceRequest>) {
+            return typed.dataset;
+        } else {
+            return typed.query.dataset;
+        }
+    }, request);
+    if (requestDataset != m_id) {
+        throw std::invalid_argument(
+            "view request uses the wrong remote dataset");
+    }
+    return m_connection->requestView(request, cancellation);
+}
+
+DatasetPage RemoteDatasetSession::requestDatasetPage(
+    const DatasetPageRequest& request, StopToken cancellation)
+{
+    requireOpen();
+    if (request.dataset != m_id) {
+        throw std::invalid_argument(
+            "page request uses the wrong remote dataset");
+    }
+    return m_connection->requestDatasetPage(request, cancellation);
+}
+
+std::optional<ValueRange> RemoteDatasetSession::requestRange(
+    const RangeRequest& request, StopToken cancellation)
+{
+    requireOpen();
+    return m_connection->requestRange(m_id, request, cancellation);
+}
+
+bool RemoteDatasetSession::rangeAvailable(
+    const RangeRequest& request) const noexcept
+{
+    if (request.field.value >= m_metadata.fields.size()
+        || request.maximumLevel < 0
+        || request.maximumLevel > m_metadata.finestLevel) {
+        return false;
+    }
+    const auto field = static_cast<std::size_t>(request.field.value);
+    if (request.scope == RangeScope::File) {
+        return field < m_fileRangeAvailable.size()
+            && m_fileRangeAvailable[field] != 0;
+    }
+    const auto levelCount = m_metadata.levels.size();
+    const auto availableAt = [&](int level) {
+        const auto index = field * levelCount
+            + static_cast<std::size_t>(level);
+        return index < m_levelRangeAvailable.size()
+            && m_levelRangeAvailable[index] != 0;
+    };
+    if (request.composition == CompositionPolicy::ExactLevel) {
+        return availableAt(request.maximumLevel);
+    }
+    for (int level = 0; level <= request.maximumLevel; ++level) {
+        if (!availableAt(level)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+ParticleSample RemoteDatasetSession::requestParticleSample(
+    const std::string& species, double fraction, std::uint64_t seed,
+    StopToken cancellation)
+{
+    requireOpen();
+    return m_connection->requestParticleSample(
+        m_id, species, fraction, seed, cancellation);
+}
+
+CacheMetrics RemoteDatasetSession::cacheMetrics() const
+{
+    requireOpen();
+    return m_connection->latestCache(m_id);
+}
+
+bool RemoteDatasetSession::setCacheBudget(std::uint64_t bytes)
+{
+    requireOpen();
+    return m_connection->setCacheBudget(m_id, bytes).budgetBytes == bytes;
+}
+
+void RemoteDatasetSession::clearUnpinnedCache()
+{
+    requireOpen();
+    static_cast<void>(m_connection->clearCache(m_id));
+}
+
+void RemoteDatasetSession::close() noexcept
+{
+    {
+        std::scoped_lock lock(m_mutex);
+        if (!m_open) {
+            return;
+        }
+        m_open = false;
+    }
+    try {
+        if (m_connection->connected()) {
+            m_connection->closeDataset(m_id);
+        }
+    } catch (...) {
+    }
+}
+
+std::shared_ptr<Connection> RemoteDatasetSession::connection() const noexcept
+{
+    return m_connection;
+}
+
+const std::string& RemoteDatasetSession::remotePath() const noexcept
+{
+    return m_path;
+}
+
+void RemoteDatasetSession::requireOpen() const
+{
+    std::scoped_lock lock(m_mutex);
+    if (!m_open) {
+        throw std::runtime_error("remote dataset session is closed");
+    }
+}
+
+} // namespace amrvis::remote

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -161,6 +161,21 @@ if(TARGET amrexplorer_remote)
     set_tests_properties(remote_connection PROPERTIES
         FIXTURES_REQUIRED remote_server_materialized
         TIMEOUT 30)
+
+    add_executable(test_remote_session
+        integration/test_remote_session.cpp)
+    target_link_libraries(test_remote_session
+        PRIVATE
+            amrexplorer::pipeline
+            amrexplorer::remote
+            amrexplorer::warnings
+            Threads::Threads
+    )
+    add_test(NAME remote_session
+        COMMAND test_remote_session "${remote_server_fixture_dir}")
+    set_tests_properties(remote_session PROPERTIES
+        FIXTURES_REQUIRED remote_server_materialized
+        TIMEOUT 30)
 endif()
 
 add_executable(test_vismf_index unit/test_vismf_index.cpp)

--- a/tests/integration/test_remote_session.cpp
+++ b/tests/integration/test_remote_session.cpp
@@ -1,3 +1,4 @@
+#include <amrexplorer/data/LocalDatasetSession.hpp>
 #include <amrexplorer/pipeline/SlicePipeline.hpp>
 #include <amrexplorer/remote/Connection.hpp>
 #include <amrexplorer/remote/RemoteDatasetSession.hpp>
@@ -65,6 +66,17 @@ amrvis::SliceRequest sliceRequest(
     return request;
 }
 
+template <typename Function>
+std::string exceptionMessage(Function&& function)
+{
+    try {
+        function();
+    } catch (const std::exception& error) {
+        return error.what();
+    }
+    return {};
+}
+
 } // namespace
 
 int main(int argc, char* argv[])
@@ -88,8 +100,20 @@ int main(int argc, char* argv[])
         auto dataset = amrvis::remote::RemoteDatasetSession::open(
             connection, std::filesystem::path(argv[1]).string(),
             16ULL * 1024ULL * 1024ULL);
+        amrvis::LocalDatasetSession localDataset(
+            std::filesystem::path(argv[1]), amrvis::DatasetId{1001},
+            16ULL * 1024ULL * 1024ULL);
         require(dataset->metadata().dimension == 2,
             "remote catalog has the wrong dimension");
+        require(dataset->metadata().dimension
+                    == localDataset.metadata().dimension
+                && dataset->metadata().finestLevel
+                    == localDataset.metadata().finestLevel
+                && dataset->metadata().physicalDomain
+                    == localDataset.metadata().physicalDomain
+                && dataset->metadata().fields.size()
+                    == localDataset.metadata().fields.size(),
+            "local and remote metadata values differ");
         require(dataset->metadata().levels.size() == 2,
             "remote catalog has the wrong level count");
         for (const auto& level : dataset->metadata().levels) {
@@ -99,11 +123,21 @@ int main(int argc, char* argv[])
                 "remote catalog omitted AMR wireframe boxes");
         }
 
+        const auto remoteSliceRequest = sliceRequest(*dataset, 8, 6);
+        const auto localSliceRequest = sliceRequest(localDataset, 8, 6);
         const auto slice = std::get<amrvis::SliceQueryResult>(
-            dataset->requestView(sliceRequest(*dataset, 8, 6)));
+            dataset->requestView(remoteSliceRequest));
+        const auto localSlice = std::get<amrvis::SliceQueryResult>(
+            localDataset.requestView(localSliceRequest));
         require(slice.plane.width == 8 && slice.plane.height == 6
                 && slice.plane.values.size() == 48,
             "remote slice did not honor the viewport extent");
+        require(slice.plane.values == localSlice.plane.values
+                && slice.plane.valid == localSlice.plane.valid
+                && slice.plane.sourceLevel == localSlice.plane.sourceLevel
+                && slice.plane.physicalRegion
+                    == localSlice.plane.physicalRegion,
+            "local and remote slice values differ");
 
         amrvis::LineViewRequest line;
         line.query.dataset = dataset->id();
@@ -115,8 +149,18 @@ int main(int argc, char* argv[])
         line.outputWidth = 2;
         const auto lineResult = std::get<amrvis::LineQueryResult>(
             dataset->requestView(line));
+        auto localLine = line;
+        localLine.query.dataset = localDataset.id();
+        const auto localLineResult = std::get<amrvis::LineQueryResult>(
+            localDataset.requestView(localLine));
         require(lineResult.line.values.size() <= 4,
             "remote line exceeded its two-samples-per-pixel bound");
+        require(lineResult.line.positions == localLineResult.line.positions
+                && lineResult.line.values == localLineResult.line.values
+                && lineResult.line.valid == localLineResult.line.valid
+                && lineResult.line.sourceLevel
+                    == localLineResult.line.sourceLevel,
+            "local and remote line values differ");
         line.outputWidth = 20000;
         try {
             static_cast<void>(dataset->requestView(line));
@@ -135,9 +179,17 @@ int main(int argc, char* argv[])
         pageRequest.normalAxis = 1;
         pageRequest.maximumExtent = 2;
         const auto page = dataset->requestDatasetPage(pageRequest);
+        auto localPageRequest = pageRequest;
+        localPageRequest.dataset = localDataset.id();
+        const auto localPage
+            = localDataset.requestDatasetPage(localPageRequest);
         require(page.nx <= 2 && page.ny <= 2
                 && page.values.size() <= 4,
             "remote dataset page exceeded its requested extent");
+        require(page.lower == localPage.lower && page.upper == localPage.upper
+                && page.values == localPage.values
+                && page.covered == localPage.covered,
+            "local and remote dataset-page values differ");
 
         const auto range = dataset->requestRange(amrvis::RangeRequest{
             .field = amrvis::FieldId{0},
@@ -145,6 +197,32 @@ int main(int argc, char* argv[])
             .composition = amrvis::CompositionPolicy::FinestAvailable,
             .scope = amrvis::RangeScope::File});
         require(range.has_value(), "remote file range is missing");
+        const auto localRange
+            = localDataset.requestRange(amrvis::RangeRequest{
+                .field = amrvis::FieldId{0},
+                .maximumLevel = localDataset.metadata().finestLevel,
+                .composition = amrvis::CompositionPolicy::FinestAvailable,
+                .scope = amrvis::RangeScope::File});
+        require(range.has_value() == localRange.has_value()
+                && (!range
+                    || (range->minimum == localRange->minimum
+                        && range->maximum == localRange->maximum)),
+            "local and remote range values differ");
+
+        const amrvis::RangeRequest invalidRange{
+            .field = amrvis::FieldId{999},
+            .maximumLevel = 0,
+            .composition = amrvis::CompositionPolicy::FinestAvailable,
+            .scope = amrvis::RangeScope::File};
+        const auto remoteRangeError = exceptionMessage([&] {
+            static_cast<void>(dataset->requestRange(invalidRange));
+        });
+        const auto localRangeError = exceptionMessage([&] {
+            static_cast<void>(localDataset.requestRange(invalidRange));
+        });
+        require(!remoteRangeError.empty()
+                && remoteRangeError == localRangeError,
+            "local and remote range validation differs");
         require(!dataset->particleSpecies().empty(),
             "remote particle catalog is missing");
         const auto particles = dataset->requestParticleSample(

--- a/tests/integration/test_remote_session.cpp
+++ b/tests/integration/test_remote_session.cpp
@@ -1,0 +1,229 @@
+#include <amrexplorer/pipeline/SlicePipeline.hpp>
+#include <amrexplorer/remote/Connection.hpp>
+#include <amrexplorer/remote/RemoteDatasetSession.hpp>
+#include <amrexplorer/remote/Server.hpp>
+
+#include <cstdlib>
+#include <filesystem>
+#include <future>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <thread>
+#include <variant>
+
+namespace {
+
+class ServerThread {
+public:
+    explicit ServerThread(amrvis::remote::Server& server)
+        : m_server(server)
+        , m_thread([&server] { server.run(); })
+    {
+    }
+
+    ~ServerThread()
+    {
+        m_server.requestStop();
+        if (m_thread.joinable()) {
+            m_thread.join();
+        }
+    }
+
+    ServerThread(const ServerThread&) = delete;
+    ServerThread& operator=(const ServerThread&) = delete;
+
+private:
+    amrvis::remote::Server& m_server;
+    std::thread m_thread;
+};
+
+void require(bool condition, const char* message)
+{
+    if (!condition) {
+        std::cerr << "FAILED: " << message << '\n';
+        std::exit(1);
+    }
+}
+
+amrvis::SliceRequest sliceRequest(
+    const amrvis::DatasetSession& dataset, int width, int height)
+{
+    amrvis::SliceRequest request;
+    request.dataset = dataset.id();
+    request.field = amrvis::FieldId{0};
+    request.normalDirection
+        = std::max(0, dataset.metadata().dimension - 1);
+    request.visibleRegion
+        = amrvis::datasetSampleBounds(dataset.metadata());
+    const auto normal = static_cast<std::size_t>(request.normalDirection);
+    request.physicalPosition
+        = 0.5 * (request.visibleRegion.lower[normal]
+            + request.visibleRegion.upper[normal]);
+    request.maximumLevel = dataset.metadata().finestLevel;
+    request.outputSize = {width, height};
+    return request;
+}
+
+} // namespace
+
+int main(int argc, char* argv[])
+{
+    if (argc != 2) {
+        std::cerr << "usage: test_remote_session MATERIALIZED_PLOTFILE\n";
+        return 2;
+    }
+    try {
+        amrvis::remote::ServerOptions options;
+        options.workerCount = 3;
+        options.maximumDatasets = 4;
+        options.maximumOutstandingRequests = 16;
+        amrvis::remote::Server server(options);
+        ServerThread serverThread(server);
+
+        auto connection = std::make_shared<amrvis::remote::Connection>(
+            "127.0.0.1", server.port());
+        require(connection->serverInfo().workerCount == 3,
+            "handshake did not report worker count");
+        auto dataset = amrvis::remote::RemoteDatasetSession::open(
+            connection, std::filesystem::path(argv[1]).string(),
+            16ULL * 1024ULL * 1024ULL);
+        require(dataset->metadata().dimension == 2,
+            "remote catalog has the wrong dimension");
+        require(dataset->metadata().levels.size() == 2,
+            "remote catalog has the wrong level count");
+        for (const auto& level : dataset->metadata().levels) {
+            require(level.blocks.empty(),
+                "remote catalog exposed storage block metadata");
+            require(!level.boxes.empty(),
+                "remote catalog omitted AMR wireframe boxes");
+        }
+
+        const auto slice = std::get<amrvis::SliceQueryResult>(
+            dataset->requestView(sliceRequest(*dataset, 8, 6)));
+        require(slice.plane.width == 8 && slice.plane.height == 6
+                && slice.plane.values.size() == 48,
+            "remote slice did not honor the viewport extent");
+
+        amrvis::LineViewRequest line;
+        line.query.dataset = dataset->id();
+        line.query.field = amrvis::FieldId{0};
+        line.query.axis = 0;
+        line.query.fixedCoordinates = {0.0, 0.5, 0.0};
+        line.query.maximumLevel = dataset->metadata().finestLevel;
+        line.query.region = amrvis::datasetSampleBounds(dataset->metadata());
+        line.outputWidth = 2;
+        const auto lineResult = std::get<amrvis::LineQueryResult>(
+            dataset->requestView(line));
+        require(lineResult.line.values.size() <= 4,
+            "remote line exceeded its two-samples-per-pixel bound");
+        line.outputWidth = 20000;
+        try {
+            static_cast<void>(dataset->requestView(line));
+            require(false, "oversized line viewport was accepted");
+        } catch (const amrvis::remote::RemoteError& error) {
+            require(error.code()
+                    == amrvis::remote::ErrorCode::ResourceLimitExceeded,
+                "oversized line returned the wrong error");
+        }
+
+        amrvis::DatasetPageRequest pageRequest;
+        pageRequest.dataset = dataset->id();
+        pageRequest.field = amrvis::FieldId{0};
+        pageRequest.level = 0;
+        pageRequest.region = amrvis::datasetSampleBounds(dataset->metadata());
+        pageRequest.normalAxis = 1;
+        pageRequest.maximumExtent = 2;
+        const auto page = dataset->requestDatasetPage(pageRequest);
+        require(page.nx <= 2 && page.ny <= 2
+                && page.values.size() <= 4,
+            "remote dataset page exceeded its requested extent");
+
+        const auto range = dataset->requestRange(amrvis::RangeRequest{
+            .field = amrvis::FieldId{0},
+            .maximumLevel = dataset->metadata().finestLevel,
+            .composition = amrvis::CompositionPolicy::FinestAvailable,
+            .scope = amrvis::RangeScope::File});
+        require(range.has_value(), "remote file range is missing");
+        require(!dataset->particleSpecies().empty(),
+            "remote particle catalog is missing");
+        const auto particles = dataset->requestParticleSample(
+            dataset->particleSpecies().front().name, 1.0, 37);
+        require(!particles.points.empty(),
+            "remote particle sample is empty");
+
+        require(dataset->setCacheBudget(8ULL * 1024ULL * 1024ULL),
+            "remote cache budget update was rejected");
+        dataset->clearUnpinnedCache();
+        require(dataset->cacheMetrics().budgetBytes
+                == 8ULL * 1024ULL * 1024ULL,
+            "remote cache snapshot is stale");
+
+        amrvis::StopSource cancelled;
+        cancelled.request_stop();
+        try {
+            static_cast<void>(dataset->requestView(
+                sliceRequest(*dataset, 4, 4), cancelled.get_token()));
+            require(false, "pre-cancelled remote request completed");
+        } catch (const amrvis::ReadCancelled&) {
+        }
+
+        auto secondDataset = amrvis::remote::RemoteDatasetSession::open(
+            connection, std::filesystem::path(argv[1]).string(),
+            8ULL * 1024ULL * 1024ULL);
+        require(secondDataset->id() != dataset->id(),
+            "multiple remote datasets reused one handle");
+        secondDataset->close();
+
+        auto parallelConnection
+            = std::make_shared<amrvis::remote::Connection>(
+                "127.0.0.1", server.port());
+        auto parallelDataset
+            = amrvis::remote::RemoteDatasetSession::open(
+                parallelConnection,
+                std::filesystem::path(argv[1]).string(),
+                8ULL * 1024ULL * 1024ULL);
+        require(std::get<amrvis::SliceQueryResult>(
+                    parallelDataset->requestView(
+                        sliceRequest(*parallelDataset, 2, 2)))
+                    .plane.values.size()
+                == 4,
+            "second client connection could not query");
+        parallelDataset->close();
+        parallelConnection->close();
+
+        const auto request = sliceRequest(*dataset, 7, 5);
+        auto first = std::async(std::launch::async,
+            [&] { return dataset->requestView(request); });
+        auto second = std::async(std::launch::async,
+            [&] { return dataset->requestView(request); });
+        require(std::get<amrvis::SliceQueryResult>(first.get())
+                    .plane.values.size()
+                == 35
+                && std::get<amrvis::SliceQueryResult>(second.get())
+                    .plane.values.size()
+                == 35,
+            "concurrent remote requests were not matched correctly");
+
+        dataset->close();
+        connection->close();
+
+        auto reconnected = std::make_shared<amrvis::remote::Connection>(
+            "127.0.0.1", server.port());
+        auto reopened = amrvis::remote::RemoteDatasetSession::open(
+            reconnected, std::filesystem::path(argv[1]).string(),
+            8ULL * 1024ULL * 1024ULL);
+        require(std::get<amrvis::SliceQueryResult>(
+                    reopened->requestView(sliceRequest(*reopened, 3, 2)))
+                    .plane.values.size()
+                == 6,
+            "reconnect/reopen did not resume queries");
+        reopened->close();
+        reconnected->close();
+
+        return 0;
+    } catch (const std::exception& error) {
+        std::cerr << error.what() << '\n';
+        return 1;
+    }
+}

--- a/tests/integration/test_remote_session.cpp
+++ b/tests/integration/test_remote_session.cpp
@@ -97,6 +97,18 @@ int main(int argc, char* argv[])
             "127.0.0.1", server.port());
         require(connection->serverInfo().workerCount == 3,
             "handshake did not report worker count");
+        amrvis::StopSource cancelledOpen;
+        cancelledOpen.request_stop();
+        bool openCancellationObserved = false;
+        try {
+            static_cast<void>(amrvis::LocalDatasetSession(
+                std::filesystem::path(argv[1]), amrvis::DatasetId{1000},
+                16ULL * 1024ULL * 1024ULL, cancelledOpen.get_token()));
+        } catch (const amrvis::ReadCancelled&) {
+            openCancellationObserved = true;
+        }
+        require(openCancellationObserved,
+            "local dataset open ignored its cancellation token");
         auto dataset = amrvis::remote::RemoteDatasetSession::open(
             connection, std::filesystem::path(argv[1]).string(),
             16ULL * 1024ULL * 1024ULL);


### PR DESCRIPTION
Part 9 of 13 in the remote client/server stack.

## Purpose

Adapt a remotely opened dataset to the same `DatasetSession` API used locally.

## Scope

- Adds `RemoteDatasetSession`.
- Preserves metadata, ranges, cache controls, pages, particles, and bounded view semantics.
- Closes remote dataset handles deterministically while sharing the underlying connection.

## Review focus

Compare this adapter with `LocalDatasetSession`; the pipeline should not need to know which implementation it received.

## Validation

- `remote_session`
- Local/remote result equivalence and lifecycle coverage
