### PR TITLE
build the remote client/server code under ThreadSanitizer

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -72,10 +72,11 @@
     {
       "name": "tsan",
       "inherits": "headless",
-      "displayName": "Headless ThreadSanitizer build",
+      "displayName": "Headless ThreadSanitizer build (includes remote)",
       "binaryDir": "${sourceDir}/build-tsan",
       "cacheVariables": {
-        "AMREXPLORER_ENABLE_TSAN": "ON"
+        "AMREXPLORER_ENABLE_TSAN": "ON",
+        "AMREXPLORER_ENABLE_REMOTE": "ON"
       }
     },
     {

--- a/docs/building.md
+++ b/docs/building.md
@@ -32,7 +32,7 @@ cmake --preset sanitizers  # Headless + ASan + UBSan → build-sanitizers/
 cmake --build --preset sanitizers
 ctest --preset sanitizers
 
-cmake --preset tsan        # Headless + ThreadSanitizer → build-tsan/
+cmake --preset tsan        # Headless + remote + ThreadSanitizer → build-tsan/
 cmake --build --preset tsan
 ctest --preset tsan
 
@@ -43,10 +43,14 @@ ctest --preset qt-sanitizers
 
 The sanitizer preset enables AddressSanitizer and UndefinedBehaviorSanitizer.
 The tsan preset enables ThreadSanitizer (mutually exclusive with the ASan
-build), covering the concurrent block-read, cache, and stop-token paths.
-The qt-sanitizers preset runs the full suite — including the offscreen Qt
-smoke tests — under ASan/UBSan with leak detection. A `windows` preset
-(usable only on Windows hosts) mirrors the CI MSVC job.
+build), covering the concurrent block-read, cache, and stop-token paths. It
+also enables remote support, so the client receiver thread, per-session reader
+threads, and the shared server worker pool are checked by the `remote_*` tests
+in the same run. The qt-sanitizers preset runs the full suite — including the
+offscreen Qt smoke tests and, because Qt implies remote, the remote tests —
+under ASan/UBSan with leak detection; the headless `sanitizers` preset stays
+local-only to avoid duplicating that coverage. A `windows` preset (usable only
+on Windows hosts) mirrors the CI MSVC job.
 
 The clang preset mirrors the CI clang job (which builds with
 `-DAMREXPLORER_WARNINGS_AS_ERRORS=ON`): run it before pushing to catch


### PR DESCRIPTION
The tsan preset inherits headless, which turns Qt off, and AMREXPLORER_ENABLE_REMOTE defaults to AMREXPLORER_ENABLE_QT -- so the Linux TSan job built and tested only the local headless libraries. The remote layer is the most concurrent code in the project: a client receiver thread with a pending-request map, one reader thread per server session, a shared worker pool, cancellation through stop tokens, dataset lifetimes, and serialized response writes. None of its happens-before relationships were ever checked, since a clean ordinary or ASan/UBSan run does not test them.

Enable remote in the tsan preset. The existing job configures, builds, and runs the whole preset, so it picks up amrexplorer_remote, amrexplorer-server, and the five remote_* tests with no workflow edit and no new package -- the remote job already builds that target set from the same apt list. ctest --preset tsan -N goes from 34 tests to 45.

TSan reported no race. The full preset passes, and the eleven remote-related tests were also run fifteen times each under --repeat until-fail:15 with halt_on_error=1. In particular Server::m_handshakeComplete and m_selectedMinorVersion -- plain members written on a session reader thread during handleHello and read from pooled workers in send() -- were not flagged, so they stay plain rather than becoming atomics on suspicion. No suppression file was needed. A clean CI-equivalent build at -j4 takes about 27 s, so the job's 30-minute timeout is untouched.

The headless sanitizers preset stays local-only on purpose: qt-sanitizers inherits debug with Qt on, and Qt implies remote, so remote code already runs under ASan/UBSan with leak detection there. Duplicating it headless would cost CI time for no new signal.