### PR TITLE
report the visible data window in raster pixels, not scene units

### DIFF
--- a/src/qt/ImageView.cpp
+++ b/src/qt/ImageView.cpp
@@ -157,6 +157,19 @@ QRectF ImageView::imageSceneRect() const
     return m_item == nullptr ? QRectF() : m_item->sceneBoundingRect();
 }
 
+QRectF ImageView::visibleImageRect() const
+{
+    if (m_item == nullptr || viewport() == nullptr) {
+        return {};
+    }
+    // mapRectFromScene undoes the item's placement -- identity in the classic
+    // scene, the cell offset and pixel-to-cell scale on a virtual canvas -- so
+    // the result is in raster pixels either way.
+    return m_item->mapRectFromScene(
+        mapToScene(viewport()->rect()).boundingRect()).intersected(
+            m_item->boundingRect());
+}
+
 // Position the raster item and size the scene. On a virtual canvas the scene
 // spans the whole domain in finest-cell units and the item maps its pixels
 // onto its fetched cell window; the classic scene is the raster at the

--- a/src/qt/ImageView.hpp
+++ b/src/qt/ImageView.hpp
@@ -101,6 +101,13 @@ public:
     // The raster item's footprint in scene coordinates (the image rect in the
     // classic raster-at-origin scene; the fetched cell window when virtual).
     [[nodiscard]] QRectF imageSceneRect() const;
+    // The visible part of the raster in raster-pixel coordinates, clamped to
+    // the raster. Scene coordinates are raster pixels only in the classic
+    // scene; on a virtual canvas they are whole-domain finest cells and the
+    // item carries both the pixel-to-cell scale and its offset within the
+    // domain, so callers that want pixels must come through here rather than
+    // intersect a scene rect with the image rect.
+    [[nodiscard]] QRectF visibleImageRect() const;
     void setGridBoxes(const std::vector<GridBoxOverlay>& boxes);
     void setOverlaySegments(const std::vector<OverlaySegment>& segments);
     // Smooth contour polylines, rendered as cosmetic-pen path items at the

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -2243,6 +2243,12 @@ QRectF MainWindow::activeViewVisibleDataWindowForTest() const
     // rect directly would report a window in the wrong space (and offset by
     // the fetched window's position in the domain) whenever the canvas
     // scrolls.
+    //
+    // The second clamp is not redundant with the one inside visibleImageRect:
+    // that one clamps to the pixmap, while the normalization below divides by
+    // the plane's dimensions, and a supersampled spherical warp makes the
+    // pixmap larger than the plane. Clamping to the plane rect keeps the
+    // fractions in range there, exactly as this probe did before.
     const auto visible = view->visibleImageRect().intersected(
         QRectF(0.0, 0.0, plane.width, plane.height));
     const auto axes = displayAxes(m_activeView->normal);

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -2035,6 +2035,20 @@ bool MainWindow::allViewsUseViewportBoundedOutputForTest() const
             [&](const auto* state) { return check(*state); });
 }
 
+int MainWindow::slicesInFlightForTest() const
+{
+    if (m_viewDimension == 2) {
+        return m_view2d.pendingRequests;
+    }
+    const std::array<const PlaneViewState*, 3> threeDimensional{
+        &m_planeViews[0], &m_planeViews[1], &m_planeViews[2]};
+    int total = 0;
+    for (const auto* state : threeDimensional) {
+        total += state->pendingRequests;
+    }
+    return total;
+}
+
 bool MainWindow::allViewsFixedScaleRasterCoversViewportForTest() const
 {
     const auto check = [](const PlaneViewState& state) {

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -2237,9 +2237,14 @@ QRectF MainWindow::activeViewVisibleDataWindowForTest() const
     if (plane.width < 1 || plane.height < 1) {
         return {};
     }
-    const auto visible = view->mapToScene(
-        view->viewport()->rect()).boundingRect().intersected(
-            QRectF(0.0, 0.0, plane.width, plane.height));
+    // Raster pixels, not scene units: a remote fixed scale hosts the fetched
+    // raster on a whole-domain virtual canvas whose scene coordinates are
+    // finest cells, so intersecting the viewport's scene rect with the pixel
+    // rect directly would report a window in the wrong space (and offset by
+    // the fetched window's position in the domain) whenever the canvas
+    // scrolls.
+    const auto visible = view->visibleImageRect().intersected(
+        QRectF(0.0, 0.0, plane.width, plane.height));
     const auto axes = displayAxes(m_activeView->normal);
     const auto xAxis = static_cast<std::size_t>(axes[0]);
     const auto yAxis = static_cast<std::size_t>(axes[1]);

--- a/src/qt/MainWindow.hpp
+++ b/src/qt/MainWindow.hpp
@@ -164,6 +164,12 @@ public:
     // everything its viewport shows of the domain backed by the raster —
     // full bleed with no unfetched gaps.
     [[nodiscard]] bool allViewsFixedScaleRasterCoversViewportForTest() const;
+    // Test-only: slice requests currently on a worker across the current
+    // panels. Zero means the displayed raster is not about to be replaced by
+    // work already in flight, which is what a probe reading the raster (or the
+    // window it implies) needs before it measures. Pair it with a settle to
+    // absorb a request that only queues its successor.
+    [[nodiscard]] int slicesInFlightForTest() const;
     // Test-only: send a real Shift+left drag through the active view's
     // viewport, exercising the same event path as interactive panning.
     void shiftDragActiveViewForTest(int dx, int dy);

--- a/src/qt/main.cpp
+++ b/src/qt/main.cpp
@@ -39,7 +39,6 @@
 #include <cstdlib>
 #include <cstring>
 #include <filesystem>
-#include <functional>
 #include <iomanip>
 #include <iostream>
 #include <memory>

--- a/src/qt/main.cpp
+++ b/src/qt/main.cpp
@@ -39,6 +39,8 @@
 #include <cstdlib>
 #include <cstring>
 #include <filesystem>
+#include <functional>
+#include <iomanip>
 #include <iostream>
 #include <memory>
 #include <optional>
@@ -456,6 +458,92 @@ bool contourSyncMatches(amrvis::qt::MainWindow& window)
     return panelsWithLevels >= 2 && sharedLevelsDrawn >= 2;
 }
 
+// What one view shows, for a local-versus-remote comparison: the physical
+// window the probe reports, the viewport pixels, and the raster size.
+struct ViewCapture {
+    QRectF window;
+    QImage viewport;
+    std::array<int, 2> image{};
+};
+
+void printDataWindow(std::ostream& stream, const QRectF& window)
+{
+    stream << std::setprecision(17) << window.x() << ',' << window.y() << ','
+           << window.width() << ',' << window.height();
+}
+
+// Local and remote must agree on the physical window, but not to the last bit:
+// a local fixed scale scrolls a whole-domain raster while a remote one scrolls
+// a whole-domain virtual canvas of finest cells, and both scroll in whole
+// viewport pixels, so their integer scroll positions may differ by a rounding
+// step. Two viewport pixels of slack covers that; the coordinate-space
+// confusion this guards against is off by many cells.
+bool dataWindowsAgree(const QRectF& local, const QRectF& remote,
+    const std::array<int, 2>& viewportPixels)
+{
+    const auto slack = [](double extent, int pixels) {
+        return pixels > 0 ? 2.0 * std::fabs(extent) / pixels : 0.0;
+    };
+    const auto slackX = std::max(slack(local.width(), viewportPixels[0]),
+        1.0e-9 * std::fabs(local.width()));
+    const auto slackY = std::max(slack(local.height(), viewportPixels[1]),
+        1.0e-9 * std::fabs(local.height()));
+    return std::fabs(local.left() - remote.left()) <= slackX
+        && std::fabs(local.right() - remote.right()) <= slackX
+        && std::fabs(local.top() - remote.top()) <= slackY
+        && std::fabs(local.bottom() - remote.bottom()) <= slackY;
+}
+
+// Rendering happens client-side for both datasets, so equal data must paint
+// equal viewport pixels. Reports the first difference (raster order) and how
+// many pixels differ, or nullopt when the two viewports are identical.
+struct ViewportDifference {
+    QString summary;
+    std::size_t differingPixels = 0;
+};
+
+std::optional<ViewportDifference> viewportDifference(
+    const QImage& local, const QImage& remote)
+{
+    if (local.size() != remote.size() || local.isNull() || remote.isNull()) {
+        return ViewportDifference{
+            QStringLiteral("viewport sizes differ (local %1x%2, remote %3x%4)")
+                .arg(local.width())
+                .arg(local.height())
+                .arg(remote.width())
+                .arg(remote.height()),
+            0};
+    }
+    const auto left = local.convertToFormat(QImage::Format_ARGB32);
+    const auto right = remote.convertToFormat(QImage::Format_ARGB32);
+    std::optional<ViewportDifference> difference;
+    std::size_t differing = 0;
+    for (int y = 0; y < left.height(); ++y) {
+        for (int x = 0; x < left.width(); ++x) {
+            const auto localPixel = left.pixel(x, y);
+            const auto remotePixel = right.pixel(x, y);
+            if (localPixel == remotePixel) {
+                continue;
+            }
+            ++differing;
+            if (!difference) {
+                difference = ViewportDifference{
+                    QStringLiteral("first differing pixel at (%1,%2): "
+                                   "local=%3 remote=%4")
+                        .arg(x)
+                        .arg(y)
+                        .arg(localPixel, 8, 16, QLatin1Char('0'))
+                        .arg(remotePixel, 8, 16, QLatin1Char('0')),
+                    0};
+            }
+        }
+    }
+    if (difference) {
+        difference->differingPixels = differing;
+    }
+    return difference;
+}
+
 } // namespace
 
 int main(int argc, char* argv[])
@@ -561,92 +649,137 @@ int main(int argc, char* argv[])
                         });
                     return;
                 }
-                const auto remoteShowsWholeImage
-                    = window.activeViewShowsWholeImageForTest();
-                const auto remoteImage = window.activeViewImageSizeForTest();
-                const auto remoteViewport
-                    = window.activeViewViewportSizeForTest();
-                const auto remoteWindow
-                    = window.activeViewVisibleDataWindowForTest();
-                const auto remoteViewportImage
-                    = window.activeViewViewportImageForTest();
-                const auto printWindow = [](const QRectF& value) {
-                    std::cout << std::setprecision(17)
-                              << value.x() << ',' << value.y() << ','
-                              << value.width() << ',' << value.height();
-                };
-                std::cout << "local 1x: image=" << probe->localImage[0]
-                          << 'x' << probe->localImage[1]
-                          << " viewport=" << probe->localViewport[0]
-                          << 'x' << probe->localViewport[1]
-                          << " whole-image-visible="
-                          << (probe->localShowsWholeImage ? "yes" : "no")
-                          << " data-window=";
-                printWindow(probe->localWindow);
-                std::cout << "\nremote 1x: image=" << remoteImage[0]
-                          << 'x' << remoteImage[1]
-                          << " viewport=" << remoteViewport[0]
-                          << 'x' << remoteViewport[1]
-                          << " whole-image-visible="
-                          << (remoteShowsWholeImage ? "yes" : "no")
-                          << " data-window=";
-                printWindow(remoteWindow);
-                std::cout << '\n';
-                const auto fillsViewport = [](const std::array<int, 2>& image,
-                                               const std::array<int, 2>& viewport) {
-                    return image[0] <= viewport[0] && image[1] <= viewport[1]
-                        && (std::abs(image[0] - viewport[0]) <= 1
-                            || std::abs(image[1] - viewport[1]) <= 1);
-                };
-                const auto localActsFit = probe->localShowsWholeImage
-                    && fillsViewport(probe->localImage, probe->localViewport);
-                const auto remoteActsFit = remoteShowsWholeImage
-                    && fillsViewport(remoteImage, remoteViewport);
-                const auto scaleMatches = probe->localImage == remoteImage
-                    && probe->localShowsWholeImage == remoteShowsWholeImage
-                    && localActsFit == remoteActsFit;
-                if (!screenshotPath.isEmpty()) {
-                    constexpr int headingHeight = 36;
-                    constexpr int gap = 12;
-                    const auto width = probe->localViewportImage.width()
-                        + remoteViewportImage.width() + gap;
-                    const auto height = headingHeight + std::max(
-                        probe->localViewportImage.height(),
-                        remoteViewportImage.height());
-                    QImage comparison(width, height,
-                        QImage::Format_ARGB32_Premultiplied);
-                    comparison.fill(QColor(30, 30, 30));
-                    QPainter painter(&comparison);
-                    painter.setPen(Qt::white);
-                    painter.drawText(QRect(0, 0,
-                        probe->localViewportImage.width(), headingHeight),
-                        Qt::AlignCenter, QStringLiteral("Local - 1x"));
-                    painter.drawText(QRect(
-                        probe->localViewportImage.width() + gap, 0,
-                        remoteViewportImage.width(), headingHeight),
-                        Qt::AlignCenter, QStringLiteral("Remote - 1x"));
-                    painter.drawImage(0, headingHeight,
-                        probe->localViewportImage);
-                    painter.drawImage(
-                        probe->localViewportImage.width() + gap,
-                        headingHeight, remoteViewportImage);
-                    painter.end();
-                    if (!comparison.save(screenshotPath, "PNG")) {
-                        std::cerr << "failed to save screenshot comparison to "
-                                  << screenshotPath.toStdString() << '\n';
-                        application.exit(5);
+                // The remote fixed scale is demand-driven: selecting it can
+                // queue a native-resolution refetch, and comparing a raster
+                // that is still being replaced would report a difference that
+                // is only a race. Measure on the settle, or after a short grace
+                // period when the switch needed no new raster at all.
+                auto measured = std::make_shared<bool>(false);
+                const auto measure = [&window, &application, probe,
+                                         screenshotPath, measured] {
+                    if (*measured) {
                         return;
                     }
-                    std::cout << "screenshot="
-                              << screenshotPath.toStdString() << '\n';
-                }
-                std::cout << (scaleMatches ? "MATCH" : "MISMATCH")
-                          << ": remote 1x "
-                          << (scaleMatches
-                                ? "has the same native extent as local 1x"
-                                : "does not have the same scale semantics as local 1x")
-                          << '\n';
-                application.exit(scaleMatches ? 0 : 1);
+                    *measured = true;
+                    const auto remoteShowsWholeImage
+                        = window.activeViewShowsWholeImageForTest();
+                    const auto remoteImage
+                        = window.activeViewImageSizeForTest();
+                    const auto remoteViewport
+                        = window.activeViewViewportSizeForTest();
+                    const auto remoteWindow
+                        = window.activeViewVisibleDataWindowForTest();
+                    const auto remoteViewportImage
+                        = window.activeViewViewportImageForTest();
+                    std::cout << "local 1x: image=" << probe->localImage[0]
+                              << 'x' << probe->localImage[1]
+                              << " viewport=" << probe->localViewport[0]
+                              << 'x' << probe->localViewport[1]
+                              << " whole-image-visible="
+                              << (probe->localShowsWholeImage ? "yes" : "no")
+                              << " data-window=";
+                    printDataWindow(std::cout, probe->localWindow);
+                    std::cout << "\nremote 1x: image=" << remoteImage[0]
+                              << 'x' << remoteImage[1]
+                              << " viewport=" << remoteViewport[0]
+                              << 'x' << remoteViewport[1]
+                              << " whole-image-visible="
+                              << (remoteShowsWholeImage ? "yes" : "no")
+                              << " data-window=";
+                    printDataWindow(std::cout, remoteWindow);
+                    std::cout << '\n';
+                    const auto fillsViewport
+                        = [](const std::array<int, 2>& image,
+                              const std::array<int, 2>& viewport) {
+                              return image[0] <= viewport[0]
+                                  && image[1] <= viewport[1]
+                                  && (std::abs(image[0] - viewport[0]) <= 1
+                                      || std::abs(image[1] - viewport[1]) <= 1);
+                          };
+                    const auto localActsFit = probe->localShowsWholeImage
+                        && fillsViewport(
+                            probe->localImage, probe->localViewport);
+                    const auto remoteActsFit = remoteShowsWholeImage
+                        && fillsViewport(remoteImage, remoteViewport);
+                    const auto scaleMatches = probe->localImage == remoteImage
+                        && probe->localShowsWholeImage == remoteShowsWholeImage
+                        && localActsFit == remoteActsFit;
+                    // The window and the pixels are part of the verdict, not
+                    // just of the printout: a probe reporting the wrong
+                    // physical window, or a raster that differs where it is
+                    // visible, is exactly what this tool exists to catch.
+                    const auto windowMatches = dataWindowsAgree(
+                        probe->localWindow, remoteWindow, probe->localViewport);
+                    const auto contentDifference = viewportDifference(
+                        probe->localViewportImage, remoteViewportImage);
+                    if (!screenshotPath.isEmpty()) {
+                        constexpr int headingHeight = 36;
+                        constexpr int gap = 12;
+                        const auto width = probe->localViewportImage.width()
+                            + remoteViewportImage.width() + gap;
+                        const auto height = headingHeight + std::max(
+                            probe->localViewportImage.height(),
+                            remoteViewportImage.height());
+                        QImage comparison(width, height,
+                            QImage::Format_ARGB32_Premultiplied);
+                        comparison.fill(QColor(30, 30, 30));
+                        QPainter painter(&comparison);
+                        painter.setPen(Qt::white);
+                        painter.drawText(QRect(0, 0,
+                            probe->localViewportImage.width(), headingHeight),
+                            Qt::AlignCenter, QStringLiteral("Local - 1x"));
+                        painter.drawText(QRect(
+                            probe->localViewportImage.width() + gap, 0,
+                            remoteViewportImage.width(), headingHeight),
+                            Qt::AlignCenter, QStringLiteral("Remote - 1x"));
+                        painter.drawImage(0, headingHeight,
+                            probe->localViewportImage);
+                        painter.drawImage(
+                            probe->localViewportImage.width() + gap,
+                            headingHeight, remoteViewportImage);
+                        painter.end();
+                        if (!comparison.save(screenshotPath, "PNG")) {
+                            std::cerr
+                                << "failed to save screenshot comparison to "
+                                << screenshotPath.toStdString() << '\n';
+                            application.exit(5);
+                            return;
+                        }
+                        std::cout << "screenshot="
+                                  << screenshotPath.toStdString() << '\n';
+                    }
+                    if (contentDifference) {
+                        std::cout << "raster-content: "
+                                  << contentDifference->summary.toStdString()
+                                  << " (" << contentDifference->differingPixels
+                                  << " differing pixels)\n";
+                    } else {
+                        std::cout << "raster-content: identical\n";
+                    }
+                    const auto matches
+                        = scaleMatches && windowMatches && !contentDifference;
+                    std::cout << (matches ? "MATCH" : "MISMATCH")
+                              << ": remote 1x ";
+                    if (matches) {
+                        std::cout << "has the same native extent, visible data "
+                                     "window, and viewport pixels as local 1x";
+                    } else if (!scaleMatches) {
+                        std::cout << "does not have the same scale semantics as "
+                                     "local 1x";
+                    } else if (!windowMatches) {
+                        std::cout << "does not show the same physical data "
+                                     "window as local 1x";
+                    } else {
+                        std::cout << "does not paint the same viewport pixels "
+                                     "as local 1x";
+                    }
+                    std::cout << '\n';
+                    application.exit(matches ? 0 : 1);
+                };
+                QObject::connect(&window,
+                    &amrvis::qt::MainWindow::interactiveSlicesSettled,
+                    &application, measure, Qt::SingleShotConnection);
+                QTimer::singleShot(750, &application, measure);
             });
         QTimer::singleShot(30000, &application,
             [&application] { application.exit(4); });
@@ -802,6 +935,200 @@ int main(int argc, char* argv[])
                 window.resize(420, 301);
                 window.openRemoteDataset(
                     "127.0.0.1", server->port(), path, server->token());
+            });
+    } else if (argc == 3
+        && std::string_view(argv[1])
+            == "--local-remote-fixed-scale-window-smoke-test") {
+        // The comparison the manual --fixed-scale-local-remote-repro cannot
+        // make, because its fixture fits the viewport whole: at 32x in a window
+        // too small for the domain, a local fixed scale scales a whole-domain
+        // raster while a remote one hosts the fetched raster on a whole-domain
+        // virtual canvas of finest cells. Both must report the same visible
+        // physical window and paint the same viewport pixels -- scrolling is
+        // what forces the two coordinate spaces apart, so an unscrolled canvas
+        // proves nothing.
+        smokeServer = std::make_shared<amrvis::remote::Server>();
+        smokeServerThread.emplace(
+            [server = smokeServer] { server->run(); });
+        constexpr int scaleFactor = 32;
+        // Drag hard against the top-left stop before measuring anything: the
+        // fixed-scale transform is applied with AnchorUnderMouse, so the scroll
+        // position it leaves behind is an artifact of the pointer, not of the
+        // data. Both sides clamp to the same stop -- the domain origin, since
+        // both scenes are the same number of view pixels across -- which leaves
+        // the pan below as the only thing positioning the view.
+        constexpr int anchorDrag = 512;
+        constexpr int panX = -96;   // three finest cells at 32x
+        constexpr int panY = -160;  // five finest cells at 32x
+        enum class Await { Scale, Anchor, Pan };
+        struct WindowProbe {
+            bool remotePhase = false;
+            Await await = Await::Scale;
+            int settles = 0;
+            int settlesAtLastTick = -1;
+            std::array<int, 2> viewport{};
+            ViewCapture localAnchored;
+            ViewCapture localPanned;
+        };
+        auto probe = std::make_shared<WindowProbe>();
+        const auto capture = [](const amrvis::qt::MainWindow& probed) {
+            return ViewCapture{probed.activeViewVisibleDataWindowForTest(),
+                probed.activeViewViewportImageForTest(),
+                probed.activeViewImageSizeForTest()};
+        };
+        QObject::connect(&window,
+            &amrvis::qt::MainWindow::interactiveSlicesSettled, &application,
+            [probe] { ++probe->settles; });
+        // A remote step may or may not demand a refetch -- an anchor drag on an
+        // already-anchored canvas demands none -- so rather than wait for a
+        // settle that may never come, poll: a step completes once the fetched
+        // raster covers the viewport and no further settle has arrived. Both
+        // pans below uncover cells (the fetch keeps only one cell of slack), so
+        // no step can be measured against the raster it is replacing. The timer
+        // belongs to the window, which outlives every tick and owns it.
+        auto* const poll = new QTimer(&window);
+        poll->setInterval(100);
+        QObject::connect(poll, &QTimer::timeout, &application,
+            [&window, &application, probe, capture, poll] {
+                const auto covered
+                    = window.allViewsFixedScaleRasterCoversViewportForTest();
+                const auto stable = probe->settles == probe->settlesAtLastTick;
+                probe->settlesAtLastTick = probe->settles;
+                if (!covered || !stable) {
+                    return;
+                }
+                if (!window.fixedScaleStateMatchesForTest(scaleFactor)
+                    || !window.activeViewScrollBarsVisibleForTest()) {
+                    std::cerr << "the remote view is not in a scrolled fixed "
+                                 "scale\n";
+                    application.exit(1);
+                    return;
+                }
+                // Both phases must measure the same viewport, or the two
+                // visible windows are not comparable in the first place.
+                if (window.activeViewViewportSizeForTest() != probe->viewport) {
+                    const auto viewport
+                        = window.activeViewViewportSizeForTest();
+                    std::cerr << "viewport size changed between the local and "
+                                 "remote phases: local=" << probe->viewport[0]
+                              << 'x' << probe->viewport[1] << " remote="
+                              << viewport[0] << 'x' << viewport[1] << '\n';
+                    application.exit(1);
+                    return;
+                }
+                if (probe->await == Await::Scale) {
+                    probe->await = Await::Anchor;
+                    window.shiftDragActiveViewForTest(anchorDrag, anchorDrag);
+                    return;
+                }
+                const bool anchored = probe->await == Await::Anchor;
+                const auto& expected = anchored
+                    ? probe->localAnchored : probe->localPanned;
+                const auto* label = anchored ? "anchored" : "panned";
+                const auto actual = capture(window);
+                if (!dataWindowsAgree(expected.window, actual.window,
+                        probe->viewport)) {
+                    std::cerr << label << " local/remote data window mismatch: "
+                                 "local=";
+                    printDataWindow(std::cerr, expected.window);
+                    std::cerr << " remote=";
+                    printDataWindow(std::cerr, actual.window);
+                    // Raster sizes are not compared -- local holds the whole
+                    // domain while remote holds only the fetched window, which
+                    // is the point of the virtual canvas -- but they explain a
+                    // mismatch.
+                    std::cerr << " local-raster=" << expected.image[0] << 'x'
+                              << expected.image[1] << " remote-raster="
+                              << actual.image[0] << 'x' << actual.image[1]
+                              << '\n';
+                    application.exit(1);
+                    return;
+                }
+                if (const auto difference = viewportDifference(
+                        expected.viewport, actual.viewport)) {
+                    std::cerr << label << " viewport content differs: "
+                              << difference->summary.toStdString() << " ("
+                              << difference->differingPixels << " pixels)\n";
+                    application.exit(1);
+                    return;
+                }
+                if (anchored) {
+                    probe->await = Await::Pan;
+                    window.shiftDragActiveViewForTest(panX, panY);
+                    return;
+                }
+                poll->stop();
+                application.exit(0);
+            });
+        QObject::connect(&window,
+            &amrvis::qt::MainWindow::initialSliceFinished,
+            &application,
+            [&window, &application, probe, capture, poll,
+                server = smokeServer,
+                path = std::string(argv[2])](bool success) {
+                if (!success) {
+                    application.exit(2);
+                    return;
+                }
+                window.selectFixedScaleForTest(scaleFactor);
+                if (probe->remotePhase) {
+                    poll->start();
+                    return;
+                }
+                if (!window.fixedScaleStateMatchesForTest(scaleFactor)
+                    || !window.activeViewScrollBarsVisibleForTest()) {
+                    std::cerr << "the local fixed scale did not overflow the "
+                                 "viewport; the fixture is too small for this "
+                                 "comparison\n";
+                    application.exit(1);
+                    return;
+                }
+                // Measure only after the as-needed scroll bars this scale just
+                // demanded have actually been laid out: they shrink the
+                // viewport, and the remote phase necessarily measures on the
+                // far side of that layout pass.
+                QTimer::singleShot(100, &window,
+                    [&window, &application, probe, capture, path, server] {
+                        probe->viewport
+                            = window.activeViewViewportSizeForTest();
+                        // The local raster spans the whole domain and is
+                        // already loaded, so every local step is synchronous.
+                        window.shiftDragActiveViewForTest(
+                            anchorDrag, anchorDrag);
+                        probe->localAnchored = capture(window);
+                        window.shiftDragActiveViewForTest(panX, panY);
+                        probe->localPanned = capture(window);
+                        if (!(probe->localPanned.window.left()
+                                > probe->localAnchored.window.left())
+                            || !(probe->localPanned.window.top()
+                                < probe->localAnchored.window.top())) {
+                            std::cerr << "the local pan did not move the view "
+                                         "on both axes: viewport="
+                                      << probe->viewport[0] << 'x'
+                                      << probe->viewport[1] << " raster="
+                                      << probe->localAnchored.image[0] << 'x'
+                                      << probe->localAnchored.image[1]
+                                      << " anchored=";
+                            printDataWindow(std::cerr,
+                                probe->localAnchored.window);
+                            std::cerr << " panned=";
+                            printDataWindow(std::cerr,
+                                probe->localPanned.window);
+                            std::cerr << '\n';
+                            application.exit(1);
+                            return;
+                        }
+                        probe->remotePhase = true;
+                        window.openRemoteDataset("127.0.0.1", server->port(),
+                            path, server->token());
+                    });
+            });
+        QTimer::singleShot(30000, &application,
+            [&application] { application.exit(4); });
+        QTimer::singleShot(0, &window,
+            [&window, path = std::filesystem::path(argv[2])] {
+                window.resize(420, 301);
+                window.openDataset(path);
             });
     } else if (argc == 3
         && std::string_view(argv[1]) == "--remote-slice-smoke-test") {

--- a/src/qt/main.cpp
+++ b/src/qt/main.cpp
@@ -631,35 +631,31 @@ int main(int argc, char* argv[])
                 }
                 window.selectFixedScaleForTest(1);
                 if (probe->phase == 0) {
-                    probe->localShowsWholeImage
-                        = window.activeViewShowsWholeImageForTest();
-                    probe->localImage = window.activeViewImageSizeForTest();
-                    probe->localViewport
-                        = window.activeViewViewportSizeForTest();
-                    probe->localWindow
-                        = window.activeViewVisibleDataWindowForTest();
-                    probe->localViewportImage
-                        = window.activeViewViewportImageForTest();
                     probe->phase = 1;
-                    QTimer::singleShot(0, &window,
-                        [&window, endpoint, token, remotePath] {
+                    // Measure only after the as-needed scroll bars this scale
+                    // may have demanded are laid out: they shrink the viewport,
+                    // and the remote phase necessarily measures on the far side
+                    // of that layout pass. On a domain that fits there are no
+                    // bars and this only costs a tick.
+                    QTimer::singleShot(100, &window,
+                        [&window, probe, endpoint, token, remotePath] {
+                            probe->localShowsWholeImage
+                                = window.activeViewShowsWholeImageForTest();
+                            probe->localImage
+                                = window.activeViewImageSizeForTest();
+                            probe->localViewport
+                                = window.activeViewViewportSizeForTest();
+                            probe->localWindow
+                                = window.activeViewVisibleDataWindowForTest();
+                            probe->localViewportImage
+                                = window.activeViewViewportImageForTest();
                             window.openRemoteDataset(endpoint.host,
                                 endpoint.port, remotePath, token);
                         });
                     return;
                 }
-                // The remote fixed scale is demand-driven: selecting it can
-                // queue a native-resolution refetch, and comparing a raster
-                // that is still being replaced would report a difference that
-                // is only a race. Measure on the settle, or after a short grace
-                // period when the switch needed no new raster at all.
-                auto measured = std::make_shared<bool>(false);
                 const auto measure = [&window, &application, probe,
-                                         screenshotPath, measured] {
-                    if (*measured) {
-                        return;
-                    }
-                    *measured = true;
+                                         screenshotPath] {
                     const auto remoteShowsWholeImage
                         = window.activeViewShowsWholeImageForTest();
                     const auto remoteImage
@@ -687,28 +683,21 @@ int main(int argc, char* argv[])
                               << " data-window=";
                     printDataWindow(std::cout, remoteWindow);
                     std::cout << '\n';
-                    const auto fillsViewport
-                        = [](const std::array<int, 2>& image,
-                              const std::array<int, 2>& viewport) {
-                              return image[0] <= viewport[0]
-                                  && image[1] <= viewport[1]
-                                  && (std::abs(image[0] - viewport[0]) <= 1
-                                      || std::abs(image[1] - viewport[1]) <= 1);
-                          };
-                    const auto localActsFit = probe->localShowsWholeImage
-                        && fillsViewport(
-                            probe->localImage, probe->localViewport);
-                    const auto remoteActsFit = remoteShowsWholeImage
-                        && fillsViewport(remoteImage, remoteViewport);
-                    const auto scaleMatches = probe->localImage == remoteImage
-                        && probe->localShowsWholeImage == remoteShowsWholeImage
-                        && localActsFit == remoteActsFit;
-                    // The window and the pixels are part of the verdict, not
-                    // just of the printout: a probe reporting the wrong
-                    // physical window, or a raster that differs where it is
-                    // visible, is exactly what this tool exists to catch.
-                    const auto windowMatches = dataWindowsAgree(
-                        probe->localWindow, remoteWindow, probe->localViewport);
+                    // The verdict is the visible physical window plus the
+                    // painted pixels -- a probe reporting the wrong window, or
+                    // a raster that differs where it is visible, is exactly
+                    // what this tool exists to catch. Backing-raster
+                    // dimensions are printed but deliberately not compared:
+                    // local keeps the whole domain while remote fetches only
+                    // the visible window, so they differ by design on any
+                    // domain larger than the viewport. Equal windows over
+                    // equal pixels already pin the scale -- a factor the two
+                    // sides disagreed on would move the window.
+                    const auto viewportMatches
+                        = probe->localViewport == remoteViewport;
+                    const auto windowMatches = viewportMatches
+                        && dataWindowsAgree(probe->localWindow, remoteWindow,
+                            probe->localViewport);
                     const auto contentDifference = viewportDifference(
                         probe->localViewportImage, remoteViewportImage);
                     if (!screenshotPath.isEmpty()) {
@@ -755,16 +744,17 @@ int main(int argc, char* argv[])
                     } else {
                         std::cout << "raster-content: identical\n";
                     }
-                    const auto matches
-                        = scaleMatches && windowMatches && !contentDifference;
+                    const auto matches = windowMatches && !contentDifference;
                     std::cout << (matches ? "MATCH" : "MISMATCH")
                               << ": remote 1x ";
                     if (matches) {
-                        std::cout << "has the same native extent, visible data "
-                                     "window, and viewport pixels as local 1x";
-                    } else if (!scaleMatches) {
-                        std::cout << "does not have the same scale semantics as "
+                        std::cout << "shows the same visible data window and "
+                                     "paints the same viewport pixels as "
                                      "local 1x";
+                    } else if (!viewportMatches) {
+                        std::cout << "was measured against a different viewport "
+                                     "than local 1x, so the two are not "
+                                     "comparable";
                     } else if (!windowMatches) {
                         std::cout << "does not show the same physical data "
                                      "window as local 1x";
@@ -775,10 +765,42 @@ int main(int argc, char* argv[])
                     std::cout << '\n';
                     application.exit(matches ? 0 : 1);
                 };
+                // The remote fixed scale is demand-driven: selecting it can
+                // queue a native-resolution refetch of the visible window, and
+                // measuring a raster that is still being replaced reports a
+                // difference that is only a race. Poll instead of guessing a
+                // grace period: measure once nothing is on a worker and no
+                // settle arrived during the last tick, so a request that only
+                // queues its successor is waited out too. A switch that needed
+                // no new raster satisfies this on the first tick.
+                auto* const poll = new QTimer(&window);
+                poll->setInterval(100);
+                auto ticks = std::make_shared<int>(0);
+                auto settles = std::make_shared<int>(0);
+                auto settlesLastTick = std::make_shared<int>(-1);
                 QObject::connect(&window,
                     &amrvis::qt::MainWindow::interactiveSlicesSettled,
-                    &application, measure, Qt::SingleShotConnection);
-                QTimer::singleShot(750, &application, measure);
+                    &application, [settles] { ++*settles; });
+                QObject::connect(poll, &QTimer::timeout, &application,
+                    [&application, &window, measure, poll, ticks, settles,
+                        settlesLastTick] {
+                        const auto quiet = window.slicesInFlightForTest() == 0
+                            && *settles == *settlesLastTick;
+                        *settlesLastTick = *settles;
+                        if (quiet) {
+                            poll->stop();
+                            measure();
+                            return;
+                        }
+                        if (++*ticks >= 200) {
+                            poll->stop();
+                            std::cerr << "the remote view never stopped "
+                                         "fetching; refusing to compare an "
+                                         "in-flight raster\n";
+                            application.exit(6);
+                        }
+                    });
+                poll->start();
             });
         QTimer::singleShot(30000, &application,
             [&application] { application.exit(4); });

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -414,6 +414,29 @@ if(TARGET amrexplorer_qt)
     set_tests_properties(qt_remote_fixed_scale_flicker_smoke PROPERTIES
         TIMEOUT 30)
 
+    # Local and remote must agree on what a scrolled fixed scale shows.
+    # Scrolling is what separates the two coordinate spaces: local scales a
+    # whole-domain raster while remote scales a whole-domain virtual canvas of
+    # finest cells with the fetched raster placed inside it. The assertion
+    # covers both the reported physical window and the painted viewport pixels.
+    # The refined fixture is the fixture for this: its 16 finest cells overflow
+    # the test window at 32x, and unlike plotfile_2d_wide its whole domain
+    # still fits in one native raster, so a fixed scale means the same number
+    # of view pixels per finest cell on both sides (see
+    # agent-notes/issues/fixed-scale-clamped-native-raster.md).
+    add_test(
+        NAME qt_local_remote_fixed_scale_window_smoke
+        COMMAND "${CMAKE_COMMAND}"
+            "-DMATERIALIZER=$<TARGET_FILE:fixture_materializer>"
+            "-DAMREXPLORER_QT=$<TARGET_FILE:amrexplorer_qt>"
+            "-DSOURCE=${CMAKE_CURRENT_SOURCE_DIR}/data/plotfile_refined_2d"
+            "-DWORK=${CMAKE_CURRENT_BINARY_DIR}/fixtures_local_remote_fixed_scale_window"
+            -DMODE=local-remote-fixed-scale-window
+            -P "${CMAKE_CURRENT_SOURCE_DIR}/qt_smoke_driver.cmake"
+    )
+    set_tests_properties(qt_local_remote_fixed_scale_window_smoke PROPERTIES
+        TIMEOUT 60)
+
     add_test(
         NAME qt_remote_fixed_scale_wide_smoke
         COMMAND "${CMAKE_COMMAND}"

--- a/tests/qt_smoke_driver.cmake
+++ b/tests/qt_smoke_driver.cmake
@@ -16,6 +16,7 @@
 #                 range-cache | fab-zoom | cache-budget |
 #                 fixed-scale-1 | fixed-scale-4 | sequence-transform-preserve |
 #                 remote-fixed-scale | remote-fixed-scale-flicker |
+#                 local-remote-fixed-scale-window |
 #                 sequence-density-preserve |
 #                 sequence-equal-size-transform-preserve |
 #                 sequence-geometry-refit
@@ -89,6 +90,10 @@ elseif(MODE STREQUAL "remote-fixed-scale-flicker")
     run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt")
     run_or_die("${AMREXPLORER_QT}" --remote-fixed-scale-flicker-smoke-test
         "${WORK}/plt")
+elseif(MODE STREQUAL "local-remote-fixed-scale-window")
+    run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt")
+    run_or_die("${AMREXPLORER_QT}"
+        --local-remote-fixed-scale-window-smoke-test "${WORK}/plt")
 elseif(MODE STREQUAL "sequence-transform-preserve")
     run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt00000")
     run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt00010" "2.5")


### PR DESCRIPTION
activeViewVisibleDataWindowForTest intersected the viewport's scene rect with QRectF(0, 0, plane.width, plane.height), i.e. it assumed scene units are raster pixels of the current plane. A remote fixed scale hosts the fetched raster on a whole-domain virtual canvas whose scene units are finest cells, with the raster placed at its cell offset, so the probe reported a window in the wrong space -- and offset by that placement -- whenever the canvas could scroll. The 8x8 fixture the local/remote comparison harness uses hides this: at 1x the domain fits, the demand collapses to the whole domain, and the two spaces coincide.

ImageView::visibleImageRect maps the viewport through the raster item, which undoes both the pixel-to-cell scale and the cell offset and is the identity in the classic raster-at-origin scene, so the non-virtual result is unchanged by construction.

qt_local_remote_fixed_scale_window_smoke is the assertion that would have caught it. On plotfile_refined_2d -- 16 finest cells across, which overflow the test viewport at 32x -- it opens the fixture locally, selects 32x, drags to the top-left stop, pans, and records the physical window and the viewport pixels; then it opens the same fixture from an in-process server and repeats the identical steps. Local and remote must report the same physical window and paint identical viewport pixels at both positions. Without the fix the panned remote window reads 0.3125,0,0.6875,0.375 against the correct local
0.1875,0.12109375,0.76171875,0.56640625.

Three details the test cannot skip:

- The fixed-scale transform is applied with AnchorUnderMouse, so the scroll position it leaves behind is an artifact of the pointer. Both sides are dragged to the same stop first, leaving the pan as the only thing that positions the view.

- The as-needed scroll bars the scale demands shrink the viewport on the next layout pass, and the remote phase necessarily measures after that pass, so the local measurement is deferred past it too. The two viewports are then compared, since two different viewports make the two windows incomparable in the first place.

- A step waits until the fetched raster covers the viewport and no further settle arrives, rather than for a settle that may never come: an anchor drag on an already-anchored canvas demands no refetch. Both pans uncover cells, so no step is measured against the raster it replaces.

The window and the pixels are now part of the manual repro's verdict instead of only its printout, and it waits for the demand refetch before measuring so the verdict is not racing a raster replacement. The screenshot stays a human artifact. plotfile_refined_2d rather than plotfile_2d_wide because the wide fixture trips a separate defect: past maxSliceOutputDimension a local fixed scale scales a clamped raster and magnifies exactly 2x less than the remote one, which fetches the visible window at finest resolution.