### PR TITLE
[stabilization] bound crafted-input allocations and cut the trickle test's cost

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,8 +126,25 @@ jobs:
           arch: win64_msvc2022_64
           cache: true
 
+      # The test hooks are on here for one reason: the whole-response write
+      # budget's regression lives in remote_server's trickle case, which needs
+      # them, and this is the only job that covers that budget on Windows.
+      # test_remote_frame proves it deterministically everywhere else, but its
+      # socket-pair cases are POSIX-only.
+      #
+      # The cost was weighed and accepted: no job now builds Windows in the
+      # configuration a user gets. That is tolerable because the hook seam is
+      # purely additive -- a hooks-off build compiles a strict subset -- and
+      # because linux, macos, qt-sanitizers and sanitizers all still build with
+      # hooks off. The one thing it could hide is a header that reaches some
+      # translation unit only by way of ServerTestHooks.hpp. Giving
+      # test_remote_frame a Windows socket pair would let this go back to OFF
+      # and cover the budget both ways; that is the way out if it ever matters.
       - name: Configure
-        run: cmake --preset windows -DAMREXPLORER_WARNINGS_AS_ERRORS=ON
+        run: >-
+          cmake --preset windows
+          -DAMREXPLORER_ENABLE_SERVER_TEST_HOOKS=ON
+          -DAMREXPLORER_WARNINGS_AS_ERRORS=ON
 
       - name: Build
         run: cmake --build --preset windows --parallel 4

--- a/include/amrexplorer/io/detail/FabHeaderParsing.hpp
+++ b/include/amrexplorer/io/detail/FabHeaderParsing.hpp
@@ -25,8 +25,10 @@ namespace amrvis::detail {
 // opaque, so it is read from a stream that has no idea where the text ends.
 // Real ones are a few hundred bytes -- a FAB's "FAB " plus a RealDescriptor, a
 // Box and a component count; a plotfile's version string -- and this ceiling
-// leaves two orders of magnitude of room. Named for headers generally, not for
-// FAB: readBoundedLine is used for both.
+// leaves two orders of magnitude of room. Named for headers generally though
+// both callers are currently FAB-path: the plotfile text readers are the
+// follow-up in text-header-readers-unbounded, and renaming this twice to say
+// so would be churn.
 inline constexpr std::size_t maximumHeaderLineBytes = 16U * 1024U;
 
 // std::getline with a ceiling, and otherwise its semantics: false when nothing

--- a/include/amrexplorer/io/detail/FabHeaderParsing.hpp
+++ b/include/amrexplorer/io/detail/FabHeaderParsing.hpp
@@ -13,12 +13,46 @@
 #include <array>
 #include <cstddef>
 #include <cstdint>
+#include <istream>
 #include <limits>
 #include <sstream>
 #include <string>
 #include <vector>
 
 namespace amrvis::detail {
+
+// A FAB header is one line of text at the head of an otherwise binary file, so
+// it is read from a stream that has no idea where the text ends. Real headers
+// are a few hundred bytes -- "FAB " plus a RealDescriptor, a Box, and a
+// component count -- and this ceiling leaves two orders of magnitude of room.
+inline constexpr std::size_t maximumFabHeaderLineBytes = 16U * 1024U;
+
+// std::getline with a ceiling, and otherwise its semantics: false when nothing
+// could be read, the line without its terminator otherwise, and the stream left
+// positioned just past the newline. The ceiling is the point: a file that opens
+// "FAB " and never supplies a newline makes plain getline accumulate the whole
+// remaining file into the string before the parse can reject it. An overlong
+// line is malformed by definition, so it throws the caller's error type rather
+// than returning a truncated one that might parse.
+template <typename Error>
+[[nodiscard]] bool readBoundedLine(std::istream& input, std::string& line,
+    std::size_t limit = maximumFabHeaderLineBytes)
+{
+    line.clear();
+    for (;;) {
+        const auto character = input.get();
+        if (character == std::char_traits<char>::eof()) {
+            return !line.empty();
+        }
+        if (character == '\n') {
+            return true;
+        }
+        if (line.size() >= limit) {
+            throw Error("FAB header line exceeds the supported length");
+        }
+        line.push_back(static_cast<char>(character));
+    }
+}
 
 // Every integer in the text, in order; any non-numeric characters act as
 // separators. Never throws — callers validate the count/shape themselves.

--- a/include/amrexplorer/io/detail/FabHeaderParsing.hpp
+++ b/include/amrexplorer/io/detail/FabHeaderParsing.hpp
@@ -42,7 +42,17 @@ template <typename Error>
     for (;;) {
         const auto character = input.get();
         if (character == std::char_traits<char>::eof()) {
-            return !line.empty();
+            // istream::get() sets failbit *and* eofbit when it runs out;
+            // std::getline sets failbit only if it extracted nothing. Drop the
+            // failbit when characters were read, so this really is a drop-in.
+            // Both current callers happen not to notice -- they only call
+            // tellg(), whose sentry sets failbit for an eof stream regardless
+            // -- but a caller that checks the stream would see the difference.
+            if (line.empty()) {
+                return false;
+            }
+            input.clear(input.rdstate() & ~std::ios::failbit);
+            return true;
         }
         if (character == '\n') {
             return true;

--- a/include/amrexplorer/io/detail/FabHeaderParsing.hpp
+++ b/include/amrexplorer/io/detail/FabHeaderParsing.hpp
@@ -21,11 +21,13 @@
 
 namespace amrvis::detail {
 
-// A FAB header is one line of text at the head of an otherwise binary file, so
-// it is read from a stream that has no idea where the text ends. Real headers
-// are a few hundred bytes -- "FAB " plus a RealDescriptor, a Box, and a
-// component count -- and this ceiling leaves two orders of magnitude of room.
-inline constexpr std::size_t maximumFabHeaderLineBytes = 16U * 1024U;
+// A header line is text at the head of a file the reader otherwise treats as
+// opaque, so it is read from a stream that has no idea where the text ends.
+// Real ones are a few hundred bytes -- a FAB's "FAB " plus a RealDescriptor, a
+// Box and a component count; a plotfile's version string -- and this ceiling
+// leaves two orders of magnitude of room. Named for headers generally, not for
+// FAB: readBoundedLine is used for both.
+inline constexpr std::size_t maximumHeaderLineBytes = 16U * 1024U;
 
 // std::getline with a ceiling, and otherwise its semantics: false when nothing
 // could be read, the line without its terminator otherwise, and the stream left
@@ -36,7 +38,7 @@ inline constexpr std::size_t maximumFabHeaderLineBytes = 16U * 1024U;
 // than returning a truncated one that might parse.
 template <typename Error>
 [[nodiscard]] bool readBoundedLine(std::istream& input, std::string& line,
-    std::size_t limit = maximumFabHeaderLineBytes)
+    std::size_t limit = maximumHeaderLineBytes)
 {
     line.clear();
     for (;;) {
@@ -58,7 +60,7 @@ template <typename Error>
             return true;
         }
         if (line.size() >= limit) {
-            throw Error("FAB header line exceeds the supported length");
+            throw Error("header line exceeds the supported length");
         }
         line.push_back(static_cast<char>(character));
     }

--- a/src/data/LocalDatasetSession.cpp
+++ b/src/data/LocalDatasetSession.cpp
@@ -3,8 +3,6 @@
 #include <amrexplorer/core/Statistics.hpp>
 #include <amrexplorer/data/SessionValidation.hpp>
 #include <amrexplorer/io/PlotfileDataset.hpp>
-#include <amrexplorer/io/PlotfileMetadataReader.hpp>
-#include <amrexplorer/io/detail/FabHeaderParsing.hpp>
 #include <amrexplorer/query/LineQuery.hpp>
 #include <amrexplorer/query/SliceQuery.hpp>
 
@@ -28,20 +26,7 @@ std::string readFileVersion(
     }
     std::ifstream header(path / "Header");
     std::string version;
-    // Bounded, like the FAB header reads: this runs on every dataset open,
-    // including inside the long-lived server, and a Header whose first line
-    // never ends would otherwise be pulled into memory whole. A version string
-    // is a few dozen bytes; anything past the ceiling is not one.
-    //
-    // Empty rather than a throw, unlike the FAB readers: this string is
-    // informational, the caller already treats an unreadable Header as an
-    // empty version, and one unparsable line should not fail the open.
-    try {
-        static_cast<void>(
-            detail::readBoundedLine<MetadataReadError>(header, version));
-    } catch (const MetadataReadError&) {
-        return {};
-    }
+    std::getline(header, version);
     while (!version.empty() && version.back() == '\r') {
         version.pop_back();
     }

--- a/src/data/LocalDatasetSession.cpp
+++ b/src/data/LocalDatasetSession.cpp
@@ -32,6 +32,10 @@ std::string readFileVersion(
     // including inside the long-lived server, and a Header whose first line
     // never ends would otherwise be pulled into memory whole. A version string
     // is a few dozen bytes; anything past the ceiling is not one.
+    //
+    // Empty rather than a throw, unlike the FAB readers: this string is
+    // informational, the caller already treats an unreadable Header as an
+    // empty version, and one unparsable line should not fail the open.
     try {
         static_cast<void>(
             detail::readBoundedLine<MetadataReadError>(header, version));

--- a/src/data/LocalDatasetSession.cpp
+++ b/src/data/LocalDatasetSession.cpp
@@ -205,6 +205,11 @@ ParticleSample LocalDatasetSession::requestParticleSample(
     const std::string& species, double fraction, std::uint64_t seed,
     std::size_t maximumPoints, StopToken cancellation)
 {
+    // The bounded overload serves the remote path, whose species and fraction
+    // arrive off the wire -- it needs this validation at least as much as the
+    // local one above, which is the caller that already had it.
+    validateSessionParticleRequest(
+        m_metadata, m_particleSpecies, species, fraction);
     return requireDataset()->requestParticleSample(
         species, fraction, seed, cancellation, maximumPoints);
 }

--- a/src/data/LocalDatasetSession.cpp
+++ b/src/data/LocalDatasetSession.cpp
@@ -3,6 +3,8 @@
 #include <amrexplorer/core/Statistics.hpp>
 #include <amrexplorer/data/SessionValidation.hpp>
 #include <amrexplorer/io/PlotfileDataset.hpp>
+#include <amrexplorer/io/PlotfileMetadataReader.hpp>
+#include <amrexplorer/io/detail/FabHeaderParsing.hpp>
 #include <amrexplorer/query/LineQuery.hpp>
 #include <amrexplorer/query/SliceQuery.hpp>
 
@@ -26,7 +28,16 @@ std::string readFileVersion(
     }
     std::ifstream header(path / "Header");
     std::string version;
-    std::getline(header, version);
+    // Bounded, like the FAB header reads: this runs on every dataset open,
+    // including inside the long-lived server, and a Header whose first line
+    // never ends would otherwise be pulled into memory whole. A version string
+    // is a few dozen bytes; anything past the ceiling is not one.
+    try {
+        static_cast<void>(
+            detail::readBoundedLine<MetadataReadError>(header, version));
+    } catch (const MetadataReadError&) {
+        return {};
+    }
     while (!version.empty() && version.back() == '\r') {
         version.pop_back();
     }

--- a/src/io/plotfile/FabCatalog.cpp
+++ b/src/io/plotfile/FabCatalog.cpp
@@ -209,7 +209,8 @@ FabRecord inspectFabRecord(
     }
     input.seekg(static_cast<std::streamoff>(offset));
     std::string line;
-    if (!std::getline(input, line) || !line.starts_with("FAB ")) {
+    if (!detail::readBoundedLine<MetadataReadError>(input, line)
+        || !line.starts_with("FAB ")) {
         throw MetadataReadError("expected FAB header at byte "
             + std::to_string(offset));
     }

--- a/src/io/plotfile/ParticleReader.cpp
+++ b/src/io/plotfile/ParticleReader.cpp
@@ -70,6 +70,17 @@ T readRequired(std::istream& input, std::string_view description)
         throw ParticleReadError(
             "malformed particle Header while reading " + std::string(description));
     }
+    if constexpr (std::is_same_v<T, std::string>) {
+        // width() stops the extraction but does not fail it: >> sets failbit
+        // only when it extracts nothing, so hitting the limit would leave the
+        // rest of the token in the stream to be read as the next field, and
+        // every field after it would shift. Bounding the allocation must not
+        // buy that -- a token this long is malformed, so say so.
+        if (value.size() >= static_cast<std::size_t>(maximumHeaderTokenBytes)) {
+            throw ParticleReadError("particle Header " + std::string(description)
+                + " exceeds the supported length");
+        }
+    }
     return value;
 }
 
@@ -510,7 +521,10 @@ std::vector<ParticleSpeciesMetadata> discoverParticleSpecies(
         std::ifstream probe(headerPath);
         std::string version;
         probe >> std::setw(maximumHeaderTokenBytes);
-        if (!(probe >> version) || !version.starts_with("Version_")) {
+        if (!(probe >> version)
+            || version.size() >= static_cast<std::size_t>(
+                   maximumHeaderTokenBytes)
+            || !version.starts_with("Version_")) {
             continue;
         }
         try {

--- a/src/io/plotfile/ParticleReader.cpp
+++ b/src/io/plotfile/ParticleReader.cpp
@@ -22,6 +22,12 @@ namespace {
 constexpr int maximumComponents = maximumParticleComponents;
 constexpr int maximumLevels = 1'000;
 constexpr int maximumGridsPerLevel = 10'000'000;
+// The per-level cap leaves their sum unbounded: a Header declaring the maximum
+// on each of the maximum levels asks for ten billion GridRecords -- hundreds of
+// gigabytes reserved from a few kilobytes of text, before a single record is
+// read. Real particle plotfiles stay orders of magnitude below one level's cap,
+// so the whole table is held to the same number.
+constexpr std::uint64_t maximumGridsTotal = maximumGridsPerLevel;
 constexpr std::uint64_t particleReadChunkBytes = 1024U * 1024U;
 
 struct GridRecord {
@@ -186,6 +192,10 @@ ParsedHeader parseHeader(
             throw ParticleReadError("particle grid count is outside supported bounds");
         }
         totalGrids += static_cast<std::uint64_t>(count);
+    }
+    if (totalGrids > maximumGridsTotal) {
+        throw ParticleReadError(
+            "particle grid total is outside supported bounds");
     }
     result.grids.reserve(static_cast<std::size_t>(totalGrids));
     std::uint64_t recordedParticles = 0;

--- a/src/io/plotfile/ParticleReader.cpp
+++ b/src/io/plotfile/ParticleReader.cpp
@@ -4,10 +4,9 @@
 #include <array>
 #include <bit>
 #include <cmath>
-#include <iomanip>
-#include <type_traits>
 #include <cstring>
 #include <fstream>
+#include <iomanip>
 #include <limits>
 #include <map>
 #include <optional>
@@ -15,6 +14,7 @@
 #include <set>
 #include <string_view>
 #include <system_error>
+#include <type_traits>
 
 namespace amrvis {
 namespace {

--- a/src/io/plotfile/ParticleReader.cpp
+++ b/src/io/plotfile/ParticleReader.cpp
@@ -197,7 +197,22 @@ ParsedHeader parseHeader(
         throw ParticleReadError(
             "particle grid total is outside supported bounds");
     }
-    result.grids.reserve(static_cast<std::size_t>(totalGrids));
+    // The cap above rejects the absurd; this bounds what is merely large. A
+    // declared count is a claim, and the file's own size is the evidence
+    // against it: every grid record still to come needs at least "0 0 0\n" --
+    // three numbers, two separators, a newline -- so the Header cannot
+    // describe more than its bytes allow. Without this a Header of a few
+    // dozen bytes could still reserve the cap's worth, a quarter of a
+    // gigabyte, which is the same trade the point reserve below refuses to
+    // make. A failure to stat falls back to the count, which the cap bounds.
+    constexpr std::uint64_t minimumBytesPerGridRecord = 6;
+    std::error_code headerSizeError;
+    const auto headerBytes = std::filesystem::file_size(path, headerSizeError);
+    const auto describableGrids = headerSizeError
+        ? totalGrids
+        : static_cast<std::uint64_t>(headerBytes) / minimumBytesPerGridRecord;
+    result.grids.reserve(
+        static_cast<std::size_t>(std::min(totalGrids, describableGrids)));
     std::uint64_t recordedParticles = 0;
     for (int level = 0; level <= result.finestLevel; ++level) {
         for (int grid = 0; grid < gridCounts[static_cast<std::size_t>(level)]; ++grid) {
@@ -324,22 +339,34 @@ std::map<DataFileKey, std::filesystem::path> particleDataPaths(
 }
 
 // Bytes one particle occupies in a DATA file: the two identity words and the
-// integer components, then the position and the real components. readGrid
-// derives the same two figures per grid to prove a grid fits its file; here
-// they turn the files on disk into an upper bound on how many particles can
-// exist at all.
-std::uint64_t particleBytesOnDisk(const ParsedHeader& header)
+// integer components, then the position and the real components. One
+// definition, used by readGrid to prove a grid fits its file and by
+// particleBytesOnDisk to turn the files into an upper bound on how many
+// particles can exist -- the two must not drift, since one validates what the
+// other sizes.
+struct ParticleRecordBytes {
+    std::uint64_t integers = 0;
+    std::uint64_t reals = 0;
+};
+
+ParticleRecordBytes particleRecordBytes(
+    const ParsedHeader& header, std::size_t realSize)
 {
     const auto intValues = static_cast<std::uint64_t>(
         2 + header.metadata.intComponentCount);
     const auto realValues = static_cast<std::uint64_t>(
         header.metadata.dimension + header.metadata.realComponentCount);
-    const auto realBytes
-        = header.metadata.precision == ParticleRealPrecision::Single
-        ? sizeof(float)
-        : sizeof(double);
-    return checkedProduct(intValues, sizeof(std::int32_t), "integer record")
-        + checkedProduct(realValues, realBytes, "real record");
+    return {checkedProduct(intValues, sizeof(std::int32_t), "integer record"),
+        checkedProduct(realValues, realSize, "real record")};
+}
+
+std::uint64_t particleBytesOnDisk(const ParsedHeader& header)
+{
+    const auto bytes = particleRecordBytes(header,
+        header.metadata.precision == ParticleRealPrecision::Single
+            ? sizeof(float)
+            : sizeof(double));
+    return bytes.integers + bytes.reals;
 }
 
 template <typename Real>
@@ -349,14 +376,8 @@ void readGrid(std::istream& input, const GridRecord& grid,
     std::size_t maximumPoints, std::vector<ParticlePoint>& output,
     ParticleReadMetrics& metrics)
 {
-    const auto intValues = static_cast<std::uint64_t>(
-        2 + header.metadata.intComponentCount);
-    const auto intRecordBytes = checkedProduct(
-        intValues, sizeof(std::int32_t), "integer record");
-    const auto realValues = static_cast<std::uint64_t>(
-        header.metadata.dimension + header.metadata.realComponentCount);
-    const auto realRecordBytes = checkedProduct(
-        realValues, sizeof(Real), "real record");
+    const auto [intRecordBytes, realRecordBytes]
+        = particleRecordBytes(header, sizeof(Real));
 
     const auto integerBytes
         = checkedProduct(grid.count, intRecordBytes, "integer data");
@@ -515,8 +536,7 @@ ParticleSample readParticleSample(
     for (const auto& [key, dataPath] : dataPaths) {
         std::error_code sizeError;
         const auto dataFileSize = std::filesystem::file_size(dataPath, sizeError);
-        if (sizeError
-            || dataFileSize > std::numeric_limits<std::uint64_t>::max()) {
+        if (sizeError) {
             throw ParticleReadError(
                 "cannot determine particle data file size for '"
                 + dataPath.string() + "'");
@@ -532,14 +552,13 @@ ParticleSample readParticleSample(
     // those bytes can hold. A valid sample is unaffected, because its own
     // points are exactly what the files do hold.
     const auto storedPointCeiling = totalDataBytes / particleBytesOnDisk(header);
-    const auto expected = std::min<long double>(
-                              static_cast<long double>(
-                                  header.metadata.particleCount),
-                              static_cast<long double>(storedPointCeiling))
-        * static_cast<long double>(fraction);
-    result.points.reserve(static_cast<std::size_t>(std::min<long double>(
-        expected + 16.0L,
-        static_cast<long double>(maximumPoints))));
+    const auto plausiblePoints
+        = std::min(header.metadata.particleCount, storedPointCeiling);
+    const auto expected
+        = static_cast<long double>(plausiblePoints) * fraction + 16.0L;
+    result.points.reserve(static_cast<std::size_t>(
+        std::min<long double>(expected,
+            static_cast<long double>(maximumPoints))));
     std::map<DataFileKey, std::vector<const GridRecord*>> gridsByFile;
     for (const auto& grid : header.grids) {
         if (grid.count != 0) {

--- a/src/io/plotfile/ParticleReader.cpp
+++ b/src/io/plotfile/ParticleReader.cpp
@@ -4,6 +4,8 @@
 #include <array>
 #include <bit>
 #include <cmath>
+#include <iomanip>
+#include <type_traits>
 #include <cstring>
 #include <fstream>
 #include <limits>
@@ -50,10 +52,20 @@ struct SelectedParticle {
     std::uint64_t id = 0;
 };
 
+// Longest string token a Header may contain -- a version string or a component
+// name. Extracting a string with >> is otherwise unbounded: it reads until
+// whitespace, so a Header holding one enormous whitespace-free run allocates
+// all of it before any count or cap is consulted. width() is how the standard
+// bounds that, and it is reset by the extraction.
+constexpr int maximumHeaderTokenBytes = 4096;
+
 template <typename T>
 T readRequired(std::istream& input, std::string_view description)
 {
     T value{};
+    if constexpr (std::is_same_v<T, std::string>) {
+        input >> std::setw(maximumHeaderTokenBytes);
+    }
     if (!(input >> value)) {
         throw ParticleReadError(
             "malformed particle Header while reading " + std::string(description));
@@ -208,11 +220,15 @@ ParsedHeader parseHeader(
     constexpr std::uint64_t minimumBytesPerGridRecord = 6;
     std::error_code headerSizeError;
     const auto headerBytes = std::filesystem::file_size(path, headerSizeError);
-    const auto describableGrids = headerSizeError
-        ? totalGrids
-        : static_cast<std::uint64_t>(headerBytes) / minimumBytesPerGridRecord;
-    result.grids.reserve(
-        static_cast<std::size_t>(std::min(totalGrids, describableGrids)));
+    if (!headerSizeError) {
+        const auto describableGrids
+            = static_cast<std::uint64_t>(headerBytes) / minimumBytesPerGridRecord;
+        result.grids.reserve(
+            static_cast<std::size_t>(std::min(totalGrids, describableGrids)));
+    }
+    // No fallback reserve when the size is unknown: this is an optimization,
+    // and the safe answer for an optimization that cannot be bounded is to
+    // skip it, not to take the largest allocation the cap still permits.
     std::uint64_t recordedParticles = 0;
     for (int level = 0; level <= result.finestLevel; ++level) {
         for (int grid = 0; grid < gridCounts[static_cast<std::size_t>(level)]; ++grid) {
@@ -487,8 +503,13 @@ std::vector<ParticleSpeciesMetadata> discoverParticleSpecies(
             continue;
         }
         const auto headerPath = entry.path() / "Header";
+        // Bounded like every other Header token: this runs before the try
+        // below, and its catch is deliberately narrow -- a malformed species
+        // is skipped, an out-of-memory machine is not something to swallow --
+        // so an unbounded read here would take the whole open down.
         std::ifstream probe(headerPath);
         std::string version;
+        probe >> std::setw(maximumHeaderTokenBytes);
         if (!(probe >> version) || !version.starts_with("Version_")) {
             continue;
         }
@@ -534,6 +555,12 @@ ParticleSample readParticleSample(
     std::map<DataFileKey, std::uint64_t> dataFileSizes;
     std::uint64_t totalDataBytes = 0;
     for (const auto& [key, dataPath] : dataPaths) {
+        // One stat per DATA file, so this window grows with their count; the
+        // read loop below polls per grid and this must not be the one stretch
+        // that ignores a cancelled request.
+        if (cancellation.stop_requested()) {
+            throw ReadCancelled();
+        }
         std::error_code sizeError;
         const auto dataFileSize = std::filesystem::file_size(dataPath, sizeError);
         if (sizeError) {

--- a/src/io/plotfile/ParticleReader.cpp
+++ b/src/io/plotfile/ParticleReader.cpp
@@ -323,6 +323,25 @@ std::map<DataFileKey, std::filesystem::path> particleDataPaths(
     return result;
 }
 
+// Bytes one particle occupies in a DATA file: the two identity words and the
+// integer components, then the position and the real components. readGrid
+// derives the same two figures per grid to prove a grid fits its file; here
+// they turn the files on disk into an upper bound on how many particles can
+// exist at all.
+std::uint64_t particleBytesOnDisk(const ParsedHeader& header)
+{
+    const auto intValues = static_cast<std::uint64_t>(
+        2 + header.metadata.intComponentCount);
+    const auto realValues = static_cast<std::uint64_t>(
+        header.metadata.dimension + header.metadata.realComponentCount);
+    const auto realBytes
+        = header.metadata.precision == ParticleRealPrecision::Single
+        ? sizeof(float)
+        : sizeof(double);
+    return checkedProduct(intValues, sizeof(std::int32_t), "integer record")
+        + checkedProduct(realValues, realBytes, "real record");
+}
+
 template <typename Real>
 void readGrid(std::istream& input, const GridRecord& grid,
     std::uint64_t dataFileSize, const ParsedHeader& header, double fraction,
@@ -489,13 +508,38 @@ ParticleSample readParticleSample(
     if (fraction == 0.0 || header.metadata.particleCount == 0) {
         return result;
     }
-    const auto expected = static_cast<long double>(header.metadata.particleCount)
+    const auto dataPaths
+        = particleDataPaths(speciesPath, header.grids, result.io);
+    std::map<DataFileKey, std::uint64_t> dataFileSizes;
+    std::uint64_t totalDataBytes = 0;
+    for (const auto& [key, dataPath] : dataPaths) {
+        std::error_code sizeError;
+        const auto dataFileSize = std::filesystem::file_size(dataPath, sizeError);
+        if (sizeError
+            || dataFileSize > std::numeric_limits<std::uint64_t>::max()) {
+            throw ParticleReadError(
+                "cannot determine particle data file size for '"
+                + dataPath.string() + "'");
+        }
+        dataFileSizes.emplace(key, static_cast<std::uint64_t>(dataFileSize));
+        totalDataBytes += static_cast<std::uint64_t>(dataFileSize);
+    }
+    // The Header's particleCount is not evidence -- it is a number in a text
+    // file, and parseHeader only checks it against the grid table, which is
+    // text from the same file. The DATA files are the evidence: readGrid
+    // already refuses a grid whose records do not fit in them, so a forged
+    // count cannot yield points, only a reserve. Bound the reserve by what
+    // those bytes can hold. A valid sample is unaffected, because its own
+    // points are exactly what the files do hold.
+    const auto storedPointCeiling = totalDataBytes / particleBytesOnDisk(header);
+    const auto expected = std::min<long double>(
+                              static_cast<long double>(
+                                  header.metadata.particleCount),
+                              static_cast<long double>(storedPointCeiling))
         * static_cast<long double>(fraction);
     result.points.reserve(static_cast<std::size_t>(std::min<long double>(
         expected + 16.0L,
         static_cast<long double>(maximumPoints))));
-    const auto dataPaths
-        = particleDataPaths(speciesPath, header.grids, result.io);
     std::map<DataFileKey, std::vector<const GridRecord*>> gridsByFile;
     for (const auto& grid : header.grids) {
         if (grid.count != 0) {
@@ -509,23 +553,14 @@ ParticleSample readParticleSample(
             throw ParticleReadError(
                 "cannot open particle data file '" + dataPath.string() + "'");
         }
-        std::error_code sizeError;
-        const auto dataFileSize = std::filesystem::file_size(dataPath, sizeError);
-        if (sizeError
-            || dataFileSize > std::numeric_limits<std::uint64_t>::max()) {
-            throw ParticleReadError(
-                "cannot determine particle data file size for '"
-                + dataPath.string() + "'");
-        }
+        const auto dataFileSize = dataFileSizes.at(key);
         ++result.io.dataFilesOpened;
         for (const auto* grid : grids) {
             if (header.metadata.precision == ParticleRealPrecision::Single) {
-                readGrid<float>(input, *grid,
-                    static_cast<std::uint64_t>(dataFileSize), header, fraction,
+                readGrid<float>(input, *grid, dataFileSize, header, fraction,
                     seed, cancellation, maximumPoints, result.points, result.io);
             } else {
-                readGrid<double>(input, *grid,
-                    static_cast<std::uint64_t>(dataFileSize), header, fraction,
+                readGrid<double>(input, *grid, dataFileSize, header, fraction,
                     seed, cancellation, maximumPoints, result.points, result.io);
             }
         }

--- a/src/io/plotfile/PlotfileBlockReader.cpp
+++ b/src/io/plotfile/PlotfileBlockReader.cpp
@@ -53,7 +53,8 @@ FabHeader readFabHeader(
         throw BlockReadError("cannot seek to indexed FAB offset");
     }
     std::string line;
-    if (!std::getline(input, line) || !line.starts_with("FAB ")) {
+    if (!detail::readBoundedLine<BlockReadError>(input, line)
+        || !line.starts_with("FAB ")) {
         throw BlockReadError("indexed FAB does not have a supported header");
     }
     const auto descriptorStart = line.find('(', 4);

--- a/src/io/plotfile/PlotfileMetadataReader.cpp
+++ b/src/io/plotfile/PlotfileMetadataReader.cpp
@@ -79,10 +79,13 @@ std::string trim(std::string value)
     return value.substr(first, last - first + 1);
 }
 
+// Bounded, like the FAB header reads: this is the reader that actually walks a
+// plotfile Header, so bounding readFileVersion's single line and leaving this
+// one unbounded would have closed nothing.
 std::string readNonEmptyLine(std::istream& input, std::string_view description)
 {
     std::string line;
-    while (std::getline(input, line)) {
+    while (detail::readBoundedLine<MetadataReadError>(input, line)) {
         line = trim(std::move(line));
         if (!line.empty()) {
             return line;

--- a/src/io/plotfile/PlotfileMetadataReader.cpp
+++ b/src/io/plotfile/PlotfileMetadataReader.cpp
@@ -79,13 +79,10 @@ std::string trim(std::string value)
     return value.substr(first, last - first + 1);
 }
 
-// Bounded, like the FAB header reads: this is the reader that actually walks a
-// plotfile Header, so bounding readFileVersion's single line and leaving this
-// one unbounded would have closed nothing.
 std::string readNonEmptyLine(std::istream& input, std::string_view description)
 {
     std::string line;
-    while (detail::readBoundedLine<MetadataReadError>(input, line)) {
+    while (std::getline(input, line)) {
         line = trim(std::move(line));
         if (!line.empty()) {
             return line;

--- a/src/remote/Frame.cpp
+++ b/src/remote/Frame.cpp
@@ -2,6 +2,10 @@
 
 #include <amrexplorer/io/PlotfileBlockReader.hpp>
 
+#ifdef AMREXPLORER_SERVER_TEST_HOOKS
+#include "ServerTestHooks.hpp"
+#endif
+
 #include <algorithm>
 #include <array>
 #include <cerrno>
@@ -402,9 +406,12 @@ void writeExact(NativeSocket descriptor,
                 : "wire frame write stayed below the minimum throughput";
         }
         waitForWritable(descriptor, limit, cancellation, lifecycle, reason);
+        auto offered = source.size() - completed;
+#ifdef AMREXPLORER_SERVER_TEST_HOOKS
+        offered = testing::writeChunkLimit(offered);
+#endif
 #ifdef _WIN32
-        const auto remaining = std::min<std::size_t>(
-            source.size() - completed, 64U * 1024U);
+        const auto remaining = std::min<std::size_t>(offered, 64U * 1024U);
         const auto count = ::send(descriptor,
             reinterpret_cast<const char*>(source.data() + completed),
             static_cast<int>(remaining), 0);
@@ -414,8 +421,8 @@ void writeExact(NativeSocket descriptor,
             MSG_NOSIGNAL |
 #endif
             MSG_DONTWAIT;
-        const auto count = ::send(descriptor, source.data() + completed,
-            source.size() - completed, noSignal);
+        const auto count = ::send(
+            descriptor, source.data() + completed, offered, noSignal);
 #endif
         if (count < 0) {
             const auto error = lastSocketError();

--- a/src/remote/Server.cpp
+++ b/src/remote/Server.cpp
@@ -911,6 +911,10 @@ private:
             if (!m_stopping.load()) {
 #ifdef AMREXPLORER_SERVER_TEST_HOOKS
                 testing::notifyBeforeResponseWrite(requestId);
+                // Marks this thread as writing a server response, which is what
+                // scopes write pacing to the server: a test's own client
+                // sockets live in the same process.
+                const testing::ResponseWriteScope pacingScope;
 #endif
                 writeFrameWithBudget(m_socket, bytes,
                     m_maximumFrameBytes.load(), writeBudget(), {},

--- a/src/remote/ServerTestHooks.cpp
+++ b/src/remote/ServerTestHooks.cpp
@@ -64,7 +64,12 @@ std::size_t writeChunkLimit(std::size_t requested)
     if (!hook) {
         return requested;
     }
-    return std::min(requested, hook(requested));
+    // Clamped into [1, requested]. Zero is the dangerous answer: writeExact
+    // reads a zero-byte send as the peer having closed the connection, so a
+    // hook returning zero would surface as a spurious disconnect rather than
+    // as an obviously wrong test. requested is never zero -- the write loop
+    // only asks while bytes remain -- so the lower bound cannot exceed it.
+    return std::clamp(hook(requested), std::size_t{1}, requested);
 }
 
 ResponseWriteScope::ResponseWriteScope() noexcept

--- a/src/remote/ServerTestHooks.cpp
+++ b/src/remote/ServerTestHooks.cpp
@@ -1,5 +1,6 @@
 #include "ServerTestHooks.hpp"
 
+#include <algorithm>
 #include <mutex>
 #include <utility>
 
@@ -8,6 +9,8 @@ namespace {
 
 std::mutex hookMutex;
 BeforeResponseWrite beforeResponseWrite;
+WriteChunkLimit writeChunkLimitHook;
+thread_local bool inResponseWrite = false;
 
 } // namespace
 
@@ -32,6 +35,46 @@ void notifyBeforeResponseWrite(std::uint64_t requestId)
     if (hook) {
         hook(requestId);
     }
+}
+
+void setWriteChunkLimit(WriteChunkLimit hook)
+{
+    std::scoped_lock lock(hookMutex);
+    writeChunkLimitHook = std::move(hook);
+}
+
+void clearWriteChunkLimit()
+{
+    setWriteChunkLimit({});
+}
+
+std::size_t writeChunkLimit(std::size_t requested)
+{
+    if (!inResponseWrite) {
+        return requested;
+    }
+    WriteChunkLimit hook;
+    {
+        std::scoped_lock lock(hookMutex);
+        hook = writeChunkLimitHook;
+    }
+    // Copied out and invoked unlocked, like the write hook above: the hook is
+    // meant to block, and holding the installer's mutex while it did would
+    // deadlock whoever tries to clear it.
+    if (!hook) {
+        return requested;
+    }
+    return std::min(requested, hook(requested));
+}
+
+ResponseWriteScope::ResponseWriteScope() noexcept
+{
+    inResponseWrite = true;
+}
+
+ResponseWriteScope::~ResponseWriteScope()
+{
+    inResponseWrite = false;
 }
 
 } // namespace amrvis::remote::testing

--- a/src/remote/ServerTestHooks.cpp
+++ b/src/remote/ServerTestHooks.cpp
@@ -73,13 +73,16 @@ std::size_t writeChunkLimit(std::size_t requested)
 }
 
 ResponseWriteScope::ResponseWriteScope() noexcept
+    : m_previous(inResponseWrite)
 {
     inResponseWrite = true;
 }
 
 ResponseWriteScope::~ResponseWriteScope()
 {
-    inResponseWrite = false;
+    // Restore, not clear: an inner scope closing must not switch pacing off
+    // for the remainder of an outer one.
+    inResponseWrite = m_previous;
 }
 
 } // namespace amrvis::remote::testing

--- a/src/remote/ServerTestHooks.cpp
+++ b/src/remote/ServerTestHooks.cpp
@@ -64,11 +64,15 @@ std::size_t writeChunkLimit(std::size_t requested)
     if (!hook) {
         return requested;
     }
-    // Clamped into [1, requested]. Zero is the dangerous answer: writeExact
-    // reads a zero-byte send as the peer having closed the connection, so a
-    // hook returning zero would surface as a spurious disconnect rather than
-    // as an obviously wrong test. requested is never zero -- the write loop
-    // only asks while bytes remain -- so the lower bound cannot exceed it.
+    // Zero is the dangerous answer: writeExact reads a zero-byte send as the
+    // peer having closed the connection, so a hook returning zero would
+    // surface as a spurious disconnect rather than as an obviously wrong test.
+    // The write loop only asks while bytes remain, so requested is never zero
+    // -- but clamp's precondition is lo <= hi, and an invariant held up by a
+    // comment in another file is not one to hand to undefined behaviour.
+    if (requested == 0) {
+        return 0;
+    }
     return std::clamp(hook(requested), std::size_t{1}, requested);
 }
 

--- a/src/remote/ServerTestHooks.hpp
+++ b/src/remote/ServerTestHooks.hpp
@@ -19,8 +19,9 @@ void notifyBeforeResponseWrite(std::uint64_t requestId);
 // that renews the no-progress deadline forever, so only the whole-response
 // budget can retire it -- and it produces that condition from a tiny response
 // instead of one large enough to exhaust the kernel's socket buffers.
-// The result is clamped into [1, requested], so a hook cannot accidentally
-// stall the write outright by answering zero.
+// The result is clamped into [1, requested] whenever requested is non-zero, so
+// a hook cannot accidentally stall the write outright by answering zero. A
+// zero request -- which the write loop never makes -- answers zero.
 using WriteChunkLimit = std::function<std::size_t(std::size_t)>;
 
 void setWriteChunkLimit(WriteChunkLimit hook);

--- a/src/remote/ServerTestHooks.hpp
+++ b/src/remote/ServerTestHooks.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 #include <functional>
 
@@ -11,5 +12,31 @@ using BeforeResponseWrite = std::function<void(std::uint64_t)>;
 void setBeforeResponseWrite(BeforeResponseWrite hook);
 void clearBeforeResponseWrite();
 void notifyBeforeResponseWrite(std::uint64_t requestId);
+
+// Pacing seam for the frame write itself. The hook is handed the bytes the
+// write would like to attempt next and returns how many it may; it is free to
+// block first. A hook that returns a few bytes slowly is a trickle -- progress
+// that renews the no-progress deadline forever, so only the whole-response
+// budget can retire it -- and it produces that condition from a tiny response
+// instead of one large enough to exhaust the kernel's socket buffers.
+using WriteChunkLimit = std::function<std::size_t(std::size_t)>;
+
+void setWriteChunkLimit(WriteChunkLimit hook);
+void clearWriteChunkLimit();
+
+// Consulted by the frame write, and only inside a ResponseWriteScope: a test
+// drives its own client sockets from its own threads in this same process, and
+// pacing those would throttle the test rather than the server.
+[[nodiscard]] std::size_t writeChunkLimit(std::size_t requested);
+
+class ResponseWriteScope {
+public:
+    ResponseWriteScope() noexcept;
+    ~ResponseWriteScope();
+    ResponseWriteScope(const ResponseWriteScope&) = delete;
+    ResponseWriteScope& operator=(const ResponseWriteScope&) = delete;
+    ResponseWriteScope(ResponseWriteScope&&) = delete;
+    ResponseWriteScope& operator=(ResponseWriteScope&&) = delete;
+};
 
 } // namespace amrvis::remote::testing

--- a/src/remote/ServerTestHooks.hpp
+++ b/src/remote/ServerTestHooks.hpp
@@ -39,6 +39,9 @@ public:
     ResponseWriteScope& operator=(const ResponseWriteScope&) = delete;
     ResponseWriteScope(ResponseWriteScope&&) = delete;
     ResponseWriteScope& operator=(ResponseWriteScope&&) = delete;
+
+private:
+    bool m_previous = false;
 };
 
 } // namespace amrvis::remote::testing

--- a/src/remote/ServerTestHooks.hpp
+++ b/src/remote/ServerTestHooks.hpp
@@ -19,6 +19,8 @@ void notifyBeforeResponseWrite(std::uint64_t requestId);
 // that renews the no-progress deadline forever, so only the whole-response
 // budget can retire it -- and it produces that condition from a tiny response
 // instead of one large enough to exhaust the kernel's socket buffers.
+// The result is clamped into [1, requested], so a hook cannot accidentally
+// stall the write outright by answering zero.
 using WriteChunkLimit = std::function<std::size_t(std::size_t)>;
 
 void setWriteChunkLimit(WriteChunkLimit hook);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -234,6 +234,10 @@ add_executable(test_plotfile_header unit/test_plotfile_header.cpp)
 target_link_libraries(test_plotfile_header PRIVATE amrexplorer::io amrexplorer::warnings)
 add_test(NAME plotfile_header COMMAND test_plotfile_header)
 
+add_executable(test_particle_header unit/test_particle_header.cpp)
+target_link_libraries(test_particle_header PRIVATE amrexplorer::io amrexplorer::warnings)
+add_test(NAME particle_header COMMAND test_particle_header)
+
 add_executable(test_fits_writer unit/test_fits_writer.cpp)
 target_link_libraries(test_fits_writer PRIVATE amrexplorer::io amrexplorer::warnings)
 add_test(NAME fits_writer COMMAND test_fits_writer)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -175,9 +175,11 @@ if(TARGET amrexplorer_remote)
         FIXTURES_SETUP remote_server_spherical_materialized)
     add_test(NAME remote_server
         COMMAND test_remote_server "${remote_server_private_fixture_dir}")
-    # The live-socket trickle case samples and encodes a large slice before the
-    # write it measures even begins. RUN_SERIAL keeps it from competing with the
-    # other sanitized tests for shared cores; 90 s leaves room on top of that.
+    # The trickle case now paces the write through the test hook instead of
+    # provoking one with a 50 MiB response, so this costs a couple of seconds
+    # rather than the ten to twelve it used to under the sanitizer presets.
+    # RUN_SERIAL stays: the case still asserts against a stall interval, and
+    # keeping it off shared cores is cheap for a test this short.
     set_tests_properties(remote_server PROPERTIES
         FIXTURES_REQUIRED remote_server_private_materialized
         RUN_SERIAL TRUE

--- a/tests/integration/test_fab_catalog.cpp
+++ b/tests/integration/test_fab_catalog.cpp
@@ -330,10 +330,9 @@ int main()
             require(static_cast<bool>(output),
                 "could not create the endless-header fixture");
             output << "FAB ";
-            const std::string filler(64U * 1024U, 'x');
-            for (int chunk = 0; chunk < 16; ++chunk) {
-                output << filler;
-            }
+            // Just past the ceiling, not a megabyte past it: the property is
+            // "longer than the limit", and this runs under the sanitizers.
+            output << std::string(32U * 1024U, 'x');
         }
         bool threw = false;
         try {

--- a/tests/integration/test_fab_catalog.cpp
+++ b/tests/integration/test_fab_catalog.cpp
@@ -318,6 +318,35 @@ int main()
                 == v1Fab.metadata->levels[0].domain,
         "v1 selected FAB block box disagrees with its domain");
 
+    // A file that opens "FAB " and never supplies a newline. The header read is
+    // the first thing to touch it, and before it was bounded it accumulated the
+    // whole remaining file into one std::string before the parse could reject
+    // it -- and scanFabFile does that per record. The specific message is the
+    // assertion: any other rejection would mean the ceiling never fired.
+    {
+        const auto endless = root / "endless_header";
+        {
+            std::ofstream output(endless, std::ios::binary);
+            require(static_cast<bool>(output),
+                "could not create the endless-header fixture");
+            output << "FAB ";
+            const std::string filler(64U * 1024U, 'x');
+            for (int chunk = 0; chunk < 16; ++chunk) {
+                output << filler;
+            }
+        }
+        bool threw = false;
+        try {
+            (void)amrvis::scanFabFile(endless);
+        } catch (const amrvis::MetadataReadError& error) {
+            threw = true;
+            require(std::string(error.what()).find("exceeds the supported length")
+                    != std::string::npos,
+                "an endless FAB header was rejected for the wrong reason");
+        }
+        require(threw, "an endless FAB header was accepted");
+    }
+
     std::filesystem::remove_all(root);
     return 0;
 }

--- a/tests/integration/test_remote_server.cpp
+++ b/tests/integration/test_remote_server.cpp
@@ -7,6 +7,7 @@
 #include <amrexplorer/remote/Frame.hpp>
 #include <amrexplorer/remote/Server.hpp>
 
+#include <algorithm>
 #include <array>
 #include <atomic>
 #include <chrono>
@@ -17,6 +18,7 @@
 #include <future>
 #include <iostream>
 #include <memory>
+#include <ranges>
 #include <cerrno>
 #include <span>
 #include <stdexcept>
@@ -190,6 +192,29 @@ void writeOversizedParticleHeader(const std::filesystem::path& root)
         "could not write oversized particle Header");
 }
 
+// A species Header whose ten levels each declare two million grids. Every count
+// is under the per-level cap, so only the whole-table cap rejects it. The point
+// here is *where* it is read: species discovery runs at dataset open, inside the
+// long-lived server, so before that cap this cost the server hundreds of
+// megabytes for a few dozen bytes of text supplied by whoever can write a
+// server-visible directory.
+void writeCraftedGridTable(const std::filesystem::path& root)
+{
+    const auto species = root / "GridBomb";
+    std::filesystem::create_directories(species);
+    std::ofstream header(species / "Header");
+    require(static_cast<bool>(header),
+        "could not create crafted grid-table Header");
+    header << "Version_Two_Dot_Zero_double\n"
+           << "2\n0\n0\n1\n"
+           << "0\n1\n9\n";
+    for (int level = 0; level < 10; ++level) {
+        header << "2000000\n";
+    }
+    require(static_cast<bool>(header),
+        "could not write crafted grid-table Header");
+}
+
 } // namespace
 
 int main(int argc, char* argv[])
@@ -202,6 +227,7 @@ int main(int argc, char* argv[])
         return 2;
     }
     writeOversizedParticleHeader(argv[1]);
+    writeCraftedGridTable(argv[1]);
 
     ServerOptions options;
     options.workerCount = 2;
@@ -329,6 +355,33 @@ int main(int argc, char* argv[])
             && codec::fromWire(*envelope->payload.AsErrorResponse()).code
                 == ErrorCode::ResourceLimitExceeded,
         "oversized particle request reached the particle reader");
+
+    // The crafted grid table was already read once, by species discovery during
+    // the open above -- an open that succeeded, which is the property under
+    // test: a crafted species costs the server a rejected species, not its
+    // memory. The species is simply absent from the catalog, and asking for it
+    // by name is an ordinary bounded error rather than anything the server has
+    // to survive.
+    // "Oversized" proves the absence below means something: its Header is
+    // well-formed, only its particle count is beyond one frame, so discovery
+    // does list it. A species missing from this list was rejected by the
+    // parser, not overlooked by the test.
+    require(std::ranges::any_of(opened.particleSpecies,
+                [](const auto& candidate) {
+                    return candidate.name == "Oversized";
+                }),
+        "a well-formed particle species was not discovered");
+    require(std::ranges::none_of(opened.particleSpecies,
+                [](const auto& candidate) {
+                    return candidate.name == "GridBomb";
+                }),
+        "a crafted particle grid table was advertised to the client");
+    envelope = exchange(socket, 13,
+        codec::toWire(opened.id, "GridBomb", 1.0, 0), hello.maximumFrameBytes);
+    require(codec::inspect(*envelope).payload == PayloadKind::ErrorResponse
+            && codec::fromWire(*envelope->payload.AsErrorResponse()).code
+                == ErrorCode::InvalidRequest,
+        "a crafted particle species was not refused by name");
 
     SliceRequest request;
     request.dataset = opened.id;
@@ -838,5 +891,7 @@ int main(int argc, char* argv[])
 
     std::filesystem::remove_all(
         std::filesystem::path(argv[1]) / "Oversized");
+    std::filesystem::remove_all(
+        std::filesystem::path(argv[1]) / "GridBomb");
     return 0;
 }

--- a/tests/integration/test_remote_server.cpp
+++ b/tests/integration/test_remote_server.cpp
@@ -138,6 +138,7 @@ std::unique_ptr<amrvis::remote::codec::NativeEnvelope> readWithDeadline(
     return pending.get();
 }
 
+#ifdef AMREXPLORER_SERVER_TEST_HOOKS
 // One recv, no framing: the trickle-reader test accepts a few kibibytes at a
 // time rather than a whole frame. These sockets are non-blocking, so an empty
 // receive buffer reports EAGAIN, which means "nothing yet" and must not be
@@ -163,6 +164,7 @@ long readRaw(const amrvis::remote::Socket& socket,
     return static_cast<long>(count);
 #endif
 }
+#endif
 
 amrvis::remote::HelloRequestData helloRequest(std::string sessionToken)
 {
@@ -191,6 +193,13 @@ void writeOversizedParticleHeader(const std::filesystem::path& root)
     require(static_cast<bool>(header),
         "could not write oversized particle Header");
 }
+
+#ifdef AMREXPLORER_SERVER_TEST_HOOKS
+// Set by the before-write hook and read by the pacing hook, which run on the
+// same worker thread around one response write. This is how pacing is aimed at
+// a single request rather than at every response the server writes.
+thread_local bool g_paceThisWrite = false;
+#endif
 
 // A species Header whose ten levels each declare two million grids. Every count
 // is under the per-level cap, so only the whole-table cap rejects it. The point
@@ -740,34 +749,36 @@ int main(int argc, char* argv[])
     require(boundedRunning.stopWithin(std::chrono::seconds{2}),
         "small-frame server shutdown exceeded its deadline");
 
+#ifdef AMREXPLORER_SERVER_TEST_HOOKS
     // A peer that keeps accepting a trickle of bytes renews the no-progress
     // deadline forever, so the stall timeout alone would let it hold a pooled
     // worker and this session's write mutex indefinitely. The whole-response
     // budget must retire it within a bound the operator can compute, and a
     // second connection must keep working while it is still being retired.
-    // The reader below drains 256 KiB every 100 ms. TCP reports a socket
-    // writable again only once about half the send buffer is free, so progress
-    // comes in bursts rather than every tick -- but it keeps coming, roughly
-    // twice a second, which is what makes this a trickle rather than a stall.
-    // Against the three-second stall grace configured here, the no-progress
-    // timeout can therefore never fire, and a server without the whole-response
-    // budget would never retire this session at all: the upper bound below is
-    // the regression assertion. test_remote_frame pins down which limit fires,
-    // deterministically, on a socket whose buffers it controls.
+    //
+    // The trickle is injected rather than provoked. Producing one from a real
+    // socket needs a response too big to fit in the kernel's buffers, which
+    // meant a 2048x2048 slice -- and the sampling and encoding of it were paid
+    // before the write this case actually measures even began. Pacing the write
+    // to one byte per 50 ms gives the same property from a 16x16 response:
+    // progress lands well inside every 500 ms stall interval, so the
+    // no-progress timeout can never fire, while one byte per 50 ms is orders of
+    // magnitude under the floor, so only the whole-response budget can end it.
+    // A server without that budget would never retire this session at all.
+    // test_remote_frame still pins down which limit fires, on a socket whose
+    // buffers it controls.
     {
         ServerOptions trickleOptions;
         trickleOptions.workerCount = 2;
         trickleOptions.maximumDatasets = 2;
         trickleOptions.maximumConnections = 4;
-        // Long enough that the bursty progress below always lands inside it.
-        trickleOptions.responseWriteStallTimeout = std::chrono::seconds{3};
-        // 32 MiB/s over the ~50 MiB response below: three seconds of grace plus
-        // about 1.6 s of transfer allowance. The floor is high only to keep the
-        // test quick; the small responses this server also serves are
-        // unaffected, since their transfer allowance rounds to nothing next to
-        // the grace.
-        trickleOptions.responseWriteMinimumBytesPerSecond
-            = 32ULL * 1024ULL * 1024ULL;
+        // Ten stall intervals fit inside the paced write below, so a stall
+        // firing instead of the budget would be a defect, not a slow runner.
+        trickleOptions.responseWriteStallTimeout
+            = std::chrono::milliseconds{500};
+        // 8 KiB/s over a response of a few kibibytes: half a second of grace
+        // plus well under a second of transfer allowance.
+        trickleOptions.responseWriteMinimumBytesPerSecond = 8ULL * 1024ULL;
         Server trickleServer(trickleOptions);
         RunningServer trickleRunning(trickleServer);
 
@@ -789,21 +800,32 @@ int main(int argc, char* argv[])
         const auto trickleOpened = codec::fromWire(
             *envelope->payload.AsDatasetOpened());
 
-        // Ask for a response far larger than the kernel socket buffers, then
-        // read it a few kibibytes at a time. Loopback send and receive buffers
-        // autotune into the megabytes, so a response of a few hundred kilobytes
-        // is absorbed whole and the server's write never even blocks; 2048x2048
-        // samples is about 50 MiB and cannot be.
-        SliceRequest large;
-        large.dataset = trickleOpened.id;
-        large.field = FieldId{0};
-        large.normalDirection = 1;
-        large.visibleRegion = trickleOpened.catalog.physicalDomain;
-        large.physicalPosition = 0.5
-            * (large.visibleRegion.lower[1] + large.visibleRegion.upper[1]);
-        large.maximumLevel = trickleOpened.catalog.finestLevel;
-        large.outputSize = {2048, 2048};
-        writeFrame(slow, codec::encode(3, codec::toWire(large)),
+        // Both hooks run on the worker thread serving one response, in this
+        // order, so the first can tell the second whether this is the write to
+        // pace. Without that, pacing would also throttle the neighbour's
+        // responses below and retire that healthy session too.
+        constexpr std::uint64_t pacedRequestId = 4242;
+        testing::setBeforeResponseWrite([](std::uint64_t requestId) {
+            g_paceThisWrite = requestId == pacedRequestId;
+        });
+        testing::setWriteChunkLimit([](std::size_t requested) {
+            if (!g_paceThisWrite) {
+                return requested;
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds{50});
+            return std::size_t{1};
+        });
+
+        SliceRequest paced;
+        paced.dataset = trickleOpened.id;
+        paced.field = FieldId{0};
+        paced.normalDirection = 1;
+        paced.visibleRegion = trickleOpened.catalog.physicalDomain;
+        paced.physicalPosition = 0.5
+            * (paced.visibleRegion.lower[1] + paced.visibleRegion.upper[1]);
+        paced.maximumLevel = trickleOpened.catalog.finestLevel;
+        paced.outputSize = {16, 16};
+        writeFrame(slow, codec::encode(pacedRequestId, codec::toWire(paced)),
             defaultMaximumFrameBytes);
 
         std::atomic_bool draining{true};
@@ -811,11 +833,9 @@ int main(int argc, char* argv[])
         auto retired = std::async(std::launch::async,
             [&slow, &draining, &drained] {
                 const auto start = std::chrono::steady_clock::now();
-                // Big enough that the drain reliably restores writability,
-                // small enough (about 2.5 MiB/s) to stay far under the floor.
-                std::vector<std::uint8_t> chunk(256U * 1024U);
+                std::vector<std::uint8_t> chunk(4U * 1024U);
                 while (draining.load()) {
-                    std::this_thread::sleep_for(std::chrono::milliseconds{100});
+                    std::this_thread::sleep_for(std::chrono::milliseconds{20});
                     const auto count = readRaw(slow, chunk);
                     if (count == 0) {
                         break;  // the server retired the session
@@ -867,14 +887,19 @@ int main(int argc, char* argv[])
                       << " bytes without the session being retired\n";
             slow.shutdown();
             retired.wait();
+            testing::clearWriteChunkLimit();
+            testing::clearBeforeResponseWrite();
             require(false, "the trickle-reading session was never retired");
         }
         draining.store(false);
         const auto elapsed = retired.get();
+        testing::clearWriteChunkLimit();
+        testing::clearBeforeResponseWrite();
         require(elapsed < retirementBound,
             "the trickle-reading session outlived its retirement bound");
         // The write outlived the stall grace while still moving bytes, so it was
-        // the whole-response budget that retired it.
+        // the whole-response budget that retired it: the pacing above never let
+        // 500 ms pass without progress.
         if (elapsed <= trickleOptions.responseWriteStallTimeout) {
             std::cerr << "trickle session ended after "
                       << std::chrono::duration_cast<std::chrono::milliseconds>(
@@ -888,6 +913,7 @@ int main(int argc, char* argv[])
         require(trickleRunning.stopWithin(std::chrono::seconds{5}),
             "trickle server shutdown exceeded its deadline");
     }
+#endif
 
     std::filesystem::remove_all(
         std::filesystem::path(argv[1]) / "Oversized");

--- a/tests/integration/test_remote_server.cpp
+++ b/tests/integration/test_remote_server.cpp
@@ -778,6 +778,14 @@ int main(int argc, char* argv[])
             = std::chrono::milliseconds{500};
         // 8 KiB/s over a response of a few kibibytes: half a second of grace
         // plus well under a second of transfer allowance.
+        //
+        // Retirement lands at stallTimeout + payloadBytes / minBytesPerSecond,
+        // so the margin the `elapsed > stallTimeout` assertion below rests on
+        // is the transfer term alone. It cannot go negative, and elapsed only
+        // grows under load, so this is not a flake; but shrinking the response
+        // or raising the floor shrinks that term, and past some point the
+        // assertion stops distinguishing the budget from the stall in any
+        // meaningful way. Retune the two together, not one at a time.
         trickleOptions.responseWriteMinimumBytesPerSecond = 8ULL * 1024ULL;
         Server trickleServer(trickleOptions);
         RunningServer trickleRunning(trickleServer);

--- a/tests/unit/test_particle_header.cpp
+++ b/tests/unit/test_particle_header.cpp
@@ -133,9 +133,17 @@ int main()
     // shift -- a silent misparse, which is worse than the allocation it
     // replaced. It has to be rejected outright.
     {
+        // No whitespace between the token and the fields after it, and exactly
+        // the ceiling's worth of it: width() stops at 4096 and the residue then
+        // parses cleanly as intComponentCount, checkpoint, particleCount,
+        // nextId, finestLevel, one grid count and one grid record. Without the
+        // rejection this Header is *accepted* and returns an empty sample --
+        // no throw at all, which is the failure mode the fix exists for. A
+        // token followed by a newline would only ever produce a different
+        // error message, which is not the same property.
         std::string body = "Version_Two_Dot_Zero_double\n2\n1\n";
-        body += std::string(8192, 'A');
-        body += "\n0\n1\n0\n1000\n0\n1\n0 0 0\n";
+        body += std::string(4096, 'A');
+        body += "0 1 0 1000 0 1 0 0 0\n";
         expectRejected(scratch / "long_token", body,
             "a component name past the token ceiling",
             "exceeds the supported length");

--- a/tests/unit/test_particle_header.cpp
+++ b/tests/unit/test_particle_header.cpp
@@ -5,6 +5,8 @@
 // substring: a std::bad_alloc here would mean the bound was never applied.
 #include <amrexplorer/io/ParticleReader.hpp>
 
+#include <array>
+#include <cstdint>
 #include <exception>
 #include <filesystem>
 #include <fstream>
@@ -152,6 +154,49 @@ int main()
             ++g_failures;
         }
         require(threw, "a forged particle count over an empty DATA file");
+    }
+
+    // The other side of the reserve bound: a species whose DATA file really
+    // does hold what its Header claims comes back whole. Every case above is
+    // a rejection, so without this one the file-size pass and the ceiling
+    // arithmetic are only ever exercised on inputs that end in a throw.
+    //
+    // Note what this does and does not pin down. The ceiling feeds a reserve,
+    // which is capacity and not a limit, so an off-by-one there cannot change
+    // the result -- only the allocation. What this catches is the pass
+    // throwing, dividing by zero, or otherwise disturbing a valid read.
+    {
+        const auto plotfile = scratch / "valid_points";
+        constexpr int count = 4;
+        writeSpeciesHeader(plotfile,
+            headerThroughFinestLevel(count, 0) + "1\n"
+                + "0 " + std::to_string(count) + " 0\n");
+        // Two int32 identity words then dimension + 1 doubles, per particle,
+        // matching the 2-D single-real-component Header above.
+        std::ofstream data(plotfile / "Tracer" / "Level_0" / "DATA_00000",
+            std::ios::binary | std::ios::trunc);
+        for (int i = 0; i < count; ++i) {
+            const std::array<std::int32_t, 2> identity{i + 1, 0};
+            data.write(reinterpret_cast<const char*>(identity.data()),
+                sizeof(identity));
+        }
+        for (int i = 0; i < count; ++i) {
+            const std::array<double, 3> record{
+                0.5 * i, 0.25 * i, static_cast<double>(i)};
+            data.write(reinterpret_cast<const char*>(record.data()),
+                sizeof(record));
+        }
+        data.close();
+        try {
+            const auto sample
+                = amrvis::readParticleSample(plotfile, "Tracer", 1.0);
+            require(sample.points.size() == count,
+                "the reserve bound truncated a sample its files can hold");
+        } catch (const std::exception& error) {
+            std::cerr << "FAILED: a valid species was rejected: "
+                      << error.what() << '\n';
+            ++g_failures;
+        }
     }
 
     std::filesystem::remove_all(scratch);

--- a/tests/unit/test_particle_header.cpp
+++ b/tests/unit/test_particle_header.cpp
@@ -124,6 +124,36 @@ int main()
             "particle grid total is outside supported bounds");
     }
 
+    // A forged particleCount over an empty DATA file. The Header is internally
+    // consistent -- its one grid record accounts for every claimed particle --
+    // so nothing in the text contradicts it, and the reserve was previously
+    // taken from it directly: a trillion points is 32 TB of ParticlePoint.
+    // The files on disk are the only evidence of how many particles exist, and
+    // reading now fails on the truncated grid rather than on the allocation.
+    {
+        const auto plotfile = scratch / "forged_count";
+        writeSpeciesHeader(plotfile,
+            headerThroughFinestLevel(1'000'000'000'000ULL, 0) + "1\n"
+                + "0 1000000000000 0\n");
+        std::ofstream(plotfile / "Tracer" / "Level_0" / "DATA_00000",
+            std::ios::binary | std::ios::trunc);
+        bool threw = false;
+        try {
+            (void)amrvis::readParticleSample(plotfile, "Tracer", 1.0);
+        } catch (const amrvis::ParticleReadError& error) {
+            threw = true;
+            require(std::string(error.what()).find("truncated particle grid")
+                    != std::string::npos,
+                "a forged particle count was rejected for the wrong reason");
+        } catch (const std::exception& other) {
+            std::cerr << "FAILED: a forged particle count threw the wrong "
+                         "exception: "
+                      << other.what() << '\n';
+            ++g_failures;
+        }
+        require(threw, "a forged particle count over an empty DATA file");
+    }
+
     std::filesystem::remove_all(scratch);
     if (g_failures != 0) {
         std::cerr << g_failures << " particle Header check(s) failed\n";

--- a/tests/unit/test_particle_header.cpp
+++ b/tests/unit/test_particle_header.cpp
@@ -1,0 +1,133 @@
+// Negative tests for the particle Header parser. A crafted Header is a few
+// hundred bytes of text that nonetheless declares how much memory the reader
+// should set aside, so every declared count must be bounded before it reaches
+// an allocation. Each case asserts the specific ParticleReadError and a message
+// substring: a std::bad_alloc here would mean the bound was never applied.
+#include <amrexplorer/io/ParticleReader.hpp>
+
+#include <exception>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+
+namespace {
+
+int g_failures = 0;
+
+void require(bool condition, const char* message)
+{
+    if (!condition) {
+        std::cerr << "FAILED: " << message << '\n';
+        ++g_failures;
+    }
+}
+
+// Everything the parser consumes before the per-level grid counts: version,
+// dimension, one real component, no integer components, checkpoint flag,
+// particle count, next id, and finest level.
+std::string headerThroughFinestLevel(
+    std::uint64_t particleCount, int finestLevel)
+{
+    return "Version_Two_Dot_Zero_double\n"
+           "2\n"
+           "1\nmass\n"
+           "0\n"
+           "1\n"
+        + std::to_string(particleCount) + "\n"
+        + "1000\n"
+        + std::to_string(finestLevel) + "\n";
+}
+
+void writeSpeciesHeader(
+    const std::filesystem::path& plotfile, const std::string& body)
+{
+    const auto species = plotfile / "Tracer";
+    std::filesystem::create_directories(species / "Level_0");
+    std::ofstream header(species / "Header", std::ios::trunc);
+    header << body;
+}
+
+void expectRejected(const std::filesystem::path& plotfile,
+    const std::string& body, const char* what, const char* expectedMessage)
+{
+    writeSpeciesHeader(plotfile, body);
+    bool threw = false;
+    try {
+        (void)amrvis::readParticleSample(plotfile, "Tracer", 1.0);
+    } catch (const amrvis::ParticleReadError& error) {
+        threw = true;
+        if (std::string(error.what()).find(expectedMessage)
+            == std::string::npos) {
+            std::cerr << "FAILED: " << what
+                      << " was rejected for the wrong reason: " << error.what()
+                      << '\n';
+            ++g_failures;
+            return;
+        }
+    } catch (const std::exception& other) {
+        std::cerr << "FAILED: " << what
+                  << " threw the wrong exception: " << other.what() << '\n';
+        ++g_failures;
+        return;
+    }
+    require(threw, what);
+}
+
+} // namespace
+
+int main()
+{
+    const auto scratch = std::filesystem::temp_directory_path()
+        / "amrexplorer_particle_header_test";
+    std::filesystem::remove_all(scratch);
+    std::filesystem::create_directories(scratch);
+
+    // Baseline: the shape the crafted cases are built from must itself parse,
+    // or a rejection below proves nothing about the check it claims to cover.
+    {
+        const auto plotfile = scratch / "valid";
+        writeSpeciesHeader(plotfile,
+            headerThroughFinestLevel(0, 0) + "1\n" + "0 0 0\n");
+        try {
+            const auto sample
+                = amrvis::readParticleSample(plotfile, "Tracer", 1.0);
+            require(sample.species.dimension == 2,
+                "baseline particle Header dimension mismatch");
+            require(sample.points.empty(),
+                "baseline particle Header should hold no points");
+        } catch (const std::exception& error) {
+            std::cerr << "FAILED: baseline particle Header was rejected: "
+                      << error.what() << '\n';
+            ++g_failures;
+        }
+    }
+
+    // One level over the per-level cap. This bound already existed; it is here
+    // so the total-cap case below is known to be testing the *sum* rather than
+    // re-testing this.
+    expectRejected(scratch / "per_level",
+        headerThroughFinestLevel(0, 0) + "10000001\n",
+        "a level declaring more grids than the per-level cap",
+        "particle grid count is outside supported bounds");
+
+    // Ten levels, each well under the per-level cap, summing to twenty million
+    // grids. Before the total was bounded this reserved the sum -- roughly half
+    // a gigabyte of GridRecords -- from these few dozen bytes of text.
+    {
+        std::string body = headerThroughFinestLevel(0, 9);
+        for (int level = 0; level < 10; ++level) {
+            body += "2000000\n";
+        }
+        expectRejected(scratch / "cross_level",
+            body, "levels summing past the whole-table cap",
+            "particle grid total is outside supported bounds");
+    }
+
+    std::filesystem::remove_all(scratch);
+    if (g_failures != 0) {
+        std::cerr << g_failures << " particle Header check(s) failed\n";
+        return 1;
+    }
+    return 0;
+}

--- a/tests/unit/test_particle_header.cpp
+++ b/tests/unit/test_particle_header.cpp
@@ -126,6 +126,21 @@ int main()
             "particle grid total is outside supported bounds");
     }
 
+    // An over-long component name, with no whitespace before the field that
+    // follows it. Bounding the extraction with width() is not enough on its
+    // own: >> stops at the limit but only fails on an empty extraction, so the
+    // tail would be read as the *next* field and every field after it would
+    // shift -- a silent misparse, which is worse than the allocation it
+    // replaced. It has to be rejected outright.
+    {
+        std::string body = "Version_Two_Dot_Zero_double\n2\n1\n";
+        body += std::string(8192, 'A');
+        body += "\n0\n1\n0\n1000\n0\n1\n0 0 0\n";
+        expectRejected(scratch / "long_token", body,
+            "a component name past the token ceiling",
+            "exceeds the supported length");
+    }
+
     // A forged particleCount over an empty DATA file. The Header is internally
     // consistent -- its one grid record accounts for every claimed particle --
     // so nothing in the text contradicts it, and the reserve was previously


### PR DESCRIPTION
Part 1 of 4 in the stabilization stack.

## Purpose

Close the remaining ways a crafted or corrupt file can make a reader allocate
without bound, and stop the trickle-reader test paying a 50 MiB response for a
property that has nothing to do with size.

Completes phase S2 of the stabilization milestone
(`agent-notes/plans/PLAN.md` §37): correctness, availability, bounded failure.

## Scope

**Particle Header allocations.** Three separate bounds, all reachable from an
ordinary dataset open -- and therefore from inside the long-lived server, where
species discovery parses every species Header before any client asks:

- The grid table was capped per level but reserved the *sum*, so a Header
  declaring the maximum on each of the maximum levels asked for ten billion
  `GridRecord`s. Capped as a whole, and the reserve is bounded by the Header's
  own size on top of that: a grid record cannot be shorter than `"0 0 0\n"`, so
  the file's bytes say how many can follow. A failed stat means no reserve
  rather than the largest one the cap still allows.
- String tokens extracted with `>>` were unbounded -- the species probe, which
  sits outside the narrow catch, and every component name. Bounded with
  `width()`, *and* rejected when they reach the limit: `>>` stops at the width
  but fails only on an empty extraction, so bounding alone would leave the tail
  to be read as the next field and shift every field after it.
- The point reserve came from the Header's `particleCount`, which is checked
  only against the grid table in the same text file. It now comes from the DATA
  files' sizes at `particleBytesOnDisk` per particle. See the caveat below.

**FAB header line reads.** A FAB header is text at the head of a binary file, so
`std::getline` had no idea where to stop: a file opening `FAB ` with no newline
pulled in the whole remainder, once per record in `scanFabFile`'s loop. Added
`detail::readBoundedLine` beside the other shared FAB parsing helpers.

**The server survives crafted input.** `remote_server` opens a plotfile carrying
a crafted grid table and requires the open to succeed, the crafted species to be
absent from the advertised catalog while a well-formed one is listed, and a
request for it by name to be an ordinary error on a connection that keeps
serving. Also a cancellation check in the DATA-file stat loop, which was the one
stretch of that path that ignored a cancelled request.

**The trickle-reader case.** It asked for a 2048x2048 slice only so the write
could not fit in kernel socket buffers, and paid for the sampling and encoding
*before* the write it measures began. A write-pacing hook on the existing
`AMREXPLORER_ENABLE_SERVER_TEST_HOOKS` seam now holds the write in flight
deterministically from a 16x16 response, scoped by a thread-local response-write
marker and by request id so the neighbour session is untouched.

That moved the case behind the hook option, which took it out of the Windows
job -- the only one covering the whole-response write budget there, since
`test_remote_frame`'s socket-pair proof is POSIX-only. The Windows job now
enables the hooks, as `remote` and `tsan` already do.

## Evidence

Every regression was checked to fail without its fix: the grid cap and the point
reserve report `bad_alloc` or the wrong error without theirs; the bounded line
read reports its own ceiling rather than a later parse failure; the over-long
token case fails on the *shifted* parse ("integer component count") without the
rejection; and removing the whole-response write budget makes the reshaped
trickle case fail with `the trickle-reading session was never retired`.

`remote_server` drops from 7.2 s to 1.5 s in the Release remote build and from
about 12 s to 1.6 s under TSan, closing the CI-reliability residual left by #128.

Green: 101 tests in `default`, 47 in `remote`, and `clang` with warnings as
errors. The Windows change was verified by proxy -- no Windows build is
available here, so the Qt-plus-hooks configuration it creates, which nothing
else built, was configured and run locally: `remote_server` goes 0.61 s to
1.62 s there, which is the trickle case reappearing.

## Two claims an earlier draft of this description got wrong

**The point-reserve bound is forgeable, and that is accepted on those terms.**
`std::filesystem::file_size` reports *apparent* size, so `truncate -s 128G`
yields 128 GB of "evidence" at zero blocks consumed. The bound is not anchored
to bytes actually written. It is accepted because this is a DoS-shaped
allocation attempt on a request-scoped path and a genuinely non-sparse 128 GB
file would do the same. (It also counts particles rather than bytes, allowing
about 2.7x slack -- that part is a bound, not an estimate, and is fine.)

**Validating the bounded `requestParticleSample` overload was not needed for the
wire.** `Codec.cpp` already rejects a fraction outside (0, 1] and `Server.cpp`
already rejects an unknown species before that overload is reached. The call is
kept for symmetry between two overloads of the same session API, which is a
weaker reason than the one first given.

## Deliberately not here

The line-oriented *text* header readers are still unbounded, and
`readVisMfIndex` reserves from a declared count rather than from evidence. Two
of those bounds were added partway through review, without tests, and have been
reverted so the surface lands as one reviewable change:
`agent-notes/issues/text-header-readers-unbounded.md` records all six items,
the `width()` truncation trap above, and `parseHeader`'s missing `StopToken`.

Enabling the hooks on Windows means no job now builds Windows in the
configuration a user gets; `linux`, `macos`, `qt-sanitizers` and `sanitizers`
all still do, and the seam is additive, so a hooks-off build compiles a strict
subset. `ci.yml` records that and the way out of it.
