### PR TITLE
check decoded wire values against the dataset they claim to describe

### DIFF
--- a/cmake/amrexplorer_sanitizers.cmake
+++ b/cmake/amrexplorer_sanitizers.cmake
@@ -4,13 +4,19 @@ function(amrexplorer_enable_sanitizers)
             "AMREXPLORER_ENABLE_SANITIZERS currently supports GNU, Clang, and AppleClang")
     endif()
 
+    # float-cast-overflow is named explicitly because GCC leaves it out of the
+    # undefined group, unlike Clang: without it both sanitizer jobs run straight
+    # over an out-of-range floating-point to integer conversion, which is how one
+    # reached review in a validator reading doubles off the wire. Naming it costs
+    # nothing on either compiler (Clang already had it) and the check is what
+    # catches the next one.
     add_compile_options(
-        -fsanitize=address,undefined
+        -fsanitize=address,undefined,float-cast-overflow
         -fno-omit-frame-pointer
         -fno-sanitize-recover=all
     )
     add_link_options(
-        -fsanitize=address,undefined
+        -fsanitize=address,undefined,float-cast-overflow
         -fno-omit-frame-pointer
         -fno-sanitize-recover=all
     )

--- a/include/amrexplorer/core/Metadata.hpp
+++ b/include/amrexplorer/core/Metadata.hpp
@@ -84,6 +84,14 @@ struct MetadataIssue {
 
 [[nodiscard]] std::vector<MetadataIssue> validateMetadata(const DatasetMetadata& metadata);
 
+// The two in-plane axes of a slice or page whose normal is normalAxis: always
+// {0, 1} below three dimensions, otherwise the two axes other than the normal.
+// These are the axes a plane region must have positive extent in; the third axis
+// of a 3-D plane region carries the slice position and may be degenerate, which
+// is why a plane region cannot simply be checked with RealBox::valid.
+[[nodiscard]] std::array<int, 2> planeAxes(
+    int dimension, int normalAxis) noexcept;
+
 [[nodiscard]] bool isNodal(const IntBox& box, int axis) noexcept;
 [[nodiscard]] Centering centeringFromIndexType(
     const Int3& indexType, int dimension) noexcept;

--- a/include/amrexplorer/data/SessionValidation.hpp
+++ b/include/amrexplorer/data/SessionValidation.hpp
@@ -17,4 +17,19 @@ void validateSessionParticleRequest(const DatasetMetadata& metadata,
     const std::vector<ParticleSpeciesMetadata>& species,
     const std::string& name, double fraction);
 
+// Results, checked against the catalog they claim to describe. A local session
+// produces its results with our own query code and needs none of this; a remote
+// one is reading a peer's answer across a trust boundary, and provenance that is
+// impossible for the catalog -- a source level no level has, a grid box on a
+// nonexistent level, a plane region with no extent, more sampled particles than
+// the species holds -- must be refused rather than stored as trusted result
+// state. Each throws std::invalid_argument describing the first violation.
+void validateSessionViewResult(const DatasetMetadata& metadata,
+    const ViewDataRequest& request, const ViewDataResult& result);
+void validateSessionDatasetPageResult(const DatasetMetadata& metadata,
+    const DatasetPageRequest& request, const DatasetPage& page);
+void validateSessionParticleSampleResult(
+    const std::vector<ParticleSpeciesMetadata>& species,
+    const std::string& requested, const ParticleSample& sample);
+
 } // namespace amrvis

--- a/include/amrexplorer/io/ParticleReader.hpp
+++ b/include/amrexplorer/io/ParticleReader.hpp
@@ -18,6 +18,11 @@ enum class ParticleRealPrecision : std::uint8_t {
     Double
 };
 
+// Component counts a species header may declare. The local parser refuses
+// anything outside this, so the wire has to as well: a negative count reaching
+// the client would describe a species that cannot exist.
+inline constexpr int maximumParticleComponents = 100'000;
+
 struct ParticleSpeciesMetadata {
     std::string name;
     int dimension = 0;

--- a/include/amrexplorer/io/ParticleReader.hpp
+++ b/include/amrexplorer/io/ParticleReader.hpp
@@ -25,6 +25,10 @@ struct ParticleSpeciesMetadata {
     int intComponentCount = 0;
     std::uint64_t particleCount = 0;
     ParticleRealPrecision precision = ParticleRealPrecision::Double;
+
+    friend bool operator==(
+        const ParticleSpeciesMetadata&, const ParticleSpeciesMetadata&)
+        = default;
 };
 
 struct ParticlePoint {

--- a/src/core/Metadata.cpp
+++ b/src/core/Metadata.cpp
@@ -9,6 +9,24 @@
 
 namespace amrvis {
 
+std::array<int, 2> planeAxes(int dimension, int normalAxis) noexcept
+{
+    if (dimension != 3) {
+        return {0, 1};
+    }
+    std::array<int, 2> axes{0, 1};
+    std::size_t next = 0;
+    for (int axis = 0; axis < 3 && next < axes.size(); ++axis) {
+        if (axis != normalAxis) {
+            axes[next++] = axis;
+        }
+    }
+    // A normal outside [0, 2] leaves {0, 1}, which is what an unvalidated
+    // request must not be able to turn into an out-of-bounds write. Callers
+    // validate the normal separately; this only keeps the helper total.
+    return axes;
+}
+
 bool isNodal(const IntBox& box, int axis) noexcept
 {
     return box.centering[static_cast<std::size_t>(axis)] != 0;

--- a/src/core/Request.cpp
+++ b/src/core/Request.cpp
@@ -1,5 +1,8 @@
 #include <amrexplorer/core/Request.hpp>
 
+#include <cmath>
+#include <cstddef>
+
 namespace amrvis {
 
 std::vector<std::string> validateBlockRequest(const BlockRequest& request)
@@ -69,6 +72,22 @@ std::vector<std::string> validateLineRequest(
     }
     if (request.maximumLevel < 0) {
         errors.emplace_back("maximum level must be non-negative");
+    }
+    // Only the line axis of an optional region is meaningful -- LineQuery reads
+    // the extent along that axis and nothing else -- so the off-axis entries are
+    // free to be degenerate and RealBox::valid is the wrong check here. Without
+    // this, a reversed or non-finite region silently produced a line running
+    // from its upper bound to its lower one.
+    if (request.region && request.axis >= 0
+        && request.axis < datasetDimension) {
+        const auto axis = static_cast<std::size_t>(request.axis);
+        const auto lower = request.region->lower[axis];
+        const auto upper = request.region->upper[axis];
+        if (!std::isfinite(lower) || !std::isfinite(upper)
+            || !(lower < upper)) {
+            errors.emplace_back(
+                "line region must have finite positive extent along its axis");
+        }
     }
     return errors;
 }

--- a/src/data/DatasetPage.cpp
+++ b/src/data/DatasetPage.cpp
@@ -14,24 +14,6 @@
 #include <stdexcept>
 
 namespace amrvis {
-namespace {
-
-std::array<int, 2> inPlaneAxes(int dimension, int normalAxis) noexcept
-{
-    if (dimension != 3) {
-        return {0, 1};
-    }
-    std::array<int, 2> axes{0, 1};
-    std::size_t next = 0;
-    for (int axis = 0; axis < 3; ++axis) {
-        if (axis != normalAxis) {
-            axes[next++] = axis;
-        }
-    }
-    return axes;
-}
-
-} // namespace
 
 DatasetPage extractDatasetPage(PlotfileDataset& dataset,
     const DatasetPageRequest& request, StopToken cancellation)
@@ -62,7 +44,7 @@ DatasetPage extractDatasetPage(PlotfileDataset& dataset,
 
     const auto& level
         = metadata.levels[static_cast<std::size_t>(request.level)];
-    const auto axes = inPlaneAxes(metadata.dimension, request.normalAxis);
+    const auto axes = planeAxes(metadata.dimension, request.normalAxis);
     for (const auto axis : axes) {
         const auto entry = static_cast<std::size_t>(axis);
         const auto lower = request.region.lower[entry];

--- a/src/data/SessionValidation.cpp
+++ b/src/data/SessionValidation.cpp
@@ -8,6 +8,7 @@
 #include <cstdint>
 #include <stdexcept>
 #include <string>
+#include <utility>
 #include <type_traits>
 #include <variant>
 #include <vector>
@@ -154,6 +155,30 @@ void validateSessionDatasetPageRequest(const DatasetMetadata& metadata,
     // boundary, and lets the remote client refuse one before a round trip.
     requirePlaneRegion(request.region, metadata.dimension, request.normalAxis,
         "dataset page region");
+    // The builder turns these coordinates into indices, and a coordinate too far
+    // out to be one makes it throw. Refusing here means no page can ever be a
+    // legitimate answer to such a request, which is what lets the result
+    // validator treat an unconvertible request as the peer's fault.
+    const auto& level
+        = metadata.levels[static_cast<std::size_t>(request.level)];
+    try {
+        for (const auto axis : planeAxes(metadata.dimension,
+                 request.normalAxis)) {
+            const auto entry = static_cast<std::size_t>(axis);
+            static_cast<void>(
+                sampleIndex(level, axis, request.region.lower[entry]));
+            static_cast<void>(sampleIndex(level, axis,
+                std::nextafter(request.region.upper[entry],
+                    -std::numeric_limits<double>::infinity())));
+        }
+        if (metadata.dimension == 3) {
+            static_cast<void>(sampleIndex(
+                level, request.normalAxis, request.slicePosition));
+        }
+    } catch (const std::out_of_range&) {
+        throw std::invalid_argument(
+            "dataset page region is too far out to index at this level");
+    }
 }
 
 void validateSessionRangeRequest(
@@ -232,12 +257,59 @@ void validateSessionViewResult(const DatasetMetadata& metadata,
         // The overlay is switched by the request: the query copies the flag and
         // collects nothing when it is off, and the window installs whatever the
         // flag says arrived.
+        if (slice->gridBoxesIncluded != query.includeGridBoxes) {
+            // The query copies the flag from the request, so a disagreement is
+            // never an answer to it -- and the window installs the overlay only
+            // when the flag is set, keeping the previous one otherwise.
+            throw std::invalid_argument(
+                "slice result disagrees with the request about grid boxes");
+        }
         if (!query.includeGridBoxes
-            && (slice->gridBoxesIncluded || !slice->gridBoxes.empty()
-                || slice->gridBoxesTruncated)) {
+            && (!slice->gridBoxes.empty() || slice->gridBoxesTruncated)) {
             throw std::invalid_argument(
                 "slice result carries grid boxes that were not requested");
         }
+        // Expected boxes per level, built once and reused: each catalog box of
+        // that level, in physical space, clipped to the visible region on the
+        // plane axes -- exactly the geometry the query derives. The
+        // slice-intersection and non-degeneracy filters it also applies are
+        // deliberately *not* mirrored, so this stays a superset: it can only
+        // reject a box that corresponds to no catalog box at all, never one the
+        // query legitimately chose to keep or drop.
+        std::vector<std::pair<int, std::vector<RealBox>>> expectedByLevel;
+        const auto expectedFor = [&](int level) -> const std::vector<RealBox>& {
+            const auto known = std::find_if(expectedByLevel.begin(),
+                expectedByLevel.end(),
+                [level](const auto& entry) { return entry.first == level; });
+            if (known != expectedByLevel.end()) {
+                return known->second;
+            }
+            std::vector<RealBox> boxes;
+            const auto& source
+                = metadata.levels[static_cast<std::size_t>(level)];
+            boxes.reserve(source.boxes.size());
+            for (const auto& indexBox : source.boxes) {
+                auto physical
+                    = sampleBounds(source, indexBox, metadata.dimension);
+                for (const auto axis : planeAxes(
+                         metadata.dimension, query.normalDirection)) {
+                    const auto entry = static_cast<std::size_t>(axis);
+                    physical.lower[entry] = std::max(physical.lower[entry],
+                        query.visibleRegion.lower[entry]);
+                    physical.upper[entry] = std::min(physical.upper[entry],
+                        query.visibleRegion.upper[entry]);
+                }
+                boxes.push_back(physical);
+            }
+            std::sort(boxes.begin(), boxes.end(),
+                [](const RealBox& left, const RealBox& right) {
+                    return left.lower.values < right.lower.values
+                        || (left.lower.values == right.lower.values
+                            && left.upper.values < right.upper.values);
+                });
+            expectedByLevel.emplace_back(level, std::move(boxes));
+            return expectedByLevel.back().second;
+        };
         for (const auto& box : slice->gridBoxes) {
             // A grid box, unlike a sample, always comes from a real level:
             // there is no sentinel for "no level drew this box".
@@ -250,20 +322,18 @@ void validateSessionViewResult(const DatasetMetadata& metadata,
             }
             requirePlaneRegion(box.physicalRegion, metadata.dimension,
                 query.normalDirection, "slice result grid box");
-            // Every box is clipped to the visible region on the plane axes
-            // before it is collected, so one reaching outside it never came
-            // from this request.
-            for (const auto axis : planeAxes(
-                     metadata.dimension, query.normalDirection)) {
-                const auto entry = static_cast<std::size_t>(axis);
-                if (box.physicalRegion.lower[entry]
-                        < query.visibleRegion.lower[entry]
-                    || box.physicalRegion.upper[entry]
-                        > query.visibleRegion.upper[entry]) {
-                    throw std::invalid_argument(
-                        "slice result grid box lies outside the visible "
-                        "region");
-                }
+            const auto& expected = expectedFor(box.level);
+            const auto found = std::lower_bound(expected.begin(),
+                expected.end(), box.physicalRegion,
+                [](const RealBox& left, const RealBox& right) {
+                    return left.lower.values < right.lower.values
+                        || (left.lower.values == right.lower.values
+                            && left.upper.values < right.upper.values);
+                });
+            if (found == expected.end()
+                || !(*found == box.physicalRegion)) {
+                throw std::invalid_argument(
+                    "slice result grid box matches no box in the catalog");
             }
         }
         return;
@@ -299,37 +369,45 @@ void validateSessionViewResult(const DatasetMetadata& metadata,
     if (metadata.levels.empty()) {
         return;
     }
-    // The walk advances along the axis and emits at most one sample per index,
-    // in order, and boundLineToViewport appends each bucket's picks in index
-    // order too, so the positions arrive sorted. Unsorted ones would plot as a
-    // line folded back over itself.
+    // Sorted, not strictly sorted. The walk emits one sample per cell in
+    // increasing order and boundLineToViewport appends each bucket's picks in
+    // index order, so non-decreasing is certain; strict increase across a level
+    // transition, where a coarse cell can share a centre with a fine one under
+    // an odd refinement ratio, is not something the producer guarantees on paper.
+    // A duplicated position plots as a vertical step, which is cosmetic; a false
+    // rejection here retires the connection, which is not.
     if (!std::is_sorted(line.positions.begin(), line.positions.end())) {
         throw std::invalid_argument("line result positions are not ordered");
     }
-    // And they lie in the extent the sampling level spans: physical bounds when
-    // the dataset has geometry, index bounds when its positions are indices.
-    // A region narrows this further; the level extent is the outer limit either
-    // way, which is what makes this check independent of the region's own rule.
+    // Positions lie in the extent LineQuery walks, which is the requested region
+    // when there is one and the sampling level's span otherwise -- with the
+    // producer's own end tolerance. Note that a region is free to reach outside
+    // the domain: the walk then emits invalid samples out there, and bounding
+    // this by the domain instead would reject a legitimate answer.
     const auto& level = metadata.levels[static_cast<std::size_t>(
         std::clamp(query.maximumLevel, 0, metadata.finestLevel))];
     const auto axis = static_cast<std::size_t>(
         std::clamp(query.axis, 0, metadata.dimension - 1));
-    double lowest = 0.0;
-    double highest = 0.0;
-    if (line.positionsAreIndices) {
-        lowest = static_cast<double>(level.domain.lower[axis]);
-        highest = static_cast<double>(level.domain.upper[axis]);
-    } else {
-        const auto bounds
-            = sampleBounds(level, level.domain, metadata.dimension);
-        lowest = bounds.lower[axis];
-        highest = bounds.upper[axis];
-    }
+    const auto bounds = sampleBounds(level, level.domain, metadata.dimension);
+    const auto lowest = query.region ? query.region->lower[axis]
+                                     : bounds.lower[axis];
+    const auto highest = query.region ? query.region->upper[axis]
+                                      : bounds.upper[axis];
+    const auto tolerance = 1.0e-9 * level.cellSize[axis];
     for (const auto position : line.positions) {
-        if (!std::isfinite(position) || position < lowest
-            || position > highest) {
+        if (!std::isfinite(position)) {
+            throw std::invalid_argument("line result position is not finite");
+        }
+        // An index position is in range when the sample it names is: the
+        // producer tests the centre, not the index. Index positions only occur
+        // on a single-level dataset, so this level is the one that emitted it.
+        const auto centre = line.positionsAreIndices
+            ? samplePosition(level, static_cast<int>(query.axis),
+                  static_cast<int>(position))
+            : position;
+        if (centre < lowest - tolerance || centre > highest + tolerance) {
             throw std::invalid_argument(
-                "line result position lies outside the sampled level");
+                "line result position lies outside the requested extent");
         }
     }
 }
@@ -376,7 +454,6 @@ void validateSessionDatasetPageResult(const DatasetMetadata& metadata,
         std::int64_t upper = 0;
     };
     std::array<Window, 2> expected{};
-    bool derived = false;
     bool expectEmpty = false;
     try {
         for (std::size_t entry = 0; entry < 2; ++entry) {
@@ -398,10 +475,13 @@ void validateSessionDatasetPageResult(const DatasetMetadata& metadata,
             expected[entry].lower = std::max(rawLower, domainLower);
             expected[entry].upper = std::min(rawUpper, domainUpper);
         }
-        derived = true;
-    } catch (const std::exception&) {
-        derived = false;
+    } catch (const std::out_of_range&) {
+        // The request validator refuses a region this far out, so the builder
+        // could only have answered with an error: a page is impossible here.
+        throw std::invalid_argument(
+            "dataset page answers a request that cannot be indexed");
     }
+    constexpr bool derived = true;
     if (derived && expectEmpty && (page.nx != 0 || page.ny != 0)) {
         throw std::invalid_argument(
             "dataset page is not empty although the request misses the level");
@@ -448,6 +528,15 @@ void validateSessionDatasetPageResult(const DatasetMetadata& metadata,
                 if (upper > expected[entry].upper) {
                     throw std::invalid_argument(
                         "dataset page reaches past the requested region");
+                }
+                const auto requestedSpan = expected[entry].upper
+                    - expected[entry].lower + 1;
+                const auto expectTruncation = requestedSpan
+                    > static_cast<std::int64_t>(request.maximumExtent);
+                if (truncated != expectTruncation) {
+                    throw std::invalid_argument(
+                        "dataset page truncation flag does not match the "
+                        "requested span");
                 }
                 if (truncated
                     && extent

--- a/src/data/SessionValidation.cpp
+++ b/src/data/SessionValidation.cpp
@@ -1,7 +1,9 @@
 #include <amrexplorer/data/SessionValidation.hpp>
 
 #include <algorithm>
+#include <array>
 #include <cmath>
+#include <limits>
 #include <cstddef>
 #include <cstdint>
 #include <stdexcept>
@@ -227,6 +229,15 @@ void validateSessionViewResult(const DatasetMetadata& metadata,
         requireSourceLevels(plane.sourceLevel,
             std::min(query.maximumLevel, metadata.finestLevel),
             "slice result");
+        // The overlay is switched by the request: the query copies the flag and
+        // collects nothing when it is off, and the window installs whatever the
+        // flag says arrived.
+        if (!query.includeGridBoxes
+            && (slice->gridBoxesIncluded || !slice->gridBoxes.empty()
+                || slice->gridBoxesTruncated)) {
+            throw std::invalid_argument(
+                "slice result carries grid boxes that were not requested");
+        }
         for (const auto& box : slice->gridBoxes) {
             // A grid box, unlike a sample, always comes from a real level:
             // there is no sentinel for "no level drew this box".
@@ -239,6 +250,21 @@ void validateSessionViewResult(const DatasetMetadata& metadata,
             }
             requirePlaneRegion(box.physicalRegion, metadata.dimension,
                 query.normalDirection, "slice result grid box");
+            // Every box is clipped to the visible region on the plane axes
+            // before it is collected, so one reaching outside it never came
+            // from this request.
+            for (const auto axis : planeAxes(
+                     metadata.dimension, query.normalDirection)) {
+                const auto entry = static_cast<std::size_t>(axis);
+                if (box.physicalRegion.lower[entry]
+                        < query.visibleRegion.lower[entry]
+                    || box.physicalRegion.upper[entry]
+                        > query.visibleRegion.upper[entry]) {
+                    throw std::invalid_argument(
+                        "slice result grid box lies outside the visible "
+                        "region");
+                }
+            }
         }
         return;
     }
@@ -264,6 +290,48 @@ void validateSessionViewResult(const DatasetMetadata& metadata,
     }
     requireSourceLevels(line.sourceLevel,
         std::min(query.maximumLevel, metadata.finestLevel), "line result");
+    // Whether the horizontal axis is physical or an index is a property of the
+    // dataset, not of the answer: the plot labels and scales its axis from this.
+    if (line.positionsAreIndices == metadata.hasPhysicalGeometry) {
+        throw std::invalid_argument(
+            "line result disagrees with the dataset about index positions");
+    }
+    if (metadata.levels.empty()) {
+        return;
+    }
+    // The walk advances along the axis and emits at most one sample per index,
+    // in order, and boundLineToViewport appends each bucket's picks in index
+    // order too, so the positions arrive sorted. Unsorted ones would plot as a
+    // line folded back over itself.
+    if (!std::is_sorted(line.positions.begin(), line.positions.end())) {
+        throw std::invalid_argument("line result positions are not ordered");
+    }
+    // And they lie in the extent the sampling level spans: physical bounds when
+    // the dataset has geometry, index bounds when its positions are indices.
+    // A region narrows this further; the level extent is the outer limit either
+    // way, which is what makes this check independent of the region's own rule.
+    const auto& level = metadata.levels[static_cast<std::size_t>(
+        std::clamp(query.maximumLevel, 0, metadata.finestLevel))];
+    const auto axis = static_cast<std::size_t>(
+        std::clamp(query.axis, 0, metadata.dimension - 1));
+    double lowest = 0.0;
+    double highest = 0.0;
+    if (line.positionsAreIndices) {
+        lowest = static_cast<double>(level.domain.lower[axis]);
+        highest = static_cast<double>(level.domain.upper[axis]);
+    } else {
+        const auto bounds
+            = sampleBounds(level, level.domain, metadata.dimension);
+        lowest = bounds.lower[axis];
+        highest = bounds.upper[axis];
+    }
+    for (const auto position : line.positions) {
+        if (!std::isfinite(position) || position < lowest
+            || position > highest) {
+            throw std::invalid_argument(
+                "line result position lies outside the sampled level");
+        }
+    }
 }
 
 void validateSessionDatasetPageResult(const DatasetMetadata& metadata,
@@ -285,16 +353,64 @@ void validateSessionDatasetPageResult(const DatasetMetadata& metadata,
         throw std::invalid_argument(
             "dataset page is empty on one axis only");
     }
-    if (page.nx > 0 && page.ny > 0) {
-        if (request.level < 0
-            || static_cast<std::size_t>(request.level)
-                >= metadata.levels.size()) {
-            throw std::invalid_argument(
-                "dataset page names a level the dataset does not have");
+    if (request.level < 0
+        || static_cast<std::size_t>(request.level) >= metadata.levels.size()) {
+        throw std::invalid_argument(
+            "dataset page names a level the dataset does not have");
+    }
+    const auto& level
+        = metadata.levels[static_cast<std::size_t>(request.level)];
+    const auto axes = planeAxes(metadata.dimension, request.normalAxis);
+    // What extractDatasetPage would have produced for this request. Mirroring it
+    // is the point: the window, the slice index, and the emptiness of a page are
+    // all determined by the region, the slice position, the level domain, and
+    // the extent limit, so anything else is not an answer to this request. Keep
+    // this in step with extractDatasetPage.
+    //
+    // sampleIndex throws when a coordinate is too far out to be an index. The
+    // server's own builder would have thrown first and answered with an error,
+    // so a response that exists at all implies the derivation succeeds; if it
+    // does not, leave the geometry unchecked rather than blame the peer.
+    struct Window {
+        std::int64_t lower = 0;
+        std::int64_t upper = 0;
+    };
+    std::array<Window, 2> expected{};
+    bool derived = false;
+    bool expectEmpty = false;
+    try {
+        for (std::size_t entry = 0; entry < 2; ++entry) {
+            const auto axis = static_cast<std::size_t>(axes[entry]);
+            const auto domainLower
+                = static_cast<std::int64_t>(level.domain.lower[axis]);
+            const auto domainUpper
+                = static_cast<std::int64_t>(level.domain.upper[axis]);
+            const auto rawLower = static_cast<std::int64_t>(
+                sampleIndex(level, axes[entry], request.region.lower[axis]));
+            const auto rawUpper = static_cast<std::int64_t>(
+                sampleIndex(level, axes[entry],
+                    std::nextafter(request.region.upper[axis],
+                        -std::numeric_limits<double>::infinity())));
+            if (rawUpper < domainLower || rawLower > domainUpper) {
+                expectEmpty = true;
+                break;
+            }
+            expected[entry].lower = std::max(rawLower, domainLower);
+            expected[entry].upper = std::min(rawUpper, domainUpper);
         }
-        const auto& level
-            = metadata.levels[static_cast<std::size_t>(request.level)];
-        const auto axes = planeAxes(metadata.dimension, request.normalAxis);
+        derived = true;
+    } catch (const std::exception&) {
+        derived = false;
+    }
+    if (derived && expectEmpty && (page.nx != 0 || page.ny != 0)) {
+        throw std::invalid_argument(
+            "dataset page is not empty although the request misses the level");
+    }
+    if (derived && !expectEmpty && page.nx == 0 && page.ny == 0) {
+        throw std::invalid_argument(
+            "dataset page is empty although the request meets the level");
+    }
+    if (page.nx > 0 && page.ny > 0) {
         for (std::size_t entry = 0; entry < page.lower.size(); ++entry) {
             // Widen before subtracting: both bounds come straight off the wire,
             // where INT_MIN and INT_MAX are reachable and int arithmetic on them
@@ -303,6 +419,8 @@ void validateSessionDatasetPageResult(const DatasetMetadata& metadata,
             const auto upper = static_cast<std::int64_t>(page.upper[entry]);
             const auto extent = static_cast<std::int64_t>(
                 entry == 0 ? page.nx : page.ny);
+            const auto truncated = entry == 0 ? page.truncatedX
+                                              : page.truncatedY;
             if (lower > upper) {
                 throw std::invalid_argument(
                     "dataset page index bounds are reversed");
@@ -320,14 +438,58 @@ void validateSessionDatasetPageResult(const DatasetMetadata& metadata,
                 throw std::invalid_argument(
                     "dataset page lies outside the level domain");
             }
+            // Truncation only ever moves the upper edge in, so the lower edge is
+            // exactly the requested one and the extent stops at the limit.
+            if (derived && !expectEmpty) {
+                if (lower != expected[entry].lower) {
+                    throw std::invalid_argument(
+                        "dataset page does not start where the request does");
+                }
+                if (upper > expected[entry].upper) {
+                    throw std::invalid_argument(
+                        "dataset page reaches past the requested region");
+                }
+                if (truncated
+                    && extent
+                        != static_cast<std::int64_t>(request.maximumExtent)) {
+                    throw std::invalid_argument(
+                        "dataset page claims truncation without filling the "
+                        "extent limit");
+                }
+                if (!truncated && upper != expected[entry].upper) {
+                    throw std::invalid_argument(
+                        "dataset page is short of the requested region without "
+                        "claiming truncation");
+                }
+            }
         }
         if (metadata.dimension == 3) {
             const auto normal = static_cast<std::size_t>(request.normalAxis);
-            if (normal < 3
-                && (page.sliceIndex < level.domain.lower[normal]
-                    || page.sliceIndex > level.domain.upper[normal])) {
+            if (normal >= 3) {
+                throw std::invalid_argument(
+                    "dataset page normal axis is invalid");
+            }
+            if (page.sliceIndex < level.domain.lower[normal]
+                || page.sliceIndex > level.domain.upper[normal]) {
                 throw std::invalid_argument(
                     "dataset page slice index is outside the level domain");
+            }
+            // The slice index is the requested position clamped to the domain,
+            // so it is determined rather than merely plausible.
+            try {
+                const auto raw = static_cast<std::int64_t>(sampleIndex(
+                    level, request.normalAxis, request.slicePosition));
+                const auto clamped = std::clamp(raw,
+                    static_cast<std::int64_t>(level.domain.lower[normal]),
+                    static_cast<std::int64_t>(level.domain.upper[normal]));
+                if (static_cast<std::int64_t>(page.sliceIndex) != clamped) {
+                    throw std::invalid_argument(
+                        "dataset page slices at a different position than was "
+                        "requested");
+                }
+            } catch (const std::out_of_range&) {
+                // Unreachable through the server, which would have failed the
+                // same conversion first.
             }
         }
     }

--- a/src/data/SessionValidation.cpp
+++ b/src/data/SessionValidation.cpp
@@ -198,6 +198,20 @@ void validateSessionViewResult(const DatasetMetadata& metadata,
         if (plane.width < 1 || plane.height < 1) {
             throw std::invalid_argument("slice result has an empty raster");
         }
+        // The raster and the window it covers are what the caller asked for,
+        // exactly: a slice too large for one frame is refused rather than
+        // reduced, and the query copies the requested region into its result.
+        // A raster of another shape, or over another window, would be displayed
+        // as if it answered the request.
+        if (plane.width != query.outputSize[0]
+            || plane.height != query.outputSize[1]) {
+            throw std::invalid_argument(
+                "slice result raster is not the size that was requested");
+        }
+        if (!(plane.physicalRegion == query.visibleRegion)) {
+            throw std::invalid_argument(
+                "slice result covers a different region than was requested");
+        }
         const auto samples = static_cast<std::size_t>(plane.width)
             * static_cast<std::size_t>(plane.height);
         if (plane.values.size() != samples || plane.valid.size() != samples
@@ -207,12 +221,18 @@ void validateSessionViewResult(const DatasetMetadata& metadata,
         }
         requirePlaneRegion(plane.physicalRegion, metadata.dimension,
             query.normalDirection, "slice result region");
-        requireSourceLevels(
-            plane.sourceLevel, metadata.finestLevel, "slice result");
+        // Provenance is bounded by what the request allowed, not merely by what
+        // the dataset has: a sample composited from a finer level than the
+        // caller asked for is not the answer to that question.
+        requireSourceLevels(plane.sourceLevel,
+            std::min(query.maximumLevel, metadata.finestLevel),
+            "slice result");
         for (const auto& box : slice->gridBoxes) {
             // A grid box, unlike a sample, always comes from a real level:
             // there is no sentinel for "no level drew this box".
-            if (box.level < 0 || box.level > metadata.finestLevel) {
+            if (box.level < 0
+                || box.level > std::min(
+                       query.maximumLevel, metadata.finestLevel)) {
                 throw std::invalid_argument(
                     "slice result grid box names a level the dataset does "
                     "not have");
@@ -222,8 +242,9 @@ void validateSessionViewResult(const DatasetMetadata& metadata,
         }
         return;
     }
+    const auto& view = std::get<LineViewRequest>(request);
     const auto& line = std::get<LineQueryResult>(result).line;
-    const auto& query = std::get<LineViewRequest>(request).query;
+    const auto& query = view.query;
     if (line.axis != query.axis) {
         throw std::invalid_argument("line result is along the wrong axis");
     }
@@ -232,14 +253,22 @@ void validateSessionViewResult(const DatasetMetadata& metadata,
         || line.sourceLevel.size() != line.positions.size()) {
         throw std::invalid_argument("line result vectors disagree");
     }
-    requireSourceLevels(
-        line.sourceLevel, metadata.finestLevel, "line result");
+    // boundLineToViewport's contract: at most two samples per output pixel, the
+    // extrema of each bucket. A longer line would be plotted at a density the
+    // caller never asked to receive.
+    if (view.outputWidth >= 1
+        && line.positions.size()
+            > static_cast<std::size_t>(view.outputWidth) * 2) {
+        throw std::invalid_argument(
+            "line result carries more samples than its viewport allows");
+    }
+    requireSourceLevels(line.sourceLevel,
+        std::min(query.maximumLevel, metadata.finestLevel), "line result");
 }
 
 void validateSessionDatasetPageResult(const DatasetMetadata& metadata,
     const DatasetPageRequest& request, const DatasetPage& page)
 {
-    static_cast<void>(metadata);
     if (page.nx < 0 || page.ny < 0) {
         throw std::invalid_argument("dataset page extent is negative");
     }
@@ -250,19 +279,55 @@ void validateSessionDatasetPageResult(const DatasetMetadata& metadata,
             "dataset page is larger than the requested extent");
     }
     // An empty page is the default-constructed one, whose bounds are
-    // deliberately inverted (lower {0, 0}, upper {-1, -1}) to say "no cells";
-    // only a page that claims cells has to have bounds that describe them, and
-    // the extent it reports must be exactly the span of those bounds.
+    // deliberately inverted (lower {0, 0}, upper {-1, -1}) to say "no cells".
+    // One empty axis and one populated one is neither shape.
+    if ((page.nx == 0) != (page.ny == 0)) {
+        throw std::invalid_argument(
+            "dataset page is empty on one axis only");
+    }
     if (page.nx > 0 && page.ny > 0) {
+        if (request.level < 0
+            || static_cast<std::size_t>(request.level)
+                >= metadata.levels.size()) {
+            throw std::invalid_argument(
+                "dataset page names a level the dataset does not have");
+        }
+        const auto& level
+            = metadata.levels[static_cast<std::size_t>(request.level)];
+        const auto axes = planeAxes(metadata.dimension, request.normalAxis);
         for (std::size_t entry = 0; entry < page.lower.size(); ++entry) {
-            const auto extent = entry == 0 ? page.nx : page.ny;
-            if (page.lower[entry] > page.upper[entry]) {
+            // Widen before subtracting: both bounds come straight off the wire,
+            // where INT_MIN and INT_MAX are reachable and int arithmetic on them
+            // is undefined.
+            const auto lower = static_cast<std::int64_t>(page.lower[entry]);
+            const auto upper = static_cast<std::int64_t>(page.upper[entry]);
+            const auto extent = static_cast<std::int64_t>(
+                entry == 0 ? page.nx : page.ny);
+            if (lower > upper) {
                 throw std::invalid_argument(
                     "dataset page index bounds are reversed");
             }
-            if (page.upper[entry] - page.lower[entry] + 1 != extent) {
+            if (upper - lower + 1 != extent) {
                 throw std::invalid_argument(
                     "dataset page extent does not match its index bounds");
+            }
+            // The page indexes the level it named, so its cells have to be
+            // inside that level's domain.
+            const auto axis = static_cast<std::size_t>(axes[entry]);
+            if (lower < static_cast<std::int64_t>(level.domain.lower[axis])
+                || upper
+                    > static_cast<std::int64_t>(level.domain.upper[axis])) {
+                throw std::invalid_argument(
+                    "dataset page lies outside the level domain");
+            }
+        }
+        if (metadata.dimension == 3) {
+            const auto normal = static_cast<std::size_t>(request.normalAxis);
+            if (normal < 3
+                && (page.sliceIndex < level.domain.lower[normal]
+                    || page.sliceIndex > level.domain.upper[normal])) {
+                throw std::invalid_argument(
+                    "dataset page slice index is outside the level domain");
             }
         }
     }
@@ -291,6 +356,13 @@ void validateSessionParticleSampleResult(
     if (sample.species.dimension < 1 || sample.species.dimension > 3) {
         throw std::invalid_argument(
             "particle sample dimension is outside [1, 3]");
+    }
+    // The catalog published this species when the dataset opened; a response
+    // describing the same name with a different shape contradicts it, and the
+    // client would then report the response's numbers as the species' own.
+    if (!(sample.species == *known)) {
+        throw std::invalid_argument(
+            "particle sample metadata contradicts the catalog");
     }
     // A sample is a subset of the species, so it cannot hold more points than
     // the catalog says exist.

--- a/src/data/SessionValidation.cpp
+++ b/src/data/SessionValidation.cpp
@@ -398,13 +398,30 @@ void validateSessionViewResult(const DatasetMetadata& metadata,
         if (!std::isfinite(position)) {
             throw std::invalid_argument("line result position is not finite");
         }
-        // An index position is in range when the sample it names is: the
-        // producer tests the centre, not the index. Index positions only occur
-        // on a single-level dataset, so this level is the one that emitted it.
-        const auto centre = line.positionsAreIndices
-            ? samplePosition(level, static_cast<int>(query.axis),
-                  static_cast<int>(position))
-            : position;
+        auto centre = position;
+        if (line.positionsAreIndices) {
+            // The producer reports an int index widened to a double, so a value
+            // that is not integral is not an index at all -- 1.5 would otherwise
+            // be read as index 1 -- and one outside int's range cannot be
+            // converted back at all: narrowing 1e100 to int is undefined, which
+            // is the opposite of what a validation layer is for. Both bounds are
+            // exactly representable as doubles, so these comparisons are exact.
+            if (position != std::floor(position)
+                || position
+                    < static_cast<double>(std::numeric_limits<int>::min())
+                || position
+                    > static_cast<double>(std::numeric_limits<int>::max())) {
+                throw std::invalid_argument(
+                    "line result index position is not an index");
+            }
+            // An index position is in range when the sample it names is: the
+            // producer tests the centre, not the index. Index positions only
+            // occur on a single-level dataset, so this level is the one that
+            // emitted it. The axis is the clamped one, since samplePosition
+            // indexes fixed three-element geometry with it.
+            centre = samplePosition(level, static_cast<int>(axis),
+                static_cast<int>(position));
+        }
         if (centre < lowest - tolerance || centre > highest + tolerance) {
             throw std::invalid_argument(
                 "line result position lies outside the requested extent");

--- a/src/data/SessionValidation.cpp
+++ b/src/data/SessionValidation.cpp
@@ -2,9 +2,13 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstddef>
+#include <cstdint>
 #include <stdexcept>
+#include <string>
 #include <type_traits>
 #include <variant>
+#include <vector>
 
 namespace amrvis {
 namespace {
@@ -36,6 +40,36 @@ void requireComponent(const DatasetMetadata& metadata, FieldId field,
     if (static_cast<std::size_t>(component) >= count) {
         throw std::invalid_argument(
             std::string(operation) + " component is unavailable");
+    }
+}
+
+// A plane region is only meaningful in its two in-plane axes: the third axis of
+// a 3-D region carries the slice position and is free to be degenerate.
+void requirePlaneRegion(const RealBox& region, int dimension, int normalAxis,
+    const char* what)
+{
+    for (const auto axis : planeAxes(dimension, normalAxis)) {
+        const auto entry = static_cast<std::size_t>(axis);
+        const auto lower = region.lower[entry];
+        const auto upper = region.upper[entry];
+        if (!std::isfinite(lower) || !std::isfinite(upper)
+            || !(lower < upper)) {
+            throw std::invalid_argument(std::string(what)
+                + " must have finite positive in-plane extent");
+        }
+    }
+}
+
+// -1 marks a sample no level covered; anything else must name a real level.
+void requireSourceLevels(const std::vector<std::int16_t>& levels,
+    int finestLevel, const char* what)
+{
+    for (const auto level : levels) {
+        if (level < -1 || level > finestLevel) {
+            throw std::invalid_argument(
+                std::string(what) + " reports a source level the dataset "
+                                    "does not have");
+        }
     }
 }
 
@@ -113,6 +147,11 @@ void validateSessionDatasetPageRequest(const DatasetMetadata& metadata,
         throw std::invalid_argument(
             "dataset page slice position must be finite");
     }
+    // extractDatasetPage applies the same rule, but only once the request has
+    // already reached it. Checking here rejects a malformed region at the trust
+    // boundary, and lets the remote client refuse one before a round trip.
+    requirePlaneRegion(request.region, metadata.dimension, request.normalAxis,
+        "dataset page region");
 }
 
 void validateSessionRangeRequest(
@@ -143,6 +182,121 @@ void validateSessionParticleRequest(const DatasetMetadata& metadata,
     if (!std::isfinite(fraction) || !(fraction > 0.0) || fraction > 1.0) {
         throw std::invalid_argument(
             "particle sample fraction must be in (0, 1]");
+    }
+}
+
+void validateSessionViewResult(const DatasetMetadata& metadata,
+    const ViewDataRequest& request, const ViewDataResult& result)
+{
+    if (request.index() != result.index()) {
+        throw std::invalid_argument(
+            "view result does not answer the request that was made");
+    }
+    if (const auto* slice = std::get_if<SliceQueryResult>(&result)) {
+        const auto& query = std::get<SliceRequest>(request);
+        const auto& plane = slice->plane;
+        if (plane.width < 1 || plane.height < 1) {
+            throw std::invalid_argument("slice result has an empty raster");
+        }
+        const auto samples = static_cast<std::size_t>(plane.width)
+            * static_cast<std::size_t>(plane.height);
+        if (plane.values.size() != samples || plane.valid.size() != samples
+            || plane.sourceLevel.size() != samples) {
+            throw std::invalid_argument(
+                "slice result raster and sample vectors disagree");
+        }
+        requirePlaneRegion(plane.physicalRegion, metadata.dimension,
+            query.normalDirection, "slice result region");
+        requireSourceLevels(
+            plane.sourceLevel, metadata.finestLevel, "slice result");
+        for (const auto& box : slice->gridBoxes) {
+            // A grid box, unlike a sample, always comes from a real level:
+            // there is no sentinel for "no level drew this box".
+            if (box.level < 0 || box.level > metadata.finestLevel) {
+                throw std::invalid_argument(
+                    "slice result grid box names a level the dataset does "
+                    "not have");
+            }
+            requirePlaneRegion(box.physicalRegion, metadata.dimension,
+                query.normalDirection, "slice result grid box");
+        }
+        return;
+    }
+    const auto& line = std::get<LineQueryResult>(result).line;
+    const auto& query = std::get<LineViewRequest>(request).query;
+    if (line.axis != query.axis) {
+        throw std::invalid_argument("line result is along the wrong axis");
+    }
+    if (line.values.size() != line.positions.size()
+        || line.valid.size() != line.positions.size()
+        || line.sourceLevel.size() != line.positions.size()) {
+        throw std::invalid_argument("line result vectors disagree");
+    }
+    requireSourceLevels(
+        line.sourceLevel, metadata.finestLevel, "line result");
+}
+
+void validateSessionDatasetPageResult(const DatasetMetadata& metadata,
+    const DatasetPageRequest& request, const DatasetPage& page)
+{
+    static_cast<void>(metadata);
+    if (page.nx < 0 || page.ny < 0) {
+        throw std::invalid_argument("dataset page extent is negative");
+    }
+    // The client sizes its table from the extent it asked for; a page larger
+    // than that would overrun what the caller prepared for.
+    if (page.nx > request.maximumExtent || page.ny > request.maximumExtent) {
+        throw std::invalid_argument(
+            "dataset page is larger than the requested extent");
+    }
+    // An empty page is the default-constructed one, whose bounds are
+    // deliberately inverted (lower {0, 0}, upper {-1, -1}) to say "no cells";
+    // only a page that claims cells has to have bounds that describe them, and
+    // the extent it reports must be exactly the span of those bounds.
+    if (page.nx > 0 && page.ny > 0) {
+        for (std::size_t entry = 0; entry < page.lower.size(); ++entry) {
+            const auto extent = entry == 0 ? page.nx : page.ny;
+            if (page.lower[entry] > page.upper[entry]) {
+                throw std::invalid_argument(
+                    "dataset page index bounds are reversed");
+            }
+            if (page.upper[entry] - page.lower[entry] + 1 != extent) {
+                throw std::invalid_argument(
+                    "dataset page extent does not match its index bounds");
+            }
+        }
+    }
+    const auto samples = static_cast<std::size_t>(page.nx)
+        * static_cast<std::size_t>(page.ny);
+    if (page.values.size() != samples || page.covered.size() != samples) {
+        throw std::invalid_argument(
+            "dataset page extent and sample vectors disagree");
+    }
+}
+
+void validateSessionParticleSampleResult(
+    const std::vector<ParticleSpeciesMetadata>& species,
+    const std::string& requested, const ParticleSample& sample)
+{
+    if (sample.species.name != requested) {
+        throw std::invalid_argument(
+            "particle sample describes the wrong species");
+    }
+    const auto known = std::find_if(species.begin(), species.end(),
+        [&](const auto& entry) { return entry.name == requested; });
+    if (known == species.end()) {
+        throw std::invalid_argument(
+            "particle sample describes a species the catalog does not list");
+    }
+    if (sample.species.dimension < 1 || sample.species.dimension > 3) {
+        throw std::invalid_argument(
+            "particle sample dimension is outside [1, 3]");
+    }
+    // A sample is a subset of the species, so it cannot hold more points than
+    // the catalog says exist.
+    if (sample.points.size() > known->particleCount) {
+        throw std::invalid_argument(
+            "particle sample holds more points than the species contains");
     }
 }
 

--- a/src/io/plotfile/ParticleReader.cpp
+++ b/src/io/plotfile/ParticleReader.cpp
@@ -17,7 +17,9 @@
 namespace amrvis {
 namespace {
 
-constexpr int maximumComponents = 100'000;
+// Shared with the wire decoder through the header, so both refuse the same
+// counts (see maximumParticleComponents).
+constexpr int maximumComponents = maximumParticleComponents;
 constexpr int maximumLevels = 1'000;
 constexpr int maximumGridsPerLevel = 10'000'000;
 constexpr std::uint64_t particleReadChunkBytes = 1024U * 1024U;

--- a/src/query/SliceQuery.cpp
+++ b/src/query/SliceQuery.cpp
@@ -35,10 +35,10 @@ struct LevelBlocks {
 // so the blocks of the bracketing cell centers are loaded too.
 IntBox requestIndexBox(const RealBox& region, const SliceRequest& request,
     const DatasetMetadata& metadata, const LevelMetadata& level,
-    const std::array<int, 2>& planeAxes)
+    const std::array<int, 2>& axes)
 {
     auto result = level.domain;
-    for (const auto axis : planeAxes) {
+    for (const auto axis : axes) {
         const auto i = static_cast<std::size_t>(axis);
         result.lower[i] = physicalToIndex(
             region.lower[i], metadata, level, axis);
@@ -56,22 +56,6 @@ IntBox requestIndexBox(const RealBox& region, const SliceRequest& request,
     }
     return result;
 }
-
-std::array<int, 2> planeAxes(int dimension, int normalDirection)
-{
-    if (dimension == 2) {
-        return {0, 1};
-    }
-    std::array<int, 2> axes{};
-    std::size_t next = 0;
-    for (int axis = 0; axis < 3; ++axis) {
-        if (axis != normalDirection) {
-            axes[next++] = axis;
-        }
-    }
-    return axes;
-}
-
 
 } // namespace
 

--- a/src/remote/Codec.cpp
+++ b/src/remote/Codec.cpp
@@ -595,6 +595,26 @@ OpenedDataset fromWire(const fb::DatasetOpenedT& value)
         value.metadata_metrics->payload_bytes_read};
     result.fileVersion = value.file_version;
     result.cache = fromWire(value.cache.get());
+    // Structural checks above prove the wire is well formed; this proves the
+    // catalog is a dataset. Both local readers throw on any validateMetadata
+    // issue, so every catalog a server can serve has already satisfied this --
+    // running it here makes the remote path reject exactly what a local open
+    // would, instead of publishing a session whose box ordering, containment,
+    // level numbering, or cell sizes are impossible.
+    const auto issues = validateMetadata(result.catalog);
+    if (!issues.empty()) {
+        throw std::invalid_argument("wire dataset catalog is invalid at "
+            + issues.front().path + ": " + issues.front().message);
+    }
+    for (const auto& species : result.particleSpecies) {
+        if (species.name.empty()) {
+            throw std::invalid_argument("wire particle species has no name");
+        }
+        if (species.dimension < 1 || species.dimension > 3) {
+            throw std::invalid_argument(
+                "wire particle species dimension is outside [1, 3]");
+        }
+    }
     return result;
 }
 
@@ -912,11 +932,17 @@ fb::ParticleSampleResponseT toWire(
 
 ParticleSample fromWire(const fb::ParticleSampleResponseT& value)
 {
-    if (!value.species
-        || value.positions.size() != value.ids.size() * 3) {
+    // Divide rather than multiply: ids.size() * 3 is unreachable for a vector
+    // that fits in memory, but the wire is not the place to rely on that.
+    if (!value.species || value.positions.size() % 3 != 0
+        || value.positions.size() / 3 != value.ids.size()) {
         throw std::invalid_argument(
             "wire particle sample vectors are inconsistent");
     }
+    // NaN or infinity here would reach projection and scene-coordinate
+    // arithmetic, where it silently poisons overlay geometry.
+    requireFiniteValues(value.positions,
+        "wire particle positions contain a non-finite value");
     ParticleSample result;
     result.species = {value.species->name, value.species->dimension,
         value.species->real_component_count,

--- a/src/remote/Codec.cpp
+++ b/src/remote/Codec.cpp
@@ -614,6 +614,13 @@ OpenedDataset fromWire(const fb::DatasetOpenedT& value)
             throw std::invalid_argument(
                 "wire particle species dimension is outside [1, 3]");
         }
+        if (species.realComponentCount < 0
+            || species.realComponentCount > maximumParticleComponents
+            || species.intComponentCount < 0
+            || species.intComponentCount > maximumParticleComponents) {
+            throw std::invalid_argument(
+                "wire particle species component count is outside its bounds");
+        }
     }
     return result;
 }

--- a/src/remote/RemoteDatasetSession.cpp
+++ b/src/remote/RemoteDatasetSession.cpp
@@ -1,5 +1,6 @@
 #include <amrexplorer/remote/RemoteDatasetSession.hpp>
 
+#include <amrexplorer/cache/ByteLruCache.hpp>
 #include <amrexplorer/data/SessionValidation.hpp>
 
 #include <stdexcept>
@@ -17,8 +18,12 @@ namespace {
 // to validate yet and where the server may be holding an opened dataset for a
 // session we are about to abandon.
 //
-// Two exceptions pass through untouched: RemoteError is the server answering
-// properly, with an error, and ReadCancelled is our own stop.
+// Three exceptions pass through untouched, because none of them says the peer
+// stopped speaking the protocol: RemoteError is the server answering properly
+// with an error, ReadCancelled is our own stop, and CacheBudgetExceeded is the
+// one server error code that does not arrive as a RemoteError -- Connection
+// translates it into the cache exception the pipeline and the window already
+// recover from by clearing the cache and retrying on this same session.
 template <typename Operation>
 decltype(auto) refusingInvalidResponses(
     Connection& connection, Operation&& operation)
@@ -28,6 +33,8 @@ decltype(auto) refusingInvalidResponses(
     } catch (const RemoteError&) {
         throw;
     } catch (const ReadCancelled&) {
+        throw;
+    } catch (const CacheBudgetExceeded&) {
         throw;
     } catch (...) {
         connection.close();

--- a/src/remote/RemoteDatasetSession.cpp
+++ b/src/remote/RemoteDatasetSession.cpp
@@ -7,6 +7,23 @@
 #include <variant>
 
 namespace amrvis::remote {
+namespace {
+
+// A response that cannot describe this dataset means the peer is not speaking
+// the protocol we negotiated, so the connection goes rather than just the one
+// request: leaving it open would let the next response be trusted again.
+template <typename Check>
+void refuseUnlessValid(Connection& connection, Check&& check)
+{
+    try {
+        check();
+    } catch (...) {
+        connection.close();
+        throw;
+    }
+}
+
+} // namespace
 
 std::shared_ptr<RemoteDatasetSession> RemoteDatasetSession::open(
     std::shared_ptr<Connection> connection, const std::string& path,
@@ -81,7 +98,11 @@ ViewDataResult RemoteDatasetSession::requestView(
 {
     requireOpen();
     validateSessionViewRequest(m_metadata, m_id, request);
-    return m_connection->requestView(request, cancellation);
+    auto result = m_connection->requestView(request, cancellation);
+    refuseUnlessValid(*m_connection, [&] {
+        validateSessionViewResult(m_metadata, request, result);
+    });
+    return result;
 }
 
 DatasetPage RemoteDatasetSession::requestDatasetPage(
@@ -89,7 +110,11 @@ DatasetPage RemoteDatasetSession::requestDatasetPage(
 {
     requireOpen();
     validateSessionDatasetPageRequest(m_metadata, m_id, request);
-    return m_connection->requestDatasetPage(request, cancellation);
+    auto page = m_connection->requestDatasetPage(request, cancellation);
+    refuseUnlessValid(*m_connection, [&] {
+        validateSessionDatasetPageResult(m_metadata, request, page);
+    });
+    return page;
 }
 
 std::optional<ValueRange> RemoteDatasetSession::requestRange(
@@ -138,8 +163,13 @@ ParticleSample RemoteDatasetSession::requestParticleSample(
     requireOpen();
     validateSessionParticleRequest(
         m_metadata, m_particleSpecies, species, fraction);
-    return m_connection->requestParticleSample(
+    auto sample = m_connection->requestParticleSample(
         m_id, species, fraction, seed, cancellation);
+    refuseUnlessValid(*m_connection, [&] {
+        validateSessionParticleSampleResult(
+            m_particleSpecies, species, sample);
+    });
+    return sample;
 }
 
 CacheMetrics RemoteDatasetSession::cacheMetrics() const

--- a/src/remote/RemoteDatasetSession.cpp
+++ b/src/remote/RemoteDatasetSession.cpp
@@ -9,14 +9,26 @@
 namespace amrvis::remote {
 namespace {
 
-// A response that cannot describe this dataset means the peer is not speaking
-// the protocol we negotiated, so the connection goes rather than just the one
-// request: leaving it open would let the next response be trusted again.
-template <typename Check>
-void refuseUnlessValid(Connection& connection, Check&& check)
+// One policy over everything a response can fail at: the transport and the
+// decode inside the connection, and the contextual validation after it. A peer
+// that cannot answer in the protocol we negotiated is not one whose next answer
+// should be trusted, so the connection goes rather than just the request -- and
+// that has to include a failure raised while decoding, where there is no result
+// to validate yet and where the server may be holding an opened dataset for a
+// session we are about to abandon.
+//
+// Two exceptions pass through untouched: RemoteError is the server answering
+// properly, with an error, and ReadCancelled is our own stop.
+template <typename Operation>
+decltype(auto) refusingInvalidResponses(
+    Connection& connection, Operation&& operation)
 {
     try {
-        check();
+        return operation();
+    } catch (const RemoteError&) {
+        throw;
+    } catch (const ReadCancelled&) {
+        throw;
     } catch (...) {
         connection.close();
         throw;
@@ -33,8 +45,11 @@ std::shared_ptr<RemoteDatasetSession> RemoteDatasetSession::open(
         throw std::invalid_argument(
             "remote dataset requires a connection");
     }
-    auto opened
-        = connection->openDataset(path, cacheBudgetBytes, cancellation);
+    // The catalog is validated while it is decoded, so an impossible one throws
+    // in here rather than at a later call.
+    auto opened = refusingInvalidResponses(*connection, [&] {
+        return connection->openDataset(path, cacheBudgetBytes, cancellation);
+    });
     return std::shared_ptr<RemoteDatasetSession>(
         new RemoteDatasetSession(
             std::move(connection), path, std::move(opened)));
@@ -98,11 +113,11 @@ ViewDataResult RemoteDatasetSession::requestView(
 {
     requireOpen();
     validateSessionViewRequest(m_metadata, m_id, request);
-    auto result = m_connection->requestView(request, cancellation);
-    refuseUnlessValid(*m_connection, [&] {
+    return refusingInvalidResponses(*m_connection, [&] {
+        auto result = m_connection->requestView(request, cancellation);
         validateSessionViewResult(m_metadata, request, result);
+        return result;
     });
-    return result;
 }
 
 DatasetPage RemoteDatasetSession::requestDatasetPage(
@@ -110,11 +125,11 @@ DatasetPage RemoteDatasetSession::requestDatasetPage(
 {
     requireOpen();
     validateSessionDatasetPageRequest(m_metadata, m_id, request);
-    auto page = m_connection->requestDatasetPage(request, cancellation);
-    refuseUnlessValid(*m_connection, [&] {
+    return refusingInvalidResponses(*m_connection, [&] {
+        auto page = m_connection->requestDatasetPage(request, cancellation);
         validateSessionDatasetPageResult(m_metadata, request, page);
+        return page;
     });
-    return page;
 }
 
 std::optional<ValueRange> RemoteDatasetSession::requestRange(
@@ -122,7 +137,9 @@ std::optional<ValueRange> RemoteDatasetSession::requestRange(
 {
     requireOpen();
     validateSessionRangeRequest(m_metadata, request);
-    return m_connection->requestRange(m_id, request, cancellation);
+    return refusingInvalidResponses(*m_connection, [&] {
+        return m_connection->requestRange(m_id, request, cancellation);
+    });
 }
 
 bool RemoteDatasetSession::rangeAvailable(
@@ -163,13 +180,13 @@ ParticleSample RemoteDatasetSession::requestParticleSample(
     requireOpen();
     validateSessionParticleRequest(
         m_metadata, m_particleSpecies, species, fraction);
-    auto sample = m_connection->requestParticleSample(
-        m_id, species, fraction, seed, cancellation);
-    refuseUnlessValid(*m_connection, [&] {
+    return refusingInvalidResponses(*m_connection, [&] {
+        auto sample = m_connection->requestParticleSample(
+            m_id, species, fraction, seed, cancellation);
         validateSessionParticleSampleResult(
             m_particleSpecies, species, sample);
+        return sample;
     });
-    return sample;
 }
 
 CacheMetrics RemoteDatasetSession::cacheMetrics() const
@@ -181,13 +198,17 @@ CacheMetrics RemoteDatasetSession::cacheMetrics() const
 bool RemoteDatasetSession::setCacheBudget(std::uint64_t bytes)
 {
     requireOpen();
-    return m_connection->setCacheBudget(m_id, bytes).withinBudget();
+    return refusingInvalidResponses(*m_connection, [&] {
+        return m_connection->setCacheBudget(m_id, bytes).withinBudget();
+    });
 }
 
 void RemoteDatasetSession::clearUnpinnedCache()
 {
     requireOpen();
-    static_cast<void>(m_connection->clearCache(m_id));
+    refusingInvalidResponses(*m_connection, [&] {
+        static_cast<void>(m_connection->clearCache(m_id));
+    });
 }
 
 void RemoteDatasetSession::close() noexcept

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,6 +10,12 @@ add_executable(test_view_data unit/test_view_data.cpp)
 target_link_libraries(test_view_data PRIVATE amrexplorer::data amrexplorer::warnings)
 add_test(NAME view_data COMMAND test_view_data)
 
+add_executable(test_session_validation unit/test_session_validation.cpp)
+target_link_libraries(
+    test_session_validation PRIVATE amrexplorer::data amrexplorer::warnings
+)
+add_test(NAME session_validation COMMAND test_session_validation)
+
 add_executable(test_stop_token unit/test_stop_token.cpp)
 target_compile_definitions(
     test_stop_token PRIVATE AMREXPLORER_TEST_FORCE_FALLBACK_STOP_TOKEN

--- a/tests/integration/test_remote_connection.cpp
+++ b/tests/integration/test_remote_connection.cpp
@@ -1,5 +1,6 @@
 #include "../../src/remote/Codec.hpp"
 
+#include <amrexplorer/cache/ByteLruCache.hpp>
 #include <amrexplorer/data/ViewData.hpp>
 #include <amrexplorer/remote/Connection.hpp>
 #include <amrexplorer/remote/RemoteDatasetSession.hpp>
@@ -559,6 +560,55 @@ int main(int argc, char* argv[])
         "the connection survived a slice with impossible provenance");
     badSliceConnection->close();
     badSlicePeer.get();
+
+    // The other side of that policy: a cache-budget refusal is the server
+    // answering properly, and the client's recovery clears the cache and retries
+    // on this same session, so the connection has to survive it. It is the one
+    // server error code Connection does not raise as a RemoteError.
+    auto budgetListener = listenOnLoopback(0);
+    auto budgetPeer = std::async(std::launch::async, [&] {
+        auto peer = acceptConnection(budgetListener.socket);
+        static_cast<void>(acceptHello(peer));
+        const auto openFrame = readFrame(peer, defaultMaximumFrameBytes);
+        require(openFrame.has_value(), "client omitted the open request");
+        const auto openRequest = codec::decode(*openFrame);
+        writeFrame(peer,
+            codec::encode(openRequest->request_id,
+                codec::toWire(plausibleCatalog())),
+            defaultMaximumFrameBytes);
+        const auto sliceFrame = readFrame(peer, defaultMaximumFrameBytes);
+        require(sliceFrame.has_value(), "client omitted the slice request");
+        const auto sliceEnvelope = codec::decode(*sliceFrame);
+        writeFrame(peer,
+            codec::encode(sliceEnvelope->request_id,
+                codec::toWire(ErrorData{ErrorCode::CacheBudgetExceeded,
+                    "cache budget exceeded"})),
+            defaultMaximumFrameBytes);
+        static_cast<void>(readFrame(peer, defaultMaximumFrameBytes));
+    });
+    auto budgetConnection = std::make_shared<Connection>(
+        "127.0.0.1", budgetListener.port);
+    auto budgetDataset = RemoteDatasetSession::open(
+        budgetConnection, "/remote/plt", 16ULL * 1024ULL * 1024ULL);
+    amrvis::SliceRequest budgetSlice;
+    budgetSlice.dataset = budgetDataset->id();
+    budgetSlice.field = amrvis::FieldId{0};
+    budgetSlice.normalDirection = 1;
+    budgetSlice.visibleRegion = budgetDataset->metadata().physicalDomain;
+    budgetSlice.physicalPosition = 0.5;
+    budgetSlice.maximumLevel = 0;
+    budgetSlice.outputSize = {2, 2};
+    bool budgetReported = false;
+    try {
+        static_cast<void>(budgetDataset->requestView(budgetSlice));
+    } catch (const amrvis::CacheBudgetExceeded&) {
+        budgetReported = true;
+    }
+    require(budgetReported, "a cache-budget refusal did not reach the caller");
+    require(budgetConnection->connected(),
+        "a cache-budget refusal retired the connection");
+    budgetConnection->close();
+    budgetPeer.get();
     return 0;
 }
 #include <chrono>

--- a/tests/integration/test_remote_connection.cpp
+++ b/tests/integration/test_remote_connection.cpp
@@ -2,10 +2,12 @@
 
 #include <amrexplorer/data/ViewData.hpp>
 #include <amrexplorer/remote/Connection.hpp>
+#include <amrexplorer/remote/RemoteDatasetSession.hpp>
 #include <amrexplorer/remote/Server.hpp>
 
 #include <cstdlib>
 #include <exception>
+#include <memory>
 #include <filesystem>
 #include <future>
 #include <iostream>
@@ -93,6 +95,29 @@ std::uint64_t acceptHello(amrvis::remote::Socket& peer,
                          codec::toWire(hello), selectedMinorVersion),
         defaultMaximumFrameBytes);
     return request->request_id;
+}
+
+amrvis::remote::OpenedDataset plausibleCatalog()
+{
+    using namespace amrvis;
+    using amrvis::remote::OpenedDataset;
+    OpenedDataset opened;
+    opened.id = DatasetId{3};
+    opened.catalog.dimension = 2;
+    opened.catalog.finestLevel = 0;
+    opened.catalog.hasPhysicalGeometry = true;
+    opened.catalog.physicalDomain = RealBox{
+        Real3{{0.0, 0.0, 0.0}}, Real3{{1.0, 1.0, 1.0}}};
+    opened.catalog.fields.push_back({"density", Centering::Cell, {}});
+    LevelMetadata level;
+    level.level = 0;
+    level.domain = IntBox{
+        Int3{{0, 0, 0}}, Int3{{3, 3, 0}}, Int3{{0, 0, 0}}};
+    level.boxes.push_back(level.domain);
+    opened.catalog.levels.push_back(level);
+    opened.fileRangeAvailable = {1};
+    opened.levelRangeAvailable = {1};
+    return opened;
 }
 
 bool throwsWithin(std::future<void>& operation,
@@ -435,6 +460,105 @@ int main(int argc, char* argv[])
     require(throwsWithin(timedRequest, 1s),
         "silent request did not honor the request deadline");
     requestTimeoutPeer.get();
+
+    // A peer whose catalog cannot describe a dataset fails while the response is
+    // being decoded, before there is any result to validate. The connection must
+    // still be retired: it is also holding a server-side dataset handle for a
+    // session that is about to be abandoned.
+    auto badCatalogListener = listenOnLoopback(0);
+    auto badCatalogPeer = std::async(std::launch::async, [&] {
+        auto peer = acceptConnection(badCatalogListener.socket);
+        static_cast<void>(acceptHello(peer));
+        const auto frame = readFrame(peer, defaultMaximumFrameBytes);
+        require(frame.has_value(), "client omitted the open request");
+        const auto opening = codec::decode(*frame);
+        require(codec::inspect(*opening).payload
+                == PayloadKind::OpenDatasetRequest,
+            "client did not open a dataset first");
+        auto wire = codec::toWire(plausibleCatalog());
+        // Structurally valid, and impossible: the box leaves its domain.
+        wire.levels.front()->boxes.front()->upper
+            = codec::toWire(amrvis::Int3{{99, 3, 0}});
+        writeFrame(peer, codec::encode(opening->request_id, std::move(wire)),
+            defaultMaximumFrameBytes);
+        // Hold this end open so that a closed connection can only be the
+        // client's own doing, then drain until it goes.
+        static_cast<void>(readFrame(peer, defaultMaximumFrameBytes));
+    });
+    auto badCatalogConnection = std::make_shared<Connection>(
+        "127.0.0.1", badCatalogListener.port);
+    bool catalogRefused = false;
+    try {
+        static_cast<void>(RemoteDatasetSession::open(
+            badCatalogConnection, "/remote/plt", 16ULL * 1024ULL * 1024ULL));
+    } catch (const std::exception&) {
+        catalogRefused = true;
+    }
+    require(catalogRefused, "an impossible catalog was accepted");
+    require(!badCatalogConnection->connected(),
+        "the connection survived an impossible catalog");
+    badCatalogConnection->close();
+    badCatalogPeer.get();
+
+    // The same policy for a failure found after decoding: a slice whose
+    // provenance the catalog has no room for.
+    auto badSliceListener = listenOnLoopback(0);
+    auto badSlicePeer = std::async(std::launch::async, [&] {
+        auto peer = acceptConnection(badSliceListener.socket);
+        static_cast<void>(acceptHello(peer));
+        const auto openFrame = readFrame(peer, defaultMaximumFrameBytes);
+        require(openFrame.has_value(), "client omitted the open request");
+        const auto openRequest = codec::decode(*openFrame);
+        writeFrame(peer,
+            codec::encode(openRequest->request_id,
+                codec::toWire(plausibleCatalog())),
+            defaultMaximumFrameBytes);
+        const auto sliceFrame = readFrame(peer, defaultMaximumFrameBytes);
+        require(sliceFrame.has_value(), "client omitted the slice request");
+        const auto sliceEnvelope = codec::decode(*sliceFrame);
+        const auto* asked = sliceEnvelope->payload.AsSliceViewRequest();
+        require(asked != nullptr, "client did not request a slice");
+        amrvis::SliceQueryResult answer;
+        answer.plane.width = asked->width;
+        answer.plane.height = asked->height;
+        answer.plane.physicalRegion = codec::fromWire(
+            asked->visible_region.get());
+        const auto samples = static_cast<std::size_t>(asked->width)
+            * static_cast<std::size_t>(asked->height);
+        answer.plane.values.assign(samples, 1.0F);
+        answer.plane.valid.assign(samples, 1);
+        // The catalog has one level; this sample claims a fourth.
+        answer.plane.sourceLevel.assign(samples, 3);
+        writeFrame(peer,
+            codec::encode(sliceEnvelope->request_id,
+                codec::toWire(answer, amrvis::CacheMetrics{})),
+            defaultMaximumFrameBytes);
+        static_cast<void>(readFrame(peer, defaultMaximumFrameBytes));
+    });
+    auto badSliceConnection = std::make_shared<Connection>(
+        "127.0.0.1", badSliceListener.port);
+    auto badSliceDataset = RemoteDatasetSession::open(
+        badSliceConnection, "/remote/plt", 16ULL * 1024ULL * 1024ULL);
+    amrvis::SliceRequest impossibleProvenance;
+    impossibleProvenance.dataset = badSliceDataset->id();
+    impossibleProvenance.field = amrvis::FieldId{0};
+    impossibleProvenance.normalDirection = 1;
+    impossibleProvenance.visibleRegion
+        = badSliceDataset->metadata().physicalDomain;
+    impossibleProvenance.physicalPosition = 0.5;
+    impossibleProvenance.maximumLevel = 0;
+    impossibleProvenance.outputSize = {2, 2};
+    bool sliceRefused = false;
+    try {
+        static_cast<void>(badSliceDataset->requestView(impossibleProvenance));
+    } catch (const std::exception&) {
+        sliceRefused = true;
+    }
+    require(sliceRefused, "a slice with impossible provenance was accepted");
+    require(!badSliceConnection->connected(),
+        "the connection survived a slice with impossible provenance");
+    badSliceConnection->close();
+    badSlicePeer.get();
     return 0;
 }
 #include <chrono>

--- a/tests/integration/test_remote_server.cpp
+++ b/tests/integration/test_remote_server.cpp
@@ -287,6 +287,37 @@ int main(int argc, char* argv[])
                 == ErrorCode::InvalidRequest,
         "server did not reject a reversed dataset-page region");
 
+    // The server owns its own trust boundary: a client that skips the
+    // client-side check must still be refused. Only the line axis of a region is
+    // meaningful, so this reverses exactly that axis.
+    LineViewRequest reversedLine;
+    reversedLine.query.dataset = opened.id;
+    reversedLine.query.field = FieldId{0};
+    reversedLine.query.axis = 0;
+    reversedLine.query.fixedCoordinates = {0.0, 0.5, 0.0};
+    reversedLine.query.maximumLevel = opened.catalog.finestLevel;
+    reversedLine.query.region = opened.catalog.physicalDomain;
+    std::swap(reversedLine.query.region->lower[0],
+        reversedLine.query.region->upper[0]);
+    reversedLine.outputWidth = 8;
+    envelope = exchange(socket, 11, codec::toWire(reversedLine),
+        hello.maximumFrameBytes);
+    require(codec::inspect(*envelope).payload == PayloadKind::ErrorResponse
+            && codec::fromWire(*envelope->payload.AsErrorResponse()).code
+                == ErrorCode::InvalidRequest,
+        "server did not reject a reversed line region");
+
+    // A region degenerate off the line axis is legitimate: a line plot along x
+    // fixes y and z.
+    LineViewRequest flatLine = reversedLine;
+    flatLine.query.region = opened.catalog.physicalDomain;
+    flatLine.query.region->lower[1] = flatLine.query.region->upper[1];
+    envelope = exchange(socket, 12, codec::toWire(flatLine),
+        hello.maximumFrameBytes);
+    require(codec::inspect(*envelope).payload
+            == PayloadKind::LineViewResponse,
+        "server rejected a line region degenerate off its axis");
+
     envelope = exchange(socket, 8,
         codec::toWire(opened.id, "Oversized", 1.0, 0),
         hello.maximumFrameBytes);

--- a/tests/unit/test_remote_codec.cpp
+++ b/tests/unit/test_remote_codec.cpp
@@ -342,6 +342,32 @@ int main()
     requireRejected([&] { static_cast<void>(codec::fromWire(badSpecies)); },
         "a particle species with an impossible dimension was accepted");
 
+    // The local parser refuses component counts outside [0, 100000]; so must the
+    // wire, or a species that cannot exist reaches the client.
+    for (const int realCount : {-1, maximumParticleComponents + 1}) {
+        auto badComponents = codec::toWire(opened);
+        badComponents.particle_species.push_back(
+            std::make_unique<codec::fb::ParticleSpeciesCatalogT>());
+        badComponents.particle_species.back()->name = "electrons";
+        badComponents.particle_species.back()->dimension = 3;
+        badComponents.particle_species.back()->real_component_count
+            = realCount;
+        requireRejected(
+            [&] { static_cast<void>(codec::fromWire(badComponents)); },
+            "an out-of-range real component count was accepted");
+    }
+    for (const int intCount : {-2, maximumParticleComponents + 1}) {
+        auto badComponents = codec::toWire(opened);
+        badComponents.particle_species.push_back(
+            std::make_unique<codec::fb::ParticleSpeciesCatalogT>());
+        badComponents.particle_species.back()->name = "electrons";
+        badComponents.particle_species.back()->dimension = 3;
+        badComponents.particle_species.back()->int_component_count = intCount;
+        requireRejected(
+            [&] { static_cast<void>(codec::fromWire(badComponents)); },
+            "an out-of-range integer component count was accepted");
+    }
+
     ParticleSample sample;
     sample.species = {"electrons", 3, 0, 0, 4, ParticleRealPrecision::Double};
     sample.points.push_back({1, Real3{{0.25, 0.5, 0.75}}});

--- a/tests/unit/test_remote_codec.cpp
+++ b/tests/unit/test_remote_codec.cpp
@@ -4,6 +4,7 @@
 #include <cstdlib>
 #include <iostream>
 #include <limits>
+#include <memory>
 #include <span>
 #include <stdexcept>
 #include <vector>
@@ -143,9 +144,12 @@ int main()
     LevelMetadata level;
     level.level = 0;
     level.domain = IntBox{
-        Int3{{0, 0, 0}}, Int3{{3, 3, 3}}, Int3{{0, 0, 0}}};
+        Int3{{0, 0, 0}}, Int3{{3, 3, 3}}, Int3{{1, 0, 0}}};
     level.boxes.push_back(
         IntBox{Int3{{0, 0, 0}}, Int3{{1, 3, 3}}, Int3{{1, 0, 0}}});
+    // A one-cell box: an IntBox is allowed equal corners, unlike a RealBox.
+    level.boxes.push_back(
+        IntBox{Int3{{2, 2, 2}}, Int3{{2, 2, 2}}, Int3{{1, 0, 0}}});
     opened.catalog.levels.push_back(level);
     bytes = codec::encode(8, codec::toWire(opened));
     envelope = codec::decode(bytes);
@@ -270,5 +274,90 @@ int main()
     nonFinite.values = {0.0, std::numeric_limits<double>::quiet_NaN(), 1.0};
     requireRejected([&] { static_cast<void>(codec::fromWire(&nonFinite)); },
         "non-finite geometry was accepted");
+
+    // The decoded catalog must prove what a local reader proves. Each of these
+    // is structurally valid wire that no local open would have produced.
+    openedWire = codec::toWire(opened);
+    openedWire.levels.front()->boxes.front()->centering
+        = codec::toWire(Int3{{0, 0, 0}});
+    requireRejected([&] { static_cast<void>(codec::fromWire(openedWire)); },
+        "a level box disagreeing with its domain centering was accepted");
+
+    openedWire = codec::toWire(opened);
+    openedWire.levels.front()->boxes.front()->upper
+        = codec::toWire(Int3{{9, 3, 3}});
+    requireRejected([&] { static_cast<void>(codec::fromWire(openedWire)); },
+        "a level box outside the level domain was accepted");
+
+    openedWire = codec::toWire(opened);
+    openedWire.levels.front()->boxes.front()->lower
+        = codec::toWire(Int3{{2, 0, 0}});
+    openedWire.levels.front()->boxes.front()->upper
+        = codec::toWire(Int3{{1, 3, 3}});
+    requireRejected([&] { static_cast<void>(codec::fromWire(openedWire)); },
+        "a reversed 3-D level box was accepted");
+
+    openedWire = codec::toWire(opened);
+    openedWire.levels.front()->cell_size = codec::toWire(Real3{{0.0, 1.0, 1.0}});
+    requireRejected([&] { static_cast<void>(codec::fromWire(openedWire)); },
+        "a zero cell size was accepted");
+
+    openedWire = codec::toWire(opened);
+    openedWire.levels.front()->level = 3;
+    requireRejected([&] { static_cast<void>(codec::fromWire(openedWire)); },
+        "a level numbered other than its index was accepted");
+
+    openedWire = codec::toWire(opened);
+    openedWire.physical_domain = codec::toWire(
+        RealBox{Real3{{1.0, 0.0, 0.0}}, Real3{{0.0, 1.0, 1.0}}});
+    requireRejected([&] { static_cast<void>(codec::fromWire(openedWire)); },
+        "a reversed physical domain was accepted");
+
+    // A 2-D catalog is free to be degenerate on the inactive third axis, and a
+    // reversed box there must stay acceptable: only active axes carry meaning.
+    OpenedDataset flat;
+    flat.id = DatasetId{4};
+    flat.catalog.dimension = 2;
+    flat.catalog.finestLevel = 0;
+    flat.catalog.physicalDomain = RealBox{
+        Real3{{0.0, 0.0, 1.0}}, Real3{{1.0, 1.0, 0.0}}};
+    LevelMetadata flatLevel;
+    flatLevel.level = 0;
+    flatLevel.domain = IntBox{
+        Int3{{0, 0, 7}}, Int3{{3, 3, 2}}, Int3{{0, 0, 0}}};
+    flatLevel.boxes.push_back(flatLevel.domain);
+    flat.catalog.levels.push_back(flatLevel);
+    const auto flatDecoded = codec::fromWire(codec::toWire(flat));
+    require(flatDecoded.catalog.levels.size() == 1
+            && flatDecoded.catalog.levels.front().boxes.front()
+                == flatLevel.domain,
+        "a 2-D catalog with a degenerate inactive axis was rejected");
+
+    // A named species with a dimension outside [1, 3] cannot describe points.
+    auto badSpecies = codec::toWire(opened);
+    badSpecies.particle_species.push_back(
+        std::make_unique<codec::fb::ParticleSpeciesCatalogT>());
+    badSpecies.particle_species.back()->name = "electrons";
+    badSpecies.particle_species.back()->dimension = 4;
+    requireRejected([&] { static_cast<void>(codec::fromWire(badSpecies)); },
+        "a particle species with an impossible dimension was accepted");
+
+    ParticleSample sample;
+    sample.species = {"electrons", 3, 0, 0, 4, ParticleRealPrecision::Double};
+    sample.points.push_back({1, Real3{{0.25, 0.5, 0.75}}});
+    auto particleWire = codec::toWire(sample, CacheMetrics{});
+    const auto particleDecoded = codec::fromWire(particleWire);
+    require(particleDecoded.points.size() == 1
+            && particleDecoded.points.front().position
+                == sample.points.front().position,
+        "a particle sample did not round-trip");
+    particleWire = codec::toWire(sample, CacheMetrics{});
+    particleWire.positions[1] = std::numeric_limits<double>::quiet_NaN();
+    requireRejected([&] { static_cast<void>(codec::fromWire(particleWire)); },
+        "a non-finite particle position was accepted");
+    particleWire = codec::toWire(sample, CacheMetrics{});
+    particleWire.positions[2] = std::numeric_limits<double>::infinity();
+    requireRejected([&] { static_cast<void>(codec::fromWire(particleWire)); },
+        "an infinite particle position was accepted");
     return 0;
 }

--- a/tests/unit/test_session_validation.cpp
+++ b/tests/unit/test_session_validation.cpp
@@ -30,6 +30,21 @@ void requireRejected(Function&& function, const char* message)
 }
 
 template <typename Function>
+void requireRejectedWith(
+    Function&& function, const char* needle, const char* message)
+{
+    try {
+        function();
+    } catch (const std::exception& error) {
+        if (std::string(error.what()).find(needle) != std::string::npos) {
+            return;
+        }
+        std::cerr << "rejected for the wrong reason: " << error.what() << '\n';
+    }
+    require(false, message);
+}
+
+template <typename Function>
 void requireAccepted(Function&& function, const char* message)
 {
     try {
@@ -514,6 +529,32 @@ int main()
         requireAccepted([&] {
             validateSessionViewResult(metadata, view, repeated);
         }, "a repeated line position was refused");
+
+        // An index arrives as an int widened to a double. A fractional one is
+        // not an index, and one outside int's range cannot even be converted
+        // back -- doing so is undefined, so it has to be refused before the
+        // cast rather than after it (UBSan proves this pair).
+        auto fractional = indexed;
+        fractional.line.positions = {0.0, 1.5};
+        requireRejectedWith([&] {
+            validateSessionViewResult(metadata, view, fractional);
+        }, "not an index", "a fractional index position was accepted");
+
+        // The reason matters here: the guard has to refuse these *before* the
+        // conversion, and an out-of-range index that survived the cast would be
+        // rejected further down for lying outside the extent, which would look
+        // like a pass while the undefined conversion had already happened.
+        for (const double extreme : {1.0e100, -1.0e100}) {
+            auto beyondInt = indexed;
+            beyondInt.line.positions = {extreme};
+            beyondInt.line.values = {1.0F};
+            beyondInt.line.valid = {1};
+            beyondInt.line.sourceLevel = {0};
+            requireRejectedWith([&] {
+                validateSessionViewResult(metadata, view, beyondInt);
+            }, "not an index",
+                "an index position outside int's range was accepted");
+        }
     }
 
     // Dataset page results.

--- a/tests/unit/test_session_validation.cpp
+++ b/tests/unit/test_session_validation.cpp
@@ -1,8 +1,10 @@
 #include <amrexplorer/core/Metadata.hpp>
 #include <amrexplorer/data/SessionValidation.hpp>
 
+#include <cmath>
 #include <cstdlib>
 #include <iostream>
+#include <limits>
 #include <string>
 #include <vector>
 
@@ -222,25 +224,41 @@ int main()
         }, "a 3-D page region degenerate on its normal axis was rejected");
     }
 
-    // Slice results: provenance and plane extent against the catalog.
+    // Slice results: tied to the request that was made, and to the catalog.
     for (const int dimension : {2, 3}) {
         const auto metadata = dataset(dimension);
         const auto request = sliceRequest(dimension);
         const ViewDataRequest view = request;
-        auto region = request.visibleRegion;
-        if (dimension == 3) {
-            // The normal axis of a slice region is degenerate by construction.
-            region.upper[2] = region.lower[2];
-        }
+        // A slice too large for one frame is refused rather than reduced, and
+        // the query copies the requested region, so a real answer carries both
+        // verbatim.
+        const auto region = request.visibleRegion;
         requireAccepted([&] {
             validateSessionViewResult(metadata, view, sliceResult(region));
         }, "a valid slice result was rejected");
+
+        auto elsewhere = region;
+        elsewhere.lower[0] += 0.25;
+        elsewhere.upper[0] += 0.25;
+        requireRejected([&] {
+            validateSessionViewResult(metadata, view, sliceResult(elsewhere));
+        }, "a slice result over another region was accepted");
 
         auto reversed = region;
         reversed.upper[0] = reversed.lower[0] - 1.0;
         requireRejected([&] {
             validateSessionViewResult(metadata, view, sliceResult(reversed));
         }, "a slice result with a reversed plane region was accepted");
+
+        auto reshaped = sliceResult(region);
+        reshaped.plane.width = 3;
+        reshaped.plane.height = 1;
+        reshaped.plane.values = {1.0F, 2.0F, 3.0F};
+        reshaped.plane.valid = {1, 1, 1};
+        reshaped.plane.sourceLevel = {0, 0, 0};
+        requireRejected([&] {
+            validateSessionViewResult(metadata, view, reshaped);
+        }, "a slice raster of another shape was accepted");
 
         auto beyond = sliceResult(region);
         beyond.plane.sourceLevel = {0, 1, 2, 0};
@@ -253,6 +271,22 @@ int main()
         requireRejected([&] {
             validateSessionViewResult(metadata, view, sentinel);
         }, "a slice source level below the no-data sentinel was accepted");
+
+        // Provenance the dataset has but the request excluded: asking for level
+        // 0 and being answered from level 1 is not the requested composition.
+        auto coarse = request;
+        coarse.maximumLevel = 0;
+        const ViewDataRequest coarseView = coarse;
+        auto finer = sliceResult(region);
+        finer.plane.sourceLevel = {0, 1, 0, 0};
+        requireRejected([&] {
+            validateSessionViewResult(metadata, coarseView, finer);
+        }, "a slice source level above the requested maximum was accepted");
+        auto atMaximum = sliceResult(region);
+        atMaximum.plane.sourceLevel = {0, 0, -1, 0};
+        requireAccepted([&] {
+            validateSessionViewResult(metadata, coarseView, atMaximum);
+        }, "a slice at the requested maximum level was rejected");
 
         auto ragged = sliceResult(region);
         ragged.plane.values.pop_back();
@@ -277,6 +311,19 @@ int main()
         requireRejected([&] {
             validateSessionViewResult(metadata, view, grid);
         }, "a grid box with a reversed region was accepted");
+
+        // A grid box may keep its own extent on the normal axis: only the plane
+        // axes are clipped to the visible region.
+        if (dimension == 3) {
+            auto normalExtent = sliceResult(region);
+            auto box = region;
+            box.lower[2] -= 1.0;
+            box.upper[2] += 1.0;
+            normalExtent.gridBoxes.push_back({1, box});
+            requireAccepted([&] {
+                validateSessionViewResult(metadata, view, normalExtent);
+            }, "a grid box with its own normal-axis extent was rejected");
+        }
 
         // A line answer to a slice request is not an answer at all.
         requireRejected([&] {
@@ -307,6 +354,25 @@ int main()
         requireRejected([&] {
             validateSessionViewResult(metadata, view, ragged);
         }, "a line result with a short validity vector was accepted");
+
+        // boundLineToViewport allows at most two samples per output pixel.
+        auto narrow = lineRequest(3, 1);
+        narrow.outputWidth = 1;
+        const ViewDataRequest narrowView = narrow;
+        requireAccepted([&] {
+            validateSessionViewResult(metadata, narrowView, lineResult(1));
+        }, "a line at exactly two samples per pixel was rejected");
+
+        auto dense = lineResult(1);
+        for (int index = 0; index < 8; ++index) {
+            dense.line.positions.push_back(0.1 * index);
+            dense.line.values.push_back(1.0F);
+            dense.line.valid.push_back(1);
+            dense.line.sourceLevel.push_back(0);
+        }
+        requireRejected([&] {
+            validateSessionViewResult(metadata, narrowView, dense);
+        }, "a line denser than its viewport allows was accepted");
     }
 
     // Dataset page results.
@@ -343,6 +409,54 @@ int main()
         requireRejected([&] {
             validateSessionDatasetPageResult(metadata, request, ragged);
         }, "a page with a short coverage vector was accepted");
+
+        auto lopsided = page(4, 4);
+        lopsided.ny = 0;
+        lopsided.values.clear();
+        lopsided.covered.clear();
+        requireRejected([&] {
+            validateSessionDatasetPageResult(metadata, request, lopsided);
+        }, "a page empty on one axis only was accepted");
+
+        // The page indexes the level it named: 1000..1003 is not inside 0..3.
+        auto outside = page(4, 4);
+        outside.lower[0] = 1000;
+        outside.upper[0] = 1003;
+        requireRejected([&] {
+            validateSessionDatasetPageResult(metadata, request, outside);
+        }, "a page outside the level domain was accepted");
+
+        // Extreme bounds come straight off the wire; the span arithmetic must
+        // not overflow while rejecting them (UBSan proves this one).
+        auto extreme = page(4, 4);
+        extreme.lower[0] = std::numeric_limits<int>::min();
+        extreme.upper[0] = std::numeric_limits<int>::max();
+        requireRejected([&] {
+            validateSessionDatasetPageResult(metadata, request, extreme);
+        }, "a page spanning the whole int range was accepted");
+        extreme = page(4, 4);
+        extreme.lower[1] = std::numeric_limits<int>::max();
+        extreme.upper[1] = std::numeric_limits<int>::min();
+        requireRejected([&] {
+            validateSessionDatasetPageResult(metadata, request, extreme);
+        }, "a page with maximally reversed bounds was accepted");
+    }
+
+    // A 3-D page also names a slice index, which has to be in the level domain.
+    {
+        const auto metadata = dataset(3);
+        const auto request = pageRequest(3);
+        auto valid = page(4, 4);
+        valid.sliceIndex = 2;
+        requireAccepted([&] {
+            validateSessionDatasetPageResult(metadata, request, valid);
+        }, "a page with an in-domain slice index was rejected");
+
+        auto beyond = page(4, 4);
+        beyond.sliceIndex = 99;
+        requireRejected([&] {
+            validateSessionDatasetPageResult(metadata, request, beyond);
+        }, "a page with a slice index outside the level domain was accepted");
     }
 
     // Particle samples against the catalog they claim to sample.
@@ -374,6 +488,36 @@ int main()
             validateSessionParticleSampleResult(
                 species, "electrons", flattened);
         }, "a sample with an impossible dimension was accepted");
+
+        // A shape that contradicts the catalog entry, in each field that could
+        // be reported back to the user as the species' own.
+        auto reshaped = sample;
+        reshaped.species.dimension = 2;
+        requireRejected([&] {
+            validateSessionParticleSampleResult(
+                species, "electrons", reshaped);
+        }, "a sample of another dimension than the catalog was accepted");
+
+        reshaped = sample;
+        reshaped.species.precision = ParticleRealPrecision::Single;
+        requireRejected([&] {
+            validateSessionParticleSampleResult(
+                species, "electrons", reshaped);
+        }, "a sample of another precision than the catalog was accepted");
+
+        reshaped = sample;
+        reshaped.species.realComponentCount = 7;
+        requireRejected([&] {
+            validateSessionParticleSampleResult(
+                species, "electrons", reshaped);
+        }, "a sample with another component count was accepted");
+
+        reshaped = sample;
+        reshaped.species.particleCount = 1000;
+        requireRejected([&] {
+            validateSessionParticleSampleResult(
+                species, "electrons", reshaped);
+        }, "a sample inflating the species particle count was accepted");
 
         auto overfull = sample;
         overfull.points.push_back({2, Real3{{0.25, 0.25, 0.25}}});

--- a/tests/unit/test_session_validation.cpp
+++ b/tests/unit/test_session_validation.cpp
@@ -56,6 +56,8 @@ amrvis::DatasetMetadata dataset(int dimension)
         entry.level = level;
         entry.domain = amrvis::IntBox{amrvis::Int3{{0, 0, 0}},
             amrvis::Int3{{3, 3, 3}}, amrvis::Int3{{0, 0, 0}}};
+        // One box covering the level, so a grid overlay has something to be.
+        entry.boxes.push_back(entry.domain);
         metadata.levels.push_back(entry);
     }
     return metadata;
@@ -76,9 +78,11 @@ amrvis::SliceRequest sliceRequest(int dimension)
     return request;
 }
 
-amrvis::SliceQueryResult sliceResult(const amrvis::RealBox& region)
+amrvis::SliceQueryResult sliceResult(
+    const amrvis::RealBox& region, bool gridBoxesIncluded = true)
 {
     amrvis::SliceQueryResult result;
+    result.gridBoxesIncluded = gridBoxesIncluded;
     result.plane.width = 2;
     result.plane.height = 2;
     result.plane.physicalRegion = region;
@@ -323,18 +327,22 @@ int main()
         const ViewDataRequest withoutView = without;
         requireAccepted([&] {
             validateSessionViewResult(
-                metadata, withoutView, sliceResult(region));
+                metadata, withoutView, sliceResult(region, false));
         }, "a slice without overlays was rejected");
-        auto unrequested = sliceResult(region);
-        unrequested.gridBoxesIncluded = true;
         requireRejected([&] {
-            validateSessionViewResult(metadata, withoutView, unrequested);
+            validateSessionViewResult(
+                metadata, withoutView, sliceResult(region, true));
         }, "an unrequested overlay flag was accepted");
-        unrequested = sliceResult(region);
+        auto unrequested = sliceResult(region, false);
         unrequested.gridBoxes.push_back({1, region});
         requireRejected([&] {
             validateSessionViewResult(metadata, withoutView, unrequested);
         }, "an unrequested grid box was accepted");
+        // The flag runs both ways: dropping it would leave the window showing
+        // the overlay from the previous slice.
+        requireRejected([&] {
+            validateSessionViewResult(metadata, view, sliceResult(region, false));
+        }, "a missing overlay flag was accepted for a request that asked");
 
         auto outside = sliceResult(region);
         auto beyondWindow = region;
@@ -344,17 +352,27 @@ int main()
             validateSessionViewResult(metadata, view, outside);
         }, "a grid box outside the visible region was accepted");
 
-        // A grid box may keep its own extent on the normal axis: only the plane
-        // axes are clipped to the visible region.
+        // The catalog says where the boxes are: an invented one inside the
+        // window corresponds to no box of that level.
+        auto invented = sliceResult(region);
+        auto smaller = region;
+        smaller.upper[0] -= 0.5;
+        invented.gridBoxes.push_back({1, smaller});
+        requireRejected([&] {
+            validateSessionViewResult(metadata, view, invented);
+        }, "a grid box matching no catalog box was accepted");
+
         if (dimension == 3) {
-            auto normalExtent = sliceResult(region);
+            // All three axes are compared, so the normal extent has to be the
+            // catalog box's own rather than anything plausible.
+            auto stretched = sliceResult(region);
             auto box = region;
             box.lower[2] -= 1.0;
             box.upper[2] += 1.0;
-            normalExtent.gridBoxes.push_back({1, box});
-            requireAccepted([&] {
-                validateSessionViewResult(metadata, view, normalExtent);
-            }, "a grid box with its own normal-axis extent was rejected");
+            stretched.gridBoxes.push_back({1, box});
+            requireRejected([&] {
+                validateSessionViewResult(metadata, view, stretched);
+            }, "a grid box with an invented normal extent was accepted");
         }
 
         // A line answer to a slice request is not an answer at all.
@@ -426,6 +444,37 @@ int main()
             validateSessionViewResult(metadata, view, beyondExtent);
         }, "a line position outside the sampled level was accepted");
 
+        // A region narrows the extent, so a sample outside it is not an answer
+        // to this request even though the level contains it.
+        auto narrowed = lineRequest(3, 1);
+        narrowed.query.region = RealBox{
+            Real3{{1.0, 1.0, 1.0}}, Real3{{2.0, 2.0, 2.0}}};
+        const ViewDataRequest narrowedView = narrowed;
+        auto inside = lineResult(1);
+        inside.line.positions = {1.5, 1.75};
+        requireAccepted([&] {
+            validateSessionViewResult(metadata, narrowedView, inside);
+        }, "a line inside the requested region was rejected");
+        auto strays = lineResult(1);
+        strays.line.positions = {0.5, 3.5};
+        requireRejected([&] {
+            validateSessionViewResult(metadata, narrowedView, strays);
+        }, "a line straying outside the requested region was accepted");
+
+        // And a region may legitimately reach past the domain: the walk then
+        // reports invalid samples out there, which must not be refused.
+        auto wide = lineRequest(3, 1);
+        wide.query.region = RealBox{
+            Real3{{-2.0, -2.0, -2.0}}, Real3{{6.0, 6.0, 6.0}}};
+        const ViewDataRequest wideView = wide;
+        auto outsideDomain = lineResult(1);
+        outsideDomain.line.positions = {-1.5, 5.5};
+        outsideDomain.line.valid = {0, 0};
+        outsideDomain.line.sourceLevel = {-1, -1};
+        requireAccepted([&] {
+            validateSessionViewResult(metadata, wideView, outsideDomain);
+        }, "invalid samples outside the domain were refused");
+
         auto nonFinite = lineResult(1);
         nonFinite.line.positions = {0.25, std::nan("")};
         requireRejected([&] {
@@ -457,6 +506,14 @@ int main()
         requireRejected([&] {
             validateSessionViewResult(metadata, view, beyondDomain);
         }, "an index position outside the level domain was accepted");
+
+        // A duplicated position is cosmetic, not a lie, and strict increase is
+        // not something the producer promises across a level transition.
+        auto repeated = indexed;
+        repeated.line.positions = {1.0, 1.0};
+        requireAccepted([&] {
+            validateSessionViewResult(metadata, view, repeated);
+        }, "a repeated line position was refused");
     }
 
     // Dataset page results.
@@ -505,6 +562,19 @@ int main()
             validateSessionDatasetPageResult(metadata, request, truncated);
         }, "a truncation claim below the extent limit was accepted");
 
+        // The requested span here is exactly the limit, which the builder does
+        // not treat as truncation.
+        auto exact = request;
+        exact.maximumExtent = 4;
+        auto claimed = page(4, 4);
+        claimed.truncatedX = true;
+        requireRejected([&] {
+            validateSessionDatasetPageResult(metadata, exact, claimed);
+        }, "truncation was accepted for a span equal to the limit");
+        requireAccepted([&] {
+            validateSessionDatasetPageResult(metadata, exact, page(4, 4));
+        }, "a page filling the limit exactly was rejected");
+
         auto limited = request;
         limited.maximumExtent = 2;
         auto atLimit = page(2, 2);
@@ -528,6 +598,20 @@ int main()
         requireRejected([&] {
             validateSessionDatasetPageResult(metadata, away, page(4, 4));
         }, "a populated page was accepted where the region misses the level");
+
+        // A region too far out to index cannot be answered with a page at all:
+        // the request is refused before it is sent, and a page claiming to
+        // answer one is impossible rather than merely unverifiable.
+        auto unindexable = request;
+        unindexable.region.lower[0] = 1.0e100;
+        unindexable.region.upper[0] = 2.0e100;
+        requireRejected([&] {
+            validateSessionDatasetPageRequest(
+                metadata, DatasetId{1}, unindexable);
+        }, "a region too far out to index was accepted");
+        requireRejected([&] {
+            validateSessionDatasetPageResult(metadata, unindexable, page(4, 4));
+        }, "a page answering an unindexable request was accepted");
 
         auto ragged = page(4, 4);
         ragged.covered.pop_back();

--- a/tests/unit/test_session_validation.cpp
+++ b/tests/unit/test_session_validation.cpp
@@ -47,8 +47,9 @@ amrvis::DatasetMetadata dataset(int dimension)
     metadata.dimension = dimension;
     metadata.finestLevel = 1;
     metadata.hasPhysicalGeometry = true;
+    // Cell size 1 over index domain 0..3, so each axis spans 0..4 physically.
     metadata.physicalDomain = amrvis::RealBox{
-        amrvis::Real3{{0.0, 0.0, 0.0}}, amrvis::Real3{{1.0, 1.0, 1.0}}};
+        amrvis::Real3{{0.0, 0.0, 0.0}}, amrvis::Real3{{4.0, 4.0, 4.0}}};
     metadata.fields.push_back({"density", amrvis::Centering::Cell, {}});
     for (int level = 0; level < 2; ++level) {
         amrvis::LevelMetadata entry;
@@ -67,10 +68,11 @@ amrvis::SliceRequest sliceRequest(int dimension)
     request.field = amrvis::FieldId{0};
     request.normalDirection = dimension == 3 ? 2 : 1;
     request.visibleRegion = amrvis::RealBox{
-        amrvis::Real3{{0.0, 0.0, 0.0}}, amrvis::Real3{{1.0, 1.0, 1.0}}};
-    request.physicalPosition = 0.5;
+        amrvis::Real3{{0.0, 0.0, 0.0}}, amrvis::Real3{{4.0, 4.0, 4.0}}};
+    request.physicalPosition = 2.0;
     request.maximumLevel = 1;
     request.outputSize = {2, 2};
+    request.includeGridBoxes = true;
     return request;
 }
 
@@ -115,10 +117,11 @@ amrvis::DatasetPageRequest pageRequest(int dimension)
     request.dataset = amrvis::DatasetId{1};
     request.field = amrvis::FieldId{0};
     request.level = 0;
+    // The whole level: index window 0..3 on each in-plane axis.
     request.region = amrvis::RealBox{
-        amrvis::Real3{{0.0, 0.0, 0.0}}, amrvis::Real3{{1.0, 1.0, 1.0}}};
+        amrvis::Real3{{0.0, 0.0, 0.0}}, amrvis::Real3{{4.0, 4.0, 4.0}}};
     request.normalAxis = dimension == 3 ? 2 : 1;
-    request.slicePosition = 0.5;
+    request.slicePosition = 2.5;
     request.maximumExtent = 8;
     return request;
 }
@@ -134,6 +137,7 @@ amrvis::DatasetPage page(int nx, int ny)
     result.ny = ny;
     result.lower = {0, 0};
     result.upper = {nx - 1, ny - 1};
+    result.sliceIndex = 2;
     const auto samples
         = static_cast<std::size_t>(nx) * static_cast<std::size_t>(ny);
     result.values.assign(samples, 0.0F);
@@ -312,6 +316,34 @@ int main()
             validateSessionViewResult(metadata, view, grid);
         }, "a grid box with a reversed region was accepted");
 
+        // The overlay is requested or it is not: a peer cannot install one the
+        // caller switched off, and cannot place a box outside the window.
+        auto without = request;
+        without.includeGridBoxes = false;
+        const ViewDataRequest withoutView = without;
+        requireAccepted([&] {
+            validateSessionViewResult(
+                metadata, withoutView, sliceResult(region));
+        }, "a slice without overlays was rejected");
+        auto unrequested = sliceResult(region);
+        unrequested.gridBoxesIncluded = true;
+        requireRejected([&] {
+            validateSessionViewResult(metadata, withoutView, unrequested);
+        }, "an unrequested overlay flag was accepted");
+        unrequested = sliceResult(region);
+        unrequested.gridBoxes.push_back({1, region});
+        requireRejected([&] {
+            validateSessionViewResult(metadata, withoutView, unrequested);
+        }, "an unrequested grid box was accepted");
+
+        auto outside = sliceResult(region);
+        auto beyondWindow = region;
+        beyondWindow.lower[0] -= 1.0;
+        outside.gridBoxes.push_back({1, beyondWindow});
+        requireRejected([&] {
+            validateSessionViewResult(metadata, view, outside);
+        }, "a grid box outside the visible region was accepted");
+
         // A grid box may keep its own extent on the normal axis: only the plane
         // axes are clipped to the visible region.
         if (dimension == 3) {
@@ -373,6 +405,58 @@ int main()
         requireRejected([&] {
             validateSessionViewResult(metadata, narrowView, dense);
         }, "a line denser than its viewport allows was accepted");
+
+        // Whether the horizontal axis is physical or an index belongs to the
+        // dataset: this one has geometry, so index positions contradict it.
+        auto indexed = lineResult(1);
+        indexed.line.positionsAreIndices = true;
+        requireRejected([&] {
+            validateSessionViewResult(metadata, view, indexed);
+        }, "index positions were accepted for a physical dataset");
+
+        auto unsorted = lineResult(1);
+        unsorted.line.positions = {0.75, 0.25};
+        requireRejected([&] {
+            validateSessionViewResult(metadata, view, unsorted);
+        }, "unordered line positions were accepted");
+
+        auto beyondExtent = lineResult(1);
+        beyondExtent.line.positions = {0.25, 99.0};
+        requireRejected([&] {
+            validateSessionViewResult(metadata, view, beyondExtent);
+        }, "a line position outside the sampled level was accepted");
+
+        auto nonFinite = lineResult(1);
+        nonFinite.line.positions = {0.25, std::nan("")};
+        requireRejected([&] {
+            validateSessionViewResult(metadata, view, nonFinite);
+        }, "a non-finite line position was accepted");
+    }
+
+    // A dataset without physical geometry reports index positions, bounded by
+    // the level's index domain rather than its physical extent.
+    {
+        auto metadata = dataset(2);
+        metadata.hasPhysicalGeometry = false;
+        const ViewDataRequest view = lineRequest(2, 0);
+        auto indexed = lineResult(0);
+        indexed.line.positionsAreIndices = true;
+        indexed.line.positions = {0.0, 3.0};
+        requireAccepted([&] {
+            validateSessionViewResult(metadata, view, indexed);
+        }, "index positions were rejected for a geometry-free dataset");
+
+        auto physical = lineResult(0);
+        physical.line.positions = {0.25, 0.75};
+        requireRejected([&] {
+            validateSessionViewResult(metadata, view, physical);
+        }, "physical positions were accepted for a geometry-free dataset");
+
+        auto beyondDomain = indexed;
+        beyondDomain.line.positions = {0.0, 9.0};
+        requireRejected([&] {
+            validateSessionViewResult(metadata, view, beyondDomain);
+        }, "an index position outside the level domain was accepted");
     }
 
     // Dataset page results.
@@ -382,10 +466,6 @@ int main()
         requireAccepted([&] {
             validateSessionDatasetPageResult(metadata, request, page(4, 4));
         }, "a valid dataset page was rejected");
-        requireAccepted([&] {
-            validateSessionDatasetPageResult(metadata, request, page(0, 0));
-        }, "an empty dataset page was rejected");
-
         auto oversized = page(4, 4);
         oversized.nx = request.maximumExtent + 1;
         requireRejected([&] {
@@ -403,6 +483,51 @@ int main()
         requireRejected([&] {
             validateSessionDatasetPageResult(metadata, request, mismatched);
         }, "a page whose bounds outrun its extent was accepted");
+
+        // The window is determined by the region: a page that starts elsewhere,
+        // or stops short without saying it truncated, is not this answer.
+        auto shifted = page(2, 2);
+        shifted.lower = {2, 2};
+        shifted.upper = {3, 3};
+        requireRejected([&] {
+            validateSessionDatasetPageResult(metadata, request, shifted);
+        }, "a page starting away from the requested region was accepted");
+
+        auto short_ = page(2, 2);
+        requireRejected([&] {
+            validateSessionDatasetPageResult(metadata, request, short_);
+        }, "a page short of the region without truncation was accepted");
+
+        auto truncated = page(2, 2);
+        truncated.truncatedX = true;
+        truncated.truncatedY = true;
+        requireRejected([&] {
+            validateSessionDatasetPageResult(metadata, request, truncated);
+        }, "a truncation claim below the extent limit was accepted");
+
+        auto limited = request;
+        limited.maximumExtent = 2;
+        auto atLimit = page(2, 2);
+        atLimit.truncatedX = true;
+        atLimit.truncatedY = true;
+        requireAccepted([&] {
+            validateSessionDatasetPageResult(metadata, limited, atLimit);
+        }, "a page truncated to the extent limit was rejected");
+
+        // Emptiness is determined too, in both directions.
+        requireRejected([&] {
+            validateSessionDatasetPageResult(metadata, request, page(0, 0));
+        }, "an empty page was accepted where the region meets the level");
+
+        auto away = request;
+        away.region.lower[0] = 90.0;
+        away.region.upper[0] = 99.0;
+        requireAccepted([&] {
+            validateSessionDatasetPageResult(metadata, away, page(0, 0));
+        }, "an empty page was rejected where the region misses the level");
+        requireRejected([&] {
+            validateSessionDatasetPageResult(metadata, away, page(4, 4));
+        }, "a populated page was accepted where the region misses the level");
 
         auto ragged = page(4, 4);
         ragged.covered.pop_back();
@@ -457,6 +582,12 @@ int main()
         requireRejected([&] {
             validateSessionDatasetPageResult(metadata, request, beyond);
         }, "a page with a slice index outside the level domain was accepted");
+
+        auto elsewhere = page(4, 4);
+        elsewhere.sliceIndex = 0;
+        requireRejected([&] {
+            validateSessionDatasetPageResult(metadata, request, elsewhere);
+        }, "a page slicing at another position than requested was accepted");
     }
 
     // Particle samples against the catalog they claim to sample.

--- a/tests/unit/test_session_validation.cpp
+++ b/tests/unit/test_session_validation.cpp
@@ -1,0 +1,387 @@
+#include <amrexplorer/core/Metadata.hpp>
+#include <amrexplorer/data/SessionValidation.hpp>
+
+#include <cstdlib>
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace {
+
+void require(bool condition, const char* message)
+{
+    if (!condition) {
+        std::cerr << "FAILED: " << message << '\n';
+        std::exit(1);
+    }
+}
+
+template <typename Function>
+void requireRejected(Function&& function, const char* message)
+{
+    try {
+        function();
+    } catch (const std::exception&) {
+        return;
+    }
+    require(false, message);
+}
+
+template <typename Function>
+void requireAccepted(Function&& function, const char* message)
+{
+    try {
+        function();
+        return;
+    } catch (const std::exception& error) {
+        std::cerr << "rejected with: " << error.what() << '\n';
+    }
+    require(false, message);
+}
+
+amrvis::DatasetMetadata dataset(int dimension)
+{
+    amrvis::DatasetMetadata metadata;
+    metadata.dimension = dimension;
+    metadata.finestLevel = 1;
+    metadata.hasPhysicalGeometry = true;
+    metadata.physicalDomain = amrvis::RealBox{
+        amrvis::Real3{{0.0, 0.0, 0.0}}, amrvis::Real3{{1.0, 1.0, 1.0}}};
+    metadata.fields.push_back({"density", amrvis::Centering::Cell, {}});
+    for (int level = 0; level < 2; ++level) {
+        amrvis::LevelMetadata entry;
+        entry.level = level;
+        entry.domain = amrvis::IntBox{amrvis::Int3{{0, 0, 0}},
+            amrvis::Int3{{3, 3, 3}}, amrvis::Int3{{0, 0, 0}}};
+        metadata.levels.push_back(entry);
+    }
+    return metadata;
+}
+
+amrvis::SliceRequest sliceRequest(int dimension)
+{
+    amrvis::SliceRequest request;
+    request.dataset = amrvis::DatasetId{1};
+    request.field = amrvis::FieldId{0};
+    request.normalDirection = dimension == 3 ? 2 : 1;
+    request.visibleRegion = amrvis::RealBox{
+        amrvis::Real3{{0.0, 0.0, 0.0}}, amrvis::Real3{{1.0, 1.0, 1.0}}};
+    request.physicalPosition = 0.5;
+    request.maximumLevel = 1;
+    request.outputSize = {2, 2};
+    return request;
+}
+
+amrvis::SliceQueryResult sliceResult(const amrvis::RealBox& region)
+{
+    amrvis::SliceQueryResult result;
+    result.plane.width = 2;
+    result.plane.height = 2;
+    result.plane.physicalRegion = region;
+    result.plane.values = {1.0F, 2.0F, 3.0F, 4.0F};
+    result.plane.valid = {1, 1, 1, 1};
+    result.plane.sourceLevel = {0, 1, -1, 0};
+    return result;
+}
+
+amrvis::LineViewRequest lineRequest(int dimension, int axis)
+{
+    amrvis::LineViewRequest request;
+    request.query.dataset = amrvis::DatasetId{1};
+    request.query.field = amrvis::FieldId{0};
+    request.query.axis = axis;
+    request.query.maximumLevel = 1;
+    request.outputWidth = 8;
+    static_cast<void>(dimension);
+    return request;
+}
+
+amrvis::LineQueryResult lineResult(int axis)
+{
+    amrvis::LineQueryResult result;
+    result.line.axis = axis;
+    result.line.positions = {0.25, 0.75};
+    result.line.values = {1.0F, 2.0F};
+    result.line.valid = {1, 1};
+    result.line.sourceLevel = {1, -1};
+    return result;
+}
+
+amrvis::DatasetPageRequest pageRequest(int dimension)
+{
+    amrvis::DatasetPageRequest request;
+    request.dataset = amrvis::DatasetId{1};
+    request.field = amrvis::FieldId{0};
+    request.level = 0;
+    request.region = amrvis::RealBox{
+        amrvis::Real3{{0.0, 0.0, 0.0}}, amrvis::Real3{{1.0, 1.0, 1.0}}};
+    request.normalAxis = dimension == 3 ? 2 : 1;
+    request.slicePosition = 0.5;
+    request.maximumExtent = 8;
+    return request;
+}
+
+// A default-constructed page is the empty one: no cells, inverted bounds.
+amrvis::DatasetPage page(int nx, int ny)
+{
+    amrvis::DatasetPage result;
+    if (nx <= 0 || ny <= 0) {
+        return result;
+    }
+    result.nx = nx;
+    result.ny = ny;
+    result.lower = {0, 0};
+    result.upper = {nx - 1, ny - 1};
+    const auto samples
+        = static_cast<std::size_t>(nx) * static_cast<std::size_t>(ny);
+    result.values.assign(samples, 0.0F);
+    result.covered.assign(samples, 1);
+    return result;
+}
+
+} // namespace
+
+int main()
+{
+    using namespace amrvis;
+
+    // planeAxes: the in-plane pair, and total for a normal it cannot honour.
+    require((planeAxes(2, 1) == std::array<int, 2>{0, 1}),
+        "a 2-D plane does not use both axes");
+    require((planeAxes(3, 0) == std::array<int, 2>{1, 2})
+            && (planeAxes(3, 1) == std::array<int, 2>{0, 2})
+            && (planeAxes(3, 2) == std::array<int, 2>{0, 1}),
+        "3-D plane axes are wrong for some normal");
+    require((planeAxes(3, 9) == std::array<int, 2>{0, 1}),
+        "an out-of-range normal did not fall back to a safe pair");
+
+    // A line region is meaningful only along the line axis, in both 2-D and
+    // 3-D: reversed or non-finite there is a malformed request, while the
+    // off-axis entries stay free to be degenerate.
+    for (const int dimension : {2, 3}) {
+        auto request = lineRequest(dimension, 0);
+        request.query.region = RealBox{
+            Real3{{0.25, 0.5, 0.5}}, Real3{{0.75, 0.5, 0.5}}};
+        require(validateLineRequest(request.query, dimension).empty(),
+            "a line region degenerate off its axis was rejected");
+
+        request.query.region = RealBox{
+            Real3{{0.75, 0.0, 0.0}}, Real3{{0.25, 1.0, 1.0}}};
+        require(!validateLineRequest(request.query, dimension).empty(),
+            "a reversed line region was accepted");
+
+        request.query.region = RealBox{
+            Real3{{0.5, 0.0, 0.0}}, Real3{{0.5, 1.0, 1.0}}};
+        require(!validateLineRequest(request.query, dimension).empty(),
+            "a zero-extent line region was accepted");
+
+        request.query.region = RealBox{
+            Real3{{std::nan(""), 0.0, 0.0}}, Real3{{1.0, 1.0, 1.0}}};
+        require(!validateLineRequest(request.query, dimension).empty(),
+            "a non-finite line region was accepted");
+
+        request.query.region.reset();
+        require(validateLineRequest(request.query, dimension).empty(),
+            "a line request without a region was rejected");
+    }
+
+    // The page region, at the trust boundary rather than inside the builder.
+    for (const int dimension : {2, 3}) {
+        const auto metadata = dataset(dimension);
+        auto request = pageRequest(dimension);
+        requireAccepted([&] {
+            validateSessionDatasetPageRequest(
+                metadata, DatasetId{1}, request);
+        }, "a valid dataset page request was rejected");
+
+        auto reversed = request;
+        reversed.region.lower[0] = 1.0;
+        reversed.region.upper[0] = 0.0;
+        requireRejected([&] {
+            validateSessionDatasetPageRequest(
+                metadata, DatasetId{1}, reversed);
+        }, "a reversed page region was accepted");
+
+        auto degenerate = request;
+        degenerate.region.upper[1] = degenerate.region.lower[1];
+        requireRejected([&] {
+            validateSessionDatasetPageRequest(
+                metadata, DatasetId{1}, degenerate);
+        }, "a page region with no in-plane extent was accepted");
+    }
+
+    // In 3-D the normal axis of a page region may be degenerate: it carries the
+    // slice position, not an extent.
+    {
+        const auto metadata = dataset(3);
+        auto request = pageRequest(3);
+        request.region.upper[2] = request.region.lower[2];
+        requireAccepted([&] {
+            validateSessionDatasetPageRequest(
+                metadata, DatasetId{1}, request);
+        }, "a 3-D page region degenerate on its normal axis was rejected");
+    }
+
+    // Slice results: provenance and plane extent against the catalog.
+    for (const int dimension : {2, 3}) {
+        const auto metadata = dataset(dimension);
+        const auto request = sliceRequest(dimension);
+        const ViewDataRequest view = request;
+        auto region = request.visibleRegion;
+        if (dimension == 3) {
+            // The normal axis of a slice region is degenerate by construction.
+            region.upper[2] = region.lower[2];
+        }
+        requireAccepted([&] {
+            validateSessionViewResult(metadata, view, sliceResult(region));
+        }, "a valid slice result was rejected");
+
+        auto reversed = region;
+        reversed.upper[0] = reversed.lower[0] - 1.0;
+        requireRejected([&] {
+            validateSessionViewResult(metadata, view, sliceResult(reversed));
+        }, "a slice result with a reversed plane region was accepted");
+
+        auto beyond = sliceResult(region);
+        beyond.plane.sourceLevel = {0, 1, 2, 0};
+        requireRejected([&] {
+            validateSessionViewResult(metadata, view, beyond);
+        }, "a slice source level past the finest level was accepted");
+
+        auto sentinel = sliceResult(region);
+        sentinel.plane.sourceLevel = {0, 1, -2, 0};
+        requireRejected([&] {
+            validateSessionViewResult(metadata, view, sentinel);
+        }, "a slice source level below the no-data sentinel was accepted");
+
+        auto ragged = sliceResult(region);
+        ragged.plane.values.pop_back();
+        requireRejected([&] {
+            validateSessionViewResult(metadata, view, ragged);
+        }, "a slice result with a short value vector was accepted");
+
+        auto grid = sliceResult(region);
+        grid.gridBoxes.push_back({2, region});
+        requireRejected([&] {
+            validateSessionViewResult(metadata, view, grid);
+        }, "a grid box on a nonexistent level was accepted");
+
+        grid = sliceResult(region);
+        grid.gridBoxes.push_back({-1, region});
+        requireRejected([&] {
+            validateSessionViewResult(metadata, view, grid);
+        }, "a grid box with no level was accepted");
+
+        grid = sliceResult(region);
+        grid.gridBoxes.push_back({1, reversed});
+        requireRejected([&] {
+            validateSessionViewResult(metadata, view, grid);
+        }, "a grid box with a reversed region was accepted");
+
+        // A line answer to a slice request is not an answer at all.
+        requireRejected([&] {
+            validateSessionViewResult(metadata, view, lineResult(0));
+        }, "a line result answered a slice request");
+    }
+
+    // Line results.
+    {
+        const auto metadata = dataset(3);
+        const ViewDataRequest view = lineRequest(3, 1);
+        requireAccepted([&] {
+            validateSessionViewResult(metadata, view, lineResult(1));
+        }, "a valid line result was rejected");
+
+        requireRejected([&] {
+            validateSessionViewResult(metadata, view, lineResult(0));
+        }, "a line result along the wrong axis was accepted");
+
+        auto beyond = lineResult(1);
+        beyond.line.sourceLevel = {1, 4};
+        requireRejected([&] {
+            validateSessionViewResult(metadata, view, beyond);
+        }, "a line source level past the finest level was accepted");
+
+        auto ragged = lineResult(1);
+        ragged.line.valid.pop_back();
+        requireRejected([&] {
+            validateSessionViewResult(metadata, view, ragged);
+        }, "a line result with a short validity vector was accepted");
+    }
+
+    // Dataset page results.
+    {
+        const auto metadata = dataset(2);
+        const auto request = pageRequest(2);
+        requireAccepted([&] {
+            validateSessionDatasetPageResult(metadata, request, page(4, 4));
+        }, "a valid dataset page was rejected");
+        requireAccepted([&] {
+            validateSessionDatasetPageResult(metadata, request, page(0, 0));
+        }, "an empty dataset page was rejected");
+
+        auto oversized = page(4, 4);
+        oversized.nx = request.maximumExtent + 1;
+        requireRejected([&] {
+            validateSessionDatasetPageResult(metadata, request, oversized);
+        }, "a page larger than the requested extent was accepted");
+
+        auto reversed = page(4, 4);
+        reversed.lower[1] = reversed.upper[1] + 1;
+        requireRejected([&] {
+            validateSessionDatasetPageResult(metadata, request, reversed);
+        }, "a page with reversed index bounds was accepted");
+
+        auto mismatched = page(4, 4);
+        mismatched.upper[0] += 1;
+        requireRejected([&] {
+            validateSessionDatasetPageResult(metadata, request, mismatched);
+        }, "a page whose bounds outrun its extent was accepted");
+
+        auto ragged = page(4, 4);
+        ragged.covered.pop_back();
+        requireRejected([&] {
+            validateSessionDatasetPageResult(metadata, request, ragged);
+        }, "a page with a short coverage vector was accepted");
+    }
+
+    // Particle samples against the catalog they claim to sample.
+    {
+        const std::vector<ParticleSpeciesMetadata> species{
+            {"electrons", 3, 0, 0, 2, ParticleRealPrecision::Double}};
+        ParticleSample sample;
+        sample.species = species.front();
+        sample.points.push_back({1, Real3{{0.5, 0.5, 0.5}}});
+        requireAccepted([&] {
+            validateSessionParticleSampleResult(
+                species, "electrons", sample);
+        }, "a valid particle sample was rejected");
+
+        auto renamed = sample;
+        renamed.species.name = "ions";
+        requireRejected([&] {
+            validateSessionParticleSampleResult(
+                species, "electrons", renamed);
+        }, "a sample of the wrong species was accepted");
+
+        requireRejected([&] {
+            validateSessionParticleSampleResult(species, "ions", sample);
+        }, "a sample of an uncatalogued species was accepted");
+
+        auto flattened = sample;
+        flattened.species.dimension = 0;
+        requireRejected([&] {
+            validateSessionParticleSampleResult(
+                species, "electrons", flattened);
+        }, "a sample with an impossible dimension was accepted");
+
+        auto overfull = sample;
+        overfull.points.push_back({2, Real3{{0.25, 0.25, 0.25}}});
+        overfull.points.push_back({3, Real3{{0.75, 0.75, 0.75}}});
+        requireRejected([&] {
+            validateSessionParticleSampleResult(
+                species, "electrons", overfull);
+        }, "a sample larger than its species was accepted");
+    }
+    return 0;
+}


### PR DESCRIPTION
The FlatBuffers verifier and the vector-length checks prove the wire is structurally sound, which is not the same as sound for this dataset. The generic decoders stay representation-only -- the right rule needs context they do not have -- so every contextual rule now runs where the context exists.

Boxes. The core already had the right pair of predicates: RealBox::valid requires lower < upper on active axes, IntBox::valid allows equal corners for a one-cell interval. What was missing was calling them, plus their plane-wise equivalent, at the trust boundary. A plane region cannot be checked with RealBox::valid at all: the third axis of a 3-D slice or page region carries the slice position and is legitimately degenerate, so planeAxes moves into the core and the page region is validated on its in-plane axes. extractDatasetPage applied that rule already, but only once the request had reached it; at the boundary it also lets the remote client refuse a bad region before a round trip. planeAxes existed three times before this (SliceQuery, DatasetPage, and the pipeline's slicePlaneAxes); the first two now share the core one, which is total for an out-of-range normal -- both local copies would have written past a two-element array.

The decoded catalog runs validateMetadata. Both local readers throw on any issue it reports, so every catalog a server can serve has already satisfied it: the remote path now rejects exactly what a local open rejects, instead of publishing a session whose box ordering, containment, centering, level numbering, or cell sizes are impossible.

Line region. validateLineRequest validates an optional region along the line axis, the only axis LineQuery reads. A reversed or non-finite region previously produced a line running from its upper bound to its lower one.

Results. Three validators in SessionValidation, called by RemoteDatasetSession after each response: a source level or grid-box level the dataset has no room for (-1 is the no-data sentinel for a sample; a grid box has no such sentinel), a plane region with no in-plane extent, a result answering the wrong request variant or line axis, disagreeing vector lengths, a page larger than the extent asked for or whose bounds do not span its extent, and a sample holding more points than its species contains. A local session needs none of this, since it produces its results with our own query code, which is why only the remote session calls them. On failure the connection closes before the throw propagates: a peer that answers something impossible for this dataset is not speaking the protocol we negotiated, and leaving the connection open would let the next response be trusted again.

Particle positions are finite-checked in the codec beside the existing line check, finiteness needing no context, and the vector comparison divides rather than multiplying.

Tests cover reversed and degenerate boxes in 2-D and 3-D, invalid line regions at both the session and the raw-wire server boundary, non-finite particle positions, source levels outside the sentinel and level range, and six ways a catalog can violate a local invariant -- while a 2-D catalog degenerate on its inactive third axis and a one-cell IntBox stay accepted.

Two notes for the reader. The existing catalog round-trip fixture used a face-centered box inside a cell-centered domain, which no local reader would produce; its domain is face-centered now, so the case still covers a non-cell centering. And a default DatasetPage is the empty one, with lower {0, 0} and upper {-1, -1} on purpose, so the bounds rule applies only to a page that claims cells -- the first version of that check rejected the legitimate empty page and the new test caught it.