### PR TITLE
[client-server] connect the Qt client to remote datasets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,12 @@ option(AMREXPLORER_WARNINGS_AS_ERRORS "Treat compiler warnings as errors" OFF)
 option(AMREXPLORER_ENABLE_SANITIZERS "Enable AddressSanitizer and UndefinedBehaviorSanitizer" OFF)
 option(AMREXPLORER_ENABLE_TSAN "Enable ThreadSanitizer (mutually exclusive with AMREXPLORER_ENABLE_SANITIZERS)" OFF)
 
+if(AMREXPLORER_ENABLE_QT AND NOT AMREXPLORER_ENABLE_REMOTE)
+    message(FATAL_ERROR
+        "The Qt application requires AMREXPLORER_ENABLE_REMOTE=ON. "
+        "Use the headless preset for a build without remote support.")
+endif()
+
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)

--- a/include/amrexplorer/pipeline/SlicePipeline.hpp
+++ b/include/amrexplorer/pipeline/SlicePipeline.hpp
@@ -236,7 +236,7 @@ void appendContours(const std::shared_ptr<DatasetSession>& dataset,
     const std::optional<std::pair<double, double>>& userRange,
     bool logarithmic, const Palette& palette, DisplayMode displayMode,
     std::uint32_t vectorUField, std::uint32_t vectorVField,
-    int contourCount, bool rasterDirty);
+    int contourCount, bool rasterDirty, StopToken cancellation = {});
 
 // Re-extract contour polylines from an already-populated fine plane after the
 // display range is replaced downstream of appendContours/refreshCachedSlice —

--- a/include/amrexplorer/pipeline/SlicePipeline.hpp
+++ b/include/amrexplorer/pipeline/SlicePipeline.hpp
@@ -119,6 +119,7 @@ struct FrameSliceSpec {
     bool defaultPositions = true;
     std::array<double, 3> slicePositions{0.0, 0.0, 0.0};
     std::vector<std::optional<RealBox>> visibleRegions;  // per view, normal order
+    std::vector<std::array<int, 2>> outputSizes;  // per view, viewport pixels
     bool particleSelectionInitialized = false;
     std::vector<std::string> particleSpecies;
     double particleFraction = 1.0;

--- a/include/amrexplorer/pipeline/SliceRangeResolver.hpp
+++ b/include/amrexplorer/pipeline/SliceRangeResolver.hpp
@@ -52,7 +52,8 @@ struct ResolvedRange {
 // The finite extrema of a standalone FAB's payload, or nullopt for non-FAB
 // datasets / all-non-finite data.
 [[nodiscard]] std::optional<std::pair<double, double>> fabDataRange(
-    const std::shared_ptr<DatasetSession>& dataset, FieldId field);
+    const std::shared_ptr<DatasetSession>& dataset, FieldId field,
+    StopToken cancellation = {});
 
 // The display range for a slice: the user's explicit range, the level/file
 // metadata range, or the finite extrema of the plane itself, padded so
@@ -63,7 +64,7 @@ struct ResolvedRange {
     const std::shared_ptr<DatasetSession>& dataset, FieldId field,
     int maximumLevel, CompositionPolicy composition, RangeMode rangeMode,
     const std::optional<std::pair<double, double>>& userRange,
-    bool logarithmic, const ScalarPlane& plane);
+    bool logarithmic, const ScalarPlane& plane, StopToken cancellation = {});
 
 // Like resolveRange, but if a logarithmic scale is requested and the range is
 // not strictly positive it falls back to a linear range and reports
@@ -74,6 +75,6 @@ struct ResolvedRange {
     const std::shared_ptr<DatasetSession>& dataset, FieldId field,
     int maximumLevel, CompositionPolicy composition, RangeMode rangeMode,
     const std::optional<std::pair<double, double>>& userRange,
-    bool logarithmic, const ScalarPlane& plane);
+    bool logarithmic, const ScalarPlane& plane, StopToken cancellation = {});
 
 } // namespace amrvis

--- a/src/pipeline/SlicePipeline.cpp
+++ b/src/pipeline/SlicePipeline.cpp
@@ -543,8 +543,14 @@ InitialSliceResult executeSessionFrameLoad(
                     region.upper[index] = upper;
                 }
                 request.visibleRegion = region;
-                request.outputSize = finestNativeOutputSize(
-                    metadata, request.visibleRegion, request.normalDirection);
+                request.outputSize = entry < spec.outputSizes.size()
+                    ? spec.outputSizes[entry]
+                    : finestNativeOutputSize(metadata, request.visibleRegion,
+                        request.normalDirection);
+                request.outputSize[0] = std::clamp(
+                    request.outputSize[0], 1, maxSliceOutputDimension);
+                request.outputSize[1] = std::clamp(
+                    request.outputSize[1], 1, maxSliceOutputDimension);
                 request.composition = selectedLevel.composition;
                 request.maximumLevel = attemptMaximumLevel;
                 request.sphericalSupersample = spec.sphericalSupersample;

--- a/src/pipeline/SlicePipeline.cpp
+++ b/src/pipeline/SlicePipeline.cpp
@@ -207,7 +207,7 @@ SliceDisplayResult executeSlice(const std::shared_ptr<DatasetSession>& dataset,
     result.slice = requestSlice(*dataset, request, cancellation);
     const auto range = resolveDisplayRange(dataset, request.field,
         request.maximumLevel, request.composition, rangeMode, userRange,
-        logarithmic, result.slice.plane);
+        logarithmic, result.slice.plane, cancellation);
     result.minimum = range.minimum;
     result.maximum = range.maximum;
     result.logarithmic = range.logarithmic;
@@ -370,7 +370,7 @@ SliceDisplayResult refreshCachedSlice(
     const std::optional<std::pair<double, double>>& userRange,
     bool logarithmic, const Palette& palette, DisplayMode displayMode,
     std::uint32_t vectorUField, std::uint32_t vectorVField,
-    int contourCount, bool rasterDirty)
+    int contourCount, bool rasterDirty, StopToken cancellation)
 {
     SliceDisplayResult result;
     result.request = request;
@@ -381,7 +381,7 @@ SliceDisplayResult refreshCachedSlice(
     result.slice.plane = std::move(displayPlane);
     const auto range = resolveDisplayRange(dataset, request.field,
         request.maximumLevel, request.composition, rangeMode, userRange,
-        logarithmic, result.slice.plane);
+        logarithmic, result.slice.plane, cancellation);
     result.minimum = range.minimum;
     result.maximum = range.maximum;
     result.logarithmic = range.logarithmic;

--- a/src/pipeline/SliceRangeResolver.cpp
+++ b/src/pipeline/SliceRangeResolver.cpp
@@ -6,6 +6,14 @@
 #include <stdexcept>
 
 namespace amrvis {
+namespace {
+
+class LogarithmicRangeError final : public std::runtime_error {
+public:
+    using std::runtime_error::runtime_error;
+};
+
+} // namespace
 
 std::optional<std::pair<double, double>> finiteRange(const ScalarPlane& plane)
 {
@@ -93,7 +101,8 @@ RangeMode effectiveRangeMode(
 }
 
 std::optional<std::pair<double, double>> fabDataRange(
-    const std::shared_ptr<DatasetSession>& dataset, FieldId field)
+    const std::shared_ptr<DatasetSession>& dataset, FieldId field,
+    StopToken cancellation)
 {
     if (!dataset->metadata().isFab) {
         return std::nullopt;
@@ -102,7 +111,7 @@ std::optional<std::pair<double, double>> fabDataRange(
         .field = field,
         .maximumLevel = 0,
         .composition = CompositionPolicy::ExactLevel,
-        .scope = RangeScope::File});
+        .scope = RangeScope::File}, cancellation);
     if (!range) {
         return std::nullopt;
     }
@@ -113,12 +122,12 @@ std::pair<double, double> resolveRange(
     const std::shared_ptr<DatasetSession>& dataset, FieldId field,
     int maximumLevel, CompositionPolicy composition, RangeMode rangeMode,
     const std::optional<std::pair<double, double>>& userRange,
-    bool logarithmic, const ScalarPlane& plane)
+    bool logarithmic, const ScalarPlane& plane, StopToken cancellation)
 {
     auto selectedRange = userRange;
     if (rangeMode == RangeMode::Level || rangeMode == RangeMode::File) {
         if (rangeMode == RangeMode::File) {
-            selectedRange = fabDataRange(dataset, field);
+            selectedRange = fabDataRange(dataset, field, cancellation);
         }
         if (!selectedRange) {
             const auto statistics = dataset->requestRange(RangeRequest{
@@ -127,7 +136,7 @@ std::pair<double, double> resolveRange(
                 .composition = composition,
                 .scope = rangeMode == RangeMode::File
                     ? RangeScope::File
-                    : RangeScope::Level});
+                    : RangeScope::Level}, cancellation);
             if (statistics) {
                 selectedRange
                     = std::pair{statistics->minimum, statistics->maximum};
@@ -153,7 +162,8 @@ std::pair<double, double> resolveRange(
         throw std::runtime_error("user scalar range must have positive extent");
     }
     if (logarithmic && !(minimum > 0.0)) {
-        throw std::runtime_error("logarithmic scalar range must be positive");
+        throw LogarithmicRangeError(
+            "logarithmic scalar range must be positive");
     }
     return {minimum, maximum};
 }
@@ -162,19 +172,20 @@ ResolvedRange resolveDisplayRange(
     const std::shared_ptr<DatasetSession>& dataset, FieldId field,
     int maximumLevel, CompositionPolicy composition, RangeMode rangeMode,
     const std::optional<std::pair<double, double>>& userRange,
-    bool logarithmic, const ScalarPlane& plane)
+    bool logarithmic, const ScalarPlane& plane, StopToken cancellation)
 {
     if (logarithmic) {
         try {
             const auto [minimum, maximum] = resolveRange(dataset, field,
-                maximumLevel, composition, rangeMode, userRange, true, plane);
+                maximumLevel, composition, rangeMode, userRange, true, plane,
+                cancellation);
             return {minimum, maximum, true};
-        } catch (const std::exception&) {
+        } catch (const LogarithmicRangeError&) {
             // Log is not viable for this range; fall back to linear below.
         }
     }
     const auto [minimum, maximum] = resolveRange(dataset, field, maximumLevel,
-        composition, rangeMode, userRange, false, plane);
+        composition, rangeMode, userRange, false, plane, cancellation);
     return {minimum, maximum, false};
 }
 

--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -22,6 +22,7 @@ add_executable(amrexplorer_qt
     MainWindow.hpp
     NumberFormat.cpp
     NumberFormat.hpp
+    RemoteEndpoint.hpp
     ScientificDoubleSpinBox.cpp
     ScientificDoubleSpinBox.hpp
     SequenceController.cpp
@@ -68,6 +69,7 @@ target_link_libraries(amrexplorer_qt
         Qt6::Gui
         Qt6::Widgets
 )
+target_link_libraries(amrexplorer_qt PRIVATE amrexplorer::remote)
 target_compile_features(amrexplorer_qt PRIVATE cxx_std_20)
 target_compile_definitions(amrexplorer_qt PRIVATE AMREXPLORER_VERSION="${PROJECT_VERSION}")
 

--- a/src/qt/DatasetWindow.cpp
+++ b/src/qt/DatasetWindow.cpp
@@ -22,6 +22,7 @@
 #include <QtConcurrentRun>
 
 #include <algorithm>
+#include <cmath>
 #include <cstddef>
 #include <cstdint>
 #include <exception>
@@ -31,6 +32,28 @@
 
 namespace amrvis::qt {
 namespace {
+
+int datasetPageMaximumExtent(const DatasetSession& dataset)
+{
+    const auto maximumResponseBytes = dataset.maximumResponseBytes();
+    if (!maximumResponseBytes) {
+        return datasetPageMaxExtent;
+    }
+    // Dataset pages carry the same per-cell float value and byte coverage
+    // vectors as slice responses. Reserve the shared envelope allowance, then
+    // choose the largest square page that fits the negotiated frame.
+    const auto frameBytes
+        = static_cast<std::uint64_t>(*maximumResponseBytes);
+    const auto maximumCells = frameBytes > sliceResponseOverheadBytes
+        ? (frameBytes - sliceResponseOverheadBytes)
+            / sliceResponseBytesPerCell
+        : 0;
+    const auto extent = maximumCells == 0
+        ? 1
+        : static_cast<int>(std::floor(
+            std::sqrt(static_cast<double>(maximumCells))));
+    return std::clamp(extent, 1, datasetPageMaxExtent);
+}
 
 // Qt Concurrent masks worker exceptions behind QUnhandledException, so the
 // underlying library error text must be unwrapped before it is shown.
@@ -208,7 +231,8 @@ std::vector<DatasetWindow::LevelData> DatasetWindow::extractLevels(
         pageRequest.region = request.region;
         pageRequest.normalAxis = request.normalAxis;
         pageRequest.slicePosition = request.slicePosition;
-        pageRequest.maximumExtent = datasetExtractMaxExtent;
+        pageRequest.maximumExtent
+            = datasetPageMaximumExtent(*request.dataset);
         auto extract = request.dataset->requestDatasetPage(
             pageRequest, cancellation);
         // Levels the region misses geometrically get no tab.

--- a/src/qt/ImageView.cpp
+++ b/src/qt/ImageView.cpp
@@ -720,6 +720,7 @@ void ImageView::resizeEvent(QResizeEvent* event)
     if (m_transformMode == TransformMode::Fit) {
         fitImage();
     }
+    emit viewportResized(viewport()->size());
 }
 
 void ImageView::wheelEvent(QWheelEvent* event)

--- a/src/qt/ImageView.hpp
+++ b/src/qt/ImageView.hpp
@@ -163,6 +163,7 @@ signals:
     void linePlotRequested(int imageX, int imageY, Qt::MouseButton button);
     void sliceMoveRequested(int imageX, int imageY, Qt::MouseButton button);
     void fitRequested();
+    void viewportResized(const QSize& size);
 
 protected:
     void mouseDoubleClickEvent(QMouseEvent* event) override;

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -66,6 +66,7 @@
 #include <QPointer>
 #include <QProcess>
 #include <QProgressDialog>
+#include <QProgressBar>
 #include <QPushButton>
 #include <QRect>
 #include <QRegularExpressionValidator>
@@ -731,6 +732,8 @@ MainWindow::MainWindow(QWidget* parent)
             m_initialStopSource.request_stop();
             m_linePlotStopSource.request_stop();
             m_particleStopSource.request_stop();
+            m_particleLoading = false;
+            m_particleProgress->setVisible(false);
             m_pendingAllViews = false;
             m_pendingViews.clear();
             m_sliceDebounce->stop();
@@ -877,6 +880,13 @@ MainWindow::MainWindow(QWidget* parent)
     setupPanShortcuts();
 
     m_probeLabel = new QLabel(statusBar());
+    m_particleProgress = new QProgressBar(statusBar());
+    m_particleProgress->setRange(0, 0);
+    m_particleProgress->setFormat(tr("Loading particles..."));
+    m_particleProgress->setAccessibleName(tr("Loading particle sample"));
+    m_particleProgress->setFixedWidth(170);
+    m_particleProgress->setVisible(false);
+    statusBar()->addPermanentWidget(m_particleProgress);
     statusBar()->addPermanentWidget(m_probeLabel);
     statusBar()->showMessage(tr("No dataset open"));
     updateDiagnostics();
@@ -2522,7 +2532,8 @@ void MainWindow::configureParticleControls(bool preserveSelection)
         m_particleColors.try_emplace(
             species[speciesIndex].name, defaultParticleColor(speciesIndex));
     }
-    m_particlesAction->setEnabled(!species.empty());
+    m_particlesAction->setEnabled(
+        !species.empty() && !m_particleLoading);
 }
 
 void MainWindow::applyParticleSelection(
@@ -2606,6 +2617,21 @@ std::size_t MainWindow::particleOverlayCountForTest()
     return count;
 }
 
+bool MainWindow::particleLoadingForTest() const noexcept
+{
+    return m_particleLoading;
+}
+
+bool MainWindow::particleLoadingUiActiveForTest() const
+{
+    return m_particleProgress->isVisible() && !m_particlesAction->isEnabled();
+}
+
+bool MainWindow::particleLoadingUiSettledForTest() const
+{
+    return !m_particleProgress->isVisible() && m_particlesAction->isEnabled();
+}
+
 void MainWindow::requestParticleReload()
 {
     m_particleStopSource.request_stop();
@@ -2620,9 +2646,15 @@ void MainWindow::requestParticleReload()
     m_particleSamples.clear();
     updateParticleOverlays();
     if (!dataset || selectedSpecies.empty()) {
+        m_particleLoading = false;
+        m_particleProgress->setVisible(false);
+        configureParticleControls(true);
         return;
     }
 
+    m_particleLoading = true;
+    m_particleProgress->setVisible(true);
+    m_particlesAction->setEnabled(false);
     ++m_activeRequests;
     statusBar()->showMessage(tr("Loading particle sample..."));
     updateDiagnostics();
@@ -2653,6 +2685,11 @@ void MainWindow::requestParticleReload()
                         tr("Particles were not loaded: %1")
                             .arg(exceptionMessage(error)));
                 }
+            }
+            if (particleGeneration == m_particleGeneration) {
+                m_particleLoading = false;
+                m_particleProgress->setVisible(false);
+                configureParticleControls(true);
             }
             updateDiagnostics();
             watcher->deleteLater();
@@ -4489,6 +4526,8 @@ void MainWindow::openDatasetImpl(const std::filesystem::path& path,
     m_particleSamples.clear();
     m_selectedParticleSpecies.clear();
     m_particleSelectionInitialized = false;
+    m_particleLoading = false;
+    m_particleProgress->setVisible(false);
     ++m_particleGeneration;
     setWindowTitle(tr("AMReXplorer"));
     {
@@ -5934,6 +5973,8 @@ void MainWindow::openSequence(const std::vector<std::filesystem::path>& frames)
     m_particleSamples.clear();
     m_selectedParticleSpecies.clear();
     m_particleSelectionInitialized = false;
+    m_particleLoading = false;
+    m_particleProgress->setVisible(false);
     ++m_particleGeneration;
 
     auto sorted = frames;

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -11,6 +11,7 @@
 #include "LinePlotRequest.hpp"
 #include "LinePlotWindow.hpp"
 #include "PlaneMapping.hpp"
+#include "RemoteEndpoint.hpp"
 #include "ScientificDoubleSpinBox.hpp"
 #include "SetContoursDialog.hpp"
 #include "Theme.hpp"
@@ -24,6 +25,8 @@
 #include <amrexplorer/core/Statistics.hpp>
 #include <amrexplorer/pipeline/ParticleProjection.hpp>
 #include <amrexplorer/pipeline/SliceRangeResolver.hpp>
+#include <amrexplorer/remote/Connection.hpp>
+#include <amrexplorer/remote/RemoteDatasetSession.hpp>
 #include <amrexplorer/render2d/Contours.hpp>
 #include <amrexplorer/render2d/Palette.hpp>
 #include <amrexplorer/render2d/ScalarRenderer.hpp>
@@ -50,6 +53,7 @@
 #include <QHeaderView>
 #include <QHBoxLayout>
 #include <QImage>
+#include <QInputDialog>
 #include <QLabel>
 #include <QListView>
 #include <QLineEdit>
@@ -922,6 +926,17 @@ void MainWindow::wireView(PlaneViewState& state)
         });
     connect(view, &ImageView::fitRequested, this,
         [this, &state] { resetViewZoom(state); });
+    connect(view, &ImageView::viewportResized, this,
+        [this, &state](const QSize&) {
+            if (!m_dataset || !std::dynamic_pointer_cast<
+                    remote::RemoteDatasetSession>(m_dataset)) {
+                return;
+            }
+            if (!state.hasCachedRequest
+                || state.cachedRequest.outputSize != sliceOutputSize(state)) {
+                scheduleSliceRequest(state);
+            }
+        });
 }
 
 std::vector<MainWindow::PlaneViewState*> MainWindow::currentViews()
@@ -985,6 +1000,54 @@ std::array<int, 2> MainWindow::displayAxes(int normal) const
         }
     }
     return axes;
+}
+
+std::array<int, 2> MainWindow::nativeOutputSize(
+    const PlaneViewState& state) const
+{
+    if (!m_openMetadata || m_openMetadata->levels.empty()) {
+        return {1, 1};
+    }
+    const auto target = state.visibleRegion.value_or(
+        datasetSampleBounds(*m_openMetadata));
+    return finestNativeOutputSize(
+        *m_openMetadata, target, state.normal);
+}
+
+std::array<int, 2> MainWindow::sliceOutputSize(
+    const PlaneViewState& state, bool forceRemote) const
+{
+    if (!forceRemote
+        && !std::dynamic_pointer_cast<remote::RemoteDatasetSession>(m_dataset)) {
+        return nativeOutputSize(state);
+    }
+    const auto* viewport = state.view == nullptr ? nullptr : state.view->viewport();
+    if (viewport == nullptr || viewport->width() < 1 || viewport->height() < 1) {
+        return {1, 1};
+    }
+    const auto scale = state.view->devicePixelRatioF();
+    const std::array<int, 2> viewportPixels{
+        std::clamp(static_cast<int>(std::lround(viewport->width() * scale)),
+            1, maxSliceOutputDimension),
+        std::clamp(static_cast<int>(std::lround(viewport->height() * scale)),
+            1, maxSliceOutputDimension)};
+    const auto target = state.visibleRegion.value_or(
+        datasetSampleBounds(*m_openMetadata));
+    const auto axes = displayAxes(state.normal);
+    const auto extentX = target.upper[static_cast<std::size_t>(axes[0])]
+        - target.lower[static_cast<std::size_t>(axes[0])];
+    const auto extentY = target.upper[static_cast<std::size_t>(axes[1])]
+        - target.lower[static_cast<std::size_t>(axes[1])];
+    if (!(extentX > 0.0) || !(extentY > 0.0)) {
+        return {1, 1};
+    }
+    const auto fit = std::min(
+        static_cast<double>(viewportPixels[0]) / extentX,
+        static_cast<double>(viewportPixels[1]) / extentY);
+    return {std::clamp(static_cast<int>(std::lround(extentX * fit)),
+                1, viewportPixels[0]),
+        std::clamp(static_cast<int>(std::lround(extentY * fit)),
+            1, viewportPixels[1])};
 }
 
 bool MainWindow::displayIsSpherical() const
@@ -1052,6 +1115,55 @@ void MainWindow::createMenus()
     connect(openSequenceAction, &QAction::triggered, this,
         [this] { choosePlotfileSequence(); });
 
+    const auto configureRemoteEndpoint = [this]() {
+        const auto current = m_remotePort == 0
+            ? QStringLiteral("127.0.0.1:48192")
+            : QStringLiteral("%1:%2")
+                  .arg(QString::fromStdString(m_remoteHost))
+                  .arg(m_remotePort);
+        bool accepted = false;
+        const auto text = QInputDialog::getText(this,
+            tr("Connect to Remote Server"), tr("Host and port:"),
+            QLineEdit::Normal, current, &accepted);
+        if (!accepted) {
+            return false;
+        }
+        const auto endpoint = parseRemoteEndpoint(text.toStdString());
+        if (!endpoint) {
+            QMessageBox::warning(this, tr("Invalid endpoint"),
+                tr("Enter an endpoint as HOST:PORT."));
+            return false;
+        }
+        m_remoteHost = endpoint->first;
+        m_remotePort = endpoint->second;
+        statusBar()->showMessage(
+            tr("Remote endpoint set to %1").arg(text));
+        updateDiagnostics();
+        return true;
+    };
+    auto* connectRemoteAction = new QAction(
+        tr("&Connect to Remote Server..."), this);
+    connect(connectRemoteAction, &QAction::triggered, this,
+        [configureRemoteEndpoint] { configureRemoteEndpoint(); });
+
+    auto* openRemoteAction = new QAction(
+        tr("Open Remote &Plotfile..."), this);
+    connect(openRemoteAction, &QAction::triggered, this,
+        [this, configureRemoteEndpoint] {
+            if (m_remotePort == 0 && !configureRemoteEndpoint()) {
+                return;
+            }
+            bool accepted = false;
+            const auto path = QInputDialog::getText(this,
+                tr("Open Remote Plotfile"),
+                tr("Server-visible plotfile path:"), QLineEdit::Normal,
+                QString(), &accepted);
+            if (accepted && !path.trimmed().isEmpty()) {
+                openRemoteDataset(
+                    m_remoteHost, m_remotePort, path.toStdString());
+            }
+        });
+
     auto* openFabAction = new QAction(tr("Open &FAB..."), this);
     connect(openFabAction, &QAction::triggered, this,
         [this] { chooseStandaloneDataset(tr("Open AMReX FAB"), true); });
@@ -1105,6 +1217,10 @@ void MainWindow::createMenus()
     fileMenu->addSeparator();
     fileMenu->addAction(openAction);
     fileMenu->addAction(openSequenceAction);
+    fileMenu->addSeparator();
+    fileMenu->addAction(connectRemoteAction);
+    fileMenu->addAction(openRemoteAction);
+    fileMenu->addSeparator();
     fileMenu->addAction(openFabAction);
     fileMenu->addAction(openMultiFabAction);
     fileMenu->addSeparator();
@@ -1728,6 +1844,32 @@ bool MainWindow::activeViewRasterMatchesDisplayRangeForTest()
     return displayImageFor(reference) == state.view->image();
 }
 
+bool MainWindow::activeViewUsesViewportBoundedOutputForTest() const
+{
+    if (!std::dynamic_pointer_cast<remote::RemoteDatasetSession>(m_dataset)
+        || m_activeView == nullptr || m_activeView->plane->width <= 0
+        || m_activeView->plane->height <= 0) {
+        return false;
+    }
+    const auto expected = sliceOutputSize(*m_activeView, true);
+    return m_activeView->plane->width == expected[0]
+        && m_activeView->plane->height == expected[1];
+}
+
+bool MainWindow::activeViewHasPhysicalAspectForTest(
+    double expectedAspect) const
+{
+    if (!m_dataset || m_activeView == nullptr
+        || m_activeView->plane->width <= 0
+        || m_activeView->plane->height <= 0 || !(expectedAspect > 0.0)) {
+        return false;
+    }
+    const auto actualAspect = static_cast<double>(m_activeView->plane->width)
+        / m_activeView->plane->height;
+    return std::abs(actualAspect - expectedAspect)
+        <= 0.02 * expectedAspect;
+}
+
 void MainWindow::rubberBandZoomActiveViewForTest()
 {
     if (m_activeView == nullptr || m_activeView->plane->width <= 0
@@ -1738,6 +1880,18 @@ void MainWindow::rubberBandZoomActiveViewForTest()
     const auto height = static_cast<double>(m_activeView->plane->height);
     rubberBandZoom(*m_activeView,
         QRectF(0.25 * width, 0.25 * height, 0.5 * width, 0.5 * height));
+}
+
+void MainWindow::rubberBandZoomRectangularActiveViewForTest()
+{
+    if (m_activeView == nullptr || m_activeView->plane->width <= 0
+        || m_activeView->plane->height <= 0) {
+        return;
+    }
+    const auto width = static_cast<double>(m_activeView->plane->width);
+    const auto height = static_cast<double>(m_activeView->plane->height);
+    rubberBandZoom(*m_activeView,
+        QRectF(0.275 * width, 0.35 * height, 0.45 * width, 0.2 * height));
 }
 
 bool MainWindow::allViewsRubberBandZoomedForTest()
@@ -2903,25 +3057,25 @@ void MainWindow::applyRubberBandZoom(
         + (height - clamped.bottom()) / height * yExtent;
     visible.upper[yAxis] = region.lower[yAxis]
         + (height - clamped.top()) / height * yExtent;
-    // The edges above land mid-cell. Snap them outward to finest-level cell
-    // boundaries so the slice output (one pixel per finest cell, see
-    // finestNativeOutputSize) samples exactly at cell centers; fractional
-    // edges make the sampling pitch differ from the cell size and produce
-    // duplicated or skipped rows/columns of cells.
-    const auto& metadata = m_dataset->metadata();
-    const auto& finest = metadata.levels[static_cast<std::size_t>(
-        std::max(0, metadata.finestLevel))];
-    visible = snapToCellBoundaries(
-        visible, datasetSampleBounds(metadata), finest.cellSize, axes);
+    // Local slices use one output pixel per finest cell, so their edges land
+    // on cell boundaries. Remote slices are viewport-resampled; retaining the
+    // exact selection keeps an arbitrary rubber-band aspect ratio intact.
+    if (!std::dynamic_pointer_cast<remote::RemoteDatasetSession>(m_dataset)) {
+        const auto& metadata = m_dataset->metadata();
+        const auto& finest = metadata.levels[static_cast<std::size_t>(
+            std::max(0, metadata.finestLevel))];
+        visible = snapToCellBoundaries(
+            visible, datasetSampleBounds(metadata), finest.cellSize, axes);
+    }
     state.visibleRegion = visible;
-    // Zoom to the snapped region mapped back to scene pixels, so the view
+    // Zoom to the requested region mapped back to scene pixels, so the view
     // transform matches the region the requested slice will actually cover.
-    const QRectF snappedScene(
+    const QRectF requestedScene(
         QPointF((visible.lower[xAxis] - region.lower[xAxis]) / xExtent * width,
             (region.upper[yAxis] - visible.upper[yAxis]) / yExtent * height),
         QPointF((visible.upper[xAxis] - region.lower[xAxis]) / xExtent * width,
             (region.upper[yAxis] - visible.lower[yAxis]) / yExtent * height));
-    state.view->zoomToRect(snappedScene.normalized());
+    state.view->zoomToRect(requestedScene.normalized());
     scheduleSliceRequest(state);
 }
 
@@ -3641,6 +3795,7 @@ struct FabSelectorBuild {
 struct OpenedDataset {
     PlotfileMetadataResult metadata;
     std::optional<FabSelectorBuild> fabSelector;
+    std::shared_ptr<DatasetSession> session;
 };
 
 // Reads FAB/MultiFab record headers and builds the selector entries. Runs on a
@@ -4185,11 +4340,24 @@ void MainWindow::resetFabState()
     m_fabSelectorDock->setVisible(false);
 }
 
+void MainWindow::openRemoteDataset(
+    std::string host, std::uint16_t port, std::string remotePath)
+{
+    m_remoteHost = host;
+    m_remotePort = port;
+    const auto displayPath = std::filesystem::path(remotePath);
+    openDatasetImpl(displayPath, false, std::nullopt, {}, false,
+        std::nullopt,
+        std::tuple{std::move(host), port, std::move(remotePath)});
+}
+
 void MainWindow::openDatasetImpl(const std::filesystem::path& path,
     bool metadataOnly,
     std::optional<PlotfileMetadataResult> preparedMetadata,
     std::filesystem::path dataRoot, bool preserveFabSelector,
-    std::optional<FrameSliceSpec> initialSpec)
+    std::optional<FrameSliceSpec> initialSpec,
+    std::optional<std::tuple<std::string, std::uint16_t, std::string>>
+        remoteOpen)
 {
     if (!preserveFabSelector) {
         resetFabState();
@@ -4347,15 +4515,19 @@ void MainWindow::openDatasetImpl(const std::filesystem::path& path,
                     if (!metadataOnly) {
                         auto root = std::move(dataRoot);
                         if (root.empty()) {
-                            root = std::filesystem::is_directory(path)
-                                ? path : path.parent_path();
+                            root = result.session
+                                ? std::filesystem::path{"."}
+                                : (std::filesystem::is_directory(path)
+                                      ? path
+                                      : path.parent_path());
                             if (root.empty()) {
                                 root = ".";
                             }
                         }
                         requestInitialSlice(path, generation,
                             std::move(result.metadata), std::move(root),
-                            std::move(initialSpec));
+                            std::move(initialSpec),
+                            std::move(result.session));
                     }
                 } else {
                     ++m_staleResults;
@@ -4374,15 +4546,34 @@ void MainWindow::openDatasetImpl(const std::filesystem::path& path,
         });
     watcher->setFuture(QtConcurrent::run(
         [path, preparedMetadata = std::move(preparedMetadata),
-            cancellation = metadataCancellation, preserveFabSelector]() mutable {
+            cancellation = metadataCancellation, preserveFabSelector,
+            remoteOpen = std::move(remoteOpen)]() mutable {
         OpenedDataset opened;
-        opened.metadata = preparedMetadata
-            ? std::move(*preparedMetadata)
-            : readDatasetMetadata(path, cancellation);
+        if (remoteOpen) {
+            auto& [host, port, remotePath] = *remoteOpen;
+            auto connection = std::make_shared<remote::Connection>(
+                host, port, remote::ConnectionOptions{
+                    .clientName = "AMReXplorer Qt",
+                    .softwareVersion = AMREXPLORER_VERSION});
+            opened.session = remote::RemoteDatasetSession::open(
+                std::move(connection), remotePath,
+                initialCacheBudget(), cancellation);
+            opened.metadata.metadata
+                = std::make_shared<const DatasetMetadata>(
+                    opened.session->metadata());
+            opened.metadata.metrics
+                = opened.session->metadataReadMetrics();
+            opened.metadata.fileVersion
+                = opened.session->fileVersion();
+        } else {
+            opened.metadata = preparedMetadata
+                ? std::move(*preparedMetadata)
+                : readDatasetMetadata(path, cancellation);
+        }
         // Build the FAB selector entries here, off the GUI thread, so the
         // header scans / per-block preads it needs never freeze the event
         // loop. Skipped when the caller preserves the existing selector.
-        if (!preserveFabSelector) {
+        if (!preserveFabSelector && !remoteOpen) {
             opened.fabSelector = buildFabSelector(opened.metadata, path);
         }
         return opened;
@@ -4393,7 +4584,8 @@ void MainWindow::requestInitialSlice(
     const std::filesystem::path& path, std::uint64_t generation,
     std::optional<PlotfileMetadataResult> preparedMetadata,
     std::filesystem::path dataRoot,
-    std::optional<FrameSliceSpec> initialSpec)
+    std::optional<FrameSliceSpec> initialSpec,
+    std::shared_ptr<DatasetSession> preparedSession)
 {
     validateVectorMode();
     const auto& metadata = *m_openMetadata;
@@ -4434,6 +4626,16 @@ void MainWindow::requestInitialSlice(
         spec.contourCount = m_contourCount;
         spec.sphericalSupersample = m_sphericalSupersample;
         spec.sphericalDisplay = m_sphericalDisplay;
+    }
+    const auto isRemote = std::dynamic_pointer_cast<
+        remote::RemoteDatasetSession>(preparedSession) != nullptr;
+    if (spec.outputSizes.size() != views.size()) {
+        spec.outputSizes.clear();
+        spec.outputSizes.reserve(views.size());
+        for (const auto* state : views) {
+            spec.outputSizes.push_back(
+                sliceOutputSize(*state, isRemote));
+        }
     }
     const auto restoredSpec = initialSpec;
     // Per-view generations captured now: a view that gets a newer request
@@ -4576,7 +4778,12 @@ void MainWindow::requestInitialSlice(
     watcher->setFuture(QtConcurrent::run(
         [path, generation, spec = std::move(spec), cancellation,
             preparedMetadata = std::move(preparedMetadata),
-            dataRoot = std::move(dataRoot)]() mutable {
+            dataRoot = std::move(dataRoot),
+            preparedSession = std::move(preparedSession)]() mutable {
+        if (preparedSession) {
+            return executeSessionFrameLoad(
+                std::move(preparedSession), spec, cancellation);
+        }
         return executeFrameLoad(path, DatasetId{generation}, spec,
             initialCacheBudget(), cancellation,
             std::move(preparedMetadata), std::move(dataRoot));
@@ -4805,8 +5012,7 @@ void MainWindow::requestSlice(PlaneViewState& state, bool rasterDirty)
     }
     request.visibleRegion = state.visibleRegion.value_or(
         datasetSampleBounds(metadata));
-    request.outputSize = finestNativeOutputSize(
-        metadata, request.visibleRegion, state.normal);
+    request.outputSize = sliceOutputSize(state);
     const auto level = m_levelSelector->currentData().toInt();
     const auto [composition, maximumLevel] = decodeLevelData(
         level, metadata.finestLevel);
@@ -6124,6 +6330,21 @@ void MainWindow::updateDiagnostics()
             .arg(m_cachePinnedBytes)
             .arg(m_cacheEvictions)
             .arg(m_sequenceController->lastFrameSwitchMs());
+    if (m_remotePort != 0) {
+        text += tr("\nremote endpoint: %1:%2")
+                    .arg(QString::fromStdString(m_remoteHost))
+                    .arg(m_remotePort);
+        if (auto remoteSession = std::dynamic_pointer_cast<
+                remote::RemoteDatasetSession>(m_dataset)) {
+            text += tr("\nremote status: %1\nremote path: %2")
+                        .arg(remoteSession->connection()->connected()
+                                ? tr("connected") : tr("disconnected"),
+                            QString::fromStdString(
+                                remoteSession->remotePath()));
+        } else {
+            text += tr("\nremote status: configured");
+        }
+    }
     for (const auto& line : m_probeLines) {
         text += QLatin1Char('\n');
         text += line;

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -5150,12 +5150,13 @@ void MainWindow::requestSlice(PlaneViewState& state, bool rasterDirty)
             contourFineFactor = state.contourFineFactor,
             vectors = state.vectorSegments,
             rangeMode, userRange, logarithmic, palette, displayMode,
-            vectorUField, vectorVField, contourCount, rasterDirty]() mutable {
+            vectorUField, vectorVField, contourCount, rasterDirty,
+            cancellation]() mutable {
             return refreshCachedSlice(dataset, request, *displayPlane,
                 *contourPlane, *contourFinePlane,
                 contourFineFactor, std::move(vectors), rangeMode, userRange,
                 logarithmic, palette, displayMode, vectorUField, vectorVField,
-                contourCount, rasterDirty);
+                contourCount, rasterDirty, cancellation);
         });
     } else {
         future = QtConcurrent::run(

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -1021,6 +1021,9 @@ std::array<int, 2> MainWindow::sliceOutputSize(
         && !std::dynamic_pointer_cast<remote::RemoteDatasetSession>(m_dataset)) {
         return nativeOutputSize(state);
     }
+    if (!m_openMetadata || m_openMetadata->levels.empty()) {
+        return {1, 1};
+    }
     const auto* viewport = state.view == nullptr ? nullptr : state.view->viewport();
     if (viewport == nullptr || viewport->width() < 1 || viewport->height() < 1) {
         return {1, 1};
@@ -1034,10 +1037,19 @@ std::array<int, 2> MainWindow::sliceOutputSize(
     const auto target = state.visibleRegion.value_or(
         datasetSampleBounds(*m_openMetadata));
     const auto axes = displayAxes(state.normal);
-    const auto extentX = target.upper[static_cast<std::size_t>(axes[0])]
+    auto extentX = target.upper[static_cast<std::size_t>(axes[0])]
         - target.lower[static_cast<std::size_t>(axes[0])];
-    const auto extentY = target.upper[static_cast<std::size_t>(axes[1])]
+    auto extentY = target.upper[static_cast<std::size_t>(axes[1])]
         - target.lower[static_cast<std::size_t>(axes[1])];
+    if (isSpherical2D(*m_openMetadata)) {
+        // Radius and angle have heterogeneous units, so their raw physical
+        // extents do not define a meaningful display aspect. Normalize both
+        // axes to their finest-level sample counts before fitting the viewport.
+        const auto normalized = finestNativeOutputSize(
+            *m_openMetadata, target, state.normal);
+        extentX = static_cast<double>(normalized[0]);
+        extentY = static_cast<double>(normalized[1]);
+    }
     if (!(extentX > 0.0) || !(extentY > 0.0)) {
         return {1, 1};
     }
@@ -1854,6 +1866,29 @@ bool MainWindow::activeViewUsesViewportBoundedOutputForTest() const
     const auto expected = sliceOutputSize(*m_activeView, true);
     return m_activeView->plane->width == expected[0]
         && m_activeView->plane->height == expected[1];
+}
+
+bool MainWindow::allViewsUseViewportBoundedOutputForTest() const
+{
+    if (!std::dynamic_pointer_cast<remote::RemoteDatasetSession>(m_dataset)) {
+        return false;
+    }
+    const std::array<const PlaneViewState*, 3> threeDimensional{
+        &m_planeViews[0], &m_planeViews[1], &m_planeViews[2]};
+    const auto check = [&](const PlaneViewState& state) {
+        if (state.plane->width <= 1 || state.plane->height <= 1) {
+            return false;
+        }
+        const auto expected = sliceOutputSize(state, true);
+        return state.plane->width == expected[0]
+            && state.plane->height == expected[1];
+    };
+    if (m_viewDimension == 2) {
+        return check(m_view2d);
+    }
+    return m_viewDimension == 3
+        && std::all_of(threeDimensional.begin(), threeDimensional.end(),
+            [&](const auto* state) { return check(*state); });
 }
 
 bool MainWindow::activeViewHasPhysicalAspectForTest(
@@ -4554,7 +4589,8 @@ void MainWindow::openDatasetImpl(const std::filesystem::path& path,
             auto connection = std::make_shared<remote::Connection>(
                 host, port, remote::ConnectionOptions{
                     .clientName = "AMReXplorer Qt",
-                    .softwareVersion = AMREXPLORER_VERSION});
+                    .softwareVersion = AMREXPLORER_VERSION},
+                cancellation);
             opened.session = remote::RemoteDatasetSession::open(
                 std::move(connection), remotePath,
                 initialCacheBudget(), cancellation);
@@ -4590,6 +4626,14 @@ void MainWindow::requestInitialSlice(
     validateVectorMode();
     const auto& metadata = *m_openMetadata;
     m_viewDimension = metadata.dimension;
+    // Make the correct page visible and synchronously activate its layout
+    // before deriving remote viewport budgets. The 3-D grid is otherwise still
+    // the hidden stacked page and reports construction-time placeholder sizes.
+    m_stack->setCurrentIndex(m_viewDimension == 3 ? 1 : 0);
+    if (auto* page = m_stack->currentWidget(); page != nullptr
+        && page->layout() != nullptr) {
+        page->layout()->activate();
+    }
     const auto views = currentViews();
     // The XY view starts out as the active one in 3-D.
     setActiveView(m_viewDimension == 3
@@ -4652,7 +4696,7 @@ void MainWindow::requestInitialSlice(
     auto* watcher = new QFutureWatcher<InitialSliceResult>(this);
     connect(watcher, &QFutureWatcher<InitialSliceResult>::finished, this,
         [this, watcher, generation, cancellation, views, viewGenerations,
-            restoredSpec] {
+            restoredSpec, isRemote] {
             --m_activeRequests;
             if (m_closing) {
                 watcher->deleteLater();
@@ -4746,6 +4790,18 @@ void MainWindow::requestInitialSlice(
                                 : std::optional<RealBox>{};
                         }
                         showSlice(*views[index], result.displays[index]);
+                    }
+                    if (isRemote) {
+                        // A resize during the initial worker cannot submit a
+                        // slice yet because m_dataset is not published. Once
+                        // that result settles, coalesce each changed viewport
+                        // into exactly one request using its newest size.
+                        for (std::size_t index = 0; index < views.size(); ++index) {
+                            if (result.displays[index].request.outputSize
+                                != sliceOutputSize(*views[index])) {
+                                scheduleSliceRequest(*views[index]);
+                            }
+                        }
                     }
                     const auto cache = m_dataset->cacheMetrics();
                     m_cacheBudgetBytes = cache.budgetBytes;

--- a/src/qt/MainWindow.hpp
+++ b/src/qt/MainWindow.hpp
@@ -144,6 +144,7 @@ public:
     // raster-colorbar-mismatch-on-2d-visible-zoom.
     [[nodiscard]] bool activeViewRasterMatchesDisplayRangeForTest();
     [[nodiscard]] bool activeViewUsesViewportBoundedOutputForTest() const;
+    [[nodiscard]] bool allViewsUseViewportBoundedOutputForTest() const;
     [[nodiscard]] bool activeViewHasPhysicalAspectForTest(
         double expectedAspect) const;
 

--- a/src/qt/MainWindow.hpp
+++ b/src/qt/MainWindow.hpp
@@ -47,6 +47,7 @@ class QLineF;
 class QMenu;
 class QPlainTextEdit;
 class QProgressDialog;
+class QProgressBar;
 class QPushButton;
 class QStackedWidget;
 class QTimer;
@@ -212,6 +213,9 @@ public:
         const QColor& color);
     [[nodiscard]] std::size_t particleSampleCountForTest() const;
     [[nodiscard]] std::size_t particleOverlayCountForTest();
+    [[nodiscard]] bool particleLoadingForTest() const noexcept;
+    [[nodiscard]] bool particleLoadingUiActiveForTest() const;
+    [[nodiscard]] bool particleLoadingUiSettledForTest() const;
 
 signals:
     void datasetOpenFinished(bool success);
@@ -624,6 +628,7 @@ private:
     QAction* m_syncRubberBandZoomAction = nullptr;
     QAction* m_contoursAction = nullptr;
     QAction* m_particlesAction = nullptr;
+    QProgressBar* m_particleProgress = nullptr;
     QAction* m_datasetAction = nullptr;
     QAction* m_exportAnimationAction = nullptr;
 
@@ -662,6 +667,7 @@ private:
     std::uint64_t m_particleSeed = 0;
     int m_particlePointSize = 3;
     bool m_particleSelectionInitialized = false;
+    bool m_particleLoading = false;
     StopSource m_particleStopSource;
     std::uint64_t m_particleGeneration = 0;
     std::filesystem::path m_datasetPath;

--- a/src/qt/MainWindow.hpp
+++ b/src/qt/MainWindow.hpp
@@ -30,6 +30,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <tuple>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -89,6 +90,8 @@ public:
     explicit MainWindow(QWidget* parent = nullptr);
 
     void openDataset(const std::filesystem::path& path, bool metadataOnly = false);
+    void openRemoteDataset(
+        std::string host, std::uint16_t port, std::string remotePath);
     // Opens a plotfile sequence (the legacy "-a" file animation): frames are
     // the plotfile directories, sorted by name; requires at least two valid
     // plotfiles. Opening a single dataset closes the sequence again.
@@ -140,10 +143,14 @@ public:
     // i.e. the raster and color bar agree. See
     // raster-colorbar-mismatch-on-2d-visible-zoom.
     [[nodiscard]] bool activeViewRasterMatchesDisplayRangeForTest();
+    [[nodiscard]] bool activeViewUsesViewportBoundedOutputForTest() const;
+    [[nodiscard]] bool activeViewHasPhysicalAspectForTest(
+        double expectedAspect) const;
 
     // Test-only: rubber-band the central half of the active 3-D panel through
     // the same handler used by ImageView::rubberBandSelected.
     void rubberBandZoomActiveViewForTest();
+    void rubberBandZoomRectangularActiveViewForTest();
 
     // Test-only: true when every current panel has a strict visible subregion.
     // Used to lock down synchronized 3-D rubber-band zoom.
@@ -292,13 +299,17 @@ private:
     void openDatasetImpl(const std::filesystem::path& path, bool metadataOnly,
         std::optional<PlotfileMetadataResult> preparedMetadata,
         std::filesystem::path dataRoot, bool preserveFabSelector,
-        std::optional<FrameSliceSpec> initialSpec);
+        std::optional<FrameSliceSpec> initialSpec,
+        std::optional<std::tuple<std::string, std::uint16_t, std::string>>
+            remoteOpen = std::nullopt);
+
     // Clears standalone FAB/MultiFab view state (mode flag, MultiFab-return
     // record, source metadata/paths) and hides the FAB selector dock. Any path
     // that replaces the displayed dataset with a non-FAB one -- a plain dataset
     // open, or a plotfile sequence -- must call this or stale FAB state leaks
     // into the new view (see open-sequence-stale-fab-state).
     void resetFabState();
+
     void viewFab(std::size_t entry);
     void backToMultiFab();
     // A fresh independent top-level window (WA_DeleteOnClose) for the
@@ -377,6 +388,10 @@ private:
     // state. Shared by setActiveView and showSlice's active-view branch.
     void syncActiveViewColorControls(const PlaneViewState& state);
     [[nodiscard]] std::array<int, 2> displayAxes(int normal) const;
+    [[nodiscard]] std::array<int, 2> nativeOutputSize(
+        const PlaneViewState& state) const;
+    [[nodiscard]] std::array<int, 2> sliceOutputSize(
+        const PlaneViewState& state, bool forceRemote = false) const;
     // True when the active dataset is displayed as a warped 2-D spherical
     // (r, theta) plane. Gates the coordinate-warp overlay, probe, and label
     // paths; all other datasets keep their Cartesian behavior.
@@ -477,7 +492,8 @@ private:
         std::uint64_t generation,
         std::optional<PlotfileMetadataResult> preparedMetadata = std::nullopt,
         std::filesystem::path dataRoot = {},
-        std::optional<FrameSliceSpec> initialSpec = std::nullopt);
+        std::optional<FrameSliceSpec> initialSpec = std::nullopt,
+        std::shared_ptr<DatasetSession> preparedSession = {});
     void configureSliceControls();
     // Enable the dataset-dependent field/level/range/menu controls once a
     // dataset (single or sequence frame) is loaded. Shared by
@@ -648,6 +664,8 @@ private:
     StopSource m_particleStopSource;
     std::uint64_t m_particleGeneration = 0;
     std::filesystem::path m_datasetPath;
+    std::string m_remoteHost;
+    std::uint16_t m_remotePort = 0;
     struct MultiFabReturnState {
         std::filesystem::path path;
         std::filesystem::path dataRoot;

--- a/src/qt/RemoteEndpoint.hpp
+++ b/src/qt/RemoteEndpoint.hpp
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <charconv>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <utility>
+
+namespace amrvis::qt {
+
+inline std::optional<std::pair<std::string, std::uint16_t>>
+parseRemoteEndpoint(std::string_view text)
+{
+    const auto separator = text.rfind(':');
+    if (separator == std::string_view::npos || separator == 0
+        || separator + 1 == text.size()) {
+        return std::nullopt;
+    }
+    auto host = text.substr(0, separator);
+    if (host.size() >= 2 && host.front() == '[' && host.back() == ']') {
+        host.remove_prefix(1);
+        host.remove_suffix(1);
+    }
+    if (host.empty()) {
+        return std::nullopt;
+    }
+    unsigned int port = 0;
+    const auto portText = text.substr(separator + 1);
+    const auto [end, error] = std::from_chars(
+        portText.data(), portText.data() + portText.size(), port);
+    if (error != std::errc{} || end != portText.data() + portText.size()
+        || port == 0 || port > 65535) {
+        return std::nullopt;
+    }
+    return std::pair{std::string(host), static_cast<std::uint16_t>(port)};
+}
+
+} // namespace amrvis::qt

--- a/src/qt/RemoteEndpoint.hpp
+++ b/src/qt/RemoteEndpoint.hpp
@@ -12,15 +12,27 @@ namespace amrvis::qt {
 inline std::optional<std::pair<std::string, std::uint16_t>>
 parseRemoteEndpoint(std::string_view text)
 {
-    const auto separator = text.rfind(':');
+    std::size_t separator = std::string_view::npos;
+    std::string_view host;
+    if (!text.empty() && text.front() == '[') {
+        const auto close = text.find(']');
+        if (close == std::string_view::npos || close == 1
+            || close + 1 >= text.size() || text[close + 1] != ':') {
+            return std::nullopt;
+        }
+        host = text.substr(1, close - 1);
+        separator = close + 1;
+    } else {
+        separator = text.find(':');
+        if (separator != text.rfind(':')) {
+            // A bare IPv6 literal is ambiguous with the port separator.
+            return std::nullopt;
+        }
+        host = text.substr(0, separator);
+    }
     if (separator == std::string_view::npos || separator == 0
         || separator + 1 == text.size()) {
         return std::nullopt;
-    }
-    auto host = text.substr(0, separator);
-    if (host.size() >= 2 && host.front() == '[' && host.back() == ']') {
-        host.remove_prefix(1);
-        host.remove_suffix(1);
     }
     if (host.empty()) {
         return std::nullopt;

--- a/src/qt/main.cpp
+++ b/src/qt/main.cpp
@@ -1,5 +1,6 @@
 #include "MainWindow.hpp"
 #include "FabSelectorDock.hpp"
+#include "RemoteEndpoint.hpp"
 
 #include <QAction>
 #include <QApplication>
@@ -24,6 +25,7 @@
 #include <QTimer>
 
 #include <amrexplorer/render2d/Contours.hpp>
+#include <amrexplorer/remote/Server.hpp>
 
 #include <algorithm>
 #include <array>
@@ -35,6 +37,7 @@
 #include <cstring>
 #include <filesystem>
 #include <memory>
+#include <optional>
 #include <string_view>
 #include <thread>
 #include <vector>
@@ -481,7 +484,73 @@ int main(int argc, char* argv[])
     ensureDesktopEntry();
     amrvis::qt::MainWindow window;
     window.show();
-    if (argc == 3 && std::string_view(argv[1]) == "--smoke-test") {
+    std::shared_ptr<amrvis::remote::Server> smokeServer;
+    std::optional<std::thread> smokeServerThread;
+    if (argc == 3
+        && std::string_view(argv[1]) == "--remote-slice-smoke-test") {
+        smokeServer = std::make_shared<amrvis::remote::Server>();
+        smokeServerThread.emplace(
+            [server = smokeServer] { server->run(); });
+        QObject::connect(&window,
+            &amrvis::qt::MainWindow::initialSliceFinished,
+            &application, [&window, &application](bool success) {
+                application.exit(success
+                        && window.activeViewUsesViewportBoundedOutputForTest()
+                    ? 0 : 1);
+            });
+        QTimer::singleShot(15000, &application,
+            [&application] { application.exit(1); });
+        QTimer::singleShot(0, &window,
+            [&window, path = std::string(argv[2]), server = smokeServer] {
+                window.openRemoteDataset(
+                    "127.0.0.1", server->port(), path);
+            });
+    } else if (argc == 3
+        && std::string_view(argv[1]) == "--remote-rubber-aspect-smoke-test") {
+        smokeServer = std::make_shared<amrvis::remote::Server>();
+        smokeServerThread.emplace(
+            [server = smokeServer] { server->run(); });
+        QObject::connect(&window,
+            &amrvis::qt::MainWindow::initialSliceFinished,
+            &application, [&window, &application](bool success) {
+                if (!success) {
+                    application.exit(2);
+                    return;
+                }
+                QObject::connect(&window,
+                    &amrvis::qt::MainWindow::interactiveSlicesSettled,
+                    &application, [&window, &application] {
+                        application.exit(window.activeViewIsZoomedForTest()
+                                && window.activeViewHasPhysicalAspectForTest(
+                                    9.0 / 4.0)
+                            ? 0 : 1);
+                    }, Qt::SingleShotConnection);
+                window.rubberBandZoomRectangularActiveViewForTest();
+            });
+        QTimer::singleShot(15000, &application,
+            [&application] { application.exit(1); });
+        QTimer::singleShot(0, &window,
+            [&window, path = std::string(argv[2]), server = smokeServer] {
+                window.openRemoteDataset(
+                    "127.0.0.1", server->port(), path);
+            });
+    } else if (argc == 4
+        && std::string_view(argv[1]) == "--connect") {
+        const auto endpoint = amrvis::qt::parseRemoteEndpoint(argv[2]);
+        if (!endpoint || std::string_view(argv[3]).empty()) {
+            qCritical("usage: amrexplorer --connect HOST:PORT REMOTE_PATH");
+            return 2;
+        }
+        QTimer::singleShot(0, &window,
+            [&window, endpoint = *endpoint, path = std::string(argv[3])] {
+                window.openRemoteDataset(
+                    endpoint.first, endpoint.second, path);
+            });
+    } else if (argc >= 2
+        && std::string_view(argv[1]) == "--connect") {
+        qCritical("usage: amrexplorer --connect HOST:PORT REMOTE_PATH");
+        return 2;
+    } else if (argc == 3 && std::string_view(argv[1]) == "--smoke-test") {
         const std::filesystem::path path(argv[2]);
         QObject::connect(&window, &amrvis::qt::MainWindow::datasetOpenFinished,
             &application, [&application](bool success) {
@@ -1355,5 +1424,12 @@ int main(int argc, char* argv[])
             }
         });
     }
-    return application.exec();
+    const auto result = application.exec();
+    if (smokeServer) {
+        smokeServer->requestStop();
+    }
+    if (smokeServerThread) {
+        smokeServerThread->join();
+    }
+    return result;
 }

--- a/src/qt/main.cpp
+++ b/src/qt/main.cpp
@@ -25,6 +25,7 @@
 #include <QTimer>
 
 #include <amrexplorer/render2d/Contours.hpp>
+#include <amrexplorer/remote/Frame.hpp>
 #include <amrexplorer/remote/Server.hpp>
 
 #include <algorithm>
@@ -486,6 +487,7 @@ int main(int argc, char* argv[])
     window.show();
     std::shared_ptr<amrvis::remote::Server> smokeServer;
     std::optional<std::thread> smokeServerThread;
+    std::optional<std::thread> smokePeerThread;
     if (argc == 3
         && std::string_view(argv[1]) == "--remote-slice-smoke-test") {
         smokeServer = std::make_shared<amrvis::remote::Server>();
@@ -504,6 +506,60 @@ int main(int argc, char* argv[])
             [&window, path = std::string(argv[2]), server = smokeServer] {
                 window.openRemoteDataset(
                     "127.0.0.1", server->port(), path);
+            });
+    } else if (argc == 3
+        && std::string_view(argv[1])
+            == "--remote-initial-geometry-smoke-test") {
+        smokeServer = std::make_shared<amrvis::remote::Server>();
+        smokeServerThread.emplace(
+            [server = smokeServer] { server->run(); });
+        QObject::connect(&window,
+            &amrvis::qt::MainWindow::initialSliceFinished,
+            &application, [&window, &application](bool success) {
+                if (!success) {
+                    application.exit(2);
+                    return;
+                }
+                if (window.allViewsUseViewportBoundedOutputForTest()) {
+                    application.exit(0);
+                    return;
+                }
+                QObject::connect(&window,
+                    &amrvis::qt::MainWindow::interactiveSlicesSettled,
+                    &application, [&window, &application] {
+                        application.exit(
+                            window.allViewsUseViewportBoundedOutputForTest()
+                            ? 0 : 1);
+                    }, Qt::SingleShotConnection);
+            });
+        QTimer::singleShot(15000, &application,
+            [&application] { application.exit(1); });
+        QTimer::singleShot(0, &window,
+            [&window, path = std::string(argv[2]), server = smokeServer] {
+                window.openRemoteDataset(
+                    "127.0.0.1", server->port(), path);
+            });
+    } else if (argc == 2
+        && std::string_view(argv[1])
+            == "--remote-silent-hello-close-smoke-test") {
+        auto listener = std::make_shared<amrvis::remote::Listener>(
+            amrvis::remote::listenOnLoopback(0));
+        smokePeerThread.emplace([listener, &window] {
+            auto peer = amrvis::remote::acceptConnection(listener->socket);
+            // Wait until the client has entered the hello transaction before
+            // closing the window. A second read then remains silent until the
+            // cancelled Connection constructor releases its socket.
+            static_cast<void>(amrvis::remote::readFrame(peer));
+            QMetaObject::invokeMethod(&window,
+                [&window] { window.close(); }, Qt::QueuedConnection);
+            static_cast<void>(amrvis::remote::readFrame(peer));
+        });
+        QTimer::singleShot(5000, &application,
+            [&application] { application.exit(1); });
+        QTimer::singleShot(0, &window,
+            [&window, port = listener->port] {
+                window.openRemoteDataset(
+                    "127.0.0.1", port, "/not-opened-before-hello");
             });
     } else if (argc == 3
         && std::string_view(argv[1]) == "--remote-rubber-aspect-smoke-test") {
@@ -1430,6 +1486,9 @@ int main(int argc, char* argv[])
     }
     if (smokeServerThread) {
         smokeServerThread->join();
+    }
+    if (smokePeerThread) {
+        smokePeerThread->join();
     }
     return result;
 }

--- a/src/qt/main.cpp
+++ b/src/qt/main.cpp
@@ -675,6 +675,11 @@ int main(int argc, char* argv[])
                     return;
                 }
                 window.setParticleSelectionForTest({"Tracer"}, 1.0, 37);
+                if (!window.particleLoadingForTest()
+                    || !window.particleLoadingUiActiveForTest()) {
+                    application.exit(2);
+                    return;
+                }
                 poll->start();
             });
         QObject::connect(poll, &QTimer::timeout, &application,
@@ -685,7 +690,9 @@ int main(int argc, char* argv[])
                 }
                 if (window.particleSampleCountForTest() == 0
                     || window.particleOverlayCountForTest() == 0
-                    || window.particleSeedForTest() != 37) {
+                    || window.particleSeedForTest() != 37
+                    || window.particleLoadingForTest()
+                    || !window.particleLoadingUiSettledForTest()) {
                     return;
                 }
                 poll->stop();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -138,6 +138,22 @@ if(TARGET amrexplorer_remote)
             "${remote_server_private_fixture_dir}")
     set_tests_properties(remote_server_private_fixture PROPERTIES
         FIXTURES_SETUP remote_server_private_materialized)
+    set(remote_server_fixture_3d_dir
+        "${CMAKE_CURRENT_BINARY_DIR}/fixtures_remote_server_3d")
+    add_test(NAME remote_server_fixture_3d
+        COMMAND "$<TARGET_FILE:fixture_materializer>"
+            "${CMAKE_CURRENT_SOURCE_DIR}/data/plotfile_3d"
+            "${remote_server_fixture_3d_dir}")
+    set_tests_properties(remote_server_fixture_3d PROPERTIES
+        FIXTURES_SETUP remote_server_3d_materialized)
+    set(remote_server_fixture_spherical_dir
+        "${CMAKE_CURRENT_BINARY_DIR}/fixtures_remote_server_spherical")
+    add_test(NAME remote_server_fixture_spherical
+        COMMAND "$<TARGET_FILE:fixture_materializer>"
+            "${CMAKE_CURRENT_SOURCE_DIR}/data/plotfile_2d_spherical"
+            "${remote_server_fixture_spherical_dir}")
+    set_tests_properties(remote_server_fixture_spherical PROPERTIES
+        FIXTURES_SETUP remote_server_spherical_materialized)
     add_test(NAME remote_server
         COMMAND test_remote_server "${remote_server_private_fixture_dir}")
     set_tests_properties(remote_server PROPERTIES
@@ -319,6 +335,13 @@ add_test(NAME tool_line_repro
 set_tests_properties(tool_line_repro PROPERTIES TIMEOUT 60)
 
 if(TARGET amrexplorer_qt)
+    add_executable(test_remote_endpoint unit/test_remote_endpoint.cpp)
+    target_include_directories(test_remote_endpoint
+        PRIVATE "${PROJECT_SOURCE_DIR}/src/qt")
+    target_link_libraries(test_remote_endpoint
+        PRIVATE amrexplorer::warnings)
+    add_test(NAME remote_endpoint COMMAND test_remote_endpoint)
+
     add_test(
         NAME qt_remote_slice_smoke
         COMMAND "${CMAKE_COMMAND}" -E env QT_QPA_PLATFORM=offscreen
@@ -339,6 +362,37 @@ if(TARGET amrexplorer_qt)
     set_tests_properties(qt_remote_rubber_aspect_smoke PROPERTIES
         FIXTURES_REQUIRED remote_server_materialized
         TIMEOUT 30)
+
+    add_test(
+        NAME qt_remote_3d_initial_geometry_smoke
+        COMMAND "${CMAKE_COMMAND}" -E env QT_QPA_PLATFORM=offscreen
+            "$<TARGET_FILE:amrexplorer_qt>"
+            --remote-initial-geometry-smoke-test
+            "${remote_server_fixture_3d_dir}"
+    )
+    set_tests_properties(qt_remote_3d_initial_geometry_smoke PROPERTIES
+        FIXTURES_REQUIRED remote_server_3d_materialized
+        TIMEOUT 30)
+
+    add_test(
+        NAME qt_remote_spherical_initial_geometry_smoke
+        COMMAND "${CMAKE_COMMAND}" -E env QT_QPA_PLATFORM=offscreen
+            "$<TARGET_FILE:amrexplorer_qt>"
+            --remote-initial-geometry-smoke-test
+            "${remote_server_fixture_spherical_dir}"
+    )
+    set_tests_properties(qt_remote_spherical_initial_geometry_smoke PROPERTIES
+        FIXTURES_REQUIRED remote_server_spherical_materialized
+        TIMEOUT 30)
+
+    add_test(
+        NAME qt_remote_silent_hello_close_smoke
+        COMMAND "${CMAKE_COMMAND}" -E env QT_QPA_PLATFORM=offscreen
+            "$<TARGET_FILE:amrexplorer_qt>"
+            --remote-silent-hello-close-smoke-test
+    )
+    set_tests_properties(qt_remote_silent_hello_close_smoke PROPERTIES
+        TIMEOUT 10)
 
     add_executable(test_user_guide_dialog
         unit/test_user_guide_dialog.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -319,6 +319,27 @@ add_test(NAME tool_line_repro
 set_tests_properties(tool_line_repro PROPERTIES TIMEOUT 60)
 
 if(TARGET amrexplorer_qt)
+    add_test(
+        NAME qt_remote_slice_smoke
+        COMMAND "${CMAKE_COMMAND}" -E env QT_QPA_PLATFORM=offscreen
+            "$<TARGET_FILE:amrexplorer_qt>"
+            --remote-slice-smoke-test "${remote_server_fixture_dir}"
+    )
+    set_tests_properties(qt_remote_slice_smoke PROPERTIES
+        FIXTURES_REQUIRED remote_server_materialized
+        TIMEOUT 30)
+
+    add_test(
+        NAME qt_remote_rubber_aspect_smoke
+        COMMAND "${CMAKE_COMMAND}" -E env QT_QPA_PLATFORM=offscreen
+            "$<TARGET_FILE:amrexplorer_qt>"
+            --remote-rubber-aspect-smoke-test
+            "${remote_server_fixture_dir}"
+    )
+    set_tests_properties(qt_remote_rubber_aspect_smoke PROPERTIES
+        FIXTURES_REQUIRED remote_server_materialized
+        TIMEOUT 30)
+
     add_executable(test_user_guide_dialog
         unit/test_user_guide_dialog.cpp
         "${PROJECT_SOURCE_DIR}/src/qt/UserGuideDialog.cpp"

--- a/tests/unit/test_remote_endpoint.cpp
+++ b/tests/unit/test_remote_endpoint.cpp
@@ -1,0 +1,44 @@
+#include "RemoteEndpoint.hpp"
+
+#include <cstdlib>
+#include <iostream>
+
+namespace {
+
+void require(bool condition, const char* message)
+{
+    if (!condition) {
+        std::cerr << "FAILED: " << message << '\n';
+        std::exit(1);
+    }
+}
+
+} // namespace
+
+int main()
+{
+    using amrvis::qt::parseRemoteEndpoint;
+
+    const auto ipv4 = parseRemoteEndpoint("127.0.0.1:48192");
+    require(ipv4 && ipv4->first == "127.0.0.1" && ipv4->second == 48192,
+        "IPv4 endpoint was rejected");
+    const auto hostname = parseRemoteEndpoint("login.example.org:22");
+    require(hostname && hostname->first == "login.example.org"
+            && hostname->second == 22,
+        "hostname endpoint was rejected");
+    const auto ipv6 = parseRemoteEndpoint("[::1]:48192");
+    require(ipv6 && ipv6->first == "::1" && ipv6->second == 48192,
+        "bracketed IPv6 endpoint was rejected");
+
+    require(!parseRemoteEndpoint("::1:48192"),
+        "ambiguous bare IPv6 endpoint was accepted");
+    require(!parseRemoteEndpoint("host")
+            && !parseRemoteEndpoint("host:")
+            && !parseRemoteEndpoint(":48192"),
+        "missing host or port was accepted");
+    require(!parseRemoteEndpoint("[::1]48192")
+            && !parseRemoteEndpoint("[::1]:0")
+            && !parseRemoteEndpoint("[::1]:65536"),
+        "malformed bracketed endpoint was accepted");
+    return 0;
+}


### PR DESCRIPTION
Part 10 of 13 in the remote client/server stack.

## Purpose

Connect the Qt application to one remote dataset without changing local rendering behavior.

## Scope

- Adds endpoint parsing, File-menu actions, and `--connect HOST:PORT PATH`.
- Opens remote sessions off the GUI thread.
- Plans remote slices to the device-pixel viewport while preserving physical aspect ratio.
- Replans on viewport resize and keeps arbitrary remote rubber-band regions unsnapped.

## Review focus

Pay particular attention to the initial request: it is viewport-bounded before `m_dataset` is installed, avoiding the native-resolution first-frame bug from #95.

## Validation

- `qt_remote_slice_smoke`
- `qt_remote_rubber_aspect_smoke`
- Existing local slice, zoom, and sequence smokes
