### PR TITLE
silence the spurious host-portal registration warning at startup

### DIFF
--- a/src/qt/main.cpp
+++ b/src/qt/main.cpp
@@ -465,8 +465,15 @@ int main(int argc, char* argv[])
     // Installed before QApplication so it also covers construction-time output.
     g_previousMessageHandler = qInstallMessageHandler(filterWaylandPopupWarning);
 
-    // Disable Wayland warnings
-    QLoggingCategory::setFilterRules(QStringLiteral("qt.qpa.wayland.textinput=false"));
+    // Disable Wayland warnings, and the spurious "Failed to register with host
+    // portal" message Qt prints at startup: it reads the portal's Settings
+    // interface before calling host.portal.Registry.Register, so
+    // xdg-desktop-portal has already associated an app ID with the connection
+    // and rejects the registration. Nothing is lost -- the portal derived the
+    // app ID it needs, which is why the call failed in the first place.
+    QLoggingCategory::setFilterRules(
+        QStringLiteral("qt.qpa.wayland.textinput=false\n"
+                       "qt.qpa.services.warning=false"));
 
     QApplication application(argc, argv);
     // Advertise the desktop entry name and WM class as "amrexplorer" so Linux


### PR DESCRIPTION
Qt 6.10 reads the portal's Settings interface before it calls host.portal.Registry.Register, so xdg-desktop-portal 1.21 has already resolved and cached an app ID for the connection and rejects the registration:

  qt.qpa.services: Failed to register with host portal QDBusError(
  "org.freedesktop.portal.Error.Failed", "Could not register app ID:
  Connection already associated with an application ID")

Nothing is lost -- the portal derived the app ID it needs, which is exactly why the call failed -- and every Qt application on such a system that sets a desktop file name prints it. Add the category to the filter rules already installed before QApplication. Scoped to .warning so genuine qt.qpa.services failures still surface.