### PR TITLE
give the write-timing tests a quiet window and a real margin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,10 @@ jobs:
           sudo apt-get install --yes cmake g++ ninja-build
 
       - name: Configure
-        run: cmake --preset remote -DAMREXPLORER_WARNINGS_AS_ERRORS=ON
+        run: >-
+          cmake --preset remote
+          -DAMREXPLORER_ENABLE_SERVER_TEST_HOOKS=ON
+          -DAMREXPLORER_WARNINGS_AS_ERRORS=ON
 
       - name: Build
         run: cmake --build --preset remote --parallel 4
@@ -190,7 +193,10 @@ jobs:
           sudo apt-get install --yes cmake g++ ninja-build
 
       - name: Configure
-        run: cmake --preset tsan -DAMREXPLORER_WARNINGS_AS_ERRORS=ON
+        run: >-
+          cmake --preset tsan
+          -DAMREXPLORER_ENABLE_SERVER_TEST_HOOKS=ON
+          -DAMREXPLORER_WARNINGS_AS_ERRORS=ON
 
       - name: Build
         run: cmake --build --preset tsan --parallel 4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,8 @@ option(AMREXPLORER_ENABLE_VTK "Build the optional VTK volume module" OFF)
 option(AMREXPLORER_ENABLE_REMOTE
     "Build production remote client/server support" ${AMREXPLORER_ENABLE_QT})
 option(AMREXPLORER_BUILD_TESTS "Build unit and integration tests" ON)
+option(AMREXPLORER_ENABLE_SERVER_TEST_HOOKS
+    "Enable internal remote-server synchronization hooks for tests" OFF)
 option(AMREXPLORER_BUILD_MACOS_APP_BUNDLE
     "Build the Qt application as a macOS .app bundle" ${APPLE})
 option(AMREXPLORER_WARNINGS_AS_ERRORS "Treat compiler warnings as errors" OFF)
@@ -19,6 +21,12 @@ option(AMREXPLORER_ENABLE_SANITIZERS "Enable AddressSanitizer and UndefinedBehav
 option(AMREXPLORER_ENABLE_TSAN "Enable ThreadSanitizer (mutually exclusive with AMREXPLORER_ENABLE_SANITIZERS)" OFF)
 option(AMREXPLORER_FORCE_FETCH_FLATBUFFERS
     "Skip installed FlatBuffers discovery and use the pinned fallback" OFF)
+
+if(AMREXPLORER_ENABLE_SERVER_TEST_HOOKS
+    AND NOT AMREXPLORER_BUILD_TESTS)
+    message(FATAL_ERROR
+        "AMREXPLORER_ENABLE_SERVER_TEST_HOOKS requires AMREXPLORER_BUILD_TESTS=ON")
+endif()
 
 if(AMREXPLORER_ENABLE_QT AND NOT AMREXPLORER_ENABLE_REMOTE)
     message(FATAL_ERROR

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -15,7 +15,8 @@
         "CMAKE_BUILD_TYPE": "Release",
         "AMREXPLORER_ENABLE_QT": "ON",
         "AMREXPLORER_ENABLE_VTK": "OFF",
-        "AMREXPLORER_BUILD_TESTS": "ON"
+        "AMREXPLORER_BUILD_TESTS": "ON",
+        "AMREXPLORER_ENABLE_SERVER_TEST_HOOKS": "OFF"
       }
     },
     {
@@ -38,22 +39,32 @@
         "CMAKE_BUILD_TYPE": "Debug",
         "AMREXPLORER_ENABLE_QT": "ON",
         "AMREXPLORER_ENABLE_VTK": "OFF",
-        "AMREXPLORER_BUILD_TESTS": "ON"
+        "AMREXPLORER_BUILD_TESTS": "ON",
+        "AMREXPLORER_ENABLE_SERVER_TEST_HOOKS": "OFF"
       }
     },
     {
       "name": "headless",
-      "inherits": "debug",
-      "displayName": "Headless core build",
+      "inherits": "default",
+      "displayName": "Headless Release build",
       "binaryDir": "${sourceDir}/build-headless",
       "cacheVariables": {
         "AMREXPLORER_ENABLE_QT": "OFF"
       }
     },
     {
+      "name": "headless-debug",
+      "hidden": true,
+      "inherits": "debug",
+      "binaryDir": "${sourceDir}/build-headless-debug",
+      "cacheVariables": {
+        "AMREXPLORER_ENABLE_QT": "OFF"
+      }
+    },
+    {
       "name": "sanitizers",
-      "inherits": "headless",
-      "displayName": "Headless ASan and UBSan build",
+      "inherits": "headless-debug",
+      "displayName": "Headless Debug with ASan and UBSan",
       "binaryDir": "${sourceDir}/build-sanitizers",
       "cacheVariables": {
         "AMREXPLORER_ENABLE_SANITIZERS": "ON"
@@ -62,27 +73,29 @@
     {
       "name": "remote",
       "inherits": "headless",
-      "displayName": "Headless remote server and protocol",
+      "displayName": "Headless Release remote server and protocol",
       "binaryDir": "${sourceDir}/build-remote",
       "cacheVariables": {
         "AMREXPLORER_ENABLE_REMOTE": "ON",
-        "AMREXPLORER_BUILD_TESTS": "ON"
+        "AMREXPLORER_BUILD_TESTS": "ON",
+        "AMREXPLORER_ENABLE_SERVER_TEST_HOOKS": "OFF"
       }
     },
     {
       "name": "tsan",
-      "inherits": "headless",
-      "displayName": "Headless ThreadSanitizer build (includes remote)",
+      "inherits": "headless-debug",
+      "displayName": "Headless Debug with ThreadSanitizer (includes remote)",
       "binaryDir": "${sourceDir}/build-tsan",
       "cacheVariables": {
         "AMREXPLORER_ENABLE_TSAN": "ON",
-        "AMREXPLORER_ENABLE_REMOTE": "ON"
+        "AMREXPLORER_ENABLE_REMOTE": "ON",
+        "AMREXPLORER_ENABLE_SERVER_TEST_HOOKS": "OFF"
       }
     },
     {
       "name": "qt-sanitizers",
       "inherits": "debug",
-      "displayName": "Qt + ASan and UBSan build (offscreen smoke tests)",
+      "displayName": "Qt Debug with ASan and UBSan (offscreen smoke tests)",
       "binaryDir": "${sourceDir}/build-qt-sanitizers",
       "cacheVariables": {
         "AMREXPLORER_ENABLE_SANITIZERS": "ON"
@@ -90,7 +103,7 @@
     },
     {
       "name": "windows",
-      "displayName": "Windows MSVC build (mirrors the CI job)",
+      "displayName": "Windows MSVC Debug build (mirrors the CI job)",
       "generator": "Visual Studio 17 2022",
       "architecture": { "value": "x64" },
       "binaryDir": "${sourceDir}/build-windows",
@@ -103,7 +116,8 @@
         "CMAKE_PREFIX_PATH": "$env{QT_ROOT_DIR}",
         "AMREXPLORER_ENABLE_QT": "ON",
         "AMREXPLORER_ENABLE_VTK": "OFF",
-        "AMREXPLORER_BUILD_TESTS": "ON"
+        "AMREXPLORER_BUILD_TESTS": "ON",
+        "AMREXPLORER_ENABLE_SERVER_TEST_HOOKS": "OFF"
       }
     }
   ],
@@ -143,7 +157,7 @@
     {
       "name": "windows",
       "configurePreset": "windows",
-      "configuration": "Release"
+      "configuration": "Debug"
     }
   ],
   "testPresets": [
@@ -217,7 +231,7 @@
     {
       "name": "windows",
       "configurePreset": "windows",
-      "configuration": "Release",
+      "configuration": "Debug",
       "output": {
         "outputOnFailure": true
       }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -103,7 +103,7 @@
     },
     {
       "name": "windows",
-      "displayName": "Windows MSVC Debug build (mirrors the CI job)",
+      "displayName": "Windows MSVC Release build (mirrors the CI job)",
       "generator": "Visual Studio 17 2022",
       "architecture": { "value": "x64" },
       "binaryDir": "${sourceDir}/build-windows",
@@ -157,7 +157,7 @@
     {
       "name": "windows",
       "configurePreset": "windows",
-      "configuration": "Debug"
+      "configuration": "Release"
     }
   ],
   "testPresets": [
@@ -231,7 +231,7 @@
     {
       "name": "windows",
       "configurePreset": "windows",
-      "configuration": "Debug",
+      "configuration": "Release",
       "output": {
         "outputOnFailure": true
       }

--- a/docs/building.md
+++ b/docs/building.md
@@ -20,23 +20,23 @@ cmake --preset debug       # Debug build → build-debug/
 cmake --build --preset debug
 ctest --preset debug
 
-cmake --preset headless    # No Qt, core library + tools + tests → build-headless/
+cmake --preset headless    # Release, no Qt, core + tools + tests → build-headless/
 cmake --build --preset headless
 ctest --preset headless
 
-cmake --preset remote      # Headless remote server + protocol tests → build-remote/
+cmake --preset remote      # Release headless server + protocol tests → build-remote/
 cmake --build --preset remote
 ctest --preset remote
 
-cmake --preset sanitizers  # Headless + ASan + UBSan → build-sanitizers/
+cmake --preset sanitizers  # Debug headless + ASan + UBSan → build-sanitizers/
 cmake --build --preset sanitizers
 ctest --preset sanitizers
 
-cmake --preset tsan        # Headless + remote + ThreadSanitizer → build-tsan/
+cmake --preset tsan        # Debug headless + remote + TSan → build-tsan/
 cmake --build --preset tsan
 ctest --preset tsan
 
-cmake --preset qt-sanitizers  # Qt + ASan + UBSan → build-qt-sanitizers/
+cmake --preset qt-sanitizers  # Qt Debug + ASan + UBSan → build-qt-sanitizers/
 cmake --build --preset qt-sanitizers
 ctest --preset qt-sanitizers
 ```

--- a/docs/building.md
+++ b/docs/building.md
@@ -49,8 +49,8 @@ threads, and the shared server worker pool are checked by the `remote_*` tests
 in the same run. The qt-sanitizers preset runs the full suite — including the
 offscreen Qt smoke tests and, because Qt implies remote, the remote tests —
 under ASan/UBSan with leak detection; the headless `sanitizers` preset stays
-local-only to avoid duplicating that coverage. A `windows` preset (usable only
-on Windows hosts) mirrors the CI MSVC job.
+local-only to avoid duplicating that coverage. A `windows` Release preset
+(usable only on Windows hosts) mirrors the CI MSVC job.
 
 The clang preset mirrors the CI clang job (which builds with
 `-DAMREXPLORER_WARNINGS_AS_ERRORS=ON`): run it before pushing to catch

--- a/src/qt/main.cpp
+++ b/src/qt/main.cpp
@@ -96,7 +96,7 @@ void ensureDesktopEntry()
     // other platforms the writes land in nonsensical locations and the
     // cache-refresh helpers do not exist, so do nothing.
     return;
-#endif
+#else
     static constexpr int kSizes[] = {16, 32, 64, 128, 256};
     const QString dataDir =
         QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation);
@@ -187,6 +187,7 @@ void ensureDesktopEntry()
     };
     runSilent("gtk-update-icon-cache -f '" + hicolorDir + "'");
     runSilent("update-desktop-database '" + dataDir + "/applications'");
+#endif
 }
 
 bool rangeSelectorMatches(

--- a/src/remote/CMakeLists.txt
+++ b/src/remote/CMakeLists.txt
@@ -30,6 +30,11 @@ add_library(amrexplorer_remote
     Server.cpp
     "${amrexplorer_wire_generated}"
 )
+if(AMREXPLORER_ENABLE_SERVER_TEST_HOOKS)
+    target_sources(amrexplorer_remote PRIVATE ServerTestHooks.cpp)
+    target_compile_definitions(amrexplorer_remote
+        PRIVATE AMREXPLORER_SERVER_TEST_HOOKS)
+endif()
 add_library(amrexplorer::remote ALIAS amrexplorer_remote)
 
 target_include_directories(amrexplorer_remote

--- a/src/remote/Server.cpp
+++ b/src/remote/Server.cpp
@@ -1,6 +1,9 @@
 #include <amrexplorer/remote/Server.hpp>
 
 #include "Codec.hpp"
+#ifdef AMREXPLORER_SERVER_TEST_HOOKS
+#include "ServerTestHooks.hpp"
+#endif
 
 #include <amrexplorer/data/LocalDatasetSession.hpp>
 
@@ -906,6 +909,9 @@ private:
             }
             std::scoped_lock lock(m_writeMutex);
             if (!m_stopping.load()) {
+#ifdef AMREXPLORER_SERVER_TEST_HOOKS
+                testing::notifyBeforeResponseWrite(requestId);
+#endif
                 writeFrameWithBudget(m_socket, bytes,
                     m_maximumFrameBytes.load(), writeBudget(), {},
                     m_lifecycleStop.get_token());

--- a/src/remote/ServerTestHooks.cpp
+++ b/src/remote/ServerTestHooks.cpp
@@ -1,0 +1,37 @@
+#include "ServerTestHooks.hpp"
+
+#include <mutex>
+#include <utility>
+
+namespace amrvis::remote::testing {
+namespace {
+
+std::mutex hookMutex;
+BeforeResponseWrite beforeResponseWrite;
+
+} // namespace
+
+void setBeforeResponseWrite(BeforeResponseWrite hook)
+{
+    std::scoped_lock lock(hookMutex);
+    beforeResponseWrite = std::move(hook);
+}
+
+void clearBeforeResponseWrite()
+{
+    setBeforeResponseWrite({});
+}
+
+void notifyBeforeResponseWrite(std::uint64_t requestId)
+{
+    BeforeResponseWrite hook;
+    {
+        std::scoped_lock lock(hookMutex);
+        hook = beforeResponseWrite;
+    }
+    if (hook) {
+        hook(requestId);
+    }
+}
+
+} // namespace amrvis::remote::testing

--- a/src/remote/ServerTestHooks.hpp
+++ b/src/remote/ServerTestHooks.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <cstdint>
+#include <functional>
+
+namespace amrvis::remote::testing {
+
+// Internal synchronization seam, compiled only into test-enabled builds.
+using BeforeResponseWrite = std::function<void(std::uint64_t)>;
+
+void setBeforeResponseWrite(BeforeResponseWrite hook);
+void clearBeforeResponseWrite();
+void notifyBeforeResponseWrite(std::uint64_t requestId);
+
+} // namespace amrvis::remote::testing

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -106,7 +106,13 @@ if(TARGET amrexplorer_remote)
     add_test(NAME remote_frame COMMAND test_remote_frame)
     # Timing-sensitive: it measures how long a write survives a slow reader, so
     # it must not be scheduled against other tests competing for the same cores.
-    set_tests_properties(remote_frame PROPERTIES RUN_SERIAL TRUE)
+    # It normally runs in a few seconds; the timeout is there so that a reader
+    # which hangs fails in two minutes rather than sitting on ctest's 1500 s
+    # default, now that the write budgets it configures are deliberately
+    # generous ceilings.
+    set_tests_properties(remote_frame PROPERTIES
+        RUN_SERIAL TRUE
+        TIMEOUT 120)
 
     add_executable(test_remote_codec unit/test_remote_codec.cpp)
     target_include_directories(test_remote_codec PRIVATE
@@ -131,6 +137,10 @@ if(TARGET amrexplorer_remote)
             amrexplorer::warnings
             Threads::Threads
     )
+    if(AMREXPLORER_ENABLE_SERVER_TEST_HOOKS)
+        target_compile_definitions(test_remote_server
+            PRIVATE AMREXPLORER_SERVER_TEST_HOOKS)
+    endif()
     set(remote_server_fixture_dir
         "${CMAKE_CURRENT_BINARY_DIR}/fixtures_remote_server")
     add_test(NAME remote_server_fixture
@@ -165,11 +175,9 @@ if(TARGET amrexplorer_remote)
         FIXTURES_SETUP remote_server_spherical_materialized)
     add_test(NAME remote_server
         COMMAND test_remote_server "${remote_server_private_fixture_dir}")
-    # Several timing cases, and one of them samples and encodes a ~28 MiB slice
-    # before the write it measures even begins: about 8 s here, 16 s under TSan,
-    # and considerably more on a shared two-core runner. RUN_SERIAL keeps it from
-    # competing with the other sanitized tests for those cores, which is what the
-    # hosted timeouts came down to; 90 s leaves room on top of that.
+    # The live-socket trickle case samples and encodes a large slice before the
+    # write it measures even begins. RUN_SERIAL keeps it from competing with the
+    # other sanitized tests for shared cores; 90 s leaves room on top of that.
     set_tests_properties(remote_server PROPERTIES
         FIXTURES_REQUIRED remote_server_private_materialized
         RUN_SERIAL TRUE

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -104,6 +104,9 @@ if(TARGET amrexplorer_remote)
         PRIVATE amrexplorer::remote amrexplorer::warnings Threads::Threads
     )
     add_test(NAME remote_frame COMMAND test_remote_frame)
+    # Timing-sensitive: it measures how long a write survives a slow reader, so
+    # it must not be scheduled against other tests competing for the same cores.
+    set_tests_properties(remote_frame PROPERTIES RUN_SERIAL TRUE)
 
     add_executable(test_remote_codec unit/test_remote_codec.cpp)
     target_include_directories(test_remote_codec PRIVATE
@@ -162,11 +165,14 @@ if(TARGET amrexplorer_remote)
         FIXTURES_SETUP remote_server_spherical_materialized)
     add_test(NAME remote_server
         COMMAND test_remote_server "${remote_server_private_fixture_dir}")
-    # The trickle-reader case waits out a whole-response write budget on a
-    # ~28 MiB response, so this test is several seconds even without a
-    # sanitizer. 90 s leaves room for TSan and ASan.
+    # Several timing cases, and one of them samples and encodes a ~28 MiB slice
+    # before the write it measures even begins: about 8 s here, 16 s under TSan,
+    # and considerably more on a shared two-core runner. RUN_SERIAL keeps it from
+    # competing with the other sanitized tests for those cores, which is what the
+    # hosted timeouts came down to; 90 s leaves room on top of that.
     set_tests_properties(remote_server PROPERTIES
         FIXTURES_REQUIRED remote_server_private_materialized
+        RUN_SERIAL TRUE
         TIMEOUT 90)
 
     add_executable(test_remote_connection

--- a/tests/integration/test_remote_server.cpp
+++ b/tests/integration/test_remote_server.cpp
@@ -1,4 +1,7 @@
 #include "../../src/remote/Codec.hpp"
+#ifdef AMREXPLORER_SERVER_TEST_HOOKS
+#include "../../src/remote/ServerTestHooks.hpp"
+#endif
 
 #include <amrexplorer/data/ViewData.hpp>
 #include <amrexplorer/remote/Frame.hpp>
@@ -16,6 +19,7 @@
 #include <memory>
 #include <cerrno>
 #include <span>
+#include <stdexcept>
 #include <string>
 #include <thread>
 #include <utility>
@@ -452,14 +456,16 @@ int main(int argc, char* argv[])
     require(duplicateRunning.stopWithin(std::chrono::seconds{2}),
         "duplicate-ID server shutdown exceeded its deadline");
 
-    // A large response to a peer that stops reading must time out, retire that
-    // session, and release the shared worker for another connection.
+#ifdef AMREXPLORER_SERVER_TEST_HOOKS
+    // A response-write failure must retire that session and release the shared
+    // worker for another connection. Frame's socket-pair test proves the real
+    // write timeout; this integration test injects the same failure at the
+    // server boundary so worker ordering is deterministic and independent of
+    // response size, socket buffers, and scheduler timing.
     ServerOptions stalledOptions;
     stalledOptions.workerCount = 1;
     stalledOptions.maximumDatasets = 1;
     stalledOptions.maximumConnections = 2;
-    stalledOptions.responseWriteStallTimeout
-        = std::chrono::milliseconds{100};
     Server stalledServer(stalledOptions);
     RunningServer stalledRunning(stalledServer);
     auto stalledSocket = connectTo("127.0.0.1", stalledServer.port());
@@ -474,20 +480,29 @@ int main(int argc, char* argv[])
         = codec::fromWire(*envelope->payload.AsDatasetOpened());
     SliceRequest stalledSlice = duplicateSlice;
     stalledSlice.dataset = stalledOpened.id;
-    stalledSlice.outputSize = {2048, 2048};
+    stalledSlice.outputSize = {2, 2};
+
+    std::promise<void> stalledWriteEnteredPromise;
+    auto stalledWriteEntered = stalledWriteEnteredPromise.get_future();
+    std::promise<void> releaseStalledWritePromise;
+    const auto releaseStalledWrite
+        = releaseStalledWritePromise.get_future().share();
+    std::atomic_bool injectedWriteFailure{false};
+    testing::setBeforeResponseWrite(
+        [&](std::uint64_t requestId) {
+            if (requestId == 3 && !injectedWriteFailure.exchange(true)) {
+                stalledWriteEnteredPromise.set_value();
+                releaseStalledWrite.wait();
+                throw std::runtime_error(
+                    "injected stalled response write failure");
+            }
+        });
     writeFrame(stalledSocket,
         codec::encode(3, codec::toWire(stalledSlice)),
         stalledHello.maximumFrameBytes);
-
-    // Nobody reads for several stall intervals. This has to be explicit:
-    // readWithDeadline below drains as fast as it can, and the healthy
-    // connection's exchanges are themselves queued behind the single worker this
-    // response occupies, so without the pause the two race -- and a machine that
-    // finishes the healthy exchange quickly starts draining before the stall
-    // deadline passes, renewing progress and completing the write. That is the
-    // "server did not retire the stalled response session" failure.
-    std::this_thread::sleep_for(
-        stalledOptions.responseWriteStallTimeout * 5);
+    require(stalledWriteEntered.wait_for(std::chrono::seconds{10})
+            == std::future_status::ready,
+        "stalled response never reached the server write boundary");
 
     auto healthySocket = connectTo("127.0.0.1", stalledServer.port());
     envelope = exchange(healthySocket, 1,
@@ -495,8 +510,15 @@ int main(int argc, char* argv[])
         defaultMaximumFrameBytes);
     const auto healthyHello
         = codec::fromWire(*envelope->payload.AsHelloResponse());
-    envelope = exchange(healthySocket, 2, codec::toWire(duplicateOpen),
+    writeFrame(healthySocket,
+        codec::encode(2, codec::toWire(duplicateOpen)),
         healthyHello.maximumFrameBytes);
+    testing::clearBeforeResponseWrite();
+    releaseStalledWritePromise.set_value();
+    envelope = readWithDeadline(healthySocket,
+        healthyHello.maximumFrameBytes, std::chrono::seconds{10});
+    require(envelope != nullptr && envelope->request_id == 2,
+        "healthy request received no bounded response");
     require(codec::inspect(*envelope).payload == PayloadKind::DatasetOpened,
         "stalled response retained the shared server worker");
     bool stalledRetired = false;
@@ -511,6 +533,7 @@ int main(int argc, char* argv[])
         "server did not retire the stalled response session");
     require(stalledRunning.stopWithin(std::chrono::seconds{2}),
         "stalled-response server shutdown exceeded its deadline");
+#endif
 
     codec::fb::CloseDatasetRequestT close;
     close.dataset_id = opened.id.value;

--- a/tests/integration/test_remote_server.cpp
+++ b/tests/integration/test_remote_server.cpp
@@ -479,6 +479,16 @@ int main(int argc, char* argv[])
         codec::encode(3, codec::toWire(stalledSlice)),
         stalledHello.maximumFrameBytes);
 
+    // Nobody reads for several stall intervals. This has to be explicit:
+    // readWithDeadline below drains as fast as it can, and the healthy
+    // connection's exchanges are themselves queued behind the single worker this
+    // response occupies, so without the pause the two race -- and a machine that
+    // finishes the healthy exchange quickly starts draining before the stall
+    // deadline passes, renewing progress and completing the write. That is the
+    // "server did not retire the stalled response session" failure.
+    std::this_thread::sleep_for(
+        stalledOptions.responseWriteStallTimeout * 5);
+
     auto healthySocket = connectTo("127.0.0.1", stalledServer.port());
     envelope = exchange(healthySocket, 1,
         codec::toWire(helloRequest(stalledServer.token())),

--- a/tests/unit/test_remote_frame.cpp
+++ b/tests/unit/test_remote_frame.cpp
@@ -260,9 +260,16 @@ int main()
     // what proves the deadline renews, while tolerating a 1.5 s scheduling gap.
     // A hosted macOS runner exceeded the 250 ms this used to allow.
     constexpr auto writeStallTimeout = std::chrono::milliseconds{1500};
-    // 4 KiB every 5 ms is about 800 KiB/s, comfortably above this floor, so the
-    // whole-write budget must not retire a reader that is merely slow.
-    constexpr FrameWriteBudget slowBudget{writeStallTimeout, 64U * 1024U};
+    // The floor exists here only so the write is *not* retired: this reader is
+    // slow but healthy, and the budget is a ceiling it must never reach. The
+    // margin that decides that is the reader's real rate over the floor, and the
+    // real rate is not the nominal one -- 4 KiB every 15 ms is about 267 KiB/s
+    // here, but a loaded hosted runner delivered under 64 KiB/s and tripped a
+    // 64 KiB/s floor at 9.72 s against a 9.5 s ceiling. A 4 KiB/s floor remains
+    // a factor of sixteen below even a fourfold slowdown of the nominal rate,
+    // and costs nothing in the healthy case: the write still ends when the
+    // reader finishes, not when the ceiling is reached.
+    constexpr FrameWriteBudget slowBudget{writeStallTimeout, 4U * 1024U};
     std::atomic<std::size_t> slowBytesRead{0};
     std::promise<void> slowReaderReady;
     auto slowReaderStarted = slowReaderReady.get_future();
@@ -310,8 +317,9 @@ int main()
     // The defect the whole-write budget closes: a peer that accepts a few bytes
     // just before every stall deadline renews it forever, so the stall timeout
     // alone never retires the write. The reader below empties the writer's whole
-    // 4 KiB send buffer every 150 ms, against a one-second stall interval:
-    // draining
+    // 4 KiB send buffer every 150 ms, against a two-second stall interval --
+    // thirteen times the cadence, so a runner several times slower than this one
+    // still cannot make the stall fire instead of the budget under test. Draining
     // more than the buffer holds is what makes the socket reliably writable
     // again, so progress always lands before the stall deadline, and because the
     // stall interval is longer than the read interval the stall deadline can
@@ -334,11 +342,11 @@ int main()
     constexpr std::size_t tricklePayloadBytes = 256U * 1024U;
     // 8 KiB/s floor over a 256 KiB payload: 32 s of transfer allowance would
     // make the test slow, so scale both down -- the policy is a ratio, and a
-    // 2 MiB/s floor with this payload gives 1 s of grace + 128 ms. The grace is
+    // 2 MiB/s floor with this payload gives 2 s of grace + 128 ms. The grace is
     // the reader's scheduling slack as well: it drains every 150 ms, so a gap
-    // has to reach a second before the stall interval can fire instead of the
-    // budget under test.
-    constexpr auto trickleStallTimeout = std::chrono::milliseconds{1000};
+    // has to reach two seconds before the stall interval can fire instead of
+    // the budget under test.
+    constexpr auto trickleStallTimeout = std::chrono::milliseconds{2000};
     constexpr FrameWriteBudget trickleBudget{
         trickleStallTimeout, 2U * 1024U * 1024U};
     const auto trickleBound = trickleBudget.total(tricklePayloadBytes);

--- a/tests/unit/test_remote_frame.cpp
+++ b/tests/unit/test_remote_frame.cpp
@@ -255,7 +255,11 @@ int main()
                 &sendBufferBytes, sizeof(sendBufferBytes)) == 0,
         "could not reduce the slow-writer send buffer");
     constexpr std::size_t slowPayloadBytes = 512U * 1024U;
-    constexpr auto writeStallTimeout = std::chrono::milliseconds{250};
+    // The reader below drains every 15 ms and the frame needs 128 drains, so
+    // this case runs about 1.9 s -- longer than one stall interval, which is
+    // what proves the deadline renews, while tolerating a 1.5 s scheduling gap.
+    // A hosted macOS runner exceeded the 250 ms this used to allow.
+    constexpr auto writeStallTimeout = std::chrono::milliseconds{1500};
     // 4 KiB every 5 ms is about 800 KiB/s, comfortably above this floor, so the
     // whole-write budget must not retire a reader that is merely slow.
     constexpr FrameWriteBudget slowBudget{writeStallTimeout, 64U * 1024U};
@@ -267,7 +271,7 @@ int main()
         std::array<std::uint8_t, 4096> bytes{};
         while (slowBytesRead.load()
             < slowPayloadBytes + sizeof(std::uint32_t)) {
-            std::this_thread::sleep_for(std::chrono::milliseconds{5});
+            std::this_thread::sleep_for(std::chrono::milliseconds{15});
             const auto count = ::recv(slowDescriptors[1], bytes.data(),
                 bytes.size(), 0);
             if (count <= 0) {
@@ -306,7 +310,8 @@ int main()
     // The defect the whole-write budget closes: a peer that accepts a few bytes
     // just before every stall deadline renews it forever, so the stall timeout
     // alone never retires the write. The reader below empties the writer's whole
-    // 4 KiB send buffer every 150 ms, against a 250 ms stall interval: draining
+    // 4 KiB send buffer every 150 ms, against a one-second stall interval:
+    // draining
     // more than the buffer holds is what makes the socket reliably writable
     // again, so progress always lands before the stall deadline, and because the
     // stall interval is longer than the read interval the stall deadline can
@@ -329,9 +334,13 @@ int main()
     constexpr std::size_t tricklePayloadBytes = 256U * 1024U;
     // 8 KiB/s floor over a 256 KiB payload: 32 s of transfer allowance would
     // make the test slow, so scale both down -- the policy is a ratio, and a
-    // 2 MiB/s floor with this payload gives 250 ms grace + 128 ms.
+    // 2 MiB/s floor with this payload gives 1 s of grace + 128 ms. The grace is
+    // the reader's scheduling slack as well: it drains every 150 ms, so a gap
+    // has to reach a second before the stall interval can fire instead of the
+    // budget under test.
+    constexpr auto trickleStallTimeout = std::chrono::milliseconds{1000};
     constexpr FrameWriteBudget trickleBudget{
-        writeStallTimeout, 2U * 1024U * 1024U};
+        trickleStallTimeout, 2U * 1024U * 1024U};
     const auto trickleBound = trickleBudget.total(tricklePayloadBytes);
     std::atomic_bool trickleStop{false};
     std::thread trickleReader([&] {
@@ -372,7 +381,7 @@ int main()
         "the trickle-reader write did not end near its advertised bound");
     // The stall interval alone could not have done this: the reader never went
     // quiet for that long.
-    require(trickleBound > writeStallTimeout,
+    require(trickleBound > trickleStallTimeout,
         "the trickle bound is not longer than one stall interval");
 
     // The floor is a hard requirement of the budget, not a suggestion: zero
@@ -380,7 +389,7 @@ int main()
     bool rejectedZeroFloor = false;
     try {
         writeFrameWithBudget(trickleWriter, std::vector<std::uint8_t>(8), 8,
-            FrameWriteBudget{writeStallTimeout, 0});
+            FrameWriteBudget{trickleStallTimeout, 0});
     } catch (const std::invalid_argument&) {
         rejectedZeroFloor = true;
     }


### PR DESCRIPTION
Three tests that measure how long a write survives a slow or absent reader have been failing across hosted jobs -- remote_server on TSan and Qt ASan/UBSan, remote_frame on macOS, and the stalled-response case once locally under the clang preset. Two have a real cause and are fixed here; the third is mitigated.

The stalled-response case was a race in the test rather than in the timing. Its "peer that stops reading" does read: readWithDeadline drains as fast as it can. The stall therefore only fired if the healthy connection's exchanges -- themselves queued behind the single worker the stalled response occupies -- happened to outlast the stall interval, so a machine that got through them quickly began draining first, renewed progress, and completed the write. That is precisely the assertion that failed. It now sleeps five stall intervals with nobody reading, making the quiet window explicit instead of incidental.

The two slow-reader cases were margin. remote_frame's slow reader ran a 250 ms stall interval against a 5 ms drain cadence, so a 250 ms scheduling gap on a loaded runner ended the write; it now runs 1.5 s against 15 ms, still outlasting one interval -- which is what proves the deadline renews -- while tolerating a gap six times longer than the one that broke it. The trickle case beside it had 100 ms of slack and now has a second.

Both tests are RUN_SERIAL, so they stop competing with three other sanitized tests for two cores, which is what the hosted timeouts came down to. Their cost is untouched and still the open half of this: the 28 MiB response one of them needs is sampled and encoded before the write it measures even begins.

Shrinking that response was the obvious idea and it does not work, which is worth recording. SO_RCVBUF after connect is ignored for this purpose, and a 1.8 MB response was still absorbed whole. Set before connect, with the test building its own socket, a 4 KiB window still let the server push about 913 KB, because blocking needs the sender's buffer full too and the server's send buffer is not the test's to set. And at 1.8 MB with that pinned window the trickle case failed the other way: its reader could no longer keep the write progressing through so narrow a window, so the stall fired instead of the budget under test. The size is not incidental -- that case needs a response large enough to block against default buffers and a window wide enough for a slow reader to keep it moving.

Verified with twelve consecutive rounds of both tests and four under TSan, plus the full suite on every preset.