### PR TITLE
fix inconsistent arrow-key pan direction between display modes

### DIFF
--- a/src/qt/ImageView.cpp
+++ b/src/qt/ImageView.cpp
@@ -606,22 +606,20 @@ void ImageView::panViewport(const QPoint& delta)
     }
     auto* const hBar = horizontalScrollBar();
     auto* const vBar = verticalScrollBar();
-    if (hBar->maximum() > hBar->minimum()
-        || vBar->maximum() > vBar->minimum()) {
-        // Scrolling leaves the transform — and therefore the display mode —
-        // untouched: a fixed scale panned by its scroll bars is still that
-        // fixed scale, locally and on a virtual canvas alike.
-        hBar->setValue(hBar->value() - delta.x());
-        vBar->setValue(vBar->value() - delta.y());
+    if (hBar->maximum() == hBar->minimum()
+        && vBar->maximum() == vBar->minimum()) {
+        // Neither axis has anywhere to scroll: the scene already fits the
+        // viewport. Translating instead would slide a fully visible image
+        // off-centre and demote the display mode to Custom — a change
+        // MainWindow never hears about, since panning raises no mode signal
+        // the way an explicit zoom does, leaving the Scale button stale.
         return;
     }
-    const auto sx = transform().m11();
-    const auto sy = transform().m22();
-    if (sx == 0.0 || sy == 0.0) {
-        return;
-    }
-    m_transformMode = TransformMode::Custom;
-    translate(delta.x() / sx, delta.y() / sy);
+    // Scrolling leaves the transform — and therefore the display mode —
+    // untouched: a fixed scale panned by its scroll bars is still that fixed
+    // scale, locally and on a virtual canvas alike.
+    hBar->setValue(hBar->value() - delta.x());
+    vBar->setValue(vBar->value() - delta.y());
 }
 
 void ImageView::mouseDoubleClickEvent(QMouseEvent* event)

--- a/src/qt/ImageView.hpp
+++ b/src/qt/ImageView.hpp
@@ -162,9 +162,11 @@ public:
     // The rect is in image (raster-pixel) coordinates — identical to scene
     // coordinates in the classic scene, offset-corrected on a virtual canvas.
     void zoomToRect(const QRectF& imageRect);
-    // Shift+left-drag pans the viewport (scroll bars, or the view transform
-    // when the scene fits the window). When zoomed into a subregion, the
-    // drag shifts the visible data window (see panDrag* signals).
+    // Scrolls the viewport for Shift+left-drag and the arrow keys. The delta
+    // is how far the content moves, matching the sense MainWindow's
+    // shiftedPanRegion uses, and is a no-op when the scene already fits the
+    // window. When zoomed into a subregion, the drag shifts the visible data
+    // window instead (see panDrag* signals).
     void panViewport(const QPoint& delta);
     // When enabled (the 3-D slice views): a plain right click emits
     // sliceMoveRequested; a Shift+middle/right click or drag, or a right

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -3737,10 +3737,16 @@ void MainWindow::applyPanStep(PlaneViewState& state, const QPointF& direction)
         return;
     }
 
-    const auto scale = state.view->transform().m11();
+    // shiftedPanRegion above and panViewport here share one convention: the
+    // delta says how far the *content* moves. Handing both the same unnegated
+    // sceneDelta is what keeps an arrow key moving the view rather than the
+    // image once the pan falls through to the scroll bars. The axes convert
+    // independently because a fixed scale over a raster whose aspect differs
+    // from the logical size yields an anisotropic transform.
+    const auto transform = state.view->transform();
     state.view->panViewport(QPoint(
-        static_cast<int>(std::round(-sceneDelta.x() * scale)),
-        static_cast<int>(std::round(-sceneDelta.y() * scale))));
+        static_cast<int>(std::round(sceneDelta.x() * transform.m11())),
+        static_cast<int>(std::round(sceneDelta.y() * transform.m22()))));
 }
 
 std::optional<RealBox> MainWindow::shiftedPanRegion(

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -574,6 +574,23 @@ if(TARGET amrexplorer_qt)
             "$<TARGET_FILE:test_line_plot_hover>"
     )
 
+    add_executable(test_image_view_pan
+        unit/test_image_view_pan.cpp
+        "${PROJECT_SOURCE_DIR}/src/qt/ImageView.cpp"
+    )
+    set_target_properties(test_image_view_pan PROPERTIES AUTOMOC ON)
+    target_include_directories(test_image_view_pan
+        PRIVATE "${PROJECT_SOURCE_DIR}/src/qt"
+    )
+    target_link_libraries(test_image_view_pan
+        PRIVATE amrexplorer::core amrexplorer::warnings Qt6::Widgets
+    )
+    add_test(
+        NAME image_view_pan
+        COMMAND "${CMAKE_COMMAND}" -E env QT_QPA_PLATFORM=offscreen
+            "$<TARGET_FILE:test_image_view_pan>"
+    )
+
     add_test(
         NAME qt_metadata_smoke
         COMMAND "${CMAKE_COMMAND}" -E env QT_QPA_PLATFORM=offscreen

--- a/tests/unit/test_image_view_pan.cpp
+++ b/tests/unit/test_image_view_pan.cpp
@@ -1,0 +1,102 @@
+#include "ImageView.hpp"
+
+#include <QApplication>
+#include <QImage>
+#include <QPoint>
+#include <QScrollBar>
+#include <QTransform>
+
+#include <cstdlib>
+#include <iostream>
+
+namespace {
+
+void require(bool condition, const char* message)
+{
+    if (!condition) {
+        std::cerr << "FAILED: " << message << '\n';
+        std::exit(1);
+    }
+}
+
+QImage solidImage(int width, int height)
+{
+    QImage image(width, height, QImage::Format_RGB32);
+    image.fill(Qt::black);
+    return image;
+}
+
+// A scene larger than the viewport pans by its scroll bars, and the delta says
+// how far the *content* moves: content travelling +x backs the bar off by the
+// same amount. MainWindow's arrow-key step and its drag handler both hand
+// panViewport a delta in that convention, so a sign slip here silently inverts
+// the arrow keys in exactly one display mode.
+void scrollBarPanFollowsContentDelta()
+{
+    amrvis::qt::ImageView view;
+    view.resize(200, 150);
+    view.show();
+    QApplication::processEvents();
+    view.setImage(solidImage(800, 600));
+    view.setFixedScale(2);
+    QApplication::processEvents();
+
+    auto* const hBar = view.horizontalScrollBar();
+    auto* const vBar = view.verticalScrollBar();
+    require(hBar->maximum() > hBar->minimum(),
+        "a 2x scale of an 800px raster must overflow a 200px viewport");
+    require(vBar->maximum() > vBar->minimum(),
+        "a 2x scale of a 600px raster must overflow a 150px viewport");
+
+    // Park both bars mid-range so neither end clamps the step under test.
+    hBar->setValue((hBar->minimum() + hBar->maximum()) / 2);
+    vBar->setValue((vBar->minimum() + vBar->maximum()) / 2);
+    const auto startX = hBar->value();
+    const auto startY = vBar->value();
+
+    view.panViewport(QPoint(10, 6));
+    require(hBar->value() == startX - 10,
+        "content moving +x must decrease the horizontal scroll value by 10");
+    require(vBar->value() == startY - 6,
+        "content moving +y must decrease the vertical scroll value by 6");
+    require(view.transformMode()
+            == amrvis::qt::ImageView::TransformMode::FixedScale,
+        "scrolling must leave the display mode untouched");
+}
+
+// With the whole scene visible there is nowhere to scroll, so a pan is a
+// no-op. Translating instead would slide the image off-centre and demote the
+// mode to Custom without telling MainWindow, leaving the Scale button stale.
+void fullyVisibleSceneIgnoresPan()
+{
+    amrvis::qt::ImageView view;
+    view.resize(400, 300);
+    view.show();
+    QApplication::processEvents();
+    view.setImage(solidImage(50, 40));
+    view.fitToWindow();
+    QApplication::processEvents();
+
+    auto* const hBar = view.horizontalScrollBar();
+    auto* const vBar = view.verticalScrollBar();
+    require(hBar->maximum() == hBar->minimum()
+            && vBar->maximum() == vBar->minimum(),
+        "a fitted raster must leave both scroll bars without range");
+
+    const auto before = view.transform();
+    view.panViewport(QPoint(25, 25));
+    require(view.transform() == before,
+        "a fully visible scene must not be translated by a pan");
+    require(view.transformMode() == amrvis::qt::ImageView::TransformMode::Fit,
+        "panning must not demote Fit to Custom");
+}
+
+} // namespace
+
+int main(int argc, char* argv[])
+{
+    QApplication application(argc, argv);
+    scrollBarPanFollowsContentDelta();
+    fullyVisibleSceneIgnoresPan();
+    return 0;
+}


### PR DESCRIPTION
Arrow keys moved the view in the sub-region mode but the image in the scroll-bar mode. shiftedPanRegion and panViewport share one convention -- the delta says how far the content moves, which is how both drag-pan paths already pass it -- but applyPanStep handed the delta unnegated to the first and negated to the second, inverting both axes on the fall-through path. Drop the negation.

Two adjacent defects in the same statement:

- The step used transform().m11() for both axes, so the vertical step was scaled by the horizontal factor whenever applyFixedScale built an anisotropic transform from a raster whose aspect differs from the logical size. Use m22() for y.

- With the scene already fitting the viewport, panViewport fell through to translate() and demoted the display mode to Custom, so an arrow key nudged a fully visible image off-centre and silently dropped Fit. Panning raises no mode signal the way an explicit zoom does, leaving MainWindow's Scale button stale. Make it a no-op instead; drag-pan shared that path and gains the same fix.

test_image_view_pan covers panViewport's contract: a scrollable scene moves its bars opposite the content delta and keeps FixedScale, and a fitted scene ignores the pan and stays Fit. The arrow-key sign itself stays uncovered -- it lives in MainWindow::applyPanStep, which needs a constructed MainWindow and a loaded dataset to exercise.