### PR TITLE
[client-server] stream clipped grid overlays with slices

### DIFF
--- a/include/amrexplorer/core/Request.hpp
+++ b/include/amrexplorer/core/Request.hpp
@@ -5,7 +5,9 @@
 
 #include <array>
 #include <compare>
+#include <cstddef>
 #include <cstdint>
+#include <limits>
 #include <optional>
 #include <string>
 #include <vector>
@@ -53,6 +55,10 @@ struct SliceRequest {
     std::array<int, 2> outputSize{0, 0};
     SamplingPolicy sampling = SamplingPolicy::PiecewiseConstant;
     CompositionPolicy composition = CompositionPolicy::FinestAvailable;
+    bool includeGridBoxes = false;
+    // Collection bound supplied by the execution boundary. Local queries keep
+    // the default; the remote server replaces it with a frame-derived limit.
+    std::size_t maximumGridBoxes = std::numeric_limits<std::size_t>::max();
     // 2-D spherical display only: how finely the (r, theta) raster is
     // resampled into physical (R, Z). Higher values trace the curved cell
     // boundaries more smoothly at the cost of a larger warped raster. A pure
@@ -84,4 +90,3 @@ struct LineRequest {
     const LineRequest& request, int datasetDimension);
 
 } // namespace amrvis
-

--- a/include/amrexplorer/pipeline/SlicePipeline.hpp
+++ b/include/amrexplorer/pipeline/SlicePipeline.hpp
@@ -128,6 +128,7 @@ struct FrameSliceSpec {
     // dimensions; the frame loader preserves the physical aspect ratio within
     // each bound after it has opened the frame and knows its geometry.
     bool outputSizesAreViewportBounds = false;
+    bool includeGridBoxes = false;
     bool particleSelectionInitialized = false;
     std::vector<std::string> particleSpecies;
     double particleFraction = 1.0;

--- a/include/amrexplorer/query/SliceQuery.hpp
+++ b/include/amrexplorer/query/SliceQuery.hpp
@@ -6,6 +6,7 @@
 #include <amrexplorer/io/PlotfileDataset.hpp>
 
 #include <cstdint>
+#include <vector>
 
 namespace amrvis {
 
@@ -16,9 +17,17 @@ struct SliceQueryMetrics {
     std::uint64_t payloadBytesRead = 0;
 };
 
+struct SliceGridBox {
+    int level = 0;
+    RealBox physicalRegion;
+};
+
 struct SliceQueryResult {
     ScalarPlane plane;
     SliceQueryMetrics metrics;
+    bool gridBoxesIncluded = false;
+    bool gridBoxesTruncated = false;
+    std::vector<SliceGridBox> gridBoxes;
 };
 
 class SliceQuery {

--- a/schemas/amrexplorer_wire.fbs
+++ b/schemas/amrexplorer_wire.fbs
@@ -167,6 +167,12 @@ table SliceViewRequest {
   height:int (id: 8);
   sampling:SamplingPolicy (id: 9);
   composition:CompositionPolicy (id: 10);
+  include_grid_boxes:bool (id: 11);
+}
+
+table SliceGridBox {
+  level:int (id: 0);
+  physical_region:RealBox (id: 1);
 }
 
 table SliceViewResponse {
@@ -181,6 +187,9 @@ table SliceViewResponse {
   cache_hits:ulong (id: 8);
   payload_bytes_read:ulong (id: 9);
   cache:CacheState (id: 10);
+  grid_boxes_included:bool (id: 11);
+  grid_boxes:[SliceGridBox] (id: 12);
+  grid_boxes_truncated:bool (id: 13);
 }
 
 table LineViewRequest {

--- a/src/pipeline/SlicePipeline.cpp
+++ b/src/pipeline/SlicePipeline.cpp
@@ -159,7 +159,8 @@ bool sameSliceSpec(const SliceRequest& lhs, const SliceRequest& rhs)
         && lhs.maximumLevel == rhs.maximumLevel
         && lhs.outputSize == rhs.outputSize
         && lhs.sampling == rhs.sampling
-        && lhs.composition == rhs.composition;
+        && lhs.composition == rhs.composition
+        && lhs.includeGridBoxes == rhs.includeGridBoxes;
 }
 
 std::array<int, 2> slicePlaneAxes(int dimension, int normalDirection)
@@ -316,6 +317,9 @@ void appendVectorGlyphs(const std::shared_ptr<DatasetSession>& dataset,
     SliceRequest request, FieldId uField, FieldId vField, int count,
     StopToken cancellation, SliceDisplayResult& result)
 {
+    // The primary scalar request already carries the optional box list.
+    // Auxiliary vector-component planes contribute values only.
+    request.includeGridBoxes = false;
     request.field = uField;
     auto uSlice = requestSlice(*dataset, request, cancellation);
     request.field = vField;
@@ -429,6 +433,9 @@ void appendContours(const std::shared_ptr<DatasetSession>& dataset,
     // that contour staircases are invisible — at least 512 samples on the
     // shorter axis, capped at 1024. Two Chaikin passes finish the polylines.
     auto contourRequest = request;
+    // The primary scalar request already carries the optional box list.
+    // The higher-resolution contour plane contributes values only.
+    contourRequest.includeGridBoxes = false;
     contourRequest.outputSize = {
         std::min(std::max(dataWidth, 512), 1024),
         std::min(std::max(dataHeight, 512), 1024)};
@@ -656,6 +663,7 @@ InitialSliceResult executeSessionFrameLoad(
                 request.outputSize = frameBudgetBoundedOutputSize(
                     request.outputSize, result.dataset->maximumResponseBytes());
                 request.composition = selectedLevel.composition;
+                request.includeGridBoxes = spec.includeGridBoxes;
                 request.maximumLevel = attemptMaximumLevel;
                 request.sphericalSupersample = spec.sphericalSupersample;
                 request.sphericalDisplay = spec.sphericalDisplay;

--- a/src/qt/ImageView.hpp
+++ b/src/qt/ImageView.hpp
@@ -121,6 +121,10 @@ public:
         return m_fixedScaleFactor;
     }
     [[nodiscard]] const QImage& image() const noexcept;
+    [[nodiscard]] std::size_t gridBoxCount() const noexcept
+    {
+        return m_gridItems.size();
+    }
     [[nodiscard]] std::size_t pointOverlayCount() const noexcept;
     [[nodiscard]] const std::vector<QColor>& pointOverlayColors() const noexcept;
     // Renders the scene (base image plus grid boxes and any other overlays)

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -1398,8 +1398,21 @@ void MainWindow::createMenus()
     m_boxesAction->setShortcuts(
         {QKeySequence(Qt::Key_B), QKeySequence(Qt::SHIFT | Qt::Key_B)});
     m_boxesAction->setEnabled(false);
-    connect(m_boxesAction, &QAction::toggled, this, [this](bool) {
+    connect(m_boxesAction, &QAction::toggled, this, [this](bool visible) {
+        if (visible) {
+            for (auto* state : currentViews()) {
+                state->gridBoxes.clear();
+                // The displayed raster remains valid, but the next request
+                // must fetch geometry even if the last one also had boxes.
+                if (state->hasCachedRequest) {
+                    state->cachedRequest.includeGridBoxes = false;
+                }
+            }
+        }
         updateGridBoxes();
+        if (visible && m_controlsReady) {
+            scheduleSliceRequest(false);
+        }
         saveSettings();
     });
     m_slicePlanesAction = new QAction(tr("&Slice Planes"), this);
@@ -1975,6 +1988,17 @@ bool MainWindow::fabStateClearedForTest() const
         && m_fabSelectorDock->entries().empty()
         && !m_fabSelectorDock->isVisible()
         && !windowTitle().endsWith(QStringLiteral(" FAB"));
+}
+
+void MainWindow::setGridBoxesVisibleForTest(bool visible)
+{
+    m_boxesAction->setChecked(visible);
+}
+
+std::size_t MainWindow::activeViewGridBoxCountForTest() const
+{
+    return m_activeView == nullptr
+        ? 0 : m_activeView->view->gridBoxCount();
 }
 
 void MainWindow::rubberBandZoomActiveViewForTest()
@@ -4645,6 +4669,7 @@ void MainWindow::openDatasetImpl(const std::filesystem::path& path,
         state->fieldName.clear();
         state->visibleRegion.reset();
         state->vectorSegments.clear();
+        state->gridBoxes.clear();
         state->cachedRequest = {};
         state->hasCachedRequest = false;
         state->cachedMode = DisplayMode::Raster;
@@ -4889,6 +4914,7 @@ void MainWindow::requestInitialSlice(
     if (!initialSpec) {
         spec.palette = m_palette;
         spec.displayMode = m_displayMode;
+        spec.includeGridBoxes = m_boxesAction->isChecked();
         spec.vectorUField =
             static_cast<std::uint32_t>(std::max(m_vectorUField, 0));
         spec.vectorVField =
@@ -5306,6 +5332,7 @@ void MainWindow::requestSlice(PlaneViewState& state, bool rasterDirty)
         level, metadata.finestLevel);
     request.composition = composition;
     request.maximumLevel = maximumLevel;
+    request.includeGridBoxes = m_boxesAction->isChecked();
     request.sphericalSupersample = m_sphericalSupersample;
     request.sphericalDisplay = m_sphericalDisplay;
 
@@ -5521,7 +5548,6 @@ void MainWindow::updateGridBoxes(PlaneViewState& state)
 
     const auto& metadata = m_dataset->metadata();
     const auto& plane = *state.plane;
-    const auto normal = metadata.dimension == 3 ? state.normal : -1;
     const auto axes = displayAxes(state.normal);
     const auto rawLevel = m_levelSelector->currentData().toInt();
     const auto [composition, maximumLevel] = decodeLevelData(
@@ -5538,79 +5564,67 @@ void MainWindow::updateGridBoxes(PlaneViewState& state)
         - plane.physicalRegion.lower[yAxis];
     const bool spherical = displayIsSpherical();
     const auto mapping = planeMapping(state);
-    for (int levelIndex = firstLevel; levelIndex <= lastLevel; ++levelIndex) {
-        const auto& level = metadata.levels[static_cast<std::size_t>(levelIndex)];
-        for (const auto& box : level.boxes) {
-            const auto physicalBox = sampleBounds(
-                level, box, metadata.dimension);
-            if (normal >= 0) {
-                // Only boxes intersecting this view's slice position show.
-                const auto direction = static_cast<std::size_t>(normal);
-                const auto normalLower = physicalBox.lower[direction];
-                const auto normalUpper = physicalBox.upper[direction];
-                const auto slicePosition
-                    = m_slicePosition3d[static_cast<std::size_t>(normal)];
-                if (slicePosition < normalLower || slicePosition >= normalUpper) {
-                    continue;
-                }
-            }
-
-            const auto xLower = physicalBox.lower[xAxis];
-            const auto xUpper = physicalBox.upper[xAxis];
-            const auto yLower = physicalBox.lower[yAxis];
-            const auto yUpper = physicalBox.upper[yAxis];
-            const auto color = levelIndex == firstLevel
-                ? QColor(Qt::white)
-                : QColor::fromRgb(static_cast<QRgb>(
-                    m_palette.levelColor(levelIndex, lastLevel)));
-            if (spherical) {
-                // xAxis is r, yAxis is theta. Branch on the state's mode (the
-                // raster on screen), not m_sphericalDisplay (the menu
-                // selection): between a mode change and the re-rendered
-                // arrival the two disagree, and the overlay must match the
-                // displayed raster.
-                if (!(xUpper > xLower) || !(yUpper > yLower)) {
-                    continue;
-                }
-                if (state.sphericalDisplay == SphericalDisplay::RZ) {
-                    // Warped wedge: a curved annular sector.
-                    GridBoxOverlay overlay;
-                    overlay.color = color;
-                    overlay.path = sphericalSectorPath(
-                        mapping, xLower, xUpper, yLower, yUpper);
-                    overlays.push_back(std::move(overlay));
-                } else {
-                    // Logical r-theta / theta-r: an axis-aligned rectangle.
-                    QRectF rect(mapping.sceneFromLogical(xLower, yLower),
-                        mapping.sceneFromLogical(xUpper, yUpper));
-                    rect = rect.normalized();
-                    if (!rect.isEmpty()) {
-                        overlays.push_back({rect, color, QPainterPath{}});
-                    }
-                }
+    for (const auto& gridBox : state.gridBoxes) {
+        const auto levelIndex = gridBox.level;
+        if (levelIndex < firstLevel || levelIndex > lastLevel) {
+            continue;
+        }
+        const auto& physicalBox = gridBox.physicalRegion;
+        const auto xLower = physicalBox.lower[xAxis];
+        const auto xUpper = physicalBox.upper[xAxis];
+        const auto yLower = physicalBox.lower[yAxis];
+        const auto yUpper = physicalBox.upper[yAxis];
+        const auto color = levelIndex == firstLevel
+            ? QColor(Qt::white)
+            : QColor::fromRgb(static_cast<QRgb>(
+                m_palette.levelColor(levelIndex, lastLevel)));
+        if (spherical) {
+            // xAxis is r, yAxis is theta. Branch on the state's mode (the
+            // raster on screen), not m_sphericalDisplay (the menu
+            // selection): between a mode change and the re-rendered
+            // arrival the two disagree, and the overlay must match the
+            // displayed raster.
+            if (!(xUpper > xLower) || !(yUpper > yLower)) {
                 continue;
             }
-            const auto pixelX0 = std::round(
-                (xLower - plane.physicalRegion.lower[xAxis])
-                    / xExtent * plane.width);
-            const auto pixelX1 = std::round(
-                (xUpper - plane.physicalRegion.lower[xAxis])
-                    / xExtent * plane.width);
-            const auto pixelY0 = std::round(plane.height
-                - (yUpper - plane.physicalRegion.lower[yAxis])
-                    / yExtent * plane.height);
-            const auto pixelY1 = std::round(plane.height
-                - (yLower - plane.physicalRegion.lower[yAxis])
-                    / yExtent * plane.height);
-            if (pixelX0 == pixelX1 || pixelY0 == pixelY1) {
-                continue;
+            if (state.sphericalDisplay == SphericalDisplay::RZ) {
+                // Warped wedge: a curved annular sector.
+                GridBoxOverlay overlay;
+                overlay.color = color;
+                overlay.path = sphericalSectorPath(
+                    mapping, xLower, xUpper, yLower, yUpper);
+                overlays.push_back(std::move(overlay));
+            } else {
+                // Logical r-theta / theta-r: an axis-aligned rectangle.
+                QRectF rect(mapping.sceneFromLogical(xLower, yLower),
+                    mapping.sceneFromLogical(xUpper, yUpper));
+                rect = rect.normalized();
+                if (!rect.isEmpty()) {
+                    overlays.push_back({rect, color, QPainterPath{}});
+                }
             }
-            QRectF rectangle(QPointF(pixelX0, pixelY0), QPointF(pixelX1, pixelY1));
-            rectangle = rectangle.normalized().intersected(
-                QRectF(0.0, 0.0, plane.width, plane.height));
-            if (!rectangle.isEmpty()) {
-                overlays.push_back({rectangle, color, QPainterPath{}});
-            }
+            continue;
+        }
+        const auto pixelX0 = std::round(
+            (xLower - plane.physicalRegion.lower[xAxis])
+                / xExtent * plane.width);
+        const auto pixelX1 = std::round(
+            (xUpper - plane.physicalRegion.lower[xAxis])
+                / xExtent * plane.width);
+        const auto pixelY0 = std::round(plane.height
+            - (yUpper - plane.physicalRegion.lower[yAxis])
+                / yExtent * plane.height);
+        const auto pixelY1 = std::round(plane.height
+            - (yLower - plane.physicalRegion.lower[yAxis])
+                / yExtent * plane.height);
+        if (pixelX0 == pixelX1 || pixelY0 == pixelY1) {
+            continue;
+        }
+        QRectF rectangle(QPointF(pixelX0, pixelY0), QPointF(pixelX1, pixelY1));
+        rectangle = rectangle.normalized().intersected(
+            QRectF(0.0, 0.0, plane.width, plane.height));
+        if (!rectangle.isEmpty()) {
+            overlays.push_back({rectangle, color, QPainterPath{}});
         }
     }
     state.view->setGridBoxes(overlays);
@@ -5894,6 +5908,9 @@ void MainWindow::showSlice(PlaneViewState& state, const SliceDisplayResult& disp
     state.displayMaximum = display.maximum;
     state.displayLogarithmic = display.logarithmic;
     state.vectorSegments = display.vectors;
+    if (display.slice.gridBoxesIncluded) {
+        state.gridBoxes = display.slice.gridBoxes;
+    }
     // Cache key for the re-render-from-cache path (see requestSlice).
     state.cachedRequest = display.request;
     state.hasCachedRequest = true;
@@ -6568,6 +6585,7 @@ FrameSliceSpec MainWindow::buildFrameSpec()
     }
     spec.particleFraction = m_particleFraction;
     spec.particleSeed = m_particleSeed;
+    spec.includeGridBoxes = m_boxesAction->isChecked();
     const auto views = currentViews();
     spec.visibleRegions.reserve(views.size());
     if (m_remoteSequence) {

--- a/src/qt/MainWindow.hpp
+++ b/src/qt/MainWindow.hpp
@@ -153,6 +153,8 @@ public:
     [[nodiscard]] bool activeViewHasPhysicalAspectForTest(
         double expectedAspect) const;
     [[nodiscard]] bool fabStateClearedForTest() const;
+    void setGridBoxesVisibleForTest(bool visible);
+    [[nodiscard]] std::size_t activeViewGridBoxCountForTest() const;
 
     // Test-only: rubber-band the central half of the active 3-D panel through
     // the same handler used by ImageView::rubberBandSelected.
@@ -290,6 +292,7 @@ private:
         double displayMaximum = 1.0;
         bool displayLogarithmic = false;
         std::vector<VectorSegment> vectorSegments;
+        std::vector<SliceGridBox> gridBoxes;
         // Cache key of the slice that produced the planes above: a UI change
         // that leaves every key field untouched (palette/log/range/contour
         // count) is satisfied from the cached planes instead of querying

--- a/src/qt/main.cpp
+++ b/src/qt/main.cpp
@@ -591,6 +591,43 @@ int main(int argc, char* argv[])
                     "127.0.0.1", server->port(), path);
             });
     } else if (argc == 3
+        && std::string_view(argv[1]) == "--remote-grid-boxes-smoke-test") {
+        smokeServer = std::make_shared<amrvis::remote::Server>();
+        smokeServerThread.emplace(
+            [server = smokeServer] { server->run(); });
+        auto boxLoads = std::make_shared<int>(0);
+        QObject::connect(&window,
+            &amrvis::qt::MainWindow::initialSliceFinished,
+            &application, [&window, &application, boxLoads](bool success) {
+                if (!success) {
+                    application.exit(1);
+                    return;
+                }
+                window.setGridBoxesVisibleForTest(false);
+                QObject::connect(&window,
+                    &amrvis::qt::MainWindow::interactiveSlicesSettled,
+                    &application, [&window, &application, boxLoads] {
+                        if (window.activeViewGridBoxCountForTest() == 0) {
+                            application.exit(1);
+                            return;
+                        }
+                        if ((*boxLoads)++ == 0) {
+                            window.setGridBoxesVisibleForTest(false);
+                            window.setGridBoxesVisibleForTest(true);
+                            return;
+                        }
+                        application.exit(0);
+                    });
+                window.setGridBoxesVisibleForTest(true);
+            });
+        QTimer::singleShot(15000, &application,
+            [&application] { application.exit(1); });
+        QTimer::singleShot(0, &window,
+            [&window, path = std::string(argv[2]), server = smokeServer] {
+                window.openRemoteDataset(
+                    "127.0.0.1", server->port(), path);
+            });
+    } else if (argc == 3
         && std::string_view(argv[1]) == "--remote-sequence-smoke-test") {
         smokeServer = std::make_shared<amrvis::remote::Server>();
         smokeServerThread.emplace(

--- a/src/query/SliceQuery.cpp
+++ b/src/query/SliceQuery.cpp
@@ -130,6 +130,8 @@ SliceQueryResult SliceQuery::execute(
     }
 
     std::vector<LevelBlocks> levels;
+    result.gridBoxesIncluded = request.includeGridBoxes;
+    auto collectGridBoxes = request.includeGridBoxes;
     for (int levelIndex = maximumLevel; levelIndex >= minimumLevel; --levelIndex) {
         if (cancellation.stop_requested()) {
             throw ReadCancelled();
@@ -142,6 +144,43 @@ SliceQueryResult SliceQuery::execute(
             const auto& block = level.blocks[grid];
             if (!intersects(block.box, queryBox, metadata.dimension)) {
                 continue;
+            }
+            if (collectGridBoxes) {
+                auto physicalBox = sampleBounds(
+                    level, block.box, metadata.dimension);
+                bool intersectsSlice = true;
+                if (metadata.dimension == 3) {
+                    const auto normal
+                        = static_cast<std::size_t>(request.normalDirection);
+                    intersectsSlice = request.physicalPosition
+                        >= physicalBox.lower[normal]
+                        && request.physicalPosition < physicalBox.upper[normal];
+                }
+                if (intersectsSlice) {
+                    auto nondegenerate = true;
+                    for (const auto axis : axes) {
+                        const auto index = static_cast<std::size_t>(axis);
+                        physicalBox.lower[index] = std::max(
+                            physicalBox.lower[index],
+                            request.visibleRegion.lower[index]);
+                        physicalBox.upper[index] = std::min(
+                            physicalBox.upper[index],
+                            request.visibleRegion.upper[index]);
+                        nondegenerate = nondegenerate
+                            && physicalBox.lower[index]
+                                < physicalBox.upper[index];
+                    }
+                    if (nondegenerate) {
+                        if (result.gridBoxes.size()
+                            >= request.maximumGridBoxes) {
+                            result.gridBoxesTruncated = true;
+                            collectGridBoxes = false;
+                        } else {
+                            result.gridBoxes.push_back(
+                                SliceGridBox{levelIndex, physicalBox});
+                        }
+                    }
+                }
             }
             ++result.metrics.candidateBlocks;
             BlockRequest blockRequest;

--- a/src/remote/Codec.cpp
+++ b/src/remote/Codec.cpp
@@ -612,6 +612,7 @@ fb::SliceViewRequestT toWire(const SliceRequest& value)
     wire.height = value.outputSize[1];
     wire.sampling = toWireSampling(value.sampling);
     wire.composition = toWireComposition(value.composition);
+    wire.include_grid_boxes = value.includeGridBoxes;
     return wire;
 }
 
@@ -633,6 +634,7 @@ SliceRequest fromWire(const fb::SliceViewRequestT& value)
     result.outputSize = {value.width, value.height};
     result.sampling = sampling;
     result.composition = composition;
+    result.includeGridBoxes = value.include_grid_boxes;
     return result;
 }
 
@@ -646,6 +648,15 @@ fb::SliceViewResponseT toWire(
     wire.values = value.plane.values;
     wire.valid = value.plane.valid;
     wire.source_level = value.plane.sourceLevel;
+    wire.grid_boxes_included = value.gridBoxesIncluded;
+    wire.grid_boxes_truncated = value.gridBoxesTruncated;
+    wire.grid_boxes.reserve(value.gridBoxes.size());
+    for (const auto& box : value.gridBoxes) {
+        auto converted = std::make_unique<fb::SliceGridBoxT>();
+        converted->level = box.level;
+        converted->physical_region = toWire(box.physicalRegion);
+        wire.grid_boxes.push_back(std::move(converted));
+    }
     wire.candidate_blocks = value.metrics.candidateBlocks;
     wire.blocks_read = value.metrics.blocksRead;
     wire.cache_hits = value.metrics.cacheHits;
@@ -672,6 +683,16 @@ SliceQueryResult fromWire(const fb::SliceViewResponseT& value)
     result.plane.values = value.values;
     result.plane.valid = value.valid;
     result.plane.sourceLevel = value.source_level;
+    result.gridBoxesIncluded = value.grid_boxes_included;
+    result.gridBoxesTruncated = value.grid_boxes_truncated;
+    result.gridBoxes.reserve(value.grid_boxes.size());
+    for (const auto& box : value.grid_boxes) {
+        if (!box) {
+            throw std::invalid_argument("wire slice grid box is missing");
+        }
+        result.gridBoxes.push_back(
+            SliceGridBox{box->level, fromWire(box->physical_region.get())});
+    }
     result.metrics = {value.candidate_blocks, value.blocks_read,
         value.cache_hits, value.payload_bytes_read};
     return result;

--- a/src/remote/Server.cpp
+++ b/src/remote/Server.cpp
@@ -573,7 +573,7 @@ private:
         const auto responseSize = [&] {
             return codec::encode(envelope.request_id,
                 codec::toWire(result, dataset->cacheMetrics()),
-                m_selectedMinor).size();
+                m_selectedMinorVersion).size();
         };
         // The planner uses a conservative per-box budget. Keep an exact final
         // guard so FlatBuffers layout changes can only shed optional overlays,

--- a/src/remote/Server.cpp
+++ b/src/remote/Server.cpp
@@ -764,8 +764,6 @@ private:
         }
         const auto cells = static_cast<std::uint64_t>(request.outputSize[0])
             * static_cast<std::uint64_t>(request.outputSize[1]);
-        constexpr std::uint64_t bytesPerCell
-            = sizeof(float) + sizeof(std::uint8_t) + sizeof(std::int16_t);
         // A grid box carries its vector offset, table/vtable, level, RealBox
         // table, six doubles, and alignment. This conservative charge keeps
         // collection bounded before serialization; the exact guard above is
@@ -777,7 +775,7 @@ private:
             return 0;
         }
         const auto available = frameBytes - responseOverheadReserveBytes;
-        const auto rasterBytes = cells * bytesPerCell;
+        const auto rasterBytes = cells * sliceResponseBytesPerCell;
         if (available <= rasterBytes) {
             return 0;
         }
@@ -896,7 +894,8 @@ private:
     }
 
     Socket m_socket;
-    static constexpr std::uint64_t responseOverheadReserveBytes = 512;
+    static constexpr std::uint64_t responseOverheadReserveBytes
+        = sliceResponseOverheadBytes;
     ThreadPool& m_workers;
     ServerOptions m_options;
     std::chrono::steady_clock::time_point m_handshakeDeadline;

--- a/src/remote/Server.cpp
+++ b/src/remote/Server.cpp
@@ -564,11 +564,31 @@ private:
         if (payload == nullptr) {
             throw std::invalid_argument("slice-view payload is missing");
         }
-        const auto request = codec::fromWire(*payload);
+        auto request = codec::fromWire(*payload);
         validateSliceBound(request);
+        request.maximumGridBoxes = maximumSliceGridBoxes(request);
         const auto dataset = requireDataset(request.dataset);
-        const auto result = std::get<SliceQueryResult>(
+        auto result = std::get<SliceQueryResult>(
             dataset->requestView(ViewDataRequest{request}, cancellation));
+        const auto responseSize = [&] {
+            return codec::encode(envelope.request_id,
+                codec::toWire(result, dataset->cacheMetrics()),
+                m_selectedMinor).size();
+        };
+        // The planner uses a conservative per-box budget. Keep an exact final
+        // guard so FlatBuffers layout changes can only shed optional overlays,
+        // never reject an otherwise valid raster response.
+        auto encodedBytes = responseSize();
+        while (encodedBytes > m_maximumFrameBytes.load()
+            && !result.gridBoxes.empty()) {
+            result.gridBoxesTruncated = true;
+            result.gridBoxes.resize(result.gridBoxes.size() / 2U);
+            encodedBytes = responseSize();
+        }
+        if (encodedBytes > m_maximumFrameBytes.load()) {
+            throw RemoteError(ErrorCode::ResourceLimitExceeded,
+                "slice raster cannot fit in one negotiated frame");
+        }
         send(envelope.request_id,
             codec::toWire(result, dataset->cacheMetrics()));
     }
@@ -736,12 +756,40 @@ private:
         }
     }
 
+    [[nodiscard]] std::size_t maximumSliceGridBoxes(
+        const SliceRequest& request) const noexcept
+    {
+        if (!request.includeGridBoxes) {
+            return 0;
+        }
+        const auto cells = static_cast<std::uint64_t>(request.outputSize[0])
+            * static_cast<std::uint64_t>(request.outputSize[1]);
+        constexpr std::uint64_t bytesPerCell
+            = sizeof(float) + sizeof(std::uint8_t) + sizeof(std::int16_t);
+        // A grid box carries its vector offset, table/vtable, level, RealBox
+        // table, six doubles, and alignment. This conservative charge keeps
+        // collection bounded before serialization; the exact guard above is
+        // authoritative.
+        constexpr std::uint64_t bytesPerGridBox = 128;
+        const auto frameBytes
+            = static_cast<std::uint64_t>(m_maximumFrameBytes.load());
+        if (frameBytes <= responseOverheadReserveBytes) {
+            return 0;
+        }
+        const auto available = frameBytes - responseOverheadReserveBytes;
+        const auto rasterBytes = cells * bytesPerCell;
+        if (available <= rasterBytes) {
+            return 0;
+        }
+        return static_cast<std::size_t>(
+            (available - rasterBytes) / bytesPerGridBox);
+    }
+
     [[nodiscard]] bool fitsResponse(std::uint64_t vectorBytes) const noexcept
     {
         // Reserve room for the envelope, tables, vector offsets, metrics, and
         // FlatBuffers alignment. send() performs the final exact encoded-size
         // check before touching the socket.
-        constexpr std::uint64_t responseOverheadReserveBytes = 512;
         const auto frameBytes
             = static_cast<std::uint64_t>(m_maximumFrameBytes.load());
         return frameBytes >= responseOverheadReserveBytes
@@ -848,6 +896,7 @@ private:
     }
 
     Socket m_socket;
+    static constexpr std::uint64_t responseOverheadReserveBytes = 512;
     ThreadPool& m_workers;
     ServerOptions m_options;
     std::chrono::steady_clock::time_point m_handshakeDeadline;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -412,6 +412,17 @@ if(TARGET amrexplorer_qt)
         TIMEOUT 10)
 
     add_test(
+        NAME qt_remote_grid_boxes_smoke
+        COMMAND "${CMAKE_COMMAND}" -E env QT_QPA_PLATFORM=offscreen
+            "$<TARGET_FILE:amrexplorer_qt>"
+            --remote-grid-boxes-smoke-test
+            "${remote_server_fixture_dir}"
+    )
+    set_tests_properties(qt_remote_grid_boxes_smoke PROPERTIES
+        FIXTURES_REQUIRED remote_server_materialized
+        TIMEOUT 30)
+
+    add_test(
         NAME qt_remote_sequence_smoke
         COMMAND "${CMAKE_COMMAND}" -E env QT_QPA_PLATFORM=offscreen
             "$<TARGET_FILE:amrexplorer_qt>"

--- a/tests/integration/test_display_transitions.cpp
+++ b/tests/integration/test_display_transitions.cpp
@@ -290,6 +290,14 @@ public:
         const amrvis::RangeRequest& request,
         amrvis::StopToken cancellation = {}) override
     {
+        ++m_rangeRequests;
+        if (cancellation.stop_requested()) {
+            m_rangeCancellationObserved = true;
+            throw amrvis::ReadCancelled();
+        }
+        if (m_failRanges) {
+            throw std::runtime_error("range transport failed");
+        }
         return m_delegate->requestRange(request, cancellation);
     }
     [[nodiscard]] bool rangeAvailable(
@@ -320,10 +328,27 @@ public:
         return m_gridBoxRequests;
     }
     void clearGridBoxRequests() { m_gridBoxRequests.clear(); }
+    void failRanges(bool enabled) { m_failRanges = enabled; }
+    void resetRangeObservations()
+    {
+        m_rangeRequests = 0;
+        m_rangeCancellationObserved = false;
+    }
+    [[nodiscard]] std::size_t rangeRequests() const noexcept
+    {
+        return m_rangeRequests;
+    }
+    [[nodiscard]] bool rangeCancellationObserved() const noexcept
+    {
+        return m_rangeCancellationObserved;
+    }
 
 private:
     std::shared_ptr<amrvis::DatasetSession> m_delegate;
     std::vector<bool> m_gridBoxRequests;
+    bool m_failRanges = false;
+    std::size_t m_rangeRequests = 0;
+    bool m_rangeCancellationObserved = false;
 };
 
 } // namespace
@@ -630,6 +655,46 @@ int main()
         const auto baseLoad = load2d(spec);
         const auto& d0 = baseLoad.displays.front();
         const auto& metadata = baseLoad.dataset->metadata();
+
+        // A remote range failure is not a logarithmic-domain failure: it must
+        // propagate after one RPC instead of being retried as linear.
+        auto recording
+            = std::make_shared<RecordingSession>(baseLoad.dataset);
+        recording->failRanges(true);
+        bool rangeFailurePreserved = false;
+        try {
+            static_cast<void>(amrvis::resolveDisplayRange(recording,
+                d0.request.field, d0.request.maximumLevel,
+                d0.request.composition, amrvis::RangeMode::File,
+                std::nullopt, true, d0.slice.plane));
+        } catch (const std::runtime_error& error) {
+            rangeFailurePreserved
+                = std::string(error.what()) == "range transport failed";
+        }
+        require(rangeFailurePreserved && recording->rangeRequests() == 1,
+            "log fallback retried or replaced a remote range failure");
+
+        // Cached re-ranging forwards the slice worker's cancellation token to
+        // the same RPC seam.
+        recording->failRanges(false);
+        recording->resetRangeObservations();
+        amrvis::StopSource stoppedRange;
+        stoppedRange.request_stop();
+        bool rangeCancellationPreserved = false;
+        try {
+            static_cast<void>(amrvis::refreshCachedSlice(recording,
+                d0.request, d0.slice.plane, d0.contourPlane,
+                d0.contourFinePlane, d0.contourFineFactor, {},
+                amrvis::RangeMode::File, std::nullopt, true, palette,
+                amrvis::DisplayMode::RasterContours, 0, 0, 4, true,
+                stoppedRange.get_token()));
+        } catch (const amrvis::ReadCancelled&) {
+            rangeCancellationPreserved = true;
+        }
+        require(rangeCancellationPreserved
+                && recording->rangeRequests() == 1
+                && recording->rangeCancellationObserved(),
+            "cached range RPC ignored slice cancellation");
 
         // Log toggle re-ranges, re-renders, and re-contours the cached planes.
         const auto log = amrvis::refreshCachedSlice(baseLoad.dataset,

--- a/tests/integration/test_display_transitions.cpp
+++ b/tests/integration/test_display_transitions.cpp
@@ -24,6 +24,7 @@
 #include <filesystem>
 #include <fstream>
 #include <iostream>
+#include <memory>
 #include <span>
 #include <string>
 #include <string_view>
@@ -241,6 +242,90 @@ std::pair<double, double> planeExtrema(const amrvis::ScalarPlane& plane)
     return *range;
 }
 
+class RecordingSession final : public amrvis::DatasetSession {
+public:
+    explicit RecordingSession(std::shared_ptr<amrvis::DatasetSession> delegate)
+        : m_delegate(std::move(delegate))
+    {
+    }
+
+    [[nodiscard]] amrvis::DatasetId id() const noexcept override
+    {
+        return m_delegate->id();
+    }
+    [[nodiscard]] const amrvis::DatasetMetadata& metadata() const noexcept override
+    {
+        return m_delegate->metadata();
+    }
+    [[nodiscard]] const amrvis::MetadataReadMetrics& metadataReadMetrics()
+        const noexcept override
+    {
+        return m_delegate->metadataReadMetrics();
+    }
+    [[nodiscard]] const std::string& fileVersion() const noexcept override
+    {
+        return m_delegate->fileVersion();
+    }
+    [[nodiscard]] const std::vector<amrvis::ParticleSpeciesMetadata>&
+    particleSpecies() const noexcept override
+    {
+        return m_delegate->particleSpecies();
+    }
+    [[nodiscard]] amrvis::ViewDataResult requestView(
+        const amrvis::ViewDataRequest& request,
+        amrvis::StopToken cancellation = {}) override
+    {
+        if (const auto* slice = std::get_if<amrvis::SliceRequest>(&request)) {
+            m_gridBoxRequests.push_back(slice->includeGridBoxes);
+        }
+        return m_delegate->requestView(request, cancellation);
+    }
+    [[nodiscard]] amrvis::DatasetPage requestDatasetPage(
+        const amrvis::DatasetPageRequest& request,
+        amrvis::StopToken cancellation = {}) override
+    {
+        return m_delegate->requestDatasetPage(request, cancellation);
+    }
+    [[nodiscard]] std::optional<amrvis::ValueRange> requestRange(
+        const amrvis::RangeRequest& request,
+        amrvis::StopToken cancellation = {}) override
+    {
+        return m_delegate->requestRange(request, cancellation);
+    }
+    [[nodiscard]] bool rangeAvailable(
+        const amrvis::RangeRequest& request) const noexcept override
+    {
+        return m_delegate->rangeAvailable(request);
+    }
+    [[nodiscard]] amrvis::ParticleSample requestParticleSample(
+        const std::string& species, double fraction, std::uint64_t seed,
+        amrvis::StopToken cancellation = {}) override
+    {
+        return m_delegate->requestParticleSample(
+            species, fraction, seed, cancellation);
+    }
+    [[nodiscard]] amrvis::CacheMetrics cacheMetrics() const override
+    {
+        return m_delegate->cacheMetrics();
+    }
+    [[nodiscard]] bool setCacheBudget(std::uint64_t bytes) override
+    {
+        return m_delegate->setCacheBudget(bytes);
+    }
+    void clearUnpinnedCache() override { m_delegate->clearUnpinnedCache(); }
+    void close() noexcept override { m_delegate->close(); }
+
+    [[nodiscard]] const std::vector<bool>& gridBoxRequests() const noexcept
+    {
+        return m_gridBoxRequests;
+    }
+    void clearGridBoxRequests() { m_gridBoxRequests.clear(); }
+
+private:
+    std::shared_ptr<amrvis::DatasetSession> m_delegate;
+    std::vector<bool> m_gridBoxRequests;
+};
+
 } // namespace
 
 int main()
@@ -373,6 +458,34 @@ int main()
             "no vector glyphs were generated");
         requireDisplayInvariants(vectors.dataset->metadata(),
             vectors.displays.front(), palette, "initial vectors");
+
+        auto backing = std::make_shared<amrvis::LocalDatasetSession>(
+            root2d, amrvis::DatasetId{nextId++}, bigBudget);
+        auto recording = std::make_shared<RecordingSession>(backing);
+        amrvis::SliceRequest request;
+        request.dataset = recording->id();
+        request.field = amrvis::FieldId{0};
+        request.normalDirection = 1;
+        request.physicalPosition = 0.5;
+        request.visibleRegion
+            = amrvis::datasetSampleBounds(recording->metadata());
+        request.maximumLevel = recording->metadata().finestLevel;
+        request.outputSize = {16, 16};
+        request.includeGridBoxes = true;
+        static_cast<void>(amrvis::executeSliceWithFallback(recording, request,
+            amrvis::RangeMode::File, std::nullopt, false, palette,
+            amrvis::DisplayMode::RasterContours, 0, 0, 4, {}));
+        require(recording->gridBoxRequests()
+                == std::vector<bool>{true, false},
+            "contour mode requested the grid-box list more than once");
+
+        recording->clearGridBoxRequests();
+        static_cast<void>(amrvis::executeSliceWithFallback(recording, request,
+            amrvis::RangeMode::File, std::nullopt, false, palette,
+            amrvis::DisplayMode::VelocityVectors, 0, 0, 4, {}));
+        require(recording->gridBoxRequests()
+                == std::vector<bool>{true, false, false},
+            "vector mode requested the grid-box list more than once");
     }
 
     // --- zoomed load: region honored, clipped, or dropped ------------------

--- a/tests/integration/test_remote_session.cpp
+++ b/tests/integration/test_remote_session.cpp
@@ -63,6 +63,7 @@ amrvis::SliceRequest sliceRequest(
             + request.visibleRegion.upper[normal]);
     request.maximumLevel = dataset.metadata().finestLevel;
     request.outputSize = {width, height};
+    request.includeGridBoxes = true;
     return request;
 }
 
@@ -150,6 +151,41 @@ int main(int argc, char* argv[])
                 && slice.plane.physicalRegion
                     == localSlice.plane.physicalRegion,
             "local and remote slice values differ");
+        require(slice.gridBoxesIncluded && !slice.gridBoxes.empty(),
+            "remote slice omitted view-local grid geometry");
+        for (const auto& box : slice.gridBoxes) {
+            require(box.physicalRegion.lower[0]
+                        >= slice.plane.physicalRegion.lower[0]
+                    && box.physicalRegion.upper[0]
+                        <= slice.plane.physicalRegion.upper[0]
+                    && box.physicalRegion.lower[1]
+                        >= slice.plane.physicalRegion.lower[1]
+                    && box.physicalRegion.upper[1]
+                        <= slice.plane.physicalRegion.upper[1],
+                "remote grid geometry escaped the requested viewport");
+        }
+
+        // Negotiate a deliberately small frame and make the raster consume
+        // nearly all of it. The optional overlay list must be truncated by the
+        // planner while the raster response still succeeds within the frame.
+        amrvis::remote::ConnectionOptions smallFrameOptions;
+        smallFrameOptions.maximumFrameBytes = 4096;
+        auto smallFrameConnection
+            = std::make_shared<amrvis::remote::Connection>(
+                "127.0.0.1", server.port(), smallFrameOptions);
+        auto smallFrameDataset
+            = amrvis::remote::RemoteDatasetSession::open(
+                smallFrameConnection,
+                std::filesystem::path(argv[1]).string(),
+                16ULL * 1024ULL * 1024ULL);
+        const auto boundedOverlay = std::get<amrvis::SliceQueryResult>(
+            smallFrameDataset->requestView(
+                sliceRequest(*smallFrameDataset, 22, 22)));
+        require(boundedOverlay.plane.values.size() == 22U * 22U
+                && boundedOverlay.gridBoxesIncluded
+                && boundedOverlay.gridBoxesTruncated
+                && boundedOverlay.gridBoxes.size() <= 1,
+            "frame-bounded slice did not preserve its raster while truncating overlays");
 
         amrvis::LineViewRequest line;
         line.query.dataset = dataset->id();

--- a/tests/integration/test_slice_query.cpp
+++ b/tests/integration/test_slice_query.cpp
@@ -148,6 +148,41 @@ int main()
         "repeated slice did not reuse both blocks");
     require(cached.metrics.payloadBytesRead == 0, "cached slice performed payload I/O");
 
+    {
+        auto overlays = request;
+        overlays.includeGridBoxes = true;
+        overlays.maximumGridBoxes = 1;
+        const auto bounded = query.execute(overlays);
+        require(bounded.gridBoxesIncluded && bounded.gridBoxesTruncated
+                && bounded.gridBoxes.size() == 1,
+            "slice query did not stop overlay collection at its count bound");
+        for (const auto& box : bounded.gridBoxes) {
+            require(box.physicalRegion.lower[0]
+                        < box.physicalRegion.upper[0]
+                    && box.physicalRegion.lower[1]
+                        < box.physicalRegion.upper[1],
+                "slice query emitted a degenerate clipped grid box");
+        }
+
+        // Linear sampling expands the planning halo beyond the visible
+        // region. The left coarse block then touches x=0.5 only at its edge;
+        // clipping must discard that zero-width overlay while retaining the
+        // right block that has a nonempty visible intersection.
+        auto halo = request;
+        halo.includeGridBoxes = true;
+        halo.maximumLevel = 0;
+        halo.composition = amrvis::CompositionPolicy::ExactLevel;
+        halo.sampling = amrvis::SamplingPolicy::Linear;
+        halo.visibleRegion.lower[0] = 0.5;
+        const auto clipped = query.execute(halo);
+        require(!clipped.gridBoxesTruncated && clipped.gridBoxes.size() == 1
+                && clipped.gridBoxes.front().physicalRegion.lower[0]
+                    < clipped.gridBoxes.front().physicalRegion.upper[0]
+                && clipped.gridBoxes.front().physicalRegion.lower[1]
+                    < clipped.gridBoxes.front().physicalRegion.upper[1],
+            "slice query transmitted a halo-only or degenerate grid box");
+    }
+
     request.composition = amrvis::CompositionPolicy::ExactLevel;
     const auto exact = query.execute(request);
     require(exact.plane.valid[0] == 0, "exact-level slice filled a fine-level hole");
@@ -454,4 +489,3 @@ int main()
     std::filesystem::remove_all(ghostRoot);
     return 0;
 }
-

--- a/tests/unit/test_remote_codec.cpp
+++ b/tests/unit/test_remote_codec.cpp
@@ -160,12 +160,23 @@ int main()
     slice.plane.values = {1.0F, 2.0F};
     slice.plane.valid = {1, 1};
     slice.plane.sourceLevel = {0, 1};
+    slice.gridBoxesIncluded = true;
+    slice.gridBoxesTruncated = true;
+    slice.gridBoxes.push_back(
+        {1, RealBox{Real3{{0.5, 0.0, 0.0}},
+                Real3{{1.0, 1.0, 0.0}}}});
     bytes = codec::encode(
         10, codec::toWire(slice, CacheMetrics{}));
     envelope = codec::decode(bytes);
     const auto decoded = codec::fromWire(
         *envelope->payload.AsSliceViewResponse());
-    require(decoded.plane.values == slice.plane.values,
+    require(decoded.plane.values == slice.plane.values
+            && decoded.gridBoxesIncluded
+            && decoded.gridBoxesTruncated
+            && decoded.gridBoxes.size() == 1
+            && decoded.gridBoxes.front().level == 1
+            && decoded.gridBoxes.front().physicalRegion
+                == slice.gridBoxes.front().physicalRegion,
         "bounded slice response did not round-trip");
 
     auto wrongIdentifier = bytes;

--- a/tests/unit/test_slice_pipeline.cpp
+++ b/tests/unit/test_slice_pipeline.cpp
@@ -117,6 +117,12 @@ int main()
         other.composition = amrvis::CompositionPolicy::ExactLevel;
         require(!amrvis::sameSliceSpec(base, other), "composition difference missed");
     }
+    {
+        auto other = base;
+        other.includeGridBoxes = true;
+        require(!amrvis::sameSliceSpec(base, other),
+            "grid-overlay difference missed");
+    }
     // --- coveredCells -----------------------------------------------------
     // A [0,9] cell-centered level with cell size 1 spans physical [0, 10].
     const auto grid = makeMetadata(2, 1.0);


### PR DESCRIPTION
Part 12 of 13 in the remote client/server stack.

## Purpose

Carry only requested, view-local AMR grid geometry with a slice.

## Scope

- Adds the request flag and clipped `SliceGridBox` results.
- Round-trips geometry through the schema and codec.
- Makes Qt render returned geometry instead of rebuilding every overlay from the full catalog.
- Forces a fresh geometry request when Boxes is re-enabled.

## Review focus

This is intentionally a separate vertical slice because it crosses query, wire, session, pipeline, and Qt boundaries.

## Validation

- `slice_pipeline`, `slice_query`, `remote_codec`, and `remote_session`
- `qt_remote_grid_boxes_smoke`, including the off/on refetch edge
