### PR TITLE
bound a whole response write, not just a pause in one

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -63,14 +63,28 @@ LISTENING 127.0.0.1 41419 TOKEN 58f50743dff4f653b58c3a1fe5858904
 The port and token are new every time you start the server, so use the values
 from your own output (here, port `41419`), not the ones printed above.
 
-Response transfers are not limited by total duration: they may take as long as
-needed while bytes continue moving. By default, the server disconnects a client
-only after a response makes no write progress for 30 seconds. On a link that can
-pause for longer, increase that interval explicitly:
+Two limits bound how long the server will spend writing one response, and a
+client that exceeds either is disconnected. The first is a pause: by default, no
+write progress at all for 30 seconds. The second is the whole response, because a
+client that accepts a few bytes before each pause deadline would otherwise renew
+it forever and keep a worker busy indefinitely. A response must finish within
 
 ```text
-(remote) $ amrexplorer-server --write-stall-timeout-seconds 120
+write-stall-timeout-seconds + response size / write-min-kib-per-second
 ```
+
+whose default floor of 64 KiB/s is far below any usable SSH tunnel — a 64 MiB
+response is allowed about 17 minutes. On a link that pauses for longer than 30
+seconds, or that is genuinely slower than the floor, raise the pause interval and
+lower the floor:
+
+```text
+(remote) $ amrexplorer-server --write-stall-timeout-seconds 120 \
+    --write-min-kib-per-second 8
+```
+
+The floor cannot be zero, since that would remove the whole-response bound; the
+smallest value, `1`, allows roughly 18 hours for a 64 MiB response.
 
 **Step 2 — On your local machine, open an SSH tunnel** using the port from
 step 1. Leave this running while you work:

--- a/include/amrexplorer/remote/Frame.hpp
+++ b/include/amrexplorer/remote/Frame.hpp
@@ -60,11 +60,29 @@ void writeFrame(const Socket& socket, std::span<const std::uint8_t> payload,
     std::uint32_t maximumBytes,
     std::chrono::steady_clock::time_point deadline,
     StopToken cancellation = {}, StopToken lifecycle = {});
-// Writes may take arbitrarily long while the peer continues accepting bytes.
-// The operation fails only when no bytes can be written for stallTimeout.
-void writeFrameWithStallTimeout(const Socket& socket,
+// How long one frame write may take. Two limits, because either alone can be
+// defeated: stallTimeout bounds a period of no progress at all, and total()
+// bounds the whole write, so a peer that accepts a few bytes just before every
+// stall deadline -- renewing it forever -- is still retired. The whole-write
+// bound is deliberately generous: the stall interval as a fixed grace plus the
+// time the payload needs at an assumed floor throughput, so a slow but healthy
+// link is not mistaken for a wedged peer.
+struct FrameWriteBudget {
+    std::chrono::milliseconds stallTimeout{30000};
+    // Bytes per second. Must be positive: zero would restore the unbounded
+    // case. Lower it for a genuinely slow link rather than removing the bound.
+    std::uint64_t minimumBytesPerSecond = 64U * 1024U;
+
+    [[nodiscard]] std::chrono::milliseconds total(
+        std::size_t payloadBytes) const noexcept;
+};
+
+// Writes may take arbitrarily long while the peer continues accepting bytes, up
+// to budget.total(payload.size()). Fails on a stall, on falling below the
+// budget's floor throughput, on cancellation, or on a socket error.
+void writeFrameWithBudget(const Socket& socket,
     std::span<const std::uint8_t> payload, std::uint32_t maximumBytes,
-    std::chrono::milliseconds stallTimeout,
+    const FrameWriteBudget& budget,
     StopToken cancellation = {}, StopToken lifecycle = {});
 [[nodiscard]] std::optional<std::vector<std::uint8_t>> readFrame(
     const Socket& socket,

--- a/include/amrexplorer/remote/Server.hpp
+++ b/include/amrexplorer/remote/Server.hpp
@@ -20,10 +20,19 @@ struct ServerOptions {
     // small frame cap. Both limits are removed after a valid hello.
     std::chrono::milliseconds handshakeTimeout{5000};
     std::uint32_t maximumHandshakeFrameBytes = 64U * 1024U;
-    // A response may take arbitrarily long while bytes continue moving. A peer
-    // that makes no write progress for this interval is disconnected so it
-    // cannot retain a worker or the session write mutex indefinitely.
+    // A peer that makes no write progress for this interval is disconnected so
+    // it cannot retain a worker or the session write mutex indefinitely. It is
+    // also the fixed grace in the whole-response budget below.
     std::chrono::milliseconds responseWriteStallTimeout{30000};
+    // The stall timeout alone bounds only a period of *zero* progress, which a
+    // peer defeats by accepting a few bytes before each deadline. Every response
+    // therefore also has to fit in
+    //   responseWriteStallTimeout + size / responseWriteMinimumBytesPerSecond,
+    // so a trickle-reader is retired within a bound the operator can compute.
+    // The default floor, 64 KiB/s, is far below any usable SSH tunnel; lower it
+    // for a genuinely slow link (1 allows roughly 18 hours for a 64 MiB
+    // response). Zero is rejected: it would restore the unbounded case.
+    std::uint64_t responseWriteMinimumBytesPerSecond = 64U * 1024U;
     std::string softwareVersion = "unknown";
     // Per-session access token. Clients must present a byte-identical token in
     // their handshake or the connection is refused. Left empty, the server

--- a/src/remote/Frame.cpp
+++ b/src/remote/Frame.cpp
@@ -390,10 +390,18 @@ void writeExact(NativeSocket descriptor,
         ? std::chrono::steady_clock::now() + *stallTimeout
         : std::chrono::steady_clock::time_point::max();
     while (completed < source.size()) {
-        waitForWritable(descriptor, std::min(deadline, progressDeadline),
-            cancellation, lifecycle,
-            stallTimeout ? "wire frame write stalled"
-                         : "wire frame write timed out");
+        // Whichever limit bites first, and the message that explains it: with a
+        // stall timeout the absolute deadline is the whole-write budget, so
+        // hitting it means the peer stayed under the floor throughput rather
+        // than stopping outright.
+        const auto limit = std::min(deadline, progressDeadline);
+        const auto* reason = "wire frame write timed out";
+        if (stallTimeout) {
+            reason = limit == progressDeadline
+                ? "wire frame write stalled"
+                : "wire frame write stayed below the minimum throughput";
+        }
+        waitForWritable(descriptor, limit, cancellation, lifecycle, reason);
 #ifdef _WIN32
         const auto remaining = std::min<std::size_t>(
             source.size() - completed, 64U * 1024U);
@@ -679,29 +687,57 @@ void writeFrame(const Socket& socket, std::span<const std::uint8_t> payload,
         lifecycle);
 }
 
-void writeFrameWithStallTimeout(const Socket& socket,
+std::chrono::milliseconds FrameWriteBudget::total(
+    std::size_t payloadBytes) const noexcept
+{
+    // Fixed grace plus the payload's time at the floor throughput, rounded up.
+    // The floor is clamped rather than trusted: a zero would mean no bound at
+    // all, which is the defect this budget exists to close.
+    const std::uint64_t floor = minimumBytesPerSecond > 0
+        ? minimumBytesPerSecond : 1;
+    const auto transfer
+        = (static_cast<std::uint64_t>(payloadBytes) * 1000ULL + floor - 1ULL)
+        / floor;
+    const std::uint64_t grace = stallTimeout > std::chrono::milliseconds::zero()
+        ? static_cast<std::uint64_t>(stallTimeout.count()) : 0ULL;
+    // Thirty days is beyond any real transfer and keeps now() + total() far
+    // from overflowing a steady_clock time point.
+    constexpr std::uint64_t cap = 30ULL * 24ULL * 60ULL * 60ULL * 1000ULL;
+    const auto bounded = std::min<std::uint64_t>(cap, transfer);
+    const auto total = grace > cap - bounded ? cap : grace + bounded;
+    return std::chrono::milliseconds(
+        static_cast<std::chrono::milliseconds::rep>(total));
+}
+
+void writeFrameWithBudget(const Socket& socket,
     std::span<const std::uint8_t> payload, std::uint32_t maximumBytes,
-    std::chrono::milliseconds stallTimeout, StopToken cancellation,
+    const FrameWriteBudget& budget, StopToken cancellation,
     StopToken lifecycle)
 {
     if (payload.empty() || payload.size() > maximumBytes
         || payload.size() > std::numeric_limits<std::uint32_t>::max()) {
         throw std::runtime_error("wire frame size is outside the allowed range");
     }
-    if (stallTimeout <= std::chrono::milliseconds::zero()) {
+    if (budget.stallTimeout <= std::chrono::milliseconds::zero()) {
         throw std::invalid_argument(
             "wire frame write stall timeout must be greater than zero");
     }
+    if (budget.minimumBytesPerSecond == 0) {
+        throw std::invalid_argument(
+            "wire frame write minimum throughput must be greater than zero");
+    }
+    // One deadline for the whole frame, so the four-byte header cannot buy the
+    // payload extra time.
+    const auto deadline
+        = std::chrono::steady_clock::now() + budget.total(payload.size());
     const auto networkSize = htonl(static_cast<std::uint32_t>(payload.size()));
     const auto* sizeBytes
         = reinterpret_cast<const std::uint8_t*>(&networkSize);
     writeExact(native(socket.descriptor()),
         std::span<const std::uint8_t>(sizeBytes, sizeof(networkSize)),
-        std::chrono::steady_clock::time_point::max(), cancellation, lifecycle,
-        stallTimeout);
-    writeExact(native(socket.descriptor()), payload,
-        std::chrono::steady_clock::time_point::max(), cancellation, lifecycle,
-        stallTimeout);
+        deadline, cancellation, lifecycle, budget.stallTimeout);
+    writeExact(native(socket.descriptor()), payload, deadline, cancellation,
+        lifecycle, budget.stallTimeout);
 }
 
 std::optional<std::vector<std::uint8_t>> readFrame(

--- a/src/remote/Server.cpp
+++ b/src/remote/Server.cpp
@@ -906,9 +906,8 @@ private:
             }
             std::scoped_lock lock(m_writeMutex);
             if (!m_stopping.load()) {
-                writeFrameWithStallTimeout(m_socket, bytes,
-                    m_maximumFrameBytes.load(),
-                    m_options.responseWriteStallTimeout, {},
+                writeFrameWithBudget(m_socket, bytes,
+                    m_maximumFrameBytes.load(), writeBudget(), {},
                     m_lifecycleStop.get_token());
             }
         } catch (...) {
@@ -927,14 +926,23 @@ private:
             }
             std::scoped_lock lock(m_writeMutex);
             if (!m_stopping.load()) {
-                writeFrameWithStallTimeout(m_socket, bytes,
-                    m_maximumFrameBytes.load(),
-                    m_options.responseWriteStallTimeout, {},
+                writeFrameWithBudget(m_socket, bytes,
+                    m_maximumFrameBytes.load(), writeBudget(), {},
                     m_lifecycleStop.get_token());
             }
         } catch (...) {
             stop();
         }
+    }
+
+    // Both write limits, per response: no-progress and whole-write. A write
+    // that exceeds either throws, and both callers above answer a throw by
+    // retiring the session, which is what releases the worker and the write
+    // mutex a trickle-reader would otherwise hold forever.
+    [[nodiscard]] FrameWriteBudget writeBudget() const noexcept
+    {
+        return {m_options.responseWriteStallTimeout,
+            m_options.responseWriteMinimumBytesPerSecond};
     }
 
     Socket m_socket;
@@ -974,7 +982,8 @@ public:
             || m_options.handshakeTimeout
                 <= std::chrono::milliseconds::zero()
             || m_options.responseWriteStallTimeout
-                <= std::chrono::milliseconds::zero()) {
+                <= std::chrono::milliseconds::zero()
+            || m_options.responseWriteMinimumBytesPerSecond == 0) {
             throw std::invalid_argument(
                 "server resource limits must be greater than zero");
         }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -156,9 +156,12 @@ if(TARGET amrexplorer_remote)
         FIXTURES_SETUP remote_server_spherical_materialized)
     add_test(NAME remote_server
         COMMAND test_remote_server "${remote_server_private_fixture_dir}")
+    # The trickle-reader case waits out a whole-response write budget on a
+    # ~28 MiB response, so this test is several seconds even without a
+    # sanitizer. 90 s leaves room for TSan and ASan.
     set_tests_properties(remote_server PROPERTIES
         FIXTURES_REQUIRED remote_server_private_materialized
-        TIMEOUT 30)
+        TIMEOUT 90)
 
     add_executable(test_remote_connection
         integration/test_remote_connection.cpp)

--- a/tests/integration/test_remote_server.cpp
+++ b/tests/integration/test_remote_server.cpp
@@ -4,6 +4,8 @@
 #include <amrexplorer/remote/Frame.hpp>
 #include <amrexplorer/remote/Server.hpp>
 
+#include <array>
+#include <atomic>
 #include <chrono>
 #include <cstdlib>
 #include <exception>
@@ -12,9 +14,21 @@
 #include <future>
 #include <iostream>
 #include <memory>
+#include <cerrno>
+#include <span>
 #include <string>
 #include <thread>
 #include <utility>
+#include <vector>
+
+#ifdef _WIN32
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <winsock2.h>
+#else
+#include <sys/socket.h>
+#endif
 
 namespace {
 
@@ -116,6 +130,32 @@ std::unique_ptr<amrvis::remote::codec::NativeEnvelope> readWithDeadline(
         return {};
     }
     return pending.get();
+}
+
+// One recv, no framing: the trickle-reader test accepts a few kibibytes at a
+// time rather than a whole frame. These sockets are non-blocking, so an empty
+// receive buffer reports EAGAIN, which means "nothing yet" and must not be
+// confused with the close this test is waiting for. Returns the byte count, 0
+// on a closed connection, and -1 for "nothing available right now".
+long readRaw(const amrvis::remote::Socket& socket,
+    std::span<std::uint8_t> destination)
+{
+#ifdef _WIN32
+    const auto count = ::recv(static_cast<SOCKET>(socket.descriptor()),
+        reinterpret_cast<char*>(destination.data()),
+        static_cast<int>(destination.size()), 0);
+    if (count == SOCKET_ERROR) {
+        return ::WSAGetLastError() == WSAEWOULDBLOCK ? -1 : 0;
+    }
+    return count;
+#else
+    const auto count = ::recv(static_cast<int>(socket.descriptor()),
+        destination.data(), destination.size(), 0);
+    if (count < 0) {
+        return errno == EAGAIN || errno == EWOULDBLOCK ? -1 : 0;
+    }
+    return static_cast<long>(count);
+#endif
 }
 
 amrvis::remote::HelloRequestData helloRequest(std::string sessionToken)
@@ -582,6 +622,156 @@ int main(int argc, char* argv[])
     }
     require(boundedRunning.stopWithin(std::chrono::seconds{2}),
         "small-frame server shutdown exceeded its deadline");
+
+    // A peer that keeps accepting a trickle of bytes renews the no-progress
+    // deadline forever, so the stall timeout alone would let it hold a pooled
+    // worker and this session's write mutex indefinitely. The whole-response
+    // budget must retire it within a bound the operator can compute, and a
+    // second connection must keep working while it is still being retired.
+    // The reader below drains 256 KiB every 100 ms. TCP reports a socket
+    // writable again only once about half the send buffer is free, so progress
+    // comes in bursts rather than every tick -- but it keeps coming, roughly
+    // twice a second, which is what makes this a trickle rather than a stall.
+    // Against the three-second stall grace configured here, the no-progress
+    // timeout can therefore never fire, and a server without the whole-response
+    // budget would never retire this session at all: the upper bound below is
+    // the regression assertion. test_remote_frame pins down which limit fires,
+    // deterministically, on a socket whose buffers it controls.
+    {
+        ServerOptions trickleOptions;
+        trickleOptions.workerCount = 2;
+        trickleOptions.maximumDatasets = 2;
+        trickleOptions.maximumConnections = 4;
+        // Long enough that the bursty progress below always lands inside it.
+        trickleOptions.responseWriteStallTimeout = std::chrono::seconds{3};
+        // 32 MiB/s over the ~50 MiB response below: three seconds of grace plus
+        // about 1.6 s of transfer allowance. The floor is high only to keep the
+        // test quick; the small responses this server also serves are
+        // unaffected, since their transfer allowance rounds to nothing next to
+        // the grace.
+        trickleOptions.responseWriteMinimumBytesPerSecond
+            = 32ULL * 1024ULL * 1024ULL;
+        Server trickleServer(trickleOptions);
+        RunningServer trickleRunning(trickleServer);
+
+        auto slow = connectTo("127.0.0.1", trickleServer.port());
+        envelope = exchange(slow, 1,
+            codec::toWire(helloRequest(trickleServer.token())),
+            defaultMaximumFrameBytes);
+        require(codec::inspect(*envelope).payload
+                == PayloadKind::HelloResponse,
+            "trickle server rejected a valid handshake");
+        envelope = exchange(slow, 2,
+            codec::toWire(OpenDatasetData{
+                std::filesystem::path(argv[1]).string(),
+                16ULL * 1024ULL * 1024ULL}),
+            defaultMaximumFrameBytes);
+        require(codec::inspect(*envelope).payload
+                == PayloadKind::DatasetOpened,
+            "trickle server did not open the plotfile");
+        const auto trickleOpened = codec::fromWire(
+            *envelope->payload.AsDatasetOpened());
+
+        // Ask for a response far larger than the kernel socket buffers, then
+        // read it a few kibibytes at a time. Loopback send and receive buffers
+        // autotune into the megabytes, so a response of a few hundred kilobytes
+        // is absorbed whole and the server's write never even blocks; 2048x2048
+        // samples is about 50 MiB and cannot be.
+        SliceRequest large;
+        large.dataset = trickleOpened.id;
+        large.field = FieldId{0};
+        large.normalDirection = 1;
+        large.visibleRegion = trickleOpened.catalog.physicalDomain;
+        large.physicalPosition = 0.5
+            * (large.visibleRegion.lower[1] + large.visibleRegion.upper[1]);
+        large.maximumLevel = trickleOpened.catalog.finestLevel;
+        large.outputSize = {2048, 2048};
+        writeFrame(slow, codec::encode(3, codec::toWire(large)),
+            defaultMaximumFrameBytes);
+
+        std::atomic_bool draining{true};
+        std::atomic<std::uint64_t> drained{0};
+        auto retired = std::async(std::launch::async,
+            [&slow, &draining, &drained] {
+                const auto start = std::chrono::steady_clock::now();
+                // Big enough that the drain reliably restores writability,
+                // small enough (about 2.5 MiB/s) to stay far under the floor.
+                std::vector<std::uint8_t> chunk(256U * 1024U);
+                while (draining.load()) {
+                    std::this_thread::sleep_for(std::chrono::milliseconds{100});
+                    const auto count = readRaw(slow, chunk);
+                    if (count == 0) {
+                        break;  // the server retired the session
+                    }
+                    if (count > 0) {
+                        drained += static_cast<std::uint64_t>(count);
+                    }
+                }
+                return std::chrono::steady_clock::now() - start;
+            });
+
+        // While that response is still being written, a second authenticated
+        // connection opens the dataset and gets a small response.
+        auto neighbour = connectTo("127.0.0.1", trickleServer.port());
+        envelope = exchange(neighbour, 1,
+            codec::toWire(helloRequest(trickleServer.token())),
+            defaultMaximumFrameBytes);
+        require(codec::inspect(*envelope).payload
+                == PayloadKind::HelloResponse,
+            "the trickle reader blocked a second handshake");
+        envelope = exchange(neighbour, 2,
+            codec::toWire(OpenDatasetData{
+                std::filesystem::path(argv[1]).string(),
+                16ULL * 1024ULL * 1024ULL}),
+            defaultMaximumFrameBytes);
+        require(codec::inspect(*envelope).payload
+                == PayloadKind::DatasetOpened,
+            "the trickle reader blocked a second dataset open");
+        const auto neighbourOpened = codec::fromWire(
+            *envelope->payload.AsDatasetOpened());
+        DatasetPageRequest neighbourPage;
+        neighbourPage.dataset = neighbourOpened.id;
+        neighbourPage.field = FieldId{0};
+        neighbourPage.level = 0;
+        neighbourPage.region = neighbourOpened.catalog.physicalDomain;
+        neighbourPage.normalAxis = 1;
+        neighbourPage.maximumExtent = datasetPageMaxExtent;
+        envelope = exchange(neighbour, 3, codec::toWire(neighbourPage),
+            defaultMaximumFrameBytes);
+        require(codec::inspect(*envelope).payload
+                == PayloadKind::DatasetPageResponse,
+            "the trickle reader blocked a second small response");
+
+        // The slow session is retired on its own, without the server being
+        // stopped: the write throws past its budget and the session shuts down.
+        const auto retirementBound = std::chrono::seconds{15};
+        if (retired.wait_for(retirementBound) != std::future_status::ready) {
+            std::cerr << "trickle reader drained " << drained.load()
+                      << " bytes without the session being retired\n";
+            slow.shutdown();
+            retired.wait();
+            require(false, "the trickle-reading session was never retired");
+        }
+        draining.store(false);
+        const auto elapsed = retired.get();
+        require(elapsed < retirementBound,
+            "the trickle-reading session outlived its retirement bound");
+        // The write outlived the stall grace while still moving bytes, so it was
+        // the whole-response budget that retired it.
+        if (elapsed <= trickleOptions.responseWriteStallTimeout) {
+            std::cerr << "trickle session ended after "
+                      << std::chrono::duration_cast<std::chrono::milliseconds>(
+                             elapsed)
+                             .count()
+                      << " ms having drained " << drained.load()
+                      << " bytes\n";
+        }
+        require(elapsed > trickleOptions.responseWriteStallTimeout,
+            "the trickle-reading session ended within the stall grace");
+        require(trickleRunning.stopWithin(std::chrono::seconds{5}),
+            "trickle server shutdown exceeded its deadline");
+    }
+
     std::filesystem::remove_all(
         std::filesystem::path(argv[1]) / "Oversized");
     return 0;

--- a/tests/unit/test_remote_frame.cpp
+++ b/tests/unit/test_remote_frame.cpp
@@ -238,7 +238,9 @@ int main()
     require(timedOut, "a peer-blocked frame write ignored its deadline");
 
     // A slow peer that keeps draining bytes must be allowed to take longer
-    // than one stall interval to receive the complete frame.
+    // than one stall interval to receive the complete frame. The payload is also
+    // the frame limit for this write, so this is the maximum-size response a
+    // slow-but-above-policy reader has to be able to finish.
     int slowDescriptors[2]{};
     require(::socketpair(AF_UNIX, SOCK_STREAM, 0, slowDescriptors) == 0,
         "could not create the slow-reader socket pair");
@@ -254,6 +256,9 @@ int main()
         "could not reduce the slow-writer send buffer");
     constexpr std::size_t slowPayloadBytes = 512U * 1024U;
     constexpr auto writeStallTimeout = std::chrono::milliseconds{250};
+    // 4 KiB every 5 ms is about 800 KiB/s, comfortably above this floor, so the
+    // whole-write budget must not retire a reader that is merely slow.
+    constexpr FrameWriteBudget slowBudget{writeStallTimeout, 64U * 1024U};
     std::atomic<std::size_t> slowBytesRead{0};
     std::promise<void> slowReaderReady;
     auto slowReaderStarted = slowReaderReady.get_future();
@@ -276,9 +281,9 @@ int main()
     std::string slowWriteError;
     const auto slowWriteStart = std::chrono::steady_clock::now();
     try {
-        writeFrameWithStallTimeout(slowWriter,
+        writeFrameWithBudget(slowWriter,
             std::vector<std::uint8_t>(slowPayloadBytes), slowPayloadBytes,
-            writeStallTimeout);
+            slowBudget);
     } catch (const std::exception& error) {
         slowWriteCompleted = false;
         slowWriteError = error.what();
@@ -297,6 +302,89 @@ int main()
         "the slow reader did not receive the complete frame");
     require(slowWriteElapsed > writeStallTimeout,
         "the slow-reader regression did not exceed one stall interval");
+
+    // The defect the whole-write budget closes: a peer that accepts a few bytes
+    // just before every stall deadline renews it forever, so the stall timeout
+    // alone never retires the write. The reader below empties the writer's whole
+    // 4 KiB send buffer every 150 ms, against a 250 ms stall interval: draining
+    // more than the buffer holds is what makes the socket reliably writable
+    // again, so progress always lands before the stall deadline, and because the
+    // stall interval is longer than the read interval the stall deadline can
+    // never be the limit that bites. Yet ~27 KiB/s is far under the floor, so
+    // only the whole-write budget can retire this peer -- within the bound it
+    // advertises.
+    int trickleDescriptors[2]{};
+    require(::socketpair(AF_UNIX, SOCK_STREAM, 0, trickleDescriptors) == 0,
+        "could not create the trickle-reader socket pair");
+    Socket trickleWriter(trickleDescriptors[0]);
+    Socket tricklePeer(trickleDescriptors[1]);
+    const auto trickleWriterFlags = ::fcntl(trickleDescriptors[0], F_GETFL, 0);
+    require(trickleWriterFlags >= 0
+            && ::fcntl(trickleDescriptors[0], F_SETFL,
+                   trickleWriterFlags | O_NONBLOCK) == 0,
+        "could not make the trickle writer nonblocking");
+    require(::setsockopt(trickleDescriptors[0], SOL_SOCKET, SO_SNDBUF,
+                &sendBufferBytes, sizeof(sendBufferBytes)) == 0,
+        "could not reduce the trickle-writer send buffer");
+    constexpr std::size_t tricklePayloadBytes = 256U * 1024U;
+    // 8 KiB/s floor over a 256 KiB payload: 32 s of transfer allowance would
+    // make the test slow, so scale both down -- the policy is a ratio, and a
+    // 2 MiB/s floor with this payload gives 250 ms grace + 128 ms.
+    constexpr FrameWriteBudget trickleBudget{
+        writeStallTimeout, 2U * 1024U * 1024U};
+    const auto trickleBound = trickleBudget.total(tricklePayloadBytes);
+    std::atomic_bool trickleStop{false};
+    std::thread trickleReader([&] {
+        std::array<std::uint8_t, 16U * 1024U> chunk{};
+        while (!trickleStop.load()) {
+            std::this_thread::sleep_for(std::chrono::milliseconds{150});
+            if (::recv(trickleDescriptors[1], chunk.data(), chunk.size(), 0)
+                <= 0) {
+                break;
+            }
+        }
+    });
+    std::string trickleError;
+    const auto trickleStart = std::chrono::steady_clock::now();
+    try {
+        writeFrameWithBudget(trickleWriter,
+            std::vector<std::uint8_t>(tricklePayloadBytes),
+            tricklePayloadBytes, trickleBudget);
+    } catch (const std::exception& error) {
+        trickleError = error.what();
+    }
+    const auto trickleElapsed = std::chrono::steady_clock::now() - trickleStart;
+    trickleStop.store(true);
+    trickleWriter.shutdown();
+    trickleReader.join();
+    if (trickleError.find("below the minimum throughput")
+        == std::string::npos) {
+        std::cerr << "trickle write ended with: "
+                  << (trickleError.empty() ? "no error" : trickleError) << '\n';
+    }
+    require(trickleError.find("below the minimum throughput")
+            != std::string::npos,
+        "a trickle-reading peer was not retired by the whole-write budget");
+    // Never before the advertised bound, and not far after it: the writer waits
+    // on the earlier of the two deadlines every iteration.
+    require(trickleElapsed >= trickleBound
+            && trickleElapsed < trickleBound + std::chrono::seconds(5),
+        "the trickle-reader write did not end near its advertised bound");
+    // The stall interval alone could not have done this: the reader never went
+    // quiet for that long.
+    require(trickleBound > writeStallTimeout,
+        "the trickle bound is not longer than one stall interval");
+
+    // The floor is a hard requirement of the budget, not a suggestion: zero
+    // would silently restore the unbounded case.
+    bool rejectedZeroFloor = false;
+    try {
+        writeFrameWithBudget(trickleWriter, std::vector<std::uint8_t>(8), 8,
+            FrameWriteBudget{writeStallTimeout, 0});
+    } catch (const std::invalid_argument&) {
+        rejectedZeroFloor = true;
+    }
+    require(rejectedZeroFloor, "a zero throughput floor was accepted");
 #endif
 
     // A TCP-segment boundary may tear the four-byte header without making the

--- a/tools/amrexplorer_server/main.cpp
+++ b/tools/amrexplorer_server/main.cpp
@@ -33,7 +33,15 @@ void printUsage(std::ostream& output)
         << "  --max-frame-mib MIB  maximum negotiated frame size\n"
         << "  --max-datasets COUNT maximum open datasets per connection\n"
         << "  --write-stall-timeout-seconds SECONDS\n"
-        << "                       disconnect after no write progress\n"
+        << "                       disconnect after no write progress; also the\n"
+        << "                       fixed grace in the whole-response budget\n"
+        << "  --write-min-kib-per-second KIB\n"
+        << "                       floor throughput for the whole-response\n"
+        << "                       budget: a response must finish within the\n"
+        << "                       stall grace plus size / this rate, so a peer\n"
+        << "                       reading a trickle cannot hold a worker\n"
+        << "                       forever. Lower it for a slow link; it cannot\n"
+        << "                       be zero\n"
         << "  --help               show this help\n";
 }
 
@@ -139,6 +147,19 @@ int main(int argc, char* argv[])
                 }
                 options.responseWriteStallTimeout = std::chrono::seconds{
                     static_cast<std::chrono::seconds::rep>(seconds)};
+            } else if (option == "--write-min-kib-per-second") {
+                const auto kibibytes = parseUnsigned<std::uint64_t>(
+                    value, "--write-min-kib-per-second");
+                constexpr std::uint64_t oneKibibyte = 1024ULL;
+                if (kibibytes == 0
+                    || kibibytes > std::numeric_limits<std::uint64_t>::max()
+                            / oneKibibyte) {
+                    throw std::invalid_argument(
+                        "--write-min-kib-per-second is outside its allowed "
+                        "range");
+                }
+                options.responseWriteMinimumBytesPerSecond
+                    = kibibytes * oneKibibyte;
             } else {
                 throw std::invalid_argument("unknown option: " + option);
             }


### PR DESCRIPTION
writeExact renewed its stall deadline after every successful send, so the configured timeout bounded only a period of *zero* progress. A peer that accepts a few bytes before each deadline renews it forever, and because Session::send performs the write on a pooled worker while holding the session's write mutex, one such client keeps both indefinitely and enough of them delay healthy connections sharing the pool. Frame-size limits cap the memory a response costs, not the lifetime of the resources it holds.

FrameWriteBudget carries both limits and writeFrameWithBudget replaces writeFrameWithStallTimeout. The no-progress timeout keeps its meaning and becomes the fixed grace in a whole-write bound:

  total = stallTimeout + size / minimumBytesPerSecond

computed once per frame, so the four-byte header cannot buy the payload extra time, and capped at thirty days so now() + total cannot overflow a steady clock. writeExact already took an absolute deadline; it now says which limit it hit, since with a stall timeout in force the absolute deadline can only mean the peer stayed under the floor rather than stopping outright.

The floor defaults to 64 KiB/s -- far below any usable SSH tunnel, so a 64 MiB response is allowed about 17 minutes -- and is exposed as --write-min-kib-per-second. Zero is rejected by both the option validation and the frame API, because zero silently restores the unbounded case; 1 is the escape hatch for a genuinely slow link, worth roughly 18 hours for a 64 MiB response. The user guide states the formula and the units.

The two new tests are split by what each can prove deterministically.

test_remote_frame owns the policy, on an AF_UNIX pair whose send buffer it controls: a reader that empties the 4 KiB buffer every 150 ms against a 250 ms stall interval always progresses inside the stall deadline yet runs at about 27 KiB/s, so the write must fail with "below the minimum throughput" rather than "stalled", at the bound total() advertises. Draining more than the buffer holds is what makes that deterministic -- a partial drain does not reliably make a socket writable again, so a byte-at-a-time reader trips the stall timeout instead and proves nothing.

test_remote_server owns the consequences: a client asks for a ~28 MiB response and drains 256 KiB every 100 ms, about 2.5 MiB/s against a 32 MiB/s floor. TCP reports a socket writable only once about half the send buffer is free, so progress arrives in bursts roughly twice a second -- inside the three-second grace, so the no-progress timeout can never fire and a build without the whole-write bound would never retire this session at all. That is the regression. While the write is still alive a second authenticated connection completes a handshake, a dataset open, and a small page response.

Note for the next test in that file: these sockets are non-blocking, so a raw recv reports EAGAIN whenever the response has not arrived yet and a drain loop must not read that as a close; and loopback buffers autotune into the megabytes, so a response of a few hundred kilobytes is absorbed whole and the server's write never blocks at all.

remote_server's ctest timeout goes to 90 s: it now waits out a real budget, taking about 7 s ordinarily and 16 s under TSan.