### PR TITLE
[client-server] load remote plotfile sequences

### DIFF
--- a/include/amrexplorer/pipeline/SlicePipeline.hpp
+++ b/include/amrexplorer/pipeline/SlicePipeline.hpp
@@ -169,6 +169,9 @@ inline constexpr int maxSliceOutputDimension = maxViewOutputDimension;
 [[nodiscard]] std::array<int, 2> viewportBoundedOutputSize(
     const DatasetMetadata& metadata, const RealBox& region, int normal,
     std::array<int, 2> viewportSize);
+[[nodiscard]] std::array<int, 2> frameBudgetBoundedOutputSize(
+    std::array<int, 2> outputSize,
+    std::optional<std::uint32_t> maximumResponseBytes);
 
 // The cache-key comparison for a cached slice: everything a cached slice
 // depends on. Range, log scale, palette, and contour count are deliberately

--- a/include/amrexplorer/pipeline/SlicePipeline.hpp
+++ b/include/amrexplorer/pipeline/SlicePipeline.hpp
@@ -169,6 +169,12 @@ inline constexpr int maxSliceOutputDimension = maxViewOutputDimension;
 [[nodiscard]] std::array<int, 2> viewportBoundedOutputSize(
     const DatasetMetadata& metadata, const RealBox& region, int normal,
     std::array<int, 2> viewportSize);
+// Viewport-bounded remote raster size that never invents more samples than
+// the region's finest-native raster. This preserves Fit's bounded transport
+// without making a small native image behave as though it had been enlarged.
+[[nodiscard]] std::array<int, 2> nativeBoundedViewportOutputSize(
+    const DatasetMetadata& metadata, const RealBox& region, int normal,
+    std::array<int, 2> viewportSize);
 [[nodiscard]] std::array<int, 2> frameBudgetBoundedOutputSize(
     std::array<int, 2> outputSize,
     std::optional<std::uint32_t> maximumResponseBytes);

--- a/include/amrexplorer/pipeline/SlicePipeline.hpp
+++ b/include/amrexplorer/pipeline/SlicePipeline.hpp
@@ -120,6 +120,10 @@ struct FrameSliceSpec {
     std::array<double, 3> slicePositions{0.0, 0.0, 0.0};
     std::vector<std::optional<RealBox>> visibleRegions;  // per view, normal order
     std::vector<std::array<int, 2>> outputSizes;  // per view, viewport pixels
+    // When true, outputSizes are viewport bounds rather than exact raster
+    // dimensions; the frame loader preserves the physical aspect ratio within
+    // each bound after it has opened the frame and knows its geometry.
+    bool outputSizesAreViewportBounds = false;
     bool particleSelectionInitialized = false;
     std::vector<std::string> particleSpecies;
     double particleFraction = 1.0;
@@ -155,6 +159,12 @@ inline constexpr int maxSliceOutputDimension = maxViewOutputDimension;
 // fixed scales magnify it through the view zoom.
 [[nodiscard]] std::array<int, 2> finestNativeOutputSize(
     const DatasetMetadata& metadata, const RealBox& region, int normal);
+
+// Fits a physical slice region into a pixel bound without distorting its
+// in-plane aspect ratio.
+[[nodiscard]] std::array<int, 2> viewportBoundedOutputSize(
+    const DatasetMetadata& metadata, const RealBox& region, int normal,
+    std::array<int, 2> viewportSize);
 
 // The cache-key comparison for a cached slice: everything a cached slice
 // depends on. Range, log scale, palette, and contour count are deliberately

--- a/include/amrexplorer/pipeline/SlicePipeline.hpp
+++ b/include/amrexplorer/pipeline/SlicePipeline.hpp
@@ -92,6 +92,10 @@ struct InitialSliceResult {
     // retried with a lower composite maximum level.
     int cacheFallbackFromLevel = -1;
     int cacheFallbackToLevel = -1;
+    // Nonzero for remote sequence frames. Server-local dataset identifiers can
+    // restart after reconnect, so GUI caches also key their lifetime to this
+    // client-side connection generation.
+    std::uint64_t connectionGeneration = 0;
 };
 
 // Everything needed to render one frame's slice(s) off the GUI thread. The

--- a/src/pipeline/SlicePipeline.cpp
+++ b/src/pipeline/SlicePipeline.cpp
@@ -60,6 +60,41 @@ std::array<int, 2> finestNativeOutputSize(
     return {cells(axes[0]), cells(axes[1])};
 }
 
+std::array<int, 2> viewportBoundedOutputSize(
+    const DatasetMetadata& metadata, const RealBox& region, int normal,
+    std::array<int, 2> viewportSize)
+{
+    viewportSize[0] = std::clamp(
+        viewportSize[0], 1, maxSliceOutputDimension);
+    viewportSize[1] = std::clamp(
+        viewportSize[1], 1, maxSliceOutputDimension);
+    const auto axes = slicePlaneAxes(metadata.dimension, normal);
+    auto extentX = region.upper[static_cast<std::size_t>(axes[0])]
+        - region.lower[static_cast<std::size_t>(axes[0])];
+    auto extentY = region.upper[static_cast<std::size_t>(axes[1])]
+        - region.lower[static_cast<std::size_t>(axes[1])];
+    if (isSpherical2D(metadata)) {
+        // Radius and angle have heterogeneous units. Use their finest-level
+        // sample counts as the normalized display aspect instead of comparing
+        // raw physical extents with unrelated dimensions.
+        const auto normalized = finestNativeOutputSize(
+            metadata, region, normal);
+        extentX = static_cast<double>(normalized[0]);
+        extentY = static_cast<double>(normalized[1]);
+    }
+    if (!(extentX > 0.0) || !(extentY > 0.0)) {
+        return {1, 1};
+    }
+    const auto fit = std::min(
+        static_cast<double>(viewportSize[0]) / extentX,
+        static_cast<double>(viewportSize[1]) / extentY);
+    return {
+        std::clamp(static_cast<int>(std::lround(extentX * fit)),
+            1, viewportSize[0]),
+        std::clamp(static_cast<int>(std::lround(extentY * fit)),
+            1, viewportSize[1])};
+}
+
 bool sameSliceSpec(const SliceRequest& lhs, const SliceRequest& rhs)
 {
     return lhs.dataset == rhs.dataset && lhs.field == rhs.field
@@ -543,10 +578,19 @@ InitialSliceResult executeSessionFrameLoad(
                     region.upper[index] = upper;
                 }
                 request.visibleRegion = region;
+                const auto hasOutputSize = !spec.outputSizes.empty();
                 request.outputSize = entry < spec.outputSizes.size()
                     ? spec.outputSizes[entry]
-                    : finestNativeOutputSize(metadata, request.visibleRegion,
-                        request.normalDirection);
+                    : (spec.outputSizesAreViewportBounds && hasOutputSize
+                              ? spec.outputSizes.back()
+                              : finestNativeOutputSize(metadata,
+                                    request.visibleRegion,
+                                    request.normalDirection));
+                if (spec.outputSizesAreViewportBounds && hasOutputSize) {
+                    request.outputSize = viewportBoundedOutputSize(metadata,
+                        request.visibleRegion, request.normalDirection,
+                        request.outputSize);
+                }
                 request.outputSize[0] = std::clamp(
                     request.outputSize[0], 1, maxSliceOutputDimension);
                 request.outputSize[1] = std::clamp(

--- a/src/pipeline/SlicePipeline.cpp
+++ b/src/pipeline/SlicePipeline.cpp
@@ -753,10 +753,10 @@ InitialSliceResult executeFrameLoad(const std::filesystem::path& path,
     if (preparedMetadata) {
         dataset = std::make_shared<LocalDatasetSession>(
             std::move(dataRoot), datasetId, cacheBudgetBytes,
-            std::move(*preparedMetadata));
+            std::move(*preparedMetadata), cancellation);
     } else {
         dataset = std::make_shared<LocalDatasetSession>(
-            path, datasetId, cacheBudgetBytes);
+            path, datasetId, cacheBudgetBytes, cancellation);
     }
     return executeSessionFrameLoad(
         std::move(dataset), spec, cancellation);

--- a/src/pipeline/SlicePipeline.cpp
+++ b/src/pipeline/SlicePipeline.cpp
@@ -95,6 +95,43 @@ std::array<int, 2> viewportBoundedOutputSize(
             1, viewportSize[1])};
 }
 
+std::array<int, 2> frameBudgetBoundedOutputSize(
+    std::array<int, 2> outputSize,
+    std::optional<std::uint32_t> maximumResponseBytes)
+{
+    if (!maximumResponseBytes) {
+        return outputSize;
+    }
+    const auto frameBytes = static_cast<std::uint64_t>(*maximumResponseBytes);
+    const auto maximumCells = frameBytes > sliceResponseOverheadBytes
+        ? (frameBytes - sliceResponseOverheadBytes) / sliceResponseBytesPerCell
+        : 0;
+    const auto requestedCells = static_cast<std::uint64_t>(outputSize[0])
+        * static_cast<std::uint64_t>(outputSize[1]);
+    if (maximumCells == 0) {
+        return {1, 1};
+    }
+    if (requestedCells <= maximumCells) {
+        return outputSize;
+    }
+    const auto scale = std::sqrt(static_cast<double>(maximumCells)
+        / static_cast<double>(requestedCells));
+    auto bounded = std::array<int, 2>{
+        std::max(1, static_cast<int>(std::floor(outputSize[0] * scale))),
+        std::max(1, static_cast<int>(std::floor(outputSize[1] * scale)))};
+    while (static_cast<std::uint64_t>(bounded[0])
+            * static_cast<std::uint64_t>(bounded[1]) > maximumCells) {
+        if (bounded[0] >= bounded[1] && bounded[0] > 1) {
+            --bounded[0];
+        } else if (bounded[1] > 1) {
+            --bounded[1];
+        } else {
+            break;
+        }
+    }
+    return bounded;
+}
+
 bool sameSliceSpec(const SliceRequest& lhs, const SliceRequest& rhs)
 {
     return lhs.dataset == rhs.dataset && lhs.field == rhs.field
@@ -294,6 +331,8 @@ SliceDisplayResult executeSliceWithFallback(
     std::uint32_t vectorUField, std::uint32_t vectorVField, int contourCount,
     StopToken cancellation)
 {
+    request.outputSize = frameBudgetBoundedOutputSize(
+        request.outputSize, dataset->maximumResponseBytes());
     int fallbackFrom = -1;
     int fallbackTo = -1;
     for (;;) {
@@ -376,6 +415,8 @@ void appendContours(const std::shared_ptr<DatasetSession>& dataset,
     contourRequest.outputSize = {
         std::min(std::max(dataWidth, 512), 1024),
         std::min(std::max(dataHeight, 512), 1024)};
+    contourRequest.outputSize = frameBudgetBoundedOutputSize(
+        contourRequest.outputSize, dataset->maximumResponseBytes());
     contourRequest.sampling = SamplingPolicy::Linear;
     auto contour = requestSlice(*dataset, contourRequest, cancellation);
     result.contourPlane = std::move(contour.plane);
@@ -595,6 +636,8 @@ InitialSliceResult executeSessionFrameLoad(
                     request.outputSize[0], 1, maxSliceOutputDimension);
                 request.outputSize[1] = std::clamp(
                     request.outputSize[1], 1, maxSliceOutputDimension);
+                request.outputSize = frameBudgetBoundedOutputSize(
+                    request.outputSize, result.dataset->maximumResponseBytes());
                 request.composition = selectedLevel.composition;
                 request.maximumLevel = attemptMaximumLevel;
                 request.sphericalSupersample = spec.sphericalSupersample;

--- a/src/pipeline/SlicePipeline.cpp
+++ b/src/pipeline/SlicePipeline.cpp
@@ -77,10 +77,10 @@ std::array<int, 2> viewportBoundedOutputSize(
         // Radius and angle have heterogeneous units. Use their finest-level
         // sample counts as the normalized display aspect instead of comparing
         // raw physical extents with unrelated dimensions.
-        const auto normalized = finestNativeOutputSize(
-            metadata, region, normal);
-        extentX = static_cast<double>(normalized[0]);
-        extentY = static_cast<double>(normalized[1]);
+        const auto& finest = metadata.levels[static_cast<std::size_t>(
+            std::max(0, metadata.finestLevel))];
+        extentX /= finest.cellSize[static_cast<std::size_t>(axes[0])];
+        extentY /= finest.cellSize[static_cast<std::size_t>(axes[1])];
     }
     if (!(extentX > 0.0) || !(extentY > 0.0)) {
         return {1, 1};

--- a/src/pipeline/SlicePipeline.cpp
+++ b/src/pipeline/SlicePipeline.cpp
@@ -95,6 +95,23 @@ std::array<int, 2> viewportBoundedOutputSize(
             1, viewportSize[1])};
 }
 
+std::array<int, 2> nativeBoundedViewportOutputSize(
+    const DatasetMetadata& metadata, const RealBox& region, int normal,
+    std::array<int, 2> viewportSize)
+{
+    const auto viewport = viewportBoundedOutputSize(
+        metadata, region, normal, viewportSize);
+    const auto native = finestNativeOutputSize(metadata, region, normal);
+    const auto scale = std::min({1.0,
+        static_cast<double>(native[0]) / viewport[0],
+        static_cast<double>(native[1]) / viewport[1]});
+    return {
+        std::clamp(static_cast<int>(std::lround(viewport[0] * scale)),
+            1, native[0]),
+        std::clamp(static_cast<int>(std::lround(viewport[1] * scale)),
+            1, native[1])};
+}
+
 std::array<int, 2> frameBudgetBoundedOutputSize(
     std::array<int, 2> outputSize,
     std::optional<std::uint32_t> maximumResponseBytes)
@@ -628,7 +645,7 @@ InitialSliceResult executeSessionFrameLoad(
                                     request.visibleRegion,
                                     request.normalDirection));
                 if (spec.outputSizesAreViewportBounds && hasOutputSize) {
-                    request.outputSize = viewportBoundedOutputSize(metadata,
+                    request.outputSize = nativeBoundedViewportOutputSize(metadata,
                         request.visibleRegion, request.normalDirection,
                         request.outputSize);
                 }

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -496,9 +496,7 @@ MainWindow::MainWindow(QWidget* parent)
         auto* action = scaleMenu->addAction(tr("%1x").arg(factor));
         connect(action, &QAction::triggered, this, [this, factor] {
             m_scaleButton->setText(tr("%1x").arg(factor));
-            for (auto* state : currentViews()) {
-                state->view->setFixedScale(factor);
-            }
+            applyFixedScale(factor);
         });
     }
     m_syncRubberBandZoomAction =
@@ -943,6 +941,13 @@ void MainWindow::wireView(PlaneViewState& state)
                     remote::RemoteDatasetSession>(m_dataset)) {
                 return;
             }
+            if (state.view->transformMode()
+                    == ImageView::TransformMode::FixedScale
+                && !displayIsSpherical()) {
+                updateRemoteFixedScaleDemand(
+                    state, state.view->fixedScaleFactor());
+                return;
+            }
             if (!state.hasCachedRequest
                 || state.cachedRequest.outputSize != sliceOutputSize(state)) {
                 scheduleSliceRequest(state);
@@ -1038,9 +1043,22 @@ std::array<int, 2> MainWindow::sliceOutputSize(
     const auto viewportPixels = viewportPixelSize(state);
     const auto target = state.visibleRegion.value_or(
         datasetSampleBounds(*m_openMetadata));
+    std::array<int, 2> outputSize{};
+    if (state.view->transformMode() == ImageView::TransformMode::FixedScale) {
+        outputSize = finestNativeOutputSize(
+            *m_openMetadata, target, state.normal);
+    } else if (!state.visibleRegion.has_value()) {
+        outputSize = nativeBoundedViewportOutputSize(
+            *m_openMetadata, target, state.normal, viewportPixels);
+    } else {
+        // Rubber-band selections intentionally retain their exact physical
+        // aspect. Their fractional edges need not have the rounded native-cell
+        // aspect used to suppress Fit supersampling on a whole-domain view.
+        outputSize = viewportBoundedOutputSize(
+            *m_openMetadata, target, state.normal, viewportPixels);
+    }
     return frameBudgetBoundedOutputSize(
-        viewportBoundedOutputSize(
-            *m_openMetadata, target, state.normal, viewportPixels),
+        outputSize,
         m_dataset ? m_dataset->maximumResponseBytes() : std::nullopt);
 }
 
@@ -1057,6 +1075,18 @@ std::array<int, 2> MainWindow::viewportPixelSize(
             1, maxSliceOutputDimension),
         std::clamp(static_cast<int>(std::lround(viewport->height() * scale)),
             1, maxSliceOutputDimension)};
+}
+
+QSize MainWindow::logicalImageSize(const PlaneViewState& state,
+    const ScalarPlane& plane, const QImage& image) const
+{
+    if (!m_openMetadata || m_openMetadata->levels.empty()
+        || displayIsSpherical()) {
+        return image.size();
+    }
+    const auto native = finestNativeOutputSize(
+        *m_openMetadata, plane.physicalRegion, state.normal);
+    return {native[0], native[1]};
 }
 
 bool MainWindow::displayIsSpherical() const
@@ -1286,9 +1316,7 @@ void MainWindow::createMenus()
             if (m_scaleButton != nullptr) {
                 m_scaleButton->setText(tr("%1x").arg(factor));
             }
-            for (auto* state : currentViews()) {
-                state->view->setFixedScale(factor);
-            }
+            applyFixedScale(factor);
         });
         scaleMenu->addAction(action);
     }
@@ -1892,6 +1920,17 @@ bool MainWindow::activeViewUsesViewportBoundedOutputForTest() const
         && m_activeView->plane->height == expected[1];
 }
 
+bool MainWindow::activeViewUsesNativeOutputForTest() const
+{
+    if (m_activeView == nullptr || m_activeView->plane->width <= 0
+        || m_activeView->plane->height <= 0) {
+        return false;
+    }
+    const auto expected = nativeOutputSize(*m_activeView);
+    return m_activeView->plane->width == expected[0]
+        && m_activeView->plane->height == expected[1];
+}
+
 bool MainWindow::allViewsUseViewportBoundedOutputForTest() const
 {
     if (!std::dynamic_pointer_cast<remote::RemoteDatasetSession>(m_dataset)) {
@@ -2123,6 +2162,32 @@ int MainWindow::activeViewImageWidthForTest() const
         return 0;
     }
     return m_activeView->view->image().width();
+}
+
+std::array<int, 2> MainWindow::activeViewImageSizeForTest() const
+{
+    if (m_activeView == nullptr || !m_activeView->view->hasImage()) {
+        return {0, 0};
+    }
+    const auto image = m_activeView->view->image();
+    return {image.width(), image.height()};
+}
+
+std::array<int, 2> MainWindow::activeViewViewportSizeForTest() const
+{
+    if (m_activeView == nullptr || m_activeView->view->viewport() == nullptr) {
+        return {0, 0};
+    }
+    const auto* viewport = m_activeView->view->viewport();
+    return {viewport->width(), viewport->height()};
+}
+
+QImage MainWindow::activeViewViewportImageForTest() const
+{
+    if (m_activeView == nullptr || m_activeView->view->viewport() == nullptr) {
+        return {};
+    }
+    return m_activeView->view->viewport()->grab().toImage();
 }
 
 bool MainWindow::activeViewFitsWindowForTest() const
@@ -3245,6 +3310,101 @@ void MainWindow::flushPanDrag(bool finalize)
     scheduleSliceRequest(*m_panView, false);
 }
 
+std::array<double, 2> MainWindow::viewCenterInData(
+    const PlaneViewState& state) const
+{
+    const auto& plane = *state.plane;
+    const auto axes = displayAxes(state.normal);
+    const auto xAxis = static_cast<std::size_t>(axes[0]);
+    const auto yAxis = static_cast<std::size_t>(axes[1]);
+    const auto& region = plane.physicalRegion;
+    if (plane.width <= 0 || plane.height <= 0 || state.view == nullptr
+        || state.view->viewport() == nullptr) {
+        return {0.5 * (region.lower[xAxis] + region.upper[xAxis]),
+            0.5 * (region.lower[yAxis] + region.upper[yAxis])};
+    }
+    const auto scene = state.view->mapToScene(
+        state.view->viewport()->rect().center());
+    const auto sceneX = std::clamp(
+        scene.x(), 0.0, static_cast<double>(plane.width));
+    const auto sceneY = std::clamp(
+        scene.y(), 0.0, static_cast<double>(plane.height));
+    return {
+        region.lower[xAxis] + sceneX / plane.width
+            * (region.upper[xAxis] - region.lower[xAxis]),
+        region.upper[yAxis] - sceneY / plane.height
+            * (region.upper[yAxis] - region.lower[yAxis])};
+}
+
+void MainWindow::applyFixedScale(int factor)
+{
+    const auto views = currentViews();
+    std::vector<std::array<double, 2>> centers;
+    centers.reserve(views.size());
+    for (const auto* state : views) {
+        centers.push_back(viewCenterInData(*state));
+    }
+    const bool remoteDataset = std::dynamic_pointer_cast<
+        remote::RemoteDatasetSession>(m_dataset) != nullptr;
+    for (std::size_t index = 0; index < views.size(); ++index) {
+        auto& state = *views[index];
+        state.view->setFixedScale(factor);
+        if (remoteDataset && !displayIsSpherical()) {
+            updateRemoteFixedScaleDemand(state, factor, centers[index]);
+        }
+    }
+}
+
+void MainWindow::updateRemoteFixedScaleDemand(PlaneViewState& state,
+    int factor, std::optional<std::array<double, 2>> center)
+{
+    if (!m_dataset || factor < 1 || state.view == nullptr
+        || state.view->viewport() == nullptr
+        || !std::dynamic_pointer_cast<remote::RemoteDatasetSession>(m_dataset)
+        || displayIsSpherical()) {
+        return;
+    }
+    const auto& metadata = m_dataset->metadata();
+    if (metadata.levels.empty()) {
+        return;
+    }
+    const auto domain = datasetSampleBounds(metadata);
+    const auto axes = displayAxes(state.normal);
+    const auto& finest = metadata.levels[static_cast<std::size_t>(
+        std::max(0, metadata.finestLevel))];
+    const auto dataCenter = center.value_or(viewCenterInData(state));
+    auto target = domain;
+    const std::array viewport{
+        std::max(1, state.view->viewport()->width()),
+        std::max(1, state.view->viewport()->height())};
+    for (std::size_t entry = 0; entry < axes.size(); ++entry) {
+        const auto axis = static_cast<std::size_t>(axes[entry]);
+        const auto domainSpan = domain.upper[axis] - domain.lower[axis];
+        const auto requestedCells = std::max(1,
+            static_cast<int>(std::ceil(
+                static_cast<double>(viewport[entry]) / factor)));
+        const auto span = std::min(domainSpan,
+            requestedCells * finest.cellSize[axis]);
+        auto lower = dataCenter[entry] - 0.5 * span;
+        lower = std::clamp(lower, domain.lower[axis],
+            domain.upper[axis] - span);
+        target.lower[axis] = lower;
+        target.upper[axis] = lower + span;
+    }
+    target = snapToNearestCellGrid(
+        target, domain, finest.cellSize, axes);
+    if (target == domain) {
+        state.visibleRegion.reset();
+    } else {
+        state.visibleRegion = target;
+    }
+    if (!state.hasCachedRequest
+        || state.cachedRequest.visibleRegion != target
+        || state.cachedRequest.outputSize != sliceOutputSize(state)) {
+        scheduleSliceRequest(state, true);
+    }
+}
+
 void MainWindow::setupPanShortcuts()
 {
     const auto bind = [this](Qt::Key key, double x, double y) {
@@ -3280,10 +3440,16 @@ void MainWindow::applyPanStep(PlaneViewState& state, const QPointF& direction)
             return;
         }
         state.visibleRegion = *region;
-        state.view->fitToWindow();
-        m_resetZoomAction->setChecked(true);
-        if (m_scaleButton != nullptr) {
-            m_scaleButton->setText(tr("Fit"));
+        const bool remoteFixed = std::dynamic_pointer_cast<
+            remote::RemoteDatasetSession>(m_dataset) != nullptr
+            && state.view->transformMode()
+                == ImageView::TransformMode::FixedScale;
+        if (!remoteFixed) {
+            state.view->fitToWindow();
+            m_resetZoomAction->setChecked(true);
+            if (m_scaleButton != nullptr) {
+                m_scaleButton->setText(tr("Fit"));
+            }
         }
         scheduleSliceRequest(state, false);
         return;
@@ -5698,8 +5864,9 @@ void MainWindow::showSlice(PlaneViewState& state, const SliceDisplayResult& disp
                 dataWindowInNewScene = preservedDataWindow(
                     state, display.slice.plane);
             }
-            state.view->setImage(
-                displayImageFor(display.image), transformPolicy);
+            const auto image = displayImageFor(display.image);
+            state.view->setImage(image, transformPolicy,
+                logicalImageSize(state, display.slice.plane, image));
             if (dataWindowInNewScene) {
                 state.view->zoomToRect(*dataWindowInNewScene);
             }
@@ -5865,7 +6032,10 @@ void MainWindow::syncVisibleRanges()
                             = std::move(update.contourPolylines);
                     }
                     if (!outcome.images[index].isNull()) {
-                        state->view->setImage(outcome.images[index]);
+                        state->view->setImage(outcome.images[index],
+                            ImageTransformPolicy::GeometryAware,
+                            logicalImageSize(*state, *state->plane,
+                                outcome.images[index]));
                         // setImage clears the scene overlays; restore them.
                         updateGridBoxes(*state);
                         updateOverlay(*state);

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -1038,8 +1038,10 @@ std::array<int, 2> MainWindow::sliceOutputSize(
     const auto viewportPixels = viewportPixelSize(state);
     const auto target = state.visibleRegion.value_or(
         datasetSampleBounds(*m_openMetadata));
-    return viewportBoundedOutputSize(
-        *m_openMetadata, target, state.normal, viewportPixels);
+    return frameBudgetBoundedOutputSize(
+        viewportBoundedOutputSize(
+            *m_openMetadata, target, state.normal, viewportPixels),
+        m_dataset ? m_dataset->maximumResponseBytes() : std::nullopt);
 }
 
 std::array<int, 2> MainWindow::viewportPixelSize(
@@ -4737,8 +4739,12 @@ void MainWindow::requestInitialSlice(
         spec.outputSizes.clear();
         spec.outputSizes.reserve(views.size());
         for (const auto* state : views) {
-            spec.outputSizes.push_back(
-                sliceOutputSize(*state, isRemote));
+            auto outputSize = sliceOutputSize(*state, isRemote);
+            if (preparedSession) {
+                outputSize = frameBudgetBoundedOutputSize(outputSize,
+                    preparedSession->maximumResponseBytes());
+            }
+            spec.outputSizes.push_back(outputSize);
         }
     }
     const auto restoredSpec = initialSpec;

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -100,6 +100,7 @@
 #include <limits>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <stdexcept>
 #include <string>
@@ -1034,42 +1035,26 @@ std::array<int, 2> MainWindow::sliceOutputSize(
     if (!m_openMetadata || m_openMetadata->levels.empty()) {
         return {1, 1};
     }
+    const auto viewportPixels = viewportPixelSize(state);
+    const auto target = state.visibleRegion.value_or(
+        datasetSampleBounds(*m_openMetadata));
+    return viewportBoundedOutputSize(
+        *m_openMetadata, target, state.normal, viewportPixels);
+}
+
+std::array<int, 2> MainWindow::viewportPixelSize(
+    const PlaneViewState& state) const
+{
     const auto* viewport = state.view == nullptr ? nullptr : state.view->viewport();
     if (viewport == nullptr || viewport->width() < 1 || viewport->height() < 1) {
         return {1, 1};
     }
     const auto scale = state.view->devicePixelRatioF();
-    const std::array<int, 2> viewportPixels{
+    return {
         std::clamp(static_cast<int>(std::lround(viewport->width() * scale)),
             1, maxSliceOutputDimension),
         std::clamp(static_cast<int>(std::lround(viewport->height() * scale)),
             1, maxSliceOutputDimension)};
-    const auto target = state.visibleRegion.value_or(
-        datasetSampleBounds(*m_openMetadata));
-    const auto axes = displayAxes(state.normal);
-    auto extentX = target.upper[static_cast<std::size_t>(axes[0])]
-        - target.lower[static_cast<std::size_t>(axes[0])];
-    auto extentY = target.upper[static_cast<std::size_t>(axes[1])]
-        - target.lower[static_cast<std::size_t>(axes[1])];
-    if (isSpherical2D(*m_openMetadata)) {
-        // Radius and angle have heterogeneous units, so their raw physical
-        // extents do not define a meaningful display aspect. Normalize both
-        // axes to their finest-level sample counts before fitting the viewport.
-        const auto normalized = finestNativeOutputSize(
-            *m_openMetadata, target, state.normal);
-        extentX = static_cast<double>(normalized[0]);
-        extentY = static_cast<double>(normalized[1]);
-    }
-    if (!(extentX > 0.0) || !(extentY > 0.0)) {
-        return {1, 1};
-    }
-    const auto fit = std::min(
-        static_cast<double>(viewportPixels[0]) / extentX,
-        static_cast<double>(viewportPixels[1]) / extentY);
-    return {std::clamp(static_cast<int>(std::lround(extentX * fit)),
-                1, viewportPixels[0]),
-        std::clamp(static_cast<int>(std::lround(extentY * fit)),
-            1, viewportPixels[1])};
 }
 
 bool MainWindow::displayIsSpherical() const
@@ -1186,6 +1171,32 @@ void MainWindow::createMenus()
             }
         });
 
+    auto* openRemoteSequenceAction = new QAction(
+        tr("Open Remote Plotfile &Sequence..."), this);
+    connect(openRemoteSequenceAction, &QAction::triggered, this,
+        [this, configureRemoteEndpoint] {
+            if (m_remotePort == 0 && !configureRemoteEndpoint()) {
+                return;
+            }
+            bool accepted = false;
+            const auto text = QInputDialog::getMultiLineText(this,
+                tr("Open Remote Plotfile Sequence"),
+                tr("Server-visible paths, one per line, in playback order:"),
+                QString(), &accepted);
+            if (!accepted) {
+                return;
+            }
+            std::vector<std::string> paths;
+            for (const auto& line : text.split(
+                     QLatin1Char('\n'), Qt::SkipEmptyParts)) {
+                const auto path = line.trimmed();
+                if (!path.isEmpty()) {
+                    paths.push_back(path.toStdString());
+                }
+            }
+            openRemoteSequence(m_remoteHost, m_remotePort, paths);
+        });
+
     auto* openFabAction = new QAction(tr("Open &FAB..."), this);
     connect(openFabAction, &QAction::triggered, this,
         [this] { chooseStandaloneDataset(tr("Open AMReX FAB"), true); });
@@ -1242,6 +1253,7 @@ void MainWindow::createMenus()
     fileMenu->addSeparator();
     fileMenu->addAction(connectRemoteAction);
     fileMenu->addAction(openRemoteAction);
+    fileMenu->addAction(openRemoteSequenceAction);
     fileMenu->addSeparator();
     fileMenu->addAction(openFabAction);
     fileMenu->addAction(openMultiFabAction);
@@ -6014,12 +6026,80 @@ void MainWindow::openSequence(const std::vector<std::filesystem::path>& frames)
     m_sequenceController->open(std::move(sorted));
 }
 
+void MainWindow::openRemoteSequence(std::string host, std::uint16_t port,
+    const std::vector<std::string>& remotePaths)
+{
+    if (remotePaths.size() < 2
+        || std::any_of(remotePaths.begin(), remotePaths.end(),
+            [](const auto& path) { return path.empty(); })) {
+        emit sequenceFrameFailed();
+        QMessageBox::warning(this, tr("Cannot open remote sequence"),
+            tr("Enter two or more server-visible plotfile paths."));
+        return;
+    }
+
+    m_remoteHost = host;
+    m_remotePort = port;
+    setPlaybackMode(PlaybackMode::None);
+    closeSequence();
+    m_remoteSequence = true;
+    resetRangeState();
+    m_particleStopSource.request_stop();
+    m_particleSamples.clear();
+    m_selectedParticleSpecies.clear();
+    m_particleSelectionInitialized = false;
+    ++m_particleGeneration;
+
+    std::vector<std::filesystem::path> frames;
+    frames.reserve(remotePaths.size());
+    for (const auto& path : remotePaths) {
+        frames.emplace_back(path);
+    }
+    m_animationPanel->setSequenceFrameCount(
+        static_cast<int>(frames.size()));
+    m_animationPanel->setSequenceVisible(true);
+    updateAnimationDockVisibility();
+    auto* linePlotWindow = m_linePlotWindow;
+    m_linePlotWindow = nullptr;
+    if (linePlotWindow != nullptr) {
+        linePlotWindow->close();
+    }
+
+    struct SharedRemoteConnection {
+        std::mutex mutex;
+        std::shared_ptr<remote::Connection> connection;
+    };
+    auto shared = std::make_shared<SharedRemoteConnection>();
+    auto loader = [shared, host = std::move(host), port](
+                      const std::filesystem::path& path, DatasetId,
+                      const FrameSliceSpec& spec, StopToken cancellation) {
+        std::shared_ptr<remote::Connection> connection;
+        {
+            std::scoped_lock lock(shared->mutex);
+            if (!shared->connection || !shared->connection->connected()) {
+                shared->connection = std::make_shared<remote::Connection>(
+                    host, port, remote::ConnectionOptions{
+                        .clientName = "AMReXplorer Qt sequence",
+                        .softwareVersion = AMREXPLORER_VERSION});
+            }
+            connection = shared->connection;
+        }
+        auto session = remote::RemoteDatasetSession::open(
+            std::move(connection), path.string(), initialCacheBudget(),
+            cancellation);
+        return executeSessionFrameLoad(
+            std::move(session), spec, cancellation);
+    };
+    m_sequenceController->open(std::move(frames), std::move(loader));
+}
+
 void MainWindow::closeSequence()
 {
     if (m_playbackMode == PlaybackMode::Sequence) {
         setPlaybackMode(PlaybackMode::None);
     }
     m_sequenceController->close();
+    m_remoteSequence = false;
     m_animationPanel->setSequenceVisible(false);
     updateAnimationDockVisibility();
 }
@@ -6291,8 +6371,15 @@ FrameSliceSpec MainWindow::buildFrameSpec()
     spec.particleSeed = m_particleSeed;
     const auto views = currentViews();
     spec.visibleRegions.reserve(views.size());
+    if (m_remoteSequence) {
+        spec.outputSizesAreViewportBounds = true;
+        spec.outputSizes.reserve(views.size());
+    }
     for (const auto* state : views) {
         spec.visibleRegions.push_back(state->visibleRegion);
+        if (m_remoteSequence) {
+            spec.outputSizes.push_back(viewportPixelSize(*state));
+        }
     }
     return spec;
 }

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -1927,6 +1927,15 @@ bool MainWindow::activeViewHasPhysicalAspectForTest(
         <= 0.02 * expectedAspect;
 }
 
+bool MainWindow::fabStateClearedForTest() const
+{
+    return !m_fabMode && !m_multifabReturn && !m_fabSourceMetadata
+        && m_fabSourcePath.empty() && m_fabDataRoot.empty()
+        && m_fabSelectorDock->entries().empty()
+        && !m_fabSelectorDock->isVisible()
+        && !windowTitle().endsWith(QStringLiteral(" FAB"));
+}
+
 void MainWindow::rubberBandZoomActiveViewForTest()
 {
     if (m_activeView == nullptr || m_activeView->plane->width <= 0
@@ -5977,18 +5986,6 @@ void MainWindow::choosePlotfileSequence()
 
 void MainWindow::openSequence(const std::vector<std::filesystem::path>& frames)
 {
-    // Sweep and sequence playback are mutually exclusive.
-    setPlaybackMode(PlaybackMode::None);
-    closeSequence();
-    resetRangeState();
-    m_particleStopSource.request_stop();
-    m_particleSamples.clear();
-    m_selectedParticleSpecies.clear();
-    m_particleSelectionInitialized = false;
-    m_particleLoading = false;
-    m_particleProgress->setVisible(false);
-    ++m_particleGeneration;
-
     auto sorted = frames;
     std::sort(sorted.begin(), sorted.end(),
         [](const auto& lhs, const auto& rhs) {
@@ -6005,16 +6002,29 @@ void MainWindow::openSequence(const std::vector<std::filesystem::path>& frames)
         return;
     }
 
-    // A sequence replaces any standalone FAB/MultiFab with plotfile frames.
-    // openSequence does not go through openDatasetImpl, so clear the FAB view
-    // state here too; otherwise m_fabMode keeps every frame's title suffixed
-    // "— FAB" and the stale selector dock's clicks reopen the old file (see
-    // open-sequence-stale-fab-state). Only after the validity check above, so a
-    // rejected selection leaves the current FAB view untouched. The first
-    // frame's display refreshes the title with m_fabMode now false.
-    resetFabState();
+    prepareSequence(sorted.size());
+    m_sequenceController->open(std::move(sorted));
+}
 
-    m_animationPanel->setSequenceFrameCount(static_cast<int>(sorted.size()));
+void MainWindow::prepareSequence(std::size_t frameCount)
+{
+    // A sequence replaces any standalone FAB/MultiFab with plotfile frames.
+    // Both local and remote entry points bypass openDatasetImpl, so establish
+    // their complete state transition in one place after validation.
+    setPlaybackMode(PlaybackMode::None);
+    closeSequence();
+    resetRangeState();
+    resetFabState();
+    m_particleStopSource.request_stop();
+    m_particleSamples.clear();
+    m_selectedParticleSpecies.clear();
+    m_particleSelectionInitialized = false;
+    m_particleLoading = false;
+    m_particleProgress->setVisible(false);
+    ++m_particleGeneration;
+    m_remoteSequenceConnectionGeneration = 0;
+
+    m_animationPanel->setSequenceFrameCount(static_cast<int>(frameCount));
     m_animationPanel->setSequenceVisible(true);
     updateAnimationDockVisibility();
     // Line plot curves are snapshots of the previous dataset; drop the window.
@@ -6023,7 +6033,6 @@ void MainWindow::openSequence(const std::vector<std::filesystem::path>& frames)
     if (linePlotWindow != nullptr) {
         linePlotWindow->close();
     }
-    m_sequenceController->open(std::move(sorted));
 }
 
 void MainWindow::openRemoteSequence(std::string host, std::uint16_t port,
@@ -6040,55 +6049,59 @@ void MainWindow::openRemoteSequence(std::string host, std::uint16_t port,
 
     m_remoteHost = host;
     m_remotePort = port;
-    setPlaybackMode(PlaybackMode::None);
-    closeSequence();
+    prepareSequence(remotePaths.size());
     m_remoteSequence = true;
-    resetRangeState();
-    m_particleStopSource.request_stop();
-    m_particleSamples.clear();
-    m_selectedParticleSpecies.clear();
-    m_particleSelectionInitialized = false;
-    ++m_particleGeneration;
 
     std::vector<std::filesystem::path> frames;
     frames.reserve(remotePaths.size());
     for (const auto& path : remotePaths) {
         frames.emplace_back(path);
     }
-    m_animationPanel->setSequenceFrameCount(
-        static_cast<int>(frames.size()));
-    m_animationPanel->setSequenceVisible(true);
-    updateAnimationDockVisibility();
-    auto* linePlotWindow = m_linePlotWindow;
-    m_linePlotWindow = nullptr;
-    if (linePlotWindow != nullptr) {
-        linePlotWindow->close();
-    }
-
     struct SharedRemoteConnection {
         std::mutex mutex;
         std::shared_ptr<remote::Connection> connection;
+        std::uint64_t generation = 0;
     };
     auto shared = std::make_shared<SharedRemoteConnection>();
     auto loader = [shared, host = std::move(host), port](
                       const std::filesystem::path& path, DatasetId,
                       const FrameSliceSpec& spec, StopToken cancellation) {
         std::shared_ptr<remote::Connection> connection;
+        std::uint64_t connectionGeneration = 0;
         {
             std::scoped_lock lock(shared->mutex);
-            if (!shared->connection || !shared->connection->connected()) {
-                shared->connection = std::make_shared<remote::Connection>(
-                    host, port, remote::ConnectionOptions{
-                        .clientName = "AMReXplorer Qt sequence",
-                        .softwareVersion = AMREXPLORER_VERSION});
-            }
             connection = shared->connection;
+            connectionGeneration = shared->generation;
+        }
+        if (!connection || !connection->connected()) {
+            // Connect outside the shared-state mutex. Foreground loads and
+            // prefetches may overlap, and neither should inherit the other's
+            // network wait or lose its own cancellation deadline.
+            auto candidate = std::make_shared<remote::Connection>(host, port,
+                remote::ConnectionOptions{
+                    .clientName = "AMReXplorer Qt sequence",
+                    .softwareVersion = AMREXPLORER_VERSION},
+                cancellation);
+            {
+                std::scoped_lock lock(shared->mutex);
+                if (!shared->connection || !shared->connection->connected()) {
+                    shared->connection = std::move(candidate);
+                    ++shared->generation;
+                }
+                connection = shared->connection;
+                connectionGeneration = shared->generation;
+            }
+            // If another load won the connection race, release this redundant
+            // connection only after dropping the shared-state mutex.
+            candidate.reset();
         }
         auto session = remote::RemoteDatasetSession::open(
             std::move(connection), path.string(), initialCacheBudget(),
             cancellation);
-        return executeSessionFrameLoad(
+        auto result = executeSessionFrameLoad(
             std::move(session), spec, cancellation);
+        result.connectionGeneration = connectionGeneration;
+        return result;
     };
     m_sequenceController->open(std::move(frames), std::move(loader));
 }
@@ -6128,6 +6141,16 @@ void MainWindow::goToSequenceFrame(int index, bool forceRestart)
 void MainWindow::displayFrameResult(InitialSliceResult& result,
     bool defaultPositions)
 {
+    if (result.connectionGeneration != 0
+        && result.connectionGeneration
+            != m_remoteSequenceConnectionGeneration) {
+        // DatasetId is allocated by the server and can restart at one after a
+        // reconnect. Drop every dataset-scoped display range before publishing
+        // a frame from a new connection generation so an old ID cannot alias.
+        m_displayCoordinator.invalidateRangeCache();
+        m_pendingRangeStore.reset();
+        m_remoteSequenceConnectionGeneration = result.connectionGeneration;
+    }
     m_dataset = result.dataset;
     m_particleSamples = std::move(result.particles);
     configureParticleControls(true);

--- a/src/qt/MainWindow.hpp
+++ b/src/qt/MainWindow.hpp
@@ -21,6 +21,7 @@
 #include <QImage>
 #include <QMainWindow>
 #include <QRectF>
+#include <QSize>
 #include <QStringList>
 
 #include <array>
@@ -147,6 +148,7 @@ public:
     // raster-colorbar-mismatch-on-2d-visible-zoom.
     [[nodiscard]] bool activeViewRasterMatchesDisplayRangeForTest();
     [[nodiscard]] bool activeViewUsesViewportBoundedOutputForTest() const;
+    [[nodiscard]] bool activeViewUsesNativeOutputForTest() const;
     [[nodiscard]] bool allViewsUseViewportBoundedOutputForTest() const;
     [[nodiscard]] bool activeViewHasPhysicalAspectForTest(
         double expectedAspect) const;
@@ -196,6 +198,9 @@ public:
     // activeViewIsFitToWindowForTest, which refits as a side effect).
     void setSphericalSupersampleForTest(int factor);
     [[nodiscard]] int activeViewImageWidthForTest() const;
+    [[nodiscard]] std::array<int, 2> activeViewImageSizeForTest() const;
+    [[nodiscard]] std::array<int, 2> activeViewViewportSizeForTest() const;
+    [[nodiscard]] QImage activeViewViewportImageForTest() const;
     [[nodiscard]] bool activeViewFitsWindowForTest() const;
 
     // Test-only: shrink the open dataset's cache budget to force cache-pressure
@@ -402,6 +407,8 @@ private:
         const PlaneViewState& state) const;
     [[nodiscard]] std::array<int, 2> sliceOutputSize(
         const PlaneViewState& state, bool forceRemote = false) const;
+    [[nodiscard]] QSize logicalImageSize(const PlaneViewState& state,
+        const ScalarPlane& plane, const QImage& image) const;
     // True when the active dataset is displayed as a warped 2-D spherical
     // (r, theta) plane. Gates the coordinate-warp overlay, probe, and label
     // paths; all other datasets keep their Cartesian behavior.
@@ -433,6 +440,11 @@ private:
         const QPoint& viewportDelta);
     void endPanDrag(PlaneViewState& state, const QPointF& totalSceneDelta);
     void flushPanDrag(bool finalize);
+    void applyFixedScale(int factor);
+    void updateRemoteFixedScaleDemand(PlaneViewState& state, int factor,
+        std::optional<std::array<double, 2>> center = std::nullopt);
+    [[nodiscard]] std::array<double, 2> viewCenterInData(
+        const PlaneViewState& state) const;
     void applyPanStep(PlaneViewState& state, const QPointF& direction);
     void setupPanShortcuts();
     [[nodiscard]] std::optional<RealBox> shiftedPanRegion(

--- a/src/qt/MainWindow.hpp
+++ b/src/qt/MainWindow.hpp
@@ -93,6 +93,8 @@ public:
     void openDataset(const std::filesystem::path& path, bool metadataOnly = false);
     void openRemoteDataset(
         std::string host, std::uint16_t port, std::string remotePath);
+    void openRemoteSequence(std::string host, std::uint16_t port,
+        const std::vector<std::string>& remotePaths);
     // Opens a plotfile sequence (the legacy "-a" file animation): frames are
     // the plotfile directories, sorted by name; requires at least two valid
     // plotfiles. Opening a single dataset closes the sequence again.
@@ -395,6 +397,8 @@ private:
     [[nodiscard]] std::array<int, 2> displayAxes(int normal) const;
     [[nodiscard]] std::array<int, 2> nativeOutputSize(
         const PlaneViewState& state) const;
+    [[nodiscard]] std::array<int, 2> viewportPixelSize(
+        const PlaneViewState& state) const;
     [[nodiscard]] std::array<int, 2> sliceOutputSize(
         const PlaneViewState& state, bool forceRemote = false) const;
     // True when the active dataset is displayed as a warped 2-D spherical
@@ -673,6 +677,7 @@ private:
     std::filesystem::path m_datasetPath;
     std::string m_remoteHost;
     std::uint16_t m_remotePort = 0;
+    bool m_remoteSequence = false;
     struct MultiFabReturnState {
         std::filesystem::path path;
         std::filesystem::path dataRoot;

--- a/src/qt/MainWindow.hpp
+++ b/src/qt/MainWindow.hpp
@@ -150,6 +150,7 @@ public:
     [[nodiscard]] bool allViewsUseViewportBoundedOutputForTest() const;
     [[nodiscard]] bool activeViewHasPhysicalAspectForTest(
         double expectedAspect) const;
+    [[nodiscard]] bool fabStateClearedForTest() const;
 
     // Test-only: rubber-band the central half of the active 3-D panel through
     // the same handler used by ImageView::rubberBandSelected.
@@ -522,6 +523,9 @@ private:
         Sequence
     };
     void choosePlotfileSequence();
+    // Establishes the shared local/remote sequence invariants after the frame
+    // list has been validated.
+    void prepareSequence(std::size_t frameCount);
     void closeSequence();
     void goToSequenceFrame(int index, bool forceRestart = false);
     void toggleSequencePlayback();
@@ -678,6 +682,7 @@ private:
     std::string m_remoteHost;
     std::uint16_t m_remotePort = 0;
     bool m_remoteSequence = false;
+    std::uint64_t m_remoteSequenceConnectionGeneration = 0;
     struct MultiFabReturnState {
         std::filesystem::path path;
         std::filesystem::path dataRoot;

--- a/src/qt/SequenceController.cpp
+++ b/src/qt/SequenceController.cpp
@@ -104,6 +104,7 @@ void SequenceController::startLoad(int index, std::uint64_t generation)
     const auto path = m_frames[static_cast<std::size_t>(index)];
     const auto datasetId = DatasetId{
         sequenceDatasetIdBase + ++m_datasetCounter};
+    m_loadStopSource.request_stop();
     m_loadStopSource = StopSource{};
     const auto cancellation = m_loadStopSource.get_token();
     const auto loader = m_loader;

--- a/src/qt/SequenceController.cpp
+++ b/src/qt/SequenceController.cpp
@@ -24,9 +24,11 @@ SequenceController::SequenceController(Hooks hooks, QObject* parent)
 {
 }
 
-void SequenceController::open(std::vector<std::filesystem::path> frames)
+void SequenceController::open(
+    std::vector<std::filesystem::path> frames, FrameLoader loader)
 {
     m_frames = std::move(frames);
+    m_loader = std::move(loader);
     goToFrame(0);
 }
 
@@ -36,6 +38,7 @@ void SequenceController::close()
     m_loadStopSource.request_stop();
     ++m_loadGeneration;
     m_frames.clear();
+    m_loader = {};
     m_index = -1;
     m_inFlight = false;
 }
@@ -103,6 +106,7 @@ void SequenceController::startLoad(int index, std::uint64_t generation)
         sequenceDatasetIdBase + ++m_datasetCounter};
     m_loadStopSource = StopSource{};
     const auto cancellation = m_loadStopSource.get_token();
+    const auto loader = m_loader;
     emit loadActivityChanged(+1);
     emit statusMessage(tr("Loading frame %1...").arg(
         QString::fromStdString(path.filename().string())));
@@ -134,7 +138,10 @@ void SequenceController::startLoad(int index, std::uint64_t generation)
             watcher->deleteLater();
         });
     watcher->setFuture(QtConcurrent::run(
-        [path, datasetId, spec = std::move(spec), cancellation] {
+        [path, datasetId, spec = std::move(spec), cancellation, loader] {
+        if (loader) {
+            return loader(path, datasetId, spec, cancellation);
+        }
         return executeFrameLoad(path, datasetId, spec, initialCacheBudget(),
             cancellation);
     }));
@@ -179,6 +186,7 @@ void SequenceController::startPrefetch(int frameIndex)
         sequenceDatasetIdBase + ++m_datasetCounter};
     m_prefetchStopSource = StopSource{};
     const auto cancellation = m_prefetchStopSource.get_token();
+    const auto loader = m_loader;
     emit loadActivityChanged(+1);
 
     auto* watcher = new QFutureWatcher<InitialSliceResult>(this);
@@ -205,7 +213,10 @@ void SequenceController::startPrefetch(int frameIndex)
             watcher->deleteLater();
         });
     watcher->setFuture(QtConcurrent::run(
-        [path, datasetId, spec = std::move(spec), cancellation] {
+        [path, datasetId, spec = std::move(spec), cancellation, loader] {
+        if (loader) {
+            return loader(path, datasetId, spec, cancellation);
+        }
         return executeFrameLoad(path, datasetId, spec, initialCacheBudget(),
             cancellation);
     }));

--- a/src/qt/SequenceController.cpp
+++ b/src/qt/SequenceController.cpp
@@ -2,6 +2,7 @@
 
 #include "CacheConfig.hpp"
 
+#include <QException>
 #include <QFutureWatcher>
 #include <QTimer>
 #include <QtConcurrent>
@@ -15,6 +16,21 @@ namespace {
 // Sequence frames get synthetic dataset ids well above interactive ones so a
 // stale cross-dataset cache entry can never alias a frame's blocks.
 constexpr std::uint64_t sequenceDatasetIdBase = 0x4000000000000000ULL;
+
+QString exceptionMessage(const std::exception& error)
+{
+    const auto* unhandled = dynamic_cast<const QUnhandledException*>(&error);
+    if (unhandled != nullptr && unhandled->exception()) {
+        try {
+            std::rethrow_exception(unhandled->exception());
+        } catch (const std::exception& inner) {
+            return QString::fromUtf8(inner.what());
+        } catch (...) {
+            return QStringLiteral("unknown non-std exception");
+        }
+    }
+    return QString::fromUtf8(error.what());
+}
 
 } // namespace
 
@@ -130,8 +146,7 @@ void SequenceController::startLoad(int index, std::uint64_t generation)
             } catch (const std::exception& error) {
                 if (generation == m_loadGeneration && index == m_index) {
                     m_inFlight = false;
-                    emit frameLoadFailed(
-                        QString::fromUtf8(error.what()));
+                    emit frameLoadFailed(exceptionMessage(error));
                 } else {
                     emit staleResultDropped();
                 }
@@ -155,7 +170,7 @@ void SequenceController::finishLoad(
         m_hooks.displayFrame(result, defaultPositions);
     } catch (const std::exception& error) {
         m_inFlight = false;
-        emit frameLoadFailed(QString::fromUtf8(error.what()));
+        emit frameLoadFailed(exceptionMessage(error));
         return;
     }
     m_inFlight = false;

--- a/src/qt/SequenceController.hpp
+++ b/src/qt/SequenceController.hpp
@@ -27,6 +27,10 @@ class SequenceController final : public QObject {
     Q_OBJECT
 
 public:
+    using FrameLoader = std::function<InitialSliceResult(
+        const std::filesystem::path&, DatasetId, const FrameSliceSpec&,
+        StopToken)>;
+
     struct Hooks {
         // Snapshot of the current UI state for a frame load (the host's
         // buildFrameSpec).
@@ -45,7 +49,8 @@ public:
     // Takes ownership of a validated, sorted, deduplicated frame list and
     // navigates to frame 0. The host performs validation and its own UI
     // setup before calling.
-    void open(std::vector<std::filesystem::path> frames);
+    void open(std::vector<std::filesystem::path> frames,
+        FrameLoader loader = {});
     // Drops the sequence and cancels the in-flight load and prefetch. The
     // host hides its sequence UI itself.
     void close();
@@ -119,6 +124,7 @@ private:
 
     Hooks m_hooks;
     std::vector<std::filesystem::path> m_frames;
+    FrameLoader m_loader;
     int m_index = -1;
     bool m_inFlight = false;
     // Invalidates in-flight loads across frame switches and close(); the

--- a/src/qt/main.cpp
+++ b/src/qt/main.cpp
@@ -590,21 +590,67 @@ int main(int argc, char* argv[])
                 window.openRemoteDataset(
                     "127.0.0.1", server->port(), path);
             });
-    } else if (argc == 4
+    } else if (argc == 3
+        && std::string_view(argv[1]) == "--remote-sequence-smoke-test") {
+        smokeServer = std::make_shared<amrvis::remote::Server>();
+        smokeServerThread.emplace(
+            [server = smokeServer] { server->run(); });
+        auto firstFrameDisplayed = std::make_shared<bool>(false);
+        QObject::connect(&window,
+            &amrvis::qt::MainWindow::sequenceFrameDisplayed,
+            &application,
+            [&window, &application, firstFrameDisplayed](int index) {
+                if (index == 0 && !*firstFrameDisplayed) {
+                    *firstFrameDisplayed = true;
+                    window.stepSequence(1);
+                    return;
+                }
+                if (index == 1) {
+                    application.exit(
+                        window.activeViewUsesViewportBoundedOutputForTest()
+                            ? 0 : 1);
+                }
+            });
+        QObject::connect(&window,
+            &amrvis::qt::MainWindow::sequenceFrameFailed,
+            &application, [&application] { application.exit(1); });
+        QTimer::singleShot(15000, &application,
+            [&application] { application.exit(1); });
+        QTimer::singleShot(0, &window,
+            [&window, path = std::string(argv[2]), server = smokeServer] {
+                window.openRemoteSequence(
+                    "127.0.0.1", server->port(), {path, path});
+            });
+    } else if (argc >= 4
         && std::string_view(argv[1]) == "--connect") {
         const auto endpoint = amrvis::qt::parseRemoteEndpoint(argv[2]);
-        if (!endpoint || std::string_view(argv[3]).empty()) {
-            qCritical("usage: amrexplorer --connect HOST:PORT REMOTE_PATH");
+        if (!endpoint) {
+            qCritical("invalid remote endpoint; expected HOST:PORT");
             return 2;
         }
+        std::vector<std::string> paths;
+        paths.reserve(static_cast<std::size_t>(argc - 3));
+        for (int index = 3; index < argc; ++index) {
+            if (std::string_view(argv[index]).empty()) {
+                qCritical("remote paths must not be empty");
+                return 2;
+            }
+            paths.emplace_back(argv[index]);
+        }
         QTimer::singleShot(0, &window,
-            [&window, endpoint = *endpoint, path = std::string(argv[3])] {
-                window.openRemoteDataset(
-                    endpoint.first, endpoint.second, path);
+            [&window, endpoint = *endpoint, paths = std::move(paths)] {
+                if (paths.size() == 1) {
+                    window.openRemoteDataset(
+                        endpoint.first, endpoint.second, paths.front());
+                } else {
+                    window.openRemoteSequence(
+                        endpoint.first, endpoint.second, paths);
+                }
             });
     } else if (argc >= 2
         && std::string_view(argv[1]) == "--connect") {
-        qCritical("usage: amrexplorer --connect HOST:PORT REMOTE_PATH");
+        qCritical("usage: amrexplorer --connect HOST:PORT REMOTE_PATH "
+                  "[REMOTE_PATH ...]");
         return 2;
     } else if (argc == 3 && std::string_view(argv[1]) == "--smoke-test") {
         const std::filesystem::path path(argv[2]);

--- a/src/qt/main.cpp
+++ b/src/qt/main.cpp
@@ -603,6 +603,8 @@ int main(int argc, char* argv[])
                 if (index == 0 && !*firstFrameDisplayed) {
                     *firstFrameDisplayed = true;
                     window.stepSequence(1);
+                    window.stepSequence(-1);
+                    window.stepSequence(1);
                     return;
                 }
                 if (index == 1) {
@@ -1245,6 +1247,48 @@ int main(int argc, char* argv[])
         QTimer::singleShot(15000, &application,
             [&application] { application.exit(1); });
         QTimer::singleShot(0, &window, [&window, fab] { window.openDataset(fab); });
+    } else if (argc == 5
+        && std::string_view(argv[1])
+            == "--remote-sequence-after-fab-smoke-test") {
+        const std::filesystem::path fab(argv[2]);
+        const std::string first(argv[3]);
+        const std::string second(argv[4]);
+        smokeServer = std::make_shared<amrvis::remote::Server>();
+        smokeServerThread.emplace(
+            [server = smokeServer] { server->run(); });
+        auto opened = std::make_shared<bool>(false);
+        QObject::connect(&window, &amrvis::qt::MainWindow::initialSliceFinished,
+            &application, [&window, &application, first, second, opened,
+                server = smokeServer](bool success) {
+                if (*opened) {
+                    return;
+                }
+                const auto* selector
+                    = window.findChild<amrvis::qt::FabSelectorDock*>();
+                if (!success || selector == nullptr || !selector->isVisible()
+                    || !window.windowTitle().endsWith(
+                        QStringLiteral(" FAB"))) {
+                    application.exit(1);
+                    return;
+                }
+                *opened = true;
+                window.openRemoteSequence("127.0.0.1", server->port(),
+                    {first, second});
+            });
+        QObject::connect(&window,
+            &amrvis::qt::MainWindow::sequenceFrameDisplayed,
+            &application, [&window, &application](int index) {
+                if (index == 0) {
+                    application.exit(
+                        window.fabStateClearedForTest() ? 0 : 1);
+                }
+            });
+        QObject::connect(&window, &amrvis::qt::MainWindow::sequenceFrameFailed,
+            &application, [&application] { application.exit(1); });
+        QTimer::singleShot(15000, &application,
+            [&application] { application.exit(1); });
+        QTimer::singleShot(0, &window,
+            [&window, fab] { window.openDataset(fab); });
     } else if (argc == 4
         && std::string_view(argv[1])
             == "--sequence-spec-change-smoke-test") {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -785,6 +785,18 @@ if(TARGET amrexplorer_qt)
             -P "${CMAKE_CURRENT_SOURCE_DIR}/qt_smoke_driver.cmake"
     )
     set_tests_properties(qt_sequence_after_fab_smoke_2d PROPERTIES TIMEOUT 30)
+    add_test(
+        NAME qt_remote_sequence_after_fab_smoke_2d
+        COMMAND "${CMAKE_COMMAND}"
+            "-DMATERIALIZER=$<TARGET_FILE:fixture_materializer>"
+            "-DAMREXPLORER_QT=$<TARGET_FILE:amrexplorer_qt>"
+            "-DSOURCE=${CMAKE_CURRENT_SOURCE_DIR}/data/plotfile_2d"
+            "-DWORK=${CMAKE_CURRENT_BINARY_DIR}/fixtures_remote_sequence_after_fab"
+            -DMODE=remote-sequence-after-fab
+            -P "${CMAKE_CURRENT_SOURCE_DIR}/qt_smoke_driver.cmake"
+    )
+    set_tests_properties(qt_remote_sequence_after_fab_smoke_2d PROPERTIES
+        TIMEOUT 30)
     # A normal slice-affecting control change while a foreground frame is
     # loading invalidates that frame specification. The replacement load must
     # complete instead of leaving sequence playback latched in-flight.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -335,6 +335,23 @@ add_test(NAME tool_line_repro
 set_tests_properties(tool_line_repro PROPERTIES TIMEOUT 60)
 
 if(TARGET amrexplorer_qt)
+    add_executable(test_sequence_controller
+        unit/test_sequence_controller.cpp
+        "${PROJECT_SOURCE_DIR}/src/qt/SequenceController.cpp"
+        "${PROJECT_SOURCE_DIR}/src/qt/SequenceController.hpp"
+    )
+    set_target_properties(test_sequence_controller PROPERTIES AUTOMOC ON)
+    target_include_directories(test_sequence_controller
+        PRIVATE "${PROJECT_SOURCE_DIR}/src/qt")
+    target_link_libraries(test_sequence_controller
+        PRIVATE
+            amrexplorer::pipeline
+            amrexplorer::warnings
+            Qt6::Concurrent
+            Qt6::Core
+    )
+    add_test(NAME sequence_controller COMMAND test_sequence_controller)
+
     add_executable(test_remote_endpoint unit/test_remote_endpoint.cpp)
     target_include_directories(test_remote_endpoint
         PRIVATE "${PROJECT_SOURCE_DIR}/src/qt")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -394,6 +394,16 @@ if(TARGET amrexplorer_qt)
     set_tests_properties(qt_remote_silent_hello_close_smoke PROPERTIES
         TIMEOUT 10)
 
+    add_test(
+        NAME qt_remote_sequence_smoke
+        COMMAND "${CMAKE_COMMAND}" -E env QT_QPA_PLATFORM=offscreen
+            "$<TARGET_FILE:amrexplorer_qt>"
+            --remote-sequence-smoke-test "${remote_server_fixture_dir}"
+    )
+    set_tests_properties(qt_remote_sequence_smoke PROPERTIES
+        FIXTURES_REQUIRED remote_server_materialized
+        TIMEOUT 30)
+
     add_executable(test_user_guide_dialog
         unit/test_user_guide_dialog.cpp
         "${PROJECT_SOURCE_DIR}/src/qt/UserGuideDialog.cpp"

--- a/tests/integration/test_display_transitions.cpp
+++ b/tests/integration/test_display_transitions.cpp
@@ -12,6 +12,7 @@
 // Qt zoom/pan smoke tests.)
 
 #include <amrexplorer/data/LocalDatasetSession.hpp>
+#include <amrexplorer/io/PlotfileMetadataReader.hpp>
 #include <amrexplorer/pipeline/DisplayCoordinator.hpp>
 #include <amrexplorer/pipeline/ParticleProjection.hpp>
 #include <amrexplorer/pipeline/SlicePipeline.hpp>
@@ -258,6 +259,40 @@ int main()
     const amrvis::Palette palette;
     constexpr std::uint64_t bigBudget = 1ULL << 20;
     std::uint64_t nextId = 1;
+
+    // Frame cancellation must reach both local-session constructors instead
+    // of allowing stale metadata/particle discovery to finish first.
+    {
+        amrvis::StopSource cancelled;
+        cancelled.request_stop();
+        bool unpreparedCancelled = false;
+        try {
+            static_cast<void>(amrvis::executeFrameLoad(base / "missing",
+                amrvis::DatasetId{nextId++}, {}, bigBudget,
+                cancelled.get_token()));
+        } catch (const amrvis::ReadCancelled&) {
+            unpreparedCancelled = true;
+        }
+        require(unpreparedCancelled,
+            "unprepared frame construction ignored cancellation");
+
+        auto prepared = amrvis::PlotfileMetadataReader{}.read(root2d);
+        auto noFields
+            = std::make_shared<amrvis::DatasetMetadata>(*prepared.metadata);
+        noFields->fields.clear();
+        prepared.metadata = std::move(noFields);
+        bool preparedCancelled = false;
+        try {
+            static_cast<void>(amrvis::executeFrameLoad(root2d,
+                amrvis::DatasetId{nextId++}, {}, bigBudget,
+                cancelled.get_token(), std::move(prepared), root2d));
+        } catch (const amrvis::ReadCancelled&) {
+            preparedCancelled = true;
+        }
+        require(preparedCancelled,
+            "prepared frame construction ignored cancellation");
+    }
+
     const auto load2d = [&](amrvis::FrameSliceSpec spec) {
         return amrvis::executeFrameLoad(
             root2d, amrvis::DatasetId{nextId++}, spec, bigBudget, {});

--- a/tests/qt_smoke_driver.cmake
+++ b/tests/qt_smoke_driver.cmake
@@ -5,7 +5,8 @@
 #   AMREXPLORER_QT     path to the amrexplorer_qt executable
 #   SOURCE        fixture source directory (e.g. tests/data/plotfile_2d)
 #   WORK          directory the materialized copies are written into
-#   MODE          slice | sequence | sequence-after-fab | missing-range |
+#   MODE          slice | sequence | sequence-after-fab |
+#                 remote-sequence-after-fab | missing-range |
 #                 non-finite | raw-fab |
 #                 multifab-fab | quit | quit-on-failure | window-close-pool |
 #                 export-quit |
@@ -58,6 +59,12 @@ elseif(MODE STREQUAL "sequence-after-fab")
     run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt00000")
     run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt00010" "2.5")
     run_or_die("${AMREXPLORER_QT}" --sequence-after-fab-smoke-test
+        "${WORK}/plt/Level_0/Cell_D_00000" "${WORK}/plt00000" "${WORK}/plt00010")
+elseif(MODE STREQUAL "remote-sequence-after-fab")
+    run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt")
+    run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt00000")
+    run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt00010" "2.5")
+    run_or_die("${AMREXPLORER_QT}" --remote-sequence-after-fab-smoke-test
         "${WORK}/plt/Level_0/Cell_D_00000" "${WORK}/plt00000" "${WORK}/plt00010")
 elseif(MODE STREQUAL "sequence-spec-change")
     run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt00000")

--- a/tests/unit/test_sequence_controller.cpp
+++ b/tests/unit/test_sequence_controller.cpp
@@ -1,0 +1,48 @@
+#include "SequenceController.hpp"
+
+#include <QCoreApplication>
+#include <QTimer>
+
+#include <cstdlib>
+#include <filesystem>
+#include <iostream>
+#include <stdexcept>
+#include <vector>
+
+int main(int argc, char* argv[])
+{
+    QCoreApplication application(argc, argv);
+    bool receivedExpectedMessage = false;
+    amrvis::qt::SequenceController controller(
+        amrvis::qt::SequenceController::Hooks{
+            [] { return amrvis::FrameSliceSpec{}; },
+            [](amrvis::InitialSliceResult&, bool) {},
+            [] { return false; },
+        });
+    QObject::connect(&controller,
+        &amrvis::qt::SequenceController::frameLoadFailed,
+        &application, [&application, &receivedExpectedMessage](
+                          const QString& message) {
+            receivedExpectedMessage
+                = message == QStringLiteral("specific frame-load failure");
+            application.quit();
+        });
+    QTimer::singleShot(5000, &application, [&application] {
+        std::cerr << "FAILED: timed out waiting for frame failure\n";
+        application.exit(1);
+    });
+
+    controller.open(
+        std::vector<std::filesystem::path>{"frame-0", "frame-1"},
+        [](const std::filesystem::path&, amrvis::DatasetId,
+            const amrvis::FrameSliceSpec&, amrvis::StopToken)
+            -> amrvis::InitialSliceResult {
+            throw std::runtime_error("specific frame-load failure");
+        });
+    const auto result = application.exec();
+    if (result != 0 || !receivedExpectedMessage) {
+        std::cerr << "FAILED: worker exception detail was not preserved\n";
+        return 1;
+    }
+    return 0;
+}

--- a/tests/unit/test_slice_pipeline.cpp
+++ b/tests/unit/test_slice_pipeline.cpp
@@ -161,6 +161,18 @@ int main()
     require(amrvis::finestNativeOutputSize(fine3d, box, 2) == (std::array<int, 2>{10, 20}),
         "normal z did not size from the x and y extents");
 
+    // Spherical aspect uses the unclamped finest-level sample counts. An
+    // 8192x1024 logical plane must remain 8:1 even though native output is
+    // independently capped at 4096 per axis.
+    auto spherical = makeMetadata(2, 1.0);
+    spherical.coordinateSystem = 2;
+    spherical.levels[0].cellSize = {{1.0 / 8192.0, 1.0 / 1024.0, 1.0}};
+    const amrvis::RealBox sphericalRegion{
+        {{0.0, 0.0, 0.0}}, {{1.0, 1.0, 0.0}}};
+    require(amrvis::viewportBoundedOutputSize(
+                spherical, sphericalRegion, 2, {800, 800})
+            == (std::array<int, 2>{800, 100}),
+        "spherical viewport aspect was computed from clamped sample counts");
     // --- slicePlaneAxes ---------------------------------------------------
     require(amrvis::slicePlaneAxes(2, 0) == (std::array<int, 2>{0, 1}),
         "2-D plane axes are not x,y");

--- a/tests/unit/test_slice_pipeline.cpp
+++ b/tests/unit/test_slice_pipeline.cpp
@@ -161,6 +161,18 @@ int main()
     require(amrvis::finestNativeOutputSize(fine3d, box, 2) == (std::array<int, 2>{10, 20}),
         "normal z did not size from the x and y extents");
 
+    // A negotiated frame cap shrinks the raster uniformly until the server's
+    // conservative response model fits.
+    const auto budgeted = amrvis::frameBudgetBoundedOutputSize(
+        {800, 800}, 4U * 1024U * 1024U);
+    const auto budgetCells = static_cast<std::uint64_t>(budgeted[0])
+        * static_cast<std::uint64_t>(budgeted[1]);
+    require(budgeted[0] == budgeted[1] && budgeted[0] < 800,
+        "frame-budget sizing did not preserve a square raster aspect");
+    require(budgetCells * amrvis::sliceResponseBytesPerCell
+            + amrvis::sliceResponseOverheadBytes <= 4U * 1024U * 1024U,
+        "frame-budget sizing still exceeds the negotiated response cap");
+
     // Spherical aspect uses the unclamped finest-level sample counts. An
     // 8192x1024 logical plane must remain 8:1 even though native output is
     // independently capped at 4096 per axis.
@@ -173,6 +185,7 @@ int main()
                 spherical, sphericalRegion, 2, {800, 800})
             == (std::array<int, 2>{800, 100}),
         "spherical viewport aspect was computed from clamped sample counts");
+
     // --- slicePlaneAxes ---------------------------------------------------
     require(amrvis::slicePlaneAxes(2, 0) == (std::array<int, 2>{0, 1}),
         "2-D plane axes are not x,y");

--- a/tests/unit/test_slice_pipeline.cpp
+++ b/tests/unit/test_slice_pipeline.cpp
@@ -186,6 +186,18 @@ int main()
             == (std::array<int, 2>{800, 100}),
         "spherical viewport aspect was computed from clamped sample counts");
 
+    // A viewport request may downsample a large native plane, but it must not
+    // supersample a small one. Fixed 1x uses the native raster as its logical
+    // scale, so enlarging 10x10 to the viewport would make it act like Fit.
+    require(amrvis::nativeBoundedViewportOutputSize(
+                fine2d, square, 2, {800, 600})
+            == (std::array<int, 2>{10, 10}),
+        "remote viewport sizing supersampled a small native raster");
+    const auto largeViewport = amrvis::nativeBoundedViewportOutputSize(
+        fine2d, huge, 2, {800, 600});
+    require(largeViewport == (std::array<int, 2>{600, 600}),
+        "remote viewport sizing did not retain bounded downsampling");
+
     // --- slicePlaneAxes ---------------------------------------------------
     require(amrvis::slicePlaneAxes(2, 0) == (std::array<int, 2>{0, 1}),
         "2-D plane axes are not x,y");


### PR DESCRIPTION
Part 11 of 13 in the remote client/server stack.

## Purpose

Reuse the existing sequence state machine for remote frames and prefetch.

## Scope

- Injects an optional frame loader into `SequenceController`.
- Adds remote sequence UI and multi-path CLI handling.
- Reuses one concurrent connection while opening independent frame sessions.
- Keeps first and subsequent remote frames viewport-bounded even before frame geometry is known.

## Review focus

Check that local sequence behavior is unchanged and that loader/session ownership remains valid across cancellation and prefetch.

## Validation

- `qt_remote_sequence_smoke`
- All existing local sequence, spec-change, and transform-refit smokes
