### PR TITLE
[stabilization] remove the remote range round trip and the arrival copies

### DIFF
--- a/include/amrexplorer/cache/ByteLruCache.hpp
+++ b/include/amrexplorer/cache/ByteLruCache.hpp
@@ -273,13 +273,21 @@ private:
     // Handle::release behind a deallocator. Callers declare `doomed` before
     // they take the lock, so it outlives the lock and the memory is returned
     // after the mutex is free.
+    //
+    // The map entry is retired before `doomed` grows, because push_back
+    // allocates: a throw between erasing the LRU node and erasing the map entry
+    // would leave a live entry holding a freed lruPosition (which the next
+    // touch() splices) and a null value (which the returned Handle
+    // dereferences). Ordered this way the only cost of a failed push_back is
+    // that this one payload is freed under the mutex instead of after it.
     static void eraseEntry(State& state, typename EntryMap::iterator entry,
         std::vector<std::shared_ptr<const Value>>& doomed)
     {
+        auto value = std::move(entry->second.value);
         state.metrics.residentBytes -= entry->second.bytes;
         state.lru.erase(entry->second.lruPosition);
-        doomed.push_back(std::move(entry->second.value));
         state.entries.erase(entry);
+        doomed.push_back(std::move(value));
     }
 
     // Single tail-to-head sweep of the LRU list, evicting unpinned entries

--- a/include/amrexplorer/cache/ByteLruCache.hpp
+++ b/include/amrexplorer/cache/ByteLruCache.hpp
@@ -11,6 +11,7 @@
 #include <stdexcept>
 #include <unordered_map>
 #include <utility>
+#include <vector>
 
 namespace amrvis {
 
@@ -147,6 +148,9 @@ public:
         if (!value) {
             throw std::invalid_argument("cannot cache a null value");
         }
+        // Declared before the lock so it is destroyed after it: the payloads
+        // this insert evicts are freed with the mutex already released.
+        std::vector<std::shared_ptr<const Value>> doomed;
         std::scoped_lock lock(m_state->mutex);
         const auto existing = m_state->entries.find(key);
         if (existing != m_state->entries.end()) {
@@ -165,7 +169,7 @@ public:
         if (m_state->metrics.pinnedBytes + bytes > m_state->metrics.budgetBytes) {
             throw CacheBudgetExceeded("cache budget is occupied by pinned entries");
         }
-        evictFor(*m_state, bytes);
+        evictFor(*m_state, bytes, doomed);
 
         m_state->lru.push_front(key);
         Entry entry{std::move(value), bytes, 1, m_state->lru.begin()};
@@ -180,32 +184,37 @@ public:
 
     [[nodiscard]] bool erase(const Key& key)
     {
+        std::vector<std::shared_ptr<const Value>> doomed;
         std::scoped_lock lock(m_state->mutex);
         const auto found = m_state->entries.find(key);
         if (found == m_state->entries.end() || found->second.pinCount != 0) {
             return false;
         }
-        eraseEntry(*m_state, found);
+        eraseEntry(*m_state, found, doomed);
         ++m_state->metrics.clears;
         return true;
     }
 
     [[nodiscard]] bool setBudget(std::uint64_t budgetBytes)
     {
+        std::vector<std::shared_ptr<const Value>> doomed;
         std::scoped_lock lock(m_state->mutex);
         m_state->metrics.budgetBytes = budgetBytes;
-        evictFor(*m_state, 0);
+        evictFor(*m_state, 0, doomed);
         return m_state->metrics.residentBytes <= budgetBytes;
     }
 
     void clearUnpinned()
     {
+        // A full clear frees every unpinned payload; without this they would
+        // all be released serially with the mutex held.
+        std::vector<std::shared_ptr<const Value>> doomed;
         std::scoped_lock lock(m_state->mutex);
         auto current = m_state->entries.begin();
         while (current != m_state->entries.end()) {
             if (current->second.pinCount == 0) {
-                const auto doomed = current++;
-                eraseEntry(*m_state, doomed);
+                const auto entry = current++;
+                eraseEntry(*m_state, entry, doomed);
                 ++m_state->metrics.clears;
             } else {
                 ++current;
@@ -257,10 +266,19 @@ private:
 
     // Removes an entry's storage and accounting. The caller records the
     // reason (capacity eviction vs. explicit clear) in the matching counter.
-    static void eraseEntry(State& state, typename EntryMap::iterator entry)
+    //
+    // The payload is handed to `doomed` rather than released here. Every caller
+    // holds the cache mutex, and a cached block is megabytes: freeing it inline
+    // makes a panning burst's evictions stall every concurrent findAndPin and
+    // Handle::release behind a deallocator. Callers declare `doomed` before
+    // they take the lock, so it outlives the lock and the memory is returned
+    // after the mutex is free.
+    static void eraseEntry(State& state, typename EntryMap::iterator entry,
+        std::vector<std::shared_ptr<const Value>>& doomed)
     {
         state.metrics.residentBytes -= entry->second.bytes;
         state.lru.erase(entry->second.lruPosition);
+        doomed.push_back(std::move(entry->second.value));
         state.entries.erase(entry);
     }
 
@@ -268,7 +286,8 @@ private:
     // until the incoming bytes fit or the list is exhausted. Each list node is
     // examined at most once (O(n)); the previous version restarted from the
     // tail after every eviction, making it O(k*n) with a pinned-heavy tail.
-    static void evictFor(State& state, std::uint64_t incomingBytes)
+    static void evictFor(State& state, std::uint64_t incomingBytes,
+        std::vector<std::shared_ptr<const Value>>& doomed)
     {
         auto it = state.lru.end();
         while (it != state.lru.begin()
@@ -280,7 +299,7 @@ private:
                 // eraseEntry removes *candidate from the list (invalidating
                 // `candidate`); `it` points past it and stays valid, so the
                 // next std::prev(it) is the node that preceded the erased one.
-                eraseEntry(state, found);
+                eraseEntry(state, found, doomed);
                 ++state.metrics.evictions;
             } else {
                 // Keep a pinned (or already-gone) entry and move toward head.

--- a/include/amrexplorer/data/LocalDatasetSession.hpp
+++ b/include/amrexplorer/data/LocalDatasetSession.hpp
@@ -2,9 +2,12 @@
 
 #include <amrexplorer/data/DatasetSession.hpp>
 
+#include <cstdint>
 #include <filesystem>
+#include <map>
 #include <memory>
 #include <mutex>
+#include <optional>
 
 namespace amrvis {
 
@@ -58,6 +61,12 @@ private:
     std::vector<ParticleSpeciesMetadata> m_particleSpecies;
     mutable std::mutex m_mutex;
     std::shared_ptr<PlotfileDataset> m_dataset;
+    // File-scope ranges for a standalone FAB, by field. These are scanned out
+    // of the payload rather than read from a statistic, and they never change,
+    // so the scan happens once per field. Cached even when the answer is "no
+    // finite values", which costs the same scan to discover. Cancelled scans
+    // record nothing.
+    std::map<std::uint32_t, std::optional<ValueRange>> m_fabRanges;
 };
 
 } // namespace amrvis

--- a/include/amrexplorer/remote/Connection.hpp
+++ b/include/amrexplorer/remote/Connection.hpp
@@ -60,6 +60,10 @@ public:
     [[nodiscard]] CacheMetrics setCacheBudget(DatasetId dataset,
         std::uint64_t bytes, StopToken cancellation = {});
     [[nodiscard]] CacheMetrics latestCache(DatasetId dataset) const;
+    // Request/response pairs this connection has started, monotonically. The
+    // number itself is not meaningful; the difference across an operation is,
+    // which is how a test proves that a repeated query costs no round trip.
+    [[nodiscard]] std::uint64_t transactionCount() const noexcept;
     void ping(StopToken cancellation = {});
 
     void close() noexcept;

--- a/include/amrexplorer/remote/RemoteDatasetSession.hpp
+++ b/include/amrexplorer/remote/RemoteDatasetSession.hpp
@@ -3,9 +3,14 @@
 #include <amrexplorer/data/DatasetSession.hpp>
 #include <amrexplorer/remote/Connection.hpp>
 
+#include <condition_variable>
+#include <map>
 #include <memory>
 #include <mutex>
+#include <optional>
+#include <set>
 #include <string>
+#include <tuple>
 
 namespace amrvis::remote {
 
@@ -52,6 +57,18 @@ private:
         std::string path, OpenedDataset opened);
     void requireOpen() const;
 
+    // A range is immutable for a (dataset, field, level, composition, scope),
+    // and the dataset is fixed for the life of this session, so a successful
+    // answer never has to be asked for twice. The UI defaults to File range
+    // mode and resolves it after every slice, so without this each pan, zoom,
+    // sequence frame, and cosmetic re-render paid an extra serialized round
+    // trip -- and a logarithmic display resolves twice per render.
+    //
+    // RangeRequest has no equality or hash, so the key is a tuple of exactly
+    // the fields the server distinguishes.
+    using RangeKey = std::tuple<std::uint32_t, int, std::uint8_t, std::uint8_t>;
+    [[nodiscard]] static RangeKey rangeKey(const RangeRequest& request) noexcept;
+
     std::shared_ptr<Connection> m_connection;
     std::string m_path;
     DatasetId m_id;
@@ -63,6 +80,22 @@ private:
     std::vector<std::uint8_t> m_levelRangeAvailable;
     mutable std::mutex m_mutex;
     bool m_open = true;
+
+    // Successful answers only. An empty optional is one of them -- the wire
+    // carries "has range" as a boolean, so "this field has no range" is an
+    // answer rather than an absence. Errors, cancellations, and disconnects are
+    // never recorded, so none of them can poison a later retry.
+    //
+    // m_rangeInFlight plus the condition variable coalesce concurrent identical
+    // misses into one transaction: the first caller for a key does the work and
+    // the rest wait for it. A waiter whose leader failed takes the work over
+    // itself rather than inheriting the failure. Neither mutex is ever held
+    // across network I/O.
+    mutable std::mutex m_rangeMutex;
+    mutable std::condition_variable m_rangeReady;
+    std::map<RangeKey, std::optional<ValueRange>> m_ranges;
+    std::set<RangeKey> m_rangeInFlight;
+
 };
 
 } // namespace amrvis::remote

--- a/src/data/LocalDatasetSession.cpp
+++ b/src/data/LocalDatasetSession.cpp
@@ -161,6 +161,14 @@ std::optional<ValueRange> LocalDatasetSession::requestRange(
         // be scanned out of the payload. The result is immutable for this
         // (dataset, field), and the resolver asks for it on every range
         // resolve, so scan once.
+        //
+        // The check precedes the memo for the same reason it precedes the scan:
+        // the block read this used to always perform answered an already-
+        // cancelled token with ReadCancelled, and a memo hit must not turn
+        // abandoned work into a successful resolve.
+        if (cancellation.stop_requested()) {
+            throw ReadCancelled();
+        }
         {
             std::scoped_lock lock(m_mutex);
             if (const auto found = m_fabRanges.find(request.field.value);

--- a/src/data/LocalDatasetSession.cpp
+++ b/src/data/LocalDatasetSession.cpp
@@ -157,24 +157,47 @@ std::optional<ValueRange> LocalDatasetSession::requestRange(
     const auto dataset = requireDataset();
     validateSessionRangeRequest(m_metadata, request);
     if (m_metadata.isFab && request.scope == RangeScope::File) {
-        BlockRequest block;
-        block.dataset = m_id;
-        block.field = request.field;
-        const auto access = dataset->requestBlock(block, cancellation);
+        // A standalone FAB has no metadata statistic, so the File range has to
+        // be scanned out of the payload. The result is immutable for this
+        // (dataset, field), and the resolver asks for it on every range
+        // resolve, so scan once.
+        {
+            std::scoped_lock lock(m_mutex);
+            if (const auto found = m_fabRanges.find(request.field.value);
+                found != m_fabRanges.end()) {
+                return found->second;
+            }
+        }
+        const auto access = [&] {
+            BlockRequest block;
+            block.dataset = m_id;
+            block.field = request.field;
+            return dataset->requestBlock(block, cancellation);
+        }();
         auto minimum = std::numeric_limits<double>::infinity();
         auto maximum = -std::numeric_limits<double>::infinity();
-        for (std::size_t index = 0; index < access.handle->values.size();
-             ++index) {
-            const auto value = access.handle->values[index];
+        const auto& values = access.handle->values;
+        for (std::size_t index = 0; index < values.size(); ++index) {
+            // The read itself polls cancellation; this pass did not, so a
+            // cancelled request still walked every value of a large FAB before
+            // returning. One check per chunk keeps that responsive without
+            // putting a branch on every value.
+            if ((index & 0xFFFFU) == 0 && cancellation.stop_requested()) {
+                throw ReadCancelled();
+            }
+            const auto value = values[index];
             if (std::isfinite(value)) {
                 minimum = std::min(minimum, value);
                 maximum = std::max(maximum, value);
             }
         }
-        if (std::isfinite(minimum) && std::isfinite(maximum)) {
-            return ValueRange{minimum, maximum};
-        }
-        return std::nullopt;
+        const auto result = std::isfinite(minimum) && std::isfinite(maximum)
+            ? std::optional<ValueRange>{ValueRange{minimum, maximum}}
+            : std::nullopt;
+        // Only a completed scan is recorded; a cancelled one threw above.
+        std::scoped_lock lock(m_mutex);
+        m_fabRanges.insert_or_assign(request.field.value, result);
+        return result;
     }
     return compositeMetadataRange(m_metadata, request);
 }

--- a/src/qt/FabSelectorDock.cpp
+++ b/src/qt/FabSelectorDock.cpp
@@ -374,8 +374,36 @@ const std::vector<FabSelectorEntry>& FabSelectorDock::entries() const noexcept
 
 void FabSelectorDock::setBackAvailable(bool available)
 {
+    // Recorded rather than read back off the button: a widget inside a hidden
+    // dock reports isVisible() == false however it was configured, and the
+    // restore path below needs the configured value.
+    m_backAvailable = available;
     m_back->setVisible(available);
     m_back->setEnabled(available);
+}
+
+bool FabSelectorDock::backAvailable() const noexcept
+{
+    return m_backAvailable;
+}
+
+std::optional<std::size_t> FabSelectorDock::selectedOrdinal() const
+{
+    const auto index = m_table->currentIndex();
+    if (!index.isValid()) {
+        return std::nullopt;
+    }
+    const auto ordinal = index.data(Qt::UserRole);
+    if (!ordinal.isValid()) {
+        return std::nullopt;
+    }
+    return static_cast<std::size_t>(ordinal.toULongLong());
+}
+
+void FabSelectorDock::clearSelection()
+{
+    m_table->clearSelection();
+    m_table->setCurrentIndex({});
 }
 
 void FabSelectorDock::selectEntry(std::size_t ordinal)

--- a/src/qt/FabSelectorDock.hpp
+++ b/src/qt/FabSelectorDock.hpp
@@ -8,6 +8,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <filesystem>
+#include <optional>
 #include <vector>
 
 class QLineEdit;
@@ -40,7 +41,14 @@ public:
     void setEntries(std::vector<FabSelectorEntry> entries);
     [[nodiscard]] const std::vector<FabSelectorEntry>& entries() const noexcept;
     void setBackAvailable(bool available);
+    [[nodiscard]] bool backAvailable() const noexcept;
     void selectEntry(std::size_t ordinal);
+    // The ordinal the table currently highlights, or nullopt if nothing is
+    // selected. Together with backAvailable this is the selector state a
+    // caller has to put back when an open it committed to optimistically
+    // turns out to have failed.
+    [[nodiscard]] std::optional<std::size_t> selectedOrdinal() const;
+    void clearSelection();
 
 signals:
     void viewRequested(std::size_t entry);
@@ -60,6 +68,7 @@ private:
     QTableView* m_table = nullptr;
     QPushButton* m_view = nullptr;
     QPushButton* m_back = nullptr;
+    bool m_backAvailable = false;
     int m_dimension = 0;
 };
 

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -4984,8 +4984,8 @@ void MainWindow::openStandaloneFabAsync(std::filesystem::path path,
                     if (owned) {
                         applyFabSelectorRollback(*owned);
                     }
-                    reportBackgroundError(QStringLiteral("%1: %2")
-                            .arg(failureTitle, exceptionMessage(error)));
+                    reportBackgroundError(
+                        tr("%1: %2").arg(failureTitle, exceptionMessage(error)));
                 } else {
                     ++m_staleResults;
                 }
@@ -5476,12 +5476,19 @@ void MainWindow::openDataset(
 
 void MainWindow::resetFabState()
 {
-    // Tearing the selector down revokes any read still in flight against it.
-    // Moving the request token is what does that: no completion can still be
-    // current, so none can publish over the new dataset or restore an ordinal
-    // belonging to the old one. This is the only teardown site that needs to
-    // say so -- prepareSequence reaches it too, and that path bypasses
-    // openDatasetImpl entirely, so its generation bump is not available here.
+    // Belt-and-braces, not the guarantee. Tearing the selector down has to
+    // revoke any read still in flight against it, but the dataset generation
+    // already does that at both call sites: openDatasetImpl bumps it further
+    // down the same straight-line body, and prepareSequence's callers reach
+    // MainWindow's frameSwitchStarted handler -- a direct connection, so the
+    // same event-loop slot -- which bumps it too. No completion can be
+    // delivered in between, so `generation == m_generation` is already false
+    // for every earlier read and this token bump has never been what retires
+    // one. It is kept because it is cheap and because relying on a bump that
+    // happens a frame up the stack, in a signal handler, is not a property
+    // this function can see. Do not read it as load-bearing: it is not
+    // covered by a test, and it cannot be, because the state it would guard
+    // is unreachable.
     ++m_fabOpenGeneration;
     m_pendingFabOpen.reset();
     m_fabMode = false;

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -4736,19 +4736,13 @@ void MainWindow::chooseStandaloneDataset(const QString& caption, bool rawFab)
         tr("AMReX data (*)"));
     if (!filename.isEmpty()) {
         if (rawFab) {
-            try {
-                const auto path = std::filesystem::path(filename.toStdString());
-                auto metadata = StandaloneMetadataReader{}.readFab(path);
-                auto root = path.parent_path();
-                if (root.empty()) {
-                    root = ".";
-                }
-                openDatasetImpl(path, false, std::move(metadata),
-                    std::move(root), false, std::nullopt);
-            } catch (const std::exception& error) {
-                QMessageBox::critical(this, tr("Cannot open FAB"),
-                    exceptionMessage(error));
+            const auto path = std::filesystem::path(filename.toStdString());
+            auto root = path.parent_path();
+            if (root.empty()) {
+                root = ".";
             }
+            openStandaloneFabAsync(path, std::nullopt, std::move(root), false,
+                std::nullopt, tr("Cannot open FAB"));
         } else {
             openDataset(filename.toStdString());
         }
@@ -4887,6 +4881,53 @@ FabSelectorBuild buildFabSelector(
 
 } // namespace
 
+void MainWindow::openStandaloneFabAsync(std::filesystem::path path,
+    std::optional<std::uint64_t> fileOffset, std::filesystem::path dataRoot,
+    bool preserveFabSelector, std::optional<FrameSliceSpec> initialSpec,
+    QString failureTitle)
+{
+    ++m_activeRequests;
+    const auto generation = m_generation;
+    auto* watcher = new QFutureWatcher<PlotfileMetadataResult>(this);
+    connect(watcher, &QFutureWatcher<PlotfileMetadataResult>::finished, this,
+        [this, watcher, generation, path, dataRoot = std::move(dataRoot),
+            preserveFabSelector, initialSpec = std::move(initialSpec),
+            failureTitle = std::move(failureTitle)]() mutable {
+            --m_activeRequests;
+            if (m_closing) {
+                watcher->deleteLater();
+                return;
+            }
+            try {
+                auto metadata = watcher->future().takeResult();
+                // A dataset opened while this read was in flight owns the
+                // window now; publishing over it would be a stale result.
+                if (generation == m_generation) {
+                    openDatasetImpl(path, false, std::move(metadata),
+                        std::move(dataRoot), preserveFabSelector,
+                        std::move(initialSpec));
+                } else {
+                    ++m_staleResults;
+                }
+            } catch (const std::exception& error) {
+                if (generation == m_generation) {
+                    QMessageBox::critical(
+                        this, failureTitle, exceptionMessage(error));
+                } else {
+                    ++m_staleResults;
+                }
+            }
+            updateDiagnostics();
+            watcher->deleteLater();
+        });
+    watcher->setFuture(QtConcurrent::run([path, fileOffset] {
+        return fileOffset
+            ? StandaloneMetadataReader{}.readFab(path, *fileOffset)
+            : StandaloneMetadataReader{}.readFab(path);
+    }));
+    updateDiagnostics();
+}
+
 void MainWindow::viewFab(std::size_t entryIndex)
 {
     const auto& entries = m_fabSelectorDock->entries();
@@ -4905,9 +4946,18 @@ void MainWindow::viewFab(std::size_t entryIndex)
         }
         PlotfileMetadataResult selected;
         if (entry.rawRecord) {
-            selected = StandaloneMetadataReader{}.readFab(
-                entry.filePath, entry.fileOffset);
-        } else {
+            // The record's own header has to be read; do it off the GUI thread
+            // and let the completion open it. The selector state below is set
+            // first either way, so the dock reflects the choice immediately.
+            m_fabMode = true;
+            m_fabSelectorDock->setBackAvailable(m_multifabReturn.has_value());
+            m_fabSelectorDock->selectEntry(entry.ordinal);
+            openStandaloneFabAsync(m_fabSourcePath, entry.fileOffset,
+                m_fabDataRoot, true, std::move(selectedSpec),
+                tr("Cannot view FAB"));
+            return;
+        }
+        {
             if (!m_fabSourceMetadata) {
                 throw std::runtime_error(
                     "the source MultiFab is no longer available");
@@ -5804,7 +5854,7 @@ void MainWindow::requestInitialSlice(
                 return;
             }
             try {
-                auto result = watcher->result();
+                auto result = watcher->future().takeResult();
                 if (generation == m_generation) {
                     m_dataset = result.dataset;
                     m_particleSamples = std::move(result.particles);
@@ -5890,7 +5940,7 @@ void MainWindow::requestInitialSlice(
                                     result.displays[index].request.visibleRegion}
                                 : std::optional<RealBox>{};
                         }
-                        showSlice(*views[index], result.displays[index]);
+                        showSlice(*views[index], std::move(result.displays[index]));
                     }
                     if (isRemote) {
                         // A resize during the initial worker cannot submit a
@@ -6292,7 +6342,10 @@ void MainWindow::requestSlice(PlaneViewState& state, bool rasterDirty)
                 return;
             }
             try {
-                auto result = watcher->result();
+                // takeResult, not result(): result() returns a reference into
+                // the future and copying out of it duplicates every plane in
+                // the arrival before showSlice has even seen it.
+                auto result = watcher->future().takeResult();
                 if (generation == m_generation
                     && sliceGeneration == state.sliceGeneration) {
                     // Cache the full-domain range whenever we get a non-zoomed
@@ -6328,7 +6381,7 @@ void MainWindow::requestSlice(PlaneViewState& state, bool rasterDirty)
                         DisplayCoordinator::realignArrivalToRange(result,
                             *cachedRange, m_palette, m_viewDimension != 3);
                     }
-                    showSlice(state, result);
+                    showSlice(state, std::move(result));
                     syncVisibleRanges();
                     // Cache the full-domain range. In 3-D the store defers to
                     // the (async) shared-range sync's completion so the union
@@ -6702,7 +6755,7 @@ std::optional<QRectF> MainWindow::sphericalReframe(
         visible.width() * sx, visible.height() * sy);
 }
 
-void MainWindow::showSlice(PlaneViewState& state, const SliceDisplayResult& display)
+void MainWindow::showSlice(PlaneViewState& state, SliceDisplayResult display)
 {
     if (!display.rasterUnchanged) {
         if (!display.image.valid()) {
@@ -6764,7 +6817,8 @@ void MainWindow::showSlice(PlaneViewState& state, const SliceDisplayResult& disp
     }
     // Fresh immutable snapshots: replace the pointers, never mutate the
     // pointees a cached-planes refresh worker may still be reading.
-    state.plane = std::make_shared<const ScalarPlane>(display.slice.plane);
+    state.plane
+        = std::make_shared<const ScalarPlane>(std::move(display.slice.plane));
     // Spherical warps the raster into physical (R, Z); overlays and the probe
     // map through displayRegion, which for every other system is just the
     // plane's logical bounds (see PlaneMapping).
@@ -6772,19 +6826,19 @@ void MainWindow::showSlice(PlaneViewState& state, const SliceDisplayResult& disp
     state.sphericalDisplay = display.sphericalDisplay;
     state.displayRegion = display.displayRegion;
     state.contourPlane
-        = std::make_shared<const ScalarPlane>(display.contourPlane);
-    state.contourFinePlane
-        = std::make_shared<const ScalarPlane>(display.contourFinePlane);
+        = std::make_shared<const ScalarPlane>(std::move(display.contourPlane));
+    state.contourFinePlane = std::make_shared<const ScalarPlane>(
+        std::move(display.contourFinePlane));
     state.contourFineFactor = display.contourFineFactor;
-    state.contourPolylines = display.contourPolylines;
+    state.contourPolylines = std::move(display.contourPolylines);
     const auto fieldName = QString::fromStdString(display.fieldName);
     state.fieldName = fieldName;
     state.displayMinimum = display.minimum;
     state.displayMaximum = display.maximum;
     state.displayLogarithmic = display.logarithmic;
-    state.vectorSegments = display.vectors;
+    state.vectorSegments = std::move(display.vectors);
     if (display.slice.gridBoxesIncluded) {
-        state.gridBoxes = display.slice.gridBoxes;
+        state.gridBoxes = std::move(display.slice.gridBoxes);
     }
     // Cache key for the re-render-from-cache path (see requestSlice).
     state.cachedRequest = display.request;
@@ -7297,7 +7351,7 @@ void MainWindow::displayFrameResult(InitialSliceResult& result,
         throw std::runtime_error("frame slice count does not match the view set");
     }
     for (std::size_t index = 0; index < views.size(); ++index) {
-        showSlice(*views[index], result.displays[index]);
+        showSlice(*views[index], std::move(result.displays[index]));
     }
     const auto cache = m_dataset->cacheMetrics();
     m_cacheBudgetBytes = cache.budgetBytes;

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -3179,7 +3179,7 @@ void MainWindow::requestParticleReload()
         this, [this, watcher, generation, particleGeneration, cancellation] {
             --m_activeRequests;
             try {
-                auto samples = watcher->result();
+                auto samples = watcher->future().takeResult();
                 if (generation == m_generation
                     && particleGeneration == m_particleGeneration) {
                     m_particleSamples = std::move(samples);
@@ -4884,25 +4884,37 @@ FabSelectorBuild buildFabSelector(
 void MainWindow::openStandaloneFabAsync(std::filesystem::path path,
     std::optional<std::uint64_t> fileOffset, std::filesystem::path dataRoot,
     bool preserveFabSelector, std::optional<FrameSliceSpec> initialSpec,
-    QString failureTitle)
+    QString failureTitle, std::function<void()> restoreOnFailure)
 {
     ++m_activeRequests;
     const auto generation = m_generation;
+    // Two of these can be in flight at once -- clicking a second raw record
+    // while the first is still reading, which is reachable precisely because
+    // the read no longer freezes the GUI. Without a per-request token both
+    // completions match the generation they captured and the *first* to arrive
+    // opens, while the selector already shows the second: oldest-wins, and the
+    // window disagrees with the dock.
+    const auto fabGeneration = ++m_fabOpenGeneration;
     auto* watcher = new QFutureWatcher<PlotfileMetadataResult>(this);
     connect(watcher, &QFutureWatcher<PlotfileMetadataResult>::finished, this,
-        [this, watcher, generation, path, dataRoot = std::move(dataRoot),
-            preserveFabSelector, initialSpec = std::move(initialSpec),
-            failureTitle = std::move(failureTitle)]() mutable {
+        [this, watcher, generation, fabGeneration, path,
+            dataRoot = std::move(dataRoot), preserveFabSelector,
+            initialSpec = std::move(initialSpec),
+            failureTitle = std::move(failureTitle),
+            restoreOnFailure = std::move(restoreOnFailure)]() mutable {
             --m_activeRequests;
             if (m_closing) {
                 watcher->deleteLater();
                 return;
             }
+            // A dataset opened while this read was in flight owns the window
+            // now, and so does a newer FAB read; publishing over either would
+            // be a stale result.
+            const bool current = generation == m_generation
+                && fabGeneration == m_fabOpenGeneration;
             try {
                 auto metadata = watcher->future().takeResult();
-                // A dataset opened while this read was in flight owns the
-                // window now; publishing over it would be a stale result.
-                if (generation == m_generation) {
+                if (current) {
                     openDatasetImpl(path, false, std::move(metadata),
                         std::move(dataRoot), preserveFabSelector,
                         std::move(initialSpec));
@@ -4910,7 +4922,13 @@ void MainWindow::openStandaloneFabAsync(std::filesystem::path path,
                     ++m_staleResults;
                 }
             } catch (const std::exception& error) {
-                if (generation == m_generation) {
+                if (current) {
+                    // The caller may have moved UI state to this FAB before
+                    // the read returned; the open did not happen, so put it
+                    // back before saying so.
+                    if (restoreOnFailure) {
+                        restoreOnFailure();
+                    }
                     QMessageBox::critical(
                         this, failureTitle, exceptionMessage(error));
                 } else {
@@ -4947,14 +4965,30 @@ void MainWindow::viewFab(std::size_t entryIndex)
         PlotfileMetadataResult selected;
         if (entry.rawRecord) {
             // The record's own header has to be read; do it off the GUI thread
-            // and let the completion open it. The selector state below is set
-            // first either way, so the dock reflects the choice immediately.
+            // and let the completion open it. The selector state is moved to
+            // the pending record immediately so the dock reflects the choice
+            // without waiting for the read -- but only a read that succeeds
+            // actually changes what the window displays, so a failure has to
+            // put the previous state back rather than leave the dock claiming
+            // a FAB that is not on screen.
+            const auto previousFabMode = m_fabMode;
+            const auto previousBack = m_fabSelectorDock->backAvailable();
+            const auto previousOrdinal = m_fabSelectorDock->selectedOrdinal();
             m_fabMode = true;
             m_fabSelectorDock->setBackAvailable(m_multifabReturn.has_value());
             m_fabSelectorDock->selectEntry(entry.ordinal);
             openStandaloneFabAsync(m_fabSourcePath, entry.fileOffset,
                 m_fabDataRoot, true, std::move(selectedSpec),
-                tr("Cannot view FAB"));
+                tr("Cannot view FAB"),
+                [this, previousFabMode, previousBack, previousOrdinal] {
+                    m_fabMode = previousFabMode;
+                    m_fabSelectorDock->setBackAvailable(previousBack);
+                    if (previousOrdinal) {
+                        m_fabSelectorDock->selectEntry(*previousOrdinal);
+                    } else {
+                        m_fabSelectorDock->clearSelection();
+                    }
+                });
             return;
         }
         {
@@ -5917,6 +5951,17 @@ void MainWindow::requestInitialSlice(
                         throw std::runtime_error(
                             "initial slice count does not match the view set");
                     }
+                    // Copied out before the loop below moves each display into
+                    // showSlice, which now takes it by value. The remote
+                    // resize check afterwards needs the size each slice was
+                    // *requested* at, and a moved-from display is not the
+                    // place to read it from -- it happens to survive today
+                    // only because SliceRequest holds nothing but scalars.
+                    std::vector<std::array<int, 2>> requestedSizes;
+                    requestedSizes.reserve(result.displays.size());
+                    for (const auto& display : result.displays) {
+                        requestedSizes.push_back(display.request.outputSize);
+                    }
                     for (std::size_t index = 0; index < views.size(); ++index) {
                         if (views[index]->sliceGeneration
                             != viewGenerations[index]) {
@@ -5948,7 +5993,7 @@ void MainWindow::requestInitialSlice(
                         // that result settles, coalesce each changed viewport
                         // into exactly one request using its newest size.
                         for (std::size_t index = 0; index < views.size(); ++index) {
-                            if (result.displays[index].request.outputSize
+                            if (requestedSizes[index]
                                 != sliceOutputSize(*views[index])) {
                                 scheduleSliceRequest(*views[index]);
                             }
@@ -6381,6 +6426,11 @@ void MainWindow::requestSlice(PlaneViewState& state, bool rasterDirty)
                         DisplayCoordinator::realignArrivalToRange(result,
                             *cachedRange, m_palette, m_viewDimension != 3);
                     }
+                    // showSlice takes the arrival by value; the fallback levels
+                    // are still needed below, so copy them out first rather
+                    // than reading them back off a moved-from result.
+                    const auto fallbackToLevel = result.cacheFallbackToLevel;
+                    const auto fallbackFromLevel = result.cacheFallbackFromLevel;
                     showSlice(state, std::move(result));
                     syncVisibleRanges();
                     // Cache the full-domain range. In 3-D the store defers to
@@ -6404,17 +6454,15 @@ void MainWindow::requestSlice(PlaneViewState& state, bool rasterDirty)
                     // A cache-pressure fallback lowered the composite level;
                     // reflect it in the level combo (no re-slice) and inform the
                     // user, matching the initial-load handling.
-                    if (result.cacheFallbackToLevel >= 0) {
+                    if (fallbackToLevel >= 0) {
                         if (selectCacheFallbackLevel(
-                                m_levelSelector,
-                                result.cacheFallbackToLevel)) {
+                                m_levelSelector, fallbackToLevel)) {
                             configureSlicePositionControls();
                             updateRangeModeAvailability();
                             syncMenuChecks();
                         }
                         statusBar()->showMessage(cacheFallbackMessage(
-                            *dataset, result.cacheFallbackFromLevel,
-                            result.cacheFallbackToLevel));
+                            *dataset, fallbackFromLevel, fallbackToLevel));
                     }
                 } else {
                     ++m_staleResults;
@@ -6953,7 +7001,7 @@ void MainWindow::syncVisibleRanges()
                 watcher->deleteLater();
                 return;
             }
-            auto outcome = watcher->result();
+            auto outcome = watcher->future().takeResult();
             const auto nowMode = static_cast<RangeMode>(
                 m_rangeMode->currentData().toInt());
             const bool current = generation == m_generation

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -4881,10 +4881,26 @@ FabSelectorBuild buildFabSelector(
 
 } // namespace
 
+void MainWindow::restoreFabSelectorRollback()
+{
+    if (!m_fabSelectorRollback) {
+        return;
+    }
+    const auto rollback = *m_fabSelectorRollback;
+    m_fabSelectorRollback.reset();
+    m_fabMode = rollback.fabMode;
+    m_fabSelectorDock->setBackAvailable(rollback.backAvailable);
+    if (rollback.ordinal) {
+        m_fabSelectorDock->selectEntry(*rollback.ordinal);
+    } else {
+        m_fabSelectorDock->clearSelection();
+    }
+}
+
 void MainWindow::openStandaloneFabAsync(std::filesystem::path path,
     std::optional<std::uint64_t> fileOffset, std::filesystem::path dataRoot,
     bool preserveFabSelector, std::optional<FrameSliceSpec> initialSpec,
-    QString failureTitle, std::function<void()> restoreOnFailure)
+    QString failureTitle)
 {
     ++m_activeRequests;
     const auto generation = m_generation;
@@ -4900,8 +4916,7 @@ void MainWindow::openStandaloneFabAsync(std::filesystem::path path,
         [this, watcher, generation, fabGeneration, path,
             dataRoot = std::move(dataRoot), preserveFabSelector,
             initialSpec = std::move(initialSpec),
-            failureTitle = std::move(failureTitle),
-            restoreOnFailure = std::move(restoreOnFailure)]() mutable {
+            failureTitle = std::move(failureTitle)]() mutable {
             --m_activeRequests;
             if (m_closing) {
                 watcher->deleteLater();
@@ -4915,6 +4930,10 @@ void MainWindow::openStandaloneFabAsync(std::filesystem::path path,
             try {
                 auto metadata = watcher->future().takeResult();
                 if (current) {
+                    // This selection is about to become what the window
+                    // displays, so it is the state a later failure falls back
+                    // to.
+                    m_fabSelectorRollback.reset();
                     openDatasetImpl(path, false, std::move(metadata),
                         std::move(dataRoot), preserveFabSelector,
                         std::move(initialSpec));
@@ -4923,12 +4942,10 @@ void MainWindow::openStandaloneFabAsync(std::filesystem::path path,
                 }
             } catch (const std::exception& error) {
                 if (current) {
-                    // The caller may have moved UI state to this FAB before
-                    // the read returned; the open did not happen, so put it
-                    // back before saying so.
-                    if (restoreOnFailure) {
-                        restoreOnFailure();
-                    }
+                    // The caller may have moved the selector to this FAB
+                    // before the read returned; the open did not happen, so
+                    // put it back before saying so.
+                    restoreFabSelectorRollback();
                     QMessageBox::critical(
                         this, failureTitle, exceptionMessage(error));
                 } else {
@@ -4971,24 +4988,25 @@ void MainWindow::viewFab(std::size_t entryIndex)
             // actually changes what the window displays, so a failure has to
             // put the previous state back rather than leave the dock claiming
             // a FAB that is not on screen.
-            const auto previousFabMode = m_fabMode;
-            const auto previousBack = m_fabSelectorDock->backAvailable();
-            const auto previousOrdinal = m_fabSelectorDock->selectedOrdinal();
+            //
+            // Only the *first* click of an overlapping burst records that
+            // state. What the highlight shows once a read is already in flight
+            // is itself a pending selection that was never displayed: from a
+            // displayed FAB X, clicking A then B and having B fail must return
+            // to X, not to A -- A lost the request token and will never open,
+            // so restoring it would leave the dock claiming A over a window
+            // still showing X.
+            if (!m_fabSelectorRollback) {
+                m_fabSelectorRollback = FabSelectorRollback{m_fabMode,
+                    m_fabSelectorDock->backAvailable(),
+                    m_fabSelectorDock->selectedOrdinal()};
+            }
             m_fabMode = true;
             m_fabSelectorDock->setBackAvailable(m_multifabReturn.has_value());
             m_fabSelectorDock->selectEntry(entry.ordinal);
             openStandaloneFabAsync(m_fabSourcePath, entry.fileOffset,
                 m_fabDataRoot, true, std::move(selectedSpec),
-                tr("Cannot view FAB"),
-                [this, previousFabMode, previousBack, previousOrdinal] {
-                    m_fabMode = previousFabMode;
-                    m_fabSelectorDock->setBackAvailable(previousBack);
-                    if (previousOrdinal) {
-                        m_fabSelectorDock->selectEntry(*previousOrdinal);
-                    } else {
-                        m_fabSelectorDock->clearSelection();
-                    }
-                });
+                tr("Cannot view FAB"));
             return;
         }
         {
@@ -5004,6 +5022,10 @@ void MainWindow::viewFab(std::size_t entryIndex)
             selected = makeSelectedFabMetadata(*m_fabSourceMetadata->metadata,
                 entry.level, entry.blockIndex, m_fabDataRoot);
         }
+        // Committed here and now, with no read that can fail behind it, so
+        // this is the state a later failure should fall back to -- not
+        // whatever an earlier pending raw-record click recorded.
+        m_fabSelectorRollback.reset();
         m_fabMode = true;
         m_fabSelectorDock->setBackAvailable(m_multifabReturn.has_value());
         m_fabSelectorDock->selectEntry(entry.ordinal);
@@ -5022,6 +5044,9 @@ void MainWindow::backToMultiFab()
     }
     auto state = std::move(*m_multifabReturn);
     m_multifabReturn.reset();
+    // Returning to the MultiFab commits a selector state of its own; a
+    // rollback left over from a pending raw-record read must not outlive it.
+    m_fabSelectorRollback.reset();
     m_fabMode = false;
     m_fabSelectorDock->setBackAvailable(false);
     openDatasetImpl(state.path, false, std::move(state.metadata),

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -4881,13 +4881,8 @@ FabSelectorBuild buildFabSelector(
 
 } // namespace
 
-void MainWindow::restoreFabSelectorRollback()
+void MainWindow::applyFabSelectorRollback(const FabSelectorRollback& rollback)
 {
-    if (!m_fabSelectorRollback) {
-        return;
-    }
-    const auto rollback = *m_fabSelectorRollback;
-    m_fabSelectorRollback.reset();
     m_fabMode = rollback.fabMode;
     m_fabSelectorDock->setBackAvailable(rollback.backAvailable);
     if (rollback.ordinal) {
@@ -4900,7 +4895,7 @@ void MainWindow::restoreFabSelectorRollback()
 void MainWindow::openStandaloneFabAsync(std::filesystem::path path,
     std::optional<std::uint64_t> fileOffset, std::filesystem::path dataRoot,
     bool preserveFabSelector, std::optional<FrameSliceSpec> initialSpec,
-    QString failureTitle)
+    QString failureTitle, std::optional<FabSelectorRollback> rollback)
 {
     ++m_activeRequests;
     const auto generation = m_generation;
@@ -4910,10 +4905,13 @@ void MainWindow::openStandaloneFabAsync(std::filesystem::path path,
     // completions match the generation they captured and the *first* to arrive
     // opens, while the selector already shows the second: oldest-wins, and the
     // window disagrees with the dock.
-    const auto fabGeneration = ++m_fabOpenGeneration;
+    const auto requestId = ++m_fabOpenGeneration;
+    if (rollback) {
+        m_pendingFabOpen = PendingFabOpen{generation, requestId, *rollback};
+    }
     auto* watcher = new QFutureWatcher<PlotfileMetadataResult>(this);
     connect(watcher, &QFutureWatcher<PlotfileMetadataResult>::finished, this,
-        [this, watcher, generation, fabGeneration, path,
+        [this, watcher, generation, requestId, path,
             dataRoot = std::move(dataRoot), preserveFabSelector,
             initialSpec = std::move(initialSpec),
             failureTitle = std::move(failureTitle)]() mutable {
@@ -4923,17 +4921,24 @@ void MainWindow::openStandaloneFabAsync(std::filesystem::path path,
                 return;
             }
             // A dataset opened while this read was in flight owns the window
-            // now, and so does a newer FAB read; publishing over either would
-            // be a stale result.
+            // now, and so does a newer FAB read or a selector teardown;
+            // publishing over any of them would be a stale result.
             const bool current = generation == m_generation
-                && fabGeneration == m_fabOpenGeneration;
+                && requestId == m_fabOpenGeneration;
+            // Only the completion that recorded the pending entry may consume
+            // it. Anything that revoked it -- a dataset open, a teardown, a
+            // newer click -- has already made `current` false.
+            const bool ownsPending = m_pendingFabOpen
+                && m_pendingFabOpen->generation == generation
+                && m_pendingFabOpen->requestId == requestId;
             try {
                 auto metadata = watcher->future().takeResult();
                 if (current) {
                     // This selection is about to become what the window
-                    // displays, so it is the state a later failure falls back
-                    // to.
-                    m_fabSelectorRollback.reset();
+                    // displays, so there is nothing left to roll back to.
+                    if (ownsPending) {
+                        m_pendingFabOpen.reset();
+                    }
                     openDatasetImpl(path, false, std::move(metadata),
                         std::move(dataRoot), preserveFabSelector,
                         std::move(initialSpec));
@@ -4945,9 +4950,13 @@ void MainWindow::openStandaloneFabAsync(std::filesystem::path path,
                     // The caller may have moved the selector to this FAB
                     // before the read returned; the open did not happen, so
                     // put it back before saying so.
-                    restoreFabSelectorRollback();
-                    QMessageBox::critical(
-                        this, failureTitle, exceptionMessage(error));
+                    if (ownsPending) {
+                        const auto pending = m_pendingFabOpen->rollback;
+                        m_pendingFabOpen.reset();
+                        applyFabSelectorRollback(pending);
+                    }
+                    reportBackgroundError(QStringLiteral("%1: %2")
+                            .arg(failureTitle, exceptionMessage(error)));
                 } else {
                     ++m_staleResults;
                 }
@@ -4989,24 +4998,26 @@ void MainWindow::viewFab(std::size_t entryIndex)
             // put the previous state back rather than leave the dock claiming
             // a FAB that is not on screen.
             //
-            // Only the *first* click of an overlapping burst records that
-            // state. What the highlight shows once a read is already in flight
-            // is itself a pending selection that was never displayed: from a
-            // displayed FAB X, clicking A then B and having B fail must return
-            // to X, not to A -- A lost the request token and will never open,
-            // so restoring it would leave the dock claiming A over a window
-            // still showing X.
-            if (!m_fabSelectorRollback) {
-                m_fabSelectorRollback = FabSelectorRollback{m_fabMode,
+            // A click while a read is already in flight inherits that read's
+            // rollback instead of snapshotting the dock, because what the dock
+            // shows now is the pending selection, which was never displayed:
+            // from a displayed FAB X, clicking A then B and having B fail must
+            // return to X, not to A -- A lost the request token and will never
+            // open. The pending entry is inherited only while it is still live,
+            // so a dataset open or a teardown in between starts fresh.
+            const auto rollback = (m_pendingFabOpen
+                    && m_pendingFabOpen->generation == m_generation
+                    && m_pendingFabOpen->requestId == m_fabOpenGeneration)
+                ? m_pendingFabOpen->rollback
+                : FabSelectorRollback{m_fabMode,
                     m_fabSelectorDock->backAvailable(),
                     m_fabSelectorDock->selectedOrdinal()};
-            }
             m_fabMode = true;
             m_fabSelectorDock->setBackAvailable(m_multifabReturn.has_value());
             m_fabSelectorDock->selectEntry(entry.ordinal);
             openStandaloneFabAsync(m_fabSourcePath, entry.fileOffset,
                 m_fabDataRoot, true, std::move(selectedSpec),
-                tr("Cannot view FAB"));
+                tr("Cannot view FAB"), rollback);
             return;
         }
         {
@@ -5022,10 +5033,6 @@ void MainWindow::viewFab(std::size_t entryIndex)
             selected = makeSelectedFabMetadata(*m_fabSourceMetadata->metadata,
                 entry.level, entry.blockIndex, m_fabDataRoot);
         }
-        // Committed here and now, with no read that can fail behind it, so
-        // this is the state a later failure should fall back to -- not
-        // whatever an earlier pending raw-record click recorded.
-        m_fabSelectorRollback.reset();
         m_fabMode = true;
         m_fabSelectorDock->setBackAvailable(m_multifabReturn.has_value());
         m_fabSelectorDock->selectEntry(entry.ordinal);
@@ -5044,9 +5051,6 @@ void MainWindow::backToMultiFab()
     }
     auto state = std::move(*m_multifabReturn);
     m_multifabReturn.reset();
-    // Returning to the MultiFab commits a selector state of its own; a
-    // rollback left over from a pending raw-record read must not outlive it.
-    m_fabSelectorRollback.reset();
     m_fabMode = false;
     m_fabSelectorDock->setBackAvailable(false);
     openDatasetImpl(state.path, false, std::move(state.metadata),
@@ -5449,12 +5453,14 @@ void MainWindow::openDataset(
 
 void MainWindow::resetFabState()
 {
-    // The selector is being torn down entirely, so a rollback recorded against
-    // it describes a dataset that is no longer on screen. Leaving it would both
-    // suppress the recording of a real rollback for the next raw-record click
-    // (the guard there only records when none is pending) and be what a failure
-    // of that click restores -- an ordinal carried over from the previous file.
-    m_fabSelectorRollback.reset();
+    // Tearing the selector down revokes any read still in flight against it.
+    // Moving the request token is what does that: no completion can still be
+    // current, so none can publish over the new dataset or restore an ordinal
+    // belonging to the old one. This is the only teardown site that needs to
+    // say so -- prepareSequence reaches it too, and that path bypasses
+    // openDatasetImpl entirely, so its generation bump is not available here.
+    ++m_fabOpenGeneration;
+    m_pendingFabOpen.reset();
     m_fabMode = false;
     m_multifabReturn.reset();
     m_fabSourceMetadata.reset();

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -5449,6 +5449,12 @@ void MainWindow::openDataset(
 
 void MainWindow::resetFabState()
 {
+    // The selector is being torn down entirely, so a rollback recorded against
+    // it describes a dataset that is no longer on screen. Leaving it would both
+    // suppress the recording of a real rollback for the next raw-record click
+    // (the guard there only records when none is pending) and be what a failure
+    // of that click restores -- an ordinal carried over from the previous file.
+    m_fabSelectorRollback.reset();
     m_fabMode = false;
     m_multifabReturn.reset();
     m_fabSourceMetadata.reset();

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -4881,6 +4881,16 @@ FabSelectorBuild buildFabSelector(
 
 } // namespace
 
+void MainWindow::openStandaloneFabForTest(const std::filesystem::path& path)
+{
+    auto root = path.parent_path();
+    if (root.empty()) {
+        root = ".";
+    }
+    openStandaloneFabAsync(path, std::nullopt, std::move(root), false,
+        std::nullopt, tr("Cannot open FAB"));
+}
+
 void MainWindow::applyFabSelectorRollback(const FabSelectorRollback& rollback)
 {
     m_fabMode = rollback.fabMode;
@@ -4905,9 +4915,26 @@ void MainWindow::openStandaloneFabAsync(std::filesystem::path path,
     // completions match the generation they captured and the *first* to arrive
     // opens, while the selector already shows the second: oldest-wins, and the
     // window disagrees with the dock.
+    //
+    // Inheritance is decided here rather than at the call sites, because every
+    // request supersedes whatever was live -- including the direct-open entry
+    // point, which brings no rollback of its own. The read it supersedes will
+    // retire without restoring anything, so if this one fails the state to
+    // return to is still the one that was last displayed. Checked before the
+    // token moves, since moving it is what retires the other request.
+    const bool supersedesLive = m_pendingFabOpen
+        && m_pendingFabOpen->generation == generation
+        && m_pendingFabOpen->requestId == m_fabOpenGeneration;
+    if (supersedesLive) {
+        rollback = m_pendingFabOpen->rollback;
+    }
     const auto requestId = ++m_fabOpenGeneration;
     if (rollback) {
         m_pendingFabOpen = PendingFabOpen{generation, requestId, *rollback};
+    } else {
+        // Nothing live and nothing to fall back to: this request owns the slot
+        // and a failure of it has nowhere to return to.
+        m_pendingFabOpen.reset();
     }
     auto* watcher = new QFutureWatcher<PlotfileMetadataResult>(this);
     connect(watcher, &QFutureWatcher<PlotfileMetadataResult>::finished, this,
@@ -4928,17 +4955,21 @@ void MainWindow::openStandaloneFabAsync(std::filesystem::path path,
             // Only the completion that recorded the pending entry may consume
             // it. Anything that revoked it -- a dataset open, a teardown, a
             // newer click -- has already made `current` false.
-            const bool ownsPending = m_pendingFabOpen
+            // Taken out of the member up front, not read back later: this
+            // completion decides the entry's fate either way, and openDatasetImpl
+            // below can throw *after* the success path has given the entry up.
+            // Reading `m_pendingFabOpen->rollback` in the catch would then
+            // dereference a disengaged optional.
+            std::optional<FabSelectorRollback> owned;
+            if (current && m_pendingFabOpen
                 && m_pendingFabOpen->generation == generation
-                && m_pendingFabOpen->requestId == requestId;
+                && m_pendingFabOpen->requestId == requestId) {
+                owned = m_pendingFabOpen->rollback;
+                m_pendingFabOpen.reset();
+            }
             try {
                 auto metadata = watcher->future().takeResult();
                 if (current) {
-                    // This selection is about to become what the window
-                    // displays, so there is nothing left to roll back to.
-                    if (ownsPending) {
-                        m_pendingFabOpen.reset();
-                    }
                     openDatasetImpl(path, false, std::move(metadata),
                         std::move(dataRoot), preserveFabSelector,
                         std::move(initialSpec));
@@ -4950,10 +4981,8 @@ void MainWindow::openStandaloneFabAsync(std::filesystem::path path,
                     // The caller may have moved the selector to this FAB
                     // before the read returned; the open did not happen, so
                     // put it back before saying so.
-                    if (ownsPending) {
-                        const auto pending = m_pendingFabOpen->rollback;
-                        m_pendingFabOpen.reset();
-                        applyFabSelectorRollback(pending);
+                    if (owned) {
+                        applyFabSelectorRollback(*owned);
                     }
                     reportBackgroundError(QStringLiteral("%1: %2")
                             .arg(failureTitle, exceptionMessage(error)));
@@ -4998,20 +5027,14 @@ void MainWindow::viewFab(std::size_t entryIndex)
             // put the previous state back rather than leave the dock claiming
             // a FAB that is not on screen.
             //
-            // A click while a read is already in flight inherits that read's
-            // rollback instead of snapshotting the dock, because what the dock
-            // shows now is the pending selection, which was never displayed:
-            // from a displayed FAB X, clicking A then B and having B fail must
-            // return to X, not to A -- A lost the request token and will never
-            // open. The pending entry is inherited only while it is still live,
-            // so a dataset open or a teardown in between starts fresh.
-            const auto rollback = (m_pendingFabOpen
-                    && m_pendingFabOpen->generation == m_generation
-                    && m_pendingFabOpen->requestId == m_fabOpenGeneration)
-                ? m_pendingFabOpen->rollback
-                : FabSelectorRollback{m_fabMode,
-                    m_fabSelectorDock->backAvailable(),
-                    m_fabSelectorDock->selectedOrdinal()};
+            // Snapshot what is displayed now; openStandaloneFabAsync prefers a
+            // still-live pending rollback over it, because from a displayed FAB
+            // X, clicking A then B and having B fail must return to X, not to
+            // the A the dock is merely showing -- A lost the request token and
+            // will never open.
+            const FabSelectorRollback rollback{m_fabMode,
+                m_fabSelectorDock->backAvailable(),
+                m_fabSelectorDock->selectedOrdinal()};
             m_fabMode = true;
             m_fabSelectorDock->setBackAvailable(m_multifabReturn.has_value());
             m_fabSelectorDock->selectEntry(entry.ordinal);

--- a/src/qt/MainWindow.hpp
+++ b/src/qt/MainWindow.hpp
@@ -596,7 +596,11 @@ private:
     // change, or no resolution change).
     [[nodiscard]] std::optional<QRectF> sphericalReframe(
         const PlaneViewState& state, const SliceDisplayResult& display) const;
-    void showSlice(PlaneViewState& state, const SliceDisplayResult& display);
+    // By value, and callers move into it: the planes are the largest thing an
+    // arrival carries -- at the 4096 output cap a ScalarPlane is around 117 MB
+    // and the ImageBuffer around 67 MB -- and a const& forced this function to
+    // deep-copy them again into the shared_ptr snapshots it publishes.
+    void showSlice(PlaneViewState& state, SliceDisplayResult display);
     void updateOverlay(PlaneViewState& state);
     void updateOverlays();
     void updateGridBoxes(PlaneViewState& state);
@@ -661,6 +665,16 @@ private:
     // demand-driven and never clamped. Zero when there is nothing to report.
     // See agent-notes/issues/fixed-scale-clamped-native-raster.md.
     [[nodiscard]] double effectiveFixedScale(int factor) const;
+    // Reads a standalone FAB header off the GUI thread and opens it from the
+    // completion. The read is one small pread, but it is a *blocking* one, and
+    // on the network filesystems these datasets usually live on it freezes the
+    // event loop for as long as the server takes. Every other header read in
+    // this window already runs on a worker (see buildFabSelector); these two
+    // entry points were the exceptions.
+    void openStandaloneFabAsync(std::filesystem::path path,
+        std::optional<std::uint64_t> fileOffset,
+        std::filesystem::path dataRoot, bool preserveFabSelector,
+        std::optional<FrameSliceSpec> initialSpec, QString failureTitle);
     void configureSliceControls();
     // Enable the dataset-dependent field/level/range/menu controls once a
     // dataset (single or sequence frame) is loaded. Shared by

--- a/src/qt/MainWindow.hpp
+++ b/src/qt/MainWindow.hpp
@@ -198,6 +198,9 @@ public:
     // Test-only: how many failures have been reported non-modally. The FAB
     // rollback smoke tests assert on this so a passing run proves the failure
     // branch actually ran rather than the read having quietly succeeded.
+    // Saturates: reportBackgroundError keeps only the newest 50, so a test that
+    // waits for this to exceed a baseline of 50 would wait forever. Both
+    // current callers start from an empty list.
     [[nodiscard]] int backgroundErrorCountForTest() const
     {
         return static_cast<int>(m_backgroundErrors.size());

--- a/src/qt/MainWindow.hpp
+++ b/src/qt/MainWindow.hpp
@@ -29,6 +29,7 @@
 #include <atomic>
 #include <cstdint>
 #include <filesystem>
+#include <functional>
 #include <memory>
 #include <optional>
 #include <string>
@@ -671,10 +672,15 @@ private:
     // event loop for as long as the server takes. Every other header read in
     // this window already runs on a worker (see buildFabSelector); these two
     // entry points were the exceptions.
+    //
+    // `restoreOnFailure`, when set, runs if the read fails while this request
+    // is still the current one: callers that move UI state to the pending FAB
+    // before the read returns use it to put that state back.
     void openStandaloneFabAsync(std::filesystem::path path,
         std::optional<std::uint64_t> fileOffset,
         std::filesystem::path dataRoot, bool preserveFabSelector,
-        std::optional<FrameSliceSpec> initialSpec, QString failureTitle);
+        std::optional<FrameSliceSpec> initialSpec, QString failureTitle,
+        std::function<void()> restoreOnFailure = {});
     void configureSliceControls();
     // Enable the dataset-dependent field/level/range/menu controls once a
     // dataset (single or sequence frame) is loaded. Shared by
@@ -892,6 +898,11 @@ private:
     QStringList m_backgroundErrors;
     bool m_controlsReady = false;
     std::uint64_t m_generation = 0;
+    // Newest-wins among overlapping standalone-FAB header reads. m_generation
+    // alone cannot order them: it is bumped by openDatasetImpl, which only runs
+    // once a read has already completed, so two reads in flight together both
+    // still match the generation they captured.
+    std::uint64_t m_fabOpenGeneration = 0;
     std::uint64_t m_activeRequests = 0;
     bool m_closing = false;
     std::uint64_t m_staleResults = 0;

--- a/src/qt/MainWindow.hpp
+++ b/src/qt/MainWindow.hpp
@@ -202,6 +202,10 @@ public:
     {
         return static_cast<int>(m_backgroundErrors.size());
     }
+    // Test-only: the direct "open a raw FAB file" entry point, reached in the
+    // app through a file dialog. Supplies no rollback of its own, which is what
+    // makes it the interesting case when it supersedes a selector click.
+    void openStandaloneFabForTest(const std::filesystem::path& path);
     void setGridBoxesVisibleForTest(bool visible);
     [[nodiscard]] std::size_t activeViewGridBoxCountForTest() const;
 

--- a/src/qt/MainWindow.hpp
+++ b/src/qt/MainWindow.hpp
@@ -195,6 +195,13 @@ public:
     [[nodiscard]] bool activeViewHasPhysicalAspectForTest(
         double expectedAspect) const;
     [[nodiscard]] bool fabStateClearedForTest() const;
+    // Test-only: how many failures have been reported non-modally. The FAB
+    // rollback smoke tests assert on this so a passing run proves the failure
+    // branch actually ran rather than the read having quietly succeeded.
+    [[nodiscard]] int backgroundErrorCountForTest() const
+    {
+        return static_cast<int>(m_backgroundErrors.size());
+    }
     void setGridBoxesVisibleForTest(bool visible);
     [[nodiscard]] std::size_t activeViewGridBoxCountForTest() const;
 
@@ -672,14 +679,40 @@ private:
     // this window already runs on a worker (see buildFabSelector); these two
     // entry points were the exceptions.
     //
+    // The selector state a failed standalone-FAB open falls back to: the last
+    // one actually committed to the window, not merely highlighted.
+    struct FabSelectorRollback {
+        bool fabMode = false;
+        bool backAvailable = false;
+        std::optional<std::size_t> ordinal;
+    };
+    // A launched standalone-FAB header read that has not resolved yet, carrying
+    // the state to restore if it fails. The pair (generation, requestId) is what
+    // makes this safe without any site reaching in to clear it: only the
+    // completion holding both may consume the entry, so opening a dataset
+    // (which bumps m_generation) or tearing the selector down (which bumps
+    // m_fabOpenGeneration) revokes it as a side effect of what it already does.
+    // A second click while a read is in flight inherits the pending rollback
+    // rather than snapshotting the dock, because what the dock shows then is
+    // that pending selection, which was never displayed.
+    struct PendingFabOpen {
+        std::uint64_t generation = 0;
+        std::uint64_t requestId = 0;
+        FabSelectorRollback rollback;
+    };
+
     // A caller that moves the selector to the pending record before the read
-    // returns records the state to fall back to in m_fabSelectorRollback; a
-    // read that fails while it is still the current request puts it back.
+    // returns passes the state to fall back to; a read that fails while it is
+    // still the current request puts it back. Failures are reported through
+    // reportBackgroundError: this one arrives from a worker, like every other
+    // background load failure, and a modal dialog here would open a nested
+    // event loop on the arrival path.
     void openStandaloneFabAsync(std::filesystem::path path,
         std::optional<std::uint64_t> fileOffset,
         std::filesystem::path dataRoot, bool preserveFabSelector,
-        std::optional<FrameSliceSpec> initialSpec, QString failureTitle);
-    void restoreFabSelectorRollback();
+        std::optional<FrameSliceSpec> initialSpec, QString failureTitle,
+        std::optional<FabSelectorRollback> rollback = std::nullopt);
+    void applyFabSelectorRollback(const FabSelectorRollback& rollback);
     void configureSliceControls();
     // Enable the dataset-dependent field/level/range/menu controls once a
     // dataset (single or sequence frame) is loaded. Shared by
@@ -902,17 +935,7 @@ private:
     // once a read has already completed, so two reads in flight together both
     // still match the generation they captured.
     std::uint64_t m_fabOpenGeneration = 0;
-    // The selector state a failed standalone-FAB open falls back to: the last
-    // one that was actually committed to the window, not merely highlighted.
-    // Set by the first click of an overlapping burst and cleared when an open
-    // succeeds, so an intermediate selection that lost the request token is
-    // never what a later failure restores.
-    struct FabSelectorRollback {
-        bool fabMode = false;
-        bool backAvailable = false;
-        std::optional<std::size_t> ordinal;
-    };
-    std::optional<FabSelectorRollback> m_fabSelectorRollback;
+    std::optional<PendingFabOpen> m_pendingFabOpen;
     std::uint64_t m_activeRequests = 0;
     bool m_closing = false;
     std::uint64_t m_staleResults = 0;

--- a/src/qt/MainWindow.hpp
+++ b/src/qt/MainWindow.hpp
@@ -29,7 +29,6 @@
 #include <atomic>
 #include <cstdint>
 #include <filesystem>
-#include <functional>
 #include <memory>
 #include <optional>
 #include <string>
@@ -673,14 +672,14 @@ private:
     // this window already runs on a worker (see buildFabSelector); these two
     // entry points were the exceptions.
     //
-    // `restoreOnFailure`, when set, runs if the read fails while this request
-    // is still the current one: callers that move UI state to the pending FAB
-    // before the read returns use it to put that state back.
+    // A caller that moves the selector to the pending record before the read
+    // returns records the state to fall back to in m_fabSelectorRollback; a
+    // read that fails while it is still the current request puts it back.
     void openStandaloneFabAsync(std::filesystem::path path,
         std::optional<std::uint64_t> fileOffset,
         std::filesystem::path dataRoot, bool preserveFabSelector,
-        std::optional<FrameSliceSpec> initialSpec, QString failureTitle,
-        std::function<void()> restoreOnFailure = {});
+        std::optional<FrameSliceSpec> initialSpec, QString failureTitle);
+    void restoreFabSelectorRollback();
     void configureSliceControls();
     // Enable the dataset-dependent field/level/range/menu controls once a
     // dataset (single or sequence frame) is loaded. Shared by
@@ -903,6 +902,17 @@ private:
     // once a read has already completed, so two reads in flight together both
     // still match the generation they captured.
     std::uint64_t m_fabOpenGeneration = 0;
+    // The selector state a failed standalone-FAB open falls back to: the last
+    // one that was actually committed to the window, not merely highlighted.
+    // Set by the first click of an overlapping burst and cleared when an open
+    // succeeds, so an intermediate selection that lost the request token is
+    // never what a later failure restores.
+    struct FabSelectorRollback {
+        bool fabMode = false;
+        bool backAvailable = false;
+        std::optional<std::size_t> ordinal;
+    };
+    std::optional<FabSelectorRollback> m_fabSelectorRollback;
     std::uint64_t m_activeRequests = 0;
     bool m_closing = false;
     std::uint64_t m_staleResults = 0;

--- a/src/qt/SequenceController.cpp
+++ b/src/qt/SequenceController.cpp
@@ -239,7 +239,11 @@ void SequenceController::startPrefetch(int frameIndex)
             defaultPositions] {
             emit loadActivityChanged(-1);
             try {
-                auto result = watcher->result();
+                // takeResult for the same reason the frame load above uses it:
+                // a prefetched frame carries the same planes, and result()
+                // would copy every one of them on the GUI thread once per
+                // frame of playback.
+                auto result = watcher->future().takeResult();
                 if (generation == m_prefetchGeneration && !m_frames.empty()) {
                     m_prefetched = PrefetchedFrame{frameIndex, specGeneration,
                         defaultPositions, std::move(result)};

--- a/src/qt/SequenceController.cpp
+++ b/src/qt/SequenceController.cpp
@@ -159,7 +159,10 @@ void SequenceController::startLoad(int index, std::uint64_t generation)
                 return;
             }
             try {
-                auto result = watcher->result();
+                // See MainWindow's slice arrival: result() copies every plane
+                // out of the future, and a frame carries the same load a slice
+                // does.
+                auto result = watcher->future().takeResult();
                 if (generation == m_loadGeneration && index == m_index) {
                     finishLoad(std::move(result), defaultPositions);
                 } else {

--- a/src/qt/main.cpp
+++ b/src/qt/main.cpp
@@ -2031,6 +2031,79 @@ int main(int argc, char* argv[])
         QTimer::singleShot(0, &window,
             [&window, path] { window.openDataset(path); });
     } else if (argc == 3
+        && std::string_view(argv[1]) == "--fab-direct-open-failure-smoke-test") {
+        // Regression for a superseding request that brings no rollback of its
+        // own. Commit record 0 (X), click record 1 so the dock moves to it with
+        // a read in flight, then take the direct "open a raw FAB file" path --
+        // which the app reaches through a file dialog and which passes no
+        // rollback -- for a file that does not exist. The direct open retires
+        // the click, so the click restores nothing; if the direct open does not
+        // inherit the click's rollback, its own failure restores nothing either
+        // and the dock is left on record 1 while X is still displayed.
+        const std::filesystem::path path(argv[2]);
+        auto phase = std::make_shared<int>(0);
+        auto baselineErrors = std::make_shared<int>(0);
+        QObject::connect(&window, &amrvis::qt::MainWindow::initialSliceFinished,
+            &application, [&window, &application, phase, path,
+                baselineErrors](bool success) {
+                auto* selector =
+                    window.findChild<amrvis::qt::FabSelectorDock*>();
+                if (!success || selector == nullptr
+                    || selector->entries().size() < 2) {
+                    application.exit(1);
+                    return;
+                }
+                if (*phase == 0) {
+                    *phase = 1;
+                    window.viewFabForTest(0);
+                    return;
+                }
+                if (*phase != 1) {
+                    return;
+                }
+                *phase = 2;
+                if (selector->selectedOrdinal()
+                    != std::optional<std::size_t>{0}) {
+                    application.exit(1);
+                    return;
+                }
+                *baselineErrors = window.backgroundErrorCountForTest();
+                auto* pool = QThreadPool::globalInstance();
+                pool->setMaxThreadCount(1);
+                auto gate = std::make_shared<std::atomic<bool>>(false);
+                pool->start(QRunnable::create([gate] {
+                    while (!gate->load()) {
+                        std::this_thread::sleep_for(
+                            std::chrono::milliseconds(2));
+                    }
+                }));
+                // Both queued behind the gate and issued in one slot, so the
+                // click is genuinely unresolved when the direct open supersedes
+                // it. The direct open's target does not exist, so it fails.
+                window.viewFabForTest(1);
+                window.openStandaloneFabForTest(
+                    path.parent_path() / "no_such_fab_file");
+                gate->store(true);
+                auto* poll = new QTimer(&window);
+                poll->setInterval(5);
+                QObject::connect(poll, &QTimer::timeout, &window,
+                    [&window, &application, selector, poll, baselineErrors] {
+                        if (window.backgroundErrorCountForTest()
+                            <= *baselineErrors) {
+                            return;
+                        }
+                        poll->stop();
+                        application.exit(selector->selectedOrdinal()
+                                == std::optional<std::size_t>{0}
+                            ? 0 : 1);
+                    });
+                poll->start();
+            });
+        QTimer::singleShot(20000, &application,
+            [&application] { application.exit(1); });
+        QTimer::singleShot(0, &window,
+            [&window, path] { window.openDataset(path); });
+    } else if (argc == 3
         && std::string_view(argv[1]) == "--fab-zoom-smoke-test") {
         // Regression for fab-round-trip-loses-visible-region: zoom the MultiFab
         // slice, drill into a FAB, go back, and confirm the restored MultiFab

--- a/src/qt/main.cpp
+++ b/src/qt/main.cpp
@@ -1950,6 +1950,87 @@ int main(int argc, char* argv[])
         QTimer::singleShot(0, &window,
             [&window, path] { window.openDataset(path); });
     } else if (argc == 3
+        && std::string_view(argv[1]) == "--fab-overlap-failure-smoke-test") {
+        // Regression for the FAB selector rollback under overlapping opens.
+        // Commit record 0 (call it X), then click record 1 twice in one slot so
+        // both reads are in flight together, and make both fail. The second
+        // click must inherit X as its rollback rather than snapshotting the
+        // dock -- which by then shows record 1, a selection that was never
+        // displayed. Without that, the failure restores record 1 and the dock
+        // claims a FAB the window is not showing.
+        //
+        // The overlap is structural, not timed: the two viewFab calls run in
+        // one event-loop slot, so neither completion can have been delivered,
+        // and the pool gate additionally holds both reads until the file is
+        // gone so both are guaranteed to fail.
+        const std::filesystem::path path(argv[2]);
+        auto phase = std::make_shared<int>(0);
+        auto baselineErrors = std::make_shared<int>(0);
+        QObject::connect(&window, &amrvis::qt::MainWindow::initialSliceFinished,
+            &application, [&window, &application, phase, path,
+                baselineErrors](bool success) {
+                auto* selector =
+                    window.findChild<amrvis::qt::FabSelectorDock*>();
+                if (!success || selector == nullptr
+                    || selector->entries().size() < 2) {
+                    application.exit(1);
+                    return;
+                }
+                if (*phase == 0) {
+                    // Commit X = record 0 through the normal async path.
+                    *phase = 1;
+                    window.viewFabForTest(0);
+                    return;
+                }
+                if (*phase != 1) {
+                    return;
+                }
+                *phase = 2;
+                if (selector->selectedOrdinal() != std::optional<std::size_t>{0}) {
+                    application.exit(1);   // X did not commit
+                    return;
+                }
+                *baselineErrors = window.backgroundErrorCountForTest();
+                auto* pool = QThreadPool::globalInstance();
+                pool->setMaxThreadCount(1);
+                auto gate = std::make_shared<std::atomic<bool>>(false);
+                pool->start(QRunnable::create([gate] {
+                    while (!gate->load()) {
+                        std::this_thread::sleep_for(
+                            std::chrono::milliseconds(2));
+                    }
+                }));
+                // Both queued behind the gate, in one slot: A is superseded by
+                // B before either can complete.
+                window.viewFabForTest(1);
+                window.viewFabForTest(1);
+                std::error_code removeError;
+                std::filesystem::remove(path, removeError);
+                gate->store(true);
+                // Wait for the failure to be reported, then assert. A watchdog
+                // below fails the run rather than letting it hang.
+                auto* poll = new QTimer(&window);
+                poll->setInterval(5);
+                QObject::connect(poll, &QTimer::timeout, &window,
+                    [&window, &application, selector, poll, baselineErrors] {
+                        if (window.backgroundErrorCountForTest()
+                            <= *baselineErrors) {
+                            return;
+                        }
+                        poll->stop();
+                        // The rollback must be X, not the record that was
+                        // merely highlighted when the second click landed.
+                        application.exit(selector->selectedOrdinal()
+                                == std::optional<std::size_t>{0}
+                            ? 0 : 1);
+                    });
+                poll->start();
+            });
+        QTimer::singleShot(20000, &application,
+            [&application] { application.exit(1); });
+        QTimer::singleShot(0, &window,
+            [&window, path] { window.openDataset(path); });
+    } else if (argc == 3
         && std::string_view(argv[1]) == "--fab-zoom-smoke-test") {
         // Regression for fab-round-trip-loses-visible-region: zoom the MultiFab
         // slice, drill into a FAB, go back, and confirm the restored MultiFab

--- a/src/query/LineQuery.cpp
+++ b/src/query/LineQuery.cpp
@@ -104,6 +104,25 @@ LineQueryResult LineQuery::execute(
             lineBox.lower[i] = index;
             lineBox.upper[i] = index;
         }
+        // ...and only the stretch of the line axis the caller asked about. The
+        // walk below already honours request.region physically, but without
+        // this the planning stayed full-width: a line plot zoomed into a small
+        // fraction of the domain still read every block the full-domain line
+        // crosses. Clamped in index space, at this level's resolution, so the
+        // block intersection test is comparing like with like.
+        if (request.region.has_value()) {
+            const auto first = physicalToIndex(
+                physicalStart, metadata, level, request.axis);
+            const auto last = physicalToIndex(
+                physicalEnd, metadata, level, request.axis);
+            lineBox.lower[lineAxis] = std::max(
+                lineBox.lower[lineAxis], std::min(first, last));
+            lineBox.upper[lineAxis] = std::min(
+                lineBox.upper[lineAxis], std::max(first, last));
+            if (lineBox.lower[lineAxis] > lineBox.upper[lineAxis]) {
+                continue;  // the region misses this level entirely
+            }
+        }
         auto& loaded = loadedByLevel[static_cast<std::size_t>(levelIndex)];
         for (std::size_t grid = 0; grid < level.blocks.size(); ++grid) {
             const auto& block = level.blocks[grid];

--- a/src/remote/Connection.cpp
+++ b/src/remote/Connection.cpp
@@ -116,6 +116,7 @@ public:
         if (cancellation.stop_requested()) {
             throw ReadCancelled();
         }
+        m_transactions.fetch_add(1, std::memory_order_relaxed);
         const auto requestId = nextRequestId();
         auto pending = std::make_shared<Pending>();
         pending->expected = expected;
@@ -325,6 +326,11 @@ public:
         std::scoped_lock lock(m_cacheMutex);
         const auto found = m_cache.find(dataset.value);
         return found == m_cache.end() ? CacheMetrics{} : found->second;
+    }
+
+    [[nodiscard]] std::uint64_t transactionCount() const noexcept
+    {
+        return m_transactions.load(std::memory_order_relaxed);
     }
 
     void ping(StopToken cancellation)
@@ -575,6 +581,10 @@ private:
     std::chrono::milliseconds m_requestTimeout;
     StopSource m_lifecycleStop;
     std::atomic<std::uint64_t> m_nextRequestId{1};
+    // Every started transaction, including the ones that go on to fail. Kept
+    // separately from m_nextRequestId, which is an identifier rather than a
+    // count and is not otherwise observable.
+    std::atomic<std::uint64_t> m_transactions{0};
     std::atomic<std::uint64_t> m_nextPingNonce{1};
     std::mutex m_closeMutex;
     mutable std::mutex m_stateMutex;
@@ -684,6 +694,11 @@ CacheMetrics Connection::setCacheBudget(
 CacheMetrics Connection::latestCache(DatasetId dataset) const
 {
     return m_impl->latestCache(dataset);
+}
+
+std::uint64_t Connection::transactionCount() const noexcept
+{
+    return m_impl->transactionCount();
 }
 
 void Connection::ping(StopToken cancellation)

--- a/src/remote/RemoteDatasetSession.cpp
+++ b/src/remote/RemoteDatasetSession.cpp
@@ -3,6 +3,7 @@
 #include <amrexplorer/cache/ByteLruCache.hpp>
 #include <amrexplorer/data/SessionValidation.hpp>
 
+#include <chrono>
 #include <stdexcept>
 #include <utility>
 #include <variant>
@@ -139,14 +140,65 @@ DatasetPage RemoteDatasetSession::requestDatasetPage(
     });
 }
 
+RemoteDatasetSession::RangeKey RemoteDatasetSession::rangeKey(
+    const RangeRequest& request) noexcept
+{
+    return {request.field.value, request.maximumLevel,
+        static_cast<std::uint8_t>(request.composition),
+        static_cast<std::uint8_t>(request.scope)};
+}
+
 std::optional<ValueRange> RemoteDatasetSession::requestRange(
     const RangeRequest& request, StopToken cancellation)
 {
     requireOpen();
     validateSessionRangeRequest(m_metadata, request);
-    return refusingInvalidResponses(*m_connection, [&] {
-        return m_connection->requestRange(m_id, request, cancellation);
-    });
+    const auto key = rangeKey(request);
+    {
+        std::unique_lock lock(m_rangeMutex);
+        for (;;) {
+            if (const auto found = m_ranges.find(key);
+                found != m_ranges.end()) {
+                return found->second;
+            }
+            if (!m_rangeInFlight.contains(key)) {
+                // Nobody is asking; this call becomes the one that does.
+                m_rangeInFlight.insert(key);
+                break;
+            }
+            // Someone else is. Wait for them, but stay answerable to our own
+            // cancellation rather than to theirs -- a short wait keeps this
+            // responsive without a second signalling path.
+            if (cancellation.stop_requested()) {
+                throw ReadCancelled();
+            }
+            m_rangeReady.wait_for(lock, std::chrono::milliseconds{10});
+            // Loop: either the answer is cached now, or the leader failed and
+            // left the key free, in which case this call takes the work over.
+        }
+    }
+    const auto retire = [&] {
+        std::scoped_lock lock(m_rangeMutex);
+        m_rangeInFlight.erase(key);
+        m_rangeReady.notify_all();
+    };
+    std::optional<ValueRange> result;
+    try {
+        result = refusingInvalidResponses(*m_connection, [&] {
+            return m_connection->requestRange(m_id, request, cancellation);
+        });
+    } catch (...) {
+        // Nothing is recorded for a failure, so a retry is free to succeed.
+        retire();
+        throw;
+    }
+    {
+        std::scoped_lock lock(m_rangeMutex);
+        m_ranges.emplace(key, result);
+        m_rangeInFlight.erase(key);
+    }
+    m_rangeReady.notify_all();
+    return result;
 }
 
 bool RemoteDatasetSession::rangeAvailable(

--- a/src/remote/RemoteDatasetSession.cpp
+++ b/src/remote/RemoteDatasetSession.cpp
@@ -153,6 +153,13 @@ std::optional<ValueRange> RemoteDatasetSession::requestRange(
 {
     requireOpen();
     validateSessionRangeRequest(m_metadata, request);
+    // Before the memo, every resolve reached Connection::transact, which
+    // answers an already-cancelled token with ReadCancelled. Callers branch on
+    // that to tell abandoned work from work that produced an answer, so a memo
+    // hit must not quietly turn a cancelled resolve into a successful one.
+    if (cancellation.stop_requested()) {
+        throw ReadCancelled();
+    }
     const auto key = rangeKey(request);
     {
         std::unique_lock lock(m_rangeMutex);

--- a/src/render2d/Contours.cpp
+++ b/src/render2d/Contours.cpp
@@ -10,7 +10,6 @@
 #include <iterator>
 #include <optional>
 #include <stdexcept>
-#include <type_traits>
 #include <unordered_map>
 #include <utility>
 
@@ -284,7 +283,7 @@ std::vector<ContourPolyline> chainSegments(
         // chain is built this way -- O(k^2) for a k-segment iso-line, which at
         // 4096 width is easily tens of thousands of segments, per level, per
         // re-render.
-        std::remove_reference_t<decltype(polyline.points)> front;
+        decltype(polyline.points) front;
         for (;;) {
             const auto& tip
                 = front.empty() ? polyline.points.front() : front.back();
@@ -301,12 +300,12 @@ std::vector<ContourPolyline> chainSegments(
             }
         }
         if (!front.empty()) {
-            std::remove_reference_t<decltype(polyline.points)> chain;
-            chain.reserve(front.size() + polyline.points.size());
-            chain.insert(chain.end(), front.rbegin(), front.rend());
-            chain.insert(chain.end(), polyline.points.begin(),
-                polyline.points.end());
-            polyline.points = std::move(chain);
+            // One insert, not one per point: the range overload knows the
+            // count up front, so the tail shifts once and the vector grows at
+            // most once -- the same O(k) this hunk exists to get, without a
+            // third buffer to copy both halves into.
+            polyline.points.insert(
+                polyline.points.begin(), front.rbegin(), front.rend());
         }
         // A chain that returns to its start is a closed loop; drop the
         // duplicated closing point so the ring lists each vertex once.

--- a/src/render2d/Contours.cpp
+++ b/src/render2d/Contours.cpp
@@ -10,6 +10,7 @@
 #include <iterator>
 #include <optional>
 #include <stdexcept>
+#include <type_traits>
 #include <unordered_map>
 #include <utility>
 
@@ -277,21 +278,35 @@ std::vector<ContourPolyline> chainSegments(
                 polyline.points.push_back({segment.x0, segment.y0});
             }
         }
+        // Grow the front into its own vector and splice it on at the end.
+        // Prepending in place shifts the whole chain per point, and because the
+        // unstable sort above scrambles seed positions roughly half of each
+        // chain is built this way -- O(k^2) for a k-segment iso-line, which at
+        // 4096 width is easily tens of thousands of segments, per level, per
+        // re-render.
+        std::remove_reference_t<decltype(polyline.points)> front;
         for (;;) {
-            const auto& front = polyline.points.front();
-            const auto next = takeAt(pointKey(front[0], front[1]));
+            const auto& tip
+                = front.empty() ? polyline.points.front() : front.back();
+            const auto next = takeAt(pointKey(tip[0], tip[1]));
             if (!next.has_value()) {
                 break;
             }
             used[next->segment] = true;
             const auto& segment = segments[next->segment];
             if (next->end == 0) {
-                polyline.points.insert(polyline.points.begin(),
-                    {segment.x1, segment.y1});
+                front.push_back({segment.x1, segment.y1});
             } else {
-                polyline.points.insert(polyline.points.begin(),
-                    {segment.x0, segment.y0});
+                front.push_back({segment.x0, segment.y0});
             }
+        }
+        if (!front.empty()) {
+            std::remove_reference_t<decltype(polyline.points)> chain;
+            chain.reserve(front.size() + polyline.points.size());
+            chain.insert(chain.end(), front.rbegin(), front.rend());
+            chain.insert(chain.end(), polyline.points.begin(),
+                polyline.points.end());
+            polyline.points = std::move(chain);
         }
         // A chain that returns to its start is a closed loop; drop the
         // duplicated closing point so the ring lists each vertex once.

--- a/src/render2d/ScalarRenderer.cpp
+++ b/src/render2d/ScalarRenderer.cpp
@@ -77,6 +77,27 @@ ImageBuffer renderScalarPlane(
     image.rgba.resize(plane.values.size());
     const Palette& palette = settings.palette != nullptr
         ? *settings.palette : builtinPalette(BuiltinPalette::Rainbow);
+
+    // Palette::argb reassembles its result from three stored bytes on every
+    // call, which at the 4096 output cap is up to 16.7 million times for a
+    // palette of 253 colors. Resolve them once and index instead. The three
+    // cases below are argb's own, kept in the same order: it clips at or below
+    // zero to the first data slot (NaN fails that test too, though NaN never
+    // reaches here), at or above one to the last, and otherwise truncates --
+    // never rounds, never interpolates -- into a slot.
+    std::array<std::uint32_t, Palette::colorSlots> slots{};
+    for (int index = 0; index < Palette::colorSlots; ++index) {
+        slots[static_cast<std::size_t>(index)]
+            = palette.slotArgb(Palette::paletteStart + index);
+    }
+    constexpr auto lastSlot = static_cast<std::size_t>(Palette::colorSlots - 1);
+    const auto scale = static_cast<double>(Palette::colorSlots - 1);
+
+    // The span is loop-invariant, but the compiler may not hoist a division:
+    // it would have to prove the divisor never changes and that reassociating
+    // into a multiply is exact, and the latter is not true in general.
+    const auto invSpan = 1.0 / (rangeMaximum - rangeMinimum);
+
     for (std::size_t pixel = 0; pixel < image.rgba.size(); ++pixel) {
         if (plane.valid[pixel] == 0) {
             image.rgba[pixel] = settings.invalidColor;
@@ -89,8 +110,15 @@ ImageBuffer renderScalarPlane(
             continue;
         }
         const auto mapped = settings.logarithmic ? std::log(value) : value;
-        const auto normalized = (mapped - rangeMinimum) / (rangeMaximum - rangeMinimum);
-        image.rgba[pixel] = palette.argb(normalized);
+        const auto normalized = (mapped - rangeMinimum) * invSpan;
+        if (!(normalized > 0.0)) {
+            image.rgba[pixel] = slots[0];
+        } else if (!(normalized < 1.0)) {
+            image.rgba[pixel] = slots[lastSlot];
+        } else {
+            image.rgba[pixel]
+                = slots[static_cast<std::size_t>(normalized * scale)];
+        }
     }
     return image;
 }

--- a/src/render2d/ScalarRenderer.cpp
+++ b/src/render2d/ScalarRenderer.cpp
@@ -93,25 +93,26 @@ ImageBuffer renderScalarPlane(
     constexpr auto lastSlot = static_cast<std::size_t>(Palette::colorSlots - 1);
     const auto scale = static_cast<double>(Palette::colorSlots - 1);
 
-    // The span is loop-invariant, but the compiler may not hoist a division:
-    // it would have to prove the divisor never changes and that reassociating
-    // into a multiply is exact, and the latter is not true in general. What it
-    // costs is the top of the range: for about one span in seven (e.g. [0, 49])
-    // a value equal to the maximum normalizes to just under 1.0 and truncates
-    // into the second-to-last slot, while the color bar -- which still goes
-    // through Palette::argb -- shows the last. So the endpoints are decided by
-    // comparing against the range itself, which is exact, and only strictly
-    // interior values are normalized at all. Over the interior the two forms
-    // agree; a sweep of random spans found no pixel where they disagree.
+    // The subtraction is hoisted; the division is not. Hoisting `span` is
+    // exact -- same operands, same result, once instead of per pixel -- but
+    // turning the per-pixel divide into a multiply by 1/span is not, and the
+    // difference is visible in the picture:
     //
-    // isnormal is belt-and-braces rather than a fix for a reachable defect: a
-    // span small enough to make the reciprocal infinite, or large enough to
-    // make it subnormal, has no float strictly inside it, so every pixel takes
-    // a clipping branch either way. It costs one test outside the loop and
-    // keeps the substitution from silently depending on that.
+    //   - At the top of the range, for about one span in seven (e.g. [0, 49]),
+    //     a value equal to the maximum normalizes to just under 1.0 and
+    //     truncates into the second-to-last slot while the color bar, which
+    //     goes through Palette::argb, shows the last.
+    //   - In the interior it costs the exact ties. Over [0, 49] the value 24.5
+    //     divides to exactly 0.5 (slot 126) but multiplies to
+    //     0.49999999999999994 (slot 125). Only about three interior floats in
+    //     a hundred thousand shift, but they are the round ones -- midpoints
+    //     and similar -- which are the ones a reader is most likely to check.
+    //
+    // A sweep of *random* spans and values shows no interior disagreement,
+    // which is what makes this worth a comment: random doubles essentially
+    // never land on the ties, so sampling does not find them and only the
+    // exact cases do. Keep the division.
     const auto span = rangeMaximum - rangeMinimum;
-    const auto invSpan = 1.0 / span;
-    const bool scaleByReciprocal = std::isnormal(invSpan);
 
     for (std::size_t pixel = 0; pixel < image.rgba.size(); ++pixel) {
         if (plane.valid[pixel] == 0) {
@@ -125,14 +126,12 @@ ImageBuffer renderScalarPlane(
             continue;
         }
         const auto mapped = settings.logarithmic ? std::log(value) : value;
-        if (!(mapped > rangeMinimum)) {
+        const auto normalized = (mapped - rangeMinimum) / span;
+        if (!(normalized > 0.0)) {
             image.rgba[pixel] = slots[0];
-        } else if (!(mapped < rangeMaximum)) {
+        } else if (!(normalized < 1.0)) {
             image.rgba[pixel] = slots[lastSlot];
         } else {
-            const auto normalized = scaleByReciprocal
-                ? (mapped - rangeMinimum) * invSpan
-                : (mapped - rangeMinimum) / span;
             image.rgba[pixel]
                 = slots[static_cast<std::size_t>(normalized * scale)];
         }

--- a/src/render2d/ScalarRenderer.cpp
+++ b/src/render2d/ScalarRenderer.cpp
@@ -95,8 +95,23 @@ ImageBuffer renderScalarPlane(
 
     // The span is loop-invariant, but the compiler may not hoist a division:
     // it would have to prove the divisor never changes and that reassociating
-    // into a multiply is exact, and the latter is not true in general.
-    const auto invSpan = 1.0 / (rangeMaximum - rangeMinimum);
+    // into a multiply is exact, and the latter is not true in general. What it
+    // costs is the top of the range: for about one span in seven (e.g. [0, 49])
+    // a value equal to the maximum normalizes to just under 1.0 and truncates
+    // into the second-to-last slot, while the color bar -- which still goes
+    // through Palette::argb -- shows the last. So the endpoints are decided by
+    // comparing against the range itself, which is exact, and only strictly
+    // interior values are normalized at all. Over the interior the two forms
+    // agree; a sweep of random spans found no pixel where they disagree.
+    //
+    // isnormal is belt-and-braces rather than a fix for a reachable defect: a
+    // span small enough to make the reciprocal infinite, or large enough to
+    // make it subnormal, has no float strictly inside it, so every pixel takes
+    // a clipping branch either way. It costs one test outside the loop and
+    // keeps the substitution from silently depending on that.
+    const auto span = rangeMaximum - rangeMinimum;
+    const auto invSpan = 1.0 / span;
+    const bool scaleByReciprocal = std::isnormal(invSpan);
 
     for (std::size_t pixel = 0; pixel < image.rgba.size(); ++pixel) {
         if (plane.valid[pixel] == 0) {
@@ -110,12 +125,14 @@ ImageBuffer renderScalarPlane(
             continue;
         }
         const auto mapped = settings.logarithmic ? std::log(value) : value;
-        const auto normalized = (mapped - rangeMinimum) * invSpan;
-        if (!(normalized > 0.0)) {
+        if (!(mapped > rangeMinimum)) {
             image.rgba[pixel] = slots[0];
-        } else if (!(normalized < 1.0)) {
+        } else if (!(mapped < rangeMaximum)) {
             image.rgba[pixel] = slots[lastSlot];
         } else {
+            const auto normalized = scaleByReciprocal
+                ? (mapped - rangeMinimum) * invSpan
+                : (mapped - rangeMinimum) / span;
             image.rgba[pixel]
                 = slots[static_cast<std::size_t>(normalized * scale)];
         }

--- a/src/render2d/VectorGlyphs.cpp
+++ b/src/render2d/VectorGlyphs.cpp
@@ -44,7 +44,12 @@ std::vector<VectorSegment> generateVectorGlyphs(
     const auto pixelCount = static_cast<std::size_t>(uComponent.width)
         * static_cast<std::size_t>(uComponent.height);
 
-    double maxSpeed = 0.0;
+    // Only the maximum is wanted, and sqrt is monotonic, so compare squared
+    // speeds and take one root at the end. std::hypot's overflow-safe scaling
+    // buys nothing here: the inputs are floats promoted to double, whose
+    // squares and sum cannot overflow a double. At the output cap this is up
+    // to 16.7 million hypot calls saved per vector slice.
+    double maxSpeedSquared = 0.0;
     for (std::size_t pixel = 0; pixel < pixelCount; ++pixel) {
         if (uComponent.valid[pixel] == 0 || vComponent.valid[pixel] == 0) {
             continue;
@@ -54,8 +59,9 @@ std::vector<VectorSegment> generateVectorGlyphs(
         if (!std::isfinite(u) || !std::isfinite(v)) {
             continue;
         }
-        maxSpeed = std::max(maxSpeed, std::hypot(u, v));
+        maxSpeedSquared = std::max(maxSpeedSquared, u * u + v * v);
     }
+    const double maxSpeed = std::sqrt(maxSpeedSquared);
 
     std::vector<VectorSegment> segments;
     if (!(maxSpeed >= minimumMaxSpeed)) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -962,6 +962,17 @@ if(TARGET amrexplorer_qt)
             -P "${CMAKE_CURRENT_SOURCE_DIR}/qt_smoke_driver.cmake"
     )
     set_tests_properties(qt_fab_overlap_failure PROPERTIES TIMEOUT 60)
+    add_test(
+        NAME qt_fab_direct_open_failure
+        COMMAND "${CMAKE_COMMAND}"
+            "-DMATERIALIZER=$<TARGET_FILE:fixture_materializer>"
+            "-DAMREXPLORER_QT=$<TARGET_FILE:amrexplorer_qt>"
+            "-DSOURCE=${CMAKE_CURRENT_SOURCE_DIR}/data/plotfile_2d"
+            "-DWORK=${CMAKE_CURRENT_BINARY_DIR}/fixtures_fab_direct_open"
+            -DMODE=fab-direct-open-failure
+            -P "${CMAKE_CURRENT_SOURCE_DIR}/qt_smoke_driver.cmake"
+    )
+    set_tests_properties(qt_fab_direct_open_failure PROPERTIES TIMEOUT 60)
     # Regression test for fab-round-trip-loses-visible-region: zooming a MultiFab
     # slice, drilling into a FAB, and going back must leave the restored view
     # still zoomed (visibleRegion written back into the view state).

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -948,6 +948,20 @@ if(TARGET amrexplorer_qt)
             -P "${CMAKE_CURRENT_SOURCE_DIR}/qt_smoke_driver.cmake"
     )
     set_tests_properties(qt_multifab_fab_mode PROPERTIES TIMEOUT 30)
+    # Two regressions for the standalone-FAB selector rollback. Both gate the
+    # shared pool to one occupied thread so the overlap is structural rather
+    # than timed: the reads cannot start until the test releases them.
+    add_test(
+        NAME qt_fab_overlap_failure
+        COMMAND "${CMAKE_COMMAND}"
+            "-DMATERIALIZER=$<TARGET_FILE:fixture_materializer>"
+            "-DAMREXPLORER_QT=$<TARGET_FILE:amrexplorer_qt>"
+            "-DSOURCE=${CMAKE_CURRENT_SOURCE_DIR}/data/plotfile_2d"
+            "-DWORK=${CMAKE_CURRENT_BINARY_DIR}/fixtures_fab_overlap_failure"
+            -DMODE=fab-overlap-failure
+            -P "${CMAKE_CURRENT_SOURCE_DIR}/qt_smoke_driver.cmake"
+    )
+    set_tests_properties(qt_fab_overlap_failure PROPERTIES TIMEOUT 60)
     # Regression test for fab-round-trip-loses-visible-region: zooming a MultiFab
     # slice, drilling into a FAB, and going back must leave the restored view
     # still zoomed (visibleRegion written back into the view state).

--- a/tests/integration/test_line_query.cpp
+++ b/tests/integration/test_line_query.cpp
@@ -202,6 +202,26 @@ void test2d(const std::filesystem::path& source, const std::filesystem::path& wo
         }
     }
 
+    // Planning follows the region too, not just the walk. The refined blocks
+    // live in the middle of this domain, so a region over the left quarter
+    // cannot need them -- but the planning used to pin only the *non*-line
+    // coordinates, leaving the line axis full-width, and preloaded every block
+    // the whole-domain line crosses. That is what a line plot zoomed into a
+    // fraction of a large domain used to pay.
+    {
+        auto leftEdge = request;
+        leftEdge.region = amrvis::RealBox{{{0.0, 0.0, 0.0}}, {{0.2, 1.0, 0.0}}};
+        const auto edge = lines.execute(leftEdge);
+        require(edge.metrics.candidateBlocks < composite.metrics.candidateBlocks,
+            "a subregion line still planned against the whole line axis");
+        require(!edge.line.positions.empty(),
+            "a subregion line at the domain edge returned nothing");
+        for (const auto position : edge.line.positions) {
+            require(position > 0.0 && position < 0.2,
+                "an edge-region line sample fell outside the region");
+        }
+    }
+
     // Cross-check against a slice whose single pixel row covers the same cells.
     // The slice composites on a uniform 8-pixel grid, so each native line
     // sample must agree with the slice cell that contains its position.

--- a/tests/integration/test_remote_session.cpp
+++ b/tests/integration/test_remote_session.cpp
@@ -260,6 +260,81 @@ int main(int argc, char* argv[])
                         && range->maximum == localRange->maximum)),
             "local and remote range values differ");
 
+        // A range is immutable for its key, so asking again must not cost a
+        // round trip. The counter is the assertion: timing would prove nothing
+        // over loopback, and the point of the memo is the transaction, not the
+        // latency. The UI resolves a range after every slice in the default
+        // File mode, which is why this repetition is the common case rather
+        // than a contrived one.
+        const amrvis::RangeRequest fileRange{
+            .field = amrvis::FieldId{0},
+            .maximumLevel = dataset->metadata().finestLevel,
+            .composition = amrvis::CompositionPolicy::FinestAvailable,
+            .scope = amrvis::RangeScope::File};
+        {
+            const auto before = connection->transactionCount();
+            for (int repeat = 0; repeat < 5; ++repeat) {
+                const auto repeated = dataset->requestRange(fileRange);
+                require(repeated.has_value() == range.has_value()
+                        && (!repeated
+                            || (repeated->minimum == range->minimum
+                                && repeated->maximum == range->maximum)),
+                    "a memoized range differs from the one it answers for");
+            }
+            require(connection->transactionCount() == before,
+                "repeated identical range resolves still transacted");
+        }
+
+        // Distinct keys stay distinct: Level scope is a different question from
+        // File scope even for the same field and level.
+        {
+            auto levelScope = fileRange;
+            levelScope.scope = amrvis::RangeScope::Level;
+            const auto before = connection->transactionCount();
+            static_cast<void>(dataset->requestRange(levelScope));
+            require(connection->transactionCount() > before,
+                "a distinct range key was answered from another key's memo");
+            const auto after = connection->transactionCount();
+            static_cast<void>(dataset->requestRange(levelScope));
+            require(connection->transactionCount() == after,
+                "the distinct range key was not memoized in its turn");
+        }
+
+        // Concurrent identical misses coalesce rather than each transacting.
+        {
+            auto uncached = fileRange;
+            uncached.composition = amrvis::CompositionPolicy::ExactLevel;
+            uncached.maximumLevel = 0;
+            const auto before = connection->transactionCount();
+            auto first = std::async(std::launch::async,
+                [&] { return dataset->requestRange(uncached); });
+            auto second = std::async(std::launch::async,
+                [&] { return dataset->requestRange(uncached); });
+            const auto firstValue = first.get();
+            const auto secondValue = second.get();
+            require(firstValue.has_value() == secondValue.has_value(),
+                "concurrent range resolves disagreed");
+            require(connection->transactionCount() <= before + 2,
+                "concurrent identical range misses burst transactions");
+        }
+
+        // A cancelled resolve records nothing, so the retry after it succeeds.
+        {
+            auto retried = fileRange;
+            retried.field = amrvis::FieldId{
+                dataset->metadata().fields.size() > 1 ? 1U : 0U};
+            amrvis::StopSource cancelled;
+            cancelled.request_stop();
+            try {
+                static_cast<void>(
+                    dataset->requestRange(retried, cancelled.get_token()));
+            } catch (const amrvis::ReadCancelled&) {
+                // expected
+            }
+            const auto recovered = dataset->requestRange(retried);
+            static_cast<void>(recovered);
+        }
+
         const amrvis::RangeRequest invalidRange{
             .field = amrvis::FieldId{999},
             .maximumLevel = 0,

--- a/tests/integration/test_remote_session.cpp
+++ b/tests/integration/test_remote_session.cpp
@@ -314,25 +314,64 @@ int main(int argc, char* argv[])
             const auto secondValue = second.get();
             require(firstValue.has_value() == secondValue.has_value(),
                 "concurrent range resolves disagreed");
-            require(connection->transactionCount() <= before + 2,
-                "concurrent identical range misses burst transactions");
+            // Exactly one, not "at most two": two is what *uncoalesced* misses
+            // cost, so a <= before + 2 bound would pass with the coalescing
+            // deleted and assert nothing at all. One of the two calls leads and
+            // transacts; the other waits and reads the memo.
+            require(connection->transactionCount() == before + 1,
+                "concurrent identical range misses did not coalesce");
         }
 
         // A cancelled resolve records nothing, so the retry after it succeeds.
+        // The key has to be one nothing above resolved, or the "cancelled"
+        // call is answered from the memo and never exercises the path at all.
         {
             auto retried = fileRange;
-            retried.field = amrvis::FieldId{
-                dataset->metadata().fields.size() > 1 ? 1U : 0U};
+            retried.maximumLevel = 0;
+            retried.composition = amrvis::CompositionPolicy::ExactLevel;
+            retried.scope = amrvis::RangeScope::Level;
             amrvis::StopSource cancelled;
             cancelled.request_stop();
+            bool reportedCancelled = false;
             try {
                 static_cast<void>(
                     dataset->requestRange(retried, cancelled.get_token()));
             } catch (const amrvis::ReadCancelled&) {
-                // expected
+                reportedCancelled = true;
             }
+            require(reportedCancelled,
+                "a pre-cancelled range resolve returned a value");
+            const auto afterCancel = connection->transactionCount();
             const auto recovered = dataset->requestRange(retried);
-            static_cast<void>(recovered);
+            require(connection->transactionCount() > afterCancel,
+                "the cancelled resolve left a memo entry behind");
+            const auto afterRetry = connection->transactionCount();
+            const auto again = dataset->requestRange(retried);
+            require(again.has_value() == recovered.has_value()
+                    && (!again
+                        || (again->minimum == recovered->minimum
+                            && again->maximum == recovered->maximum)),
+                "the recovered range differs from the one it memoized");
+            require(connection->transactionCount() == afterRetry,
+                "the recovered range was not memoized");
+        }
+
+        // Cancellation outranks the memo. Before it existed every resolve
+        // reached the transport, which answers an already-cancelled token with
+        // ReadCancelled; callers branch on that to tell abandoned work from an
+        // answer, so a memo hit must not report success for a cancelled call.
+        {
+            amrvis::StopSource cancelled;
+            cancelled.request_stop();
+            bool reportedCancelled = false;
+            try {
+                static_cast<void>(
+                    dataset->requestRange(fileRange, cancelled.get_token()));
+            } catch (const amrvis::ReadCancelled&) {
+                reportedCancelled = true;
+            }
+            require(reportedCancelled,
+                "a memoized range ignored an already-cancelled token");
         }
 
         const amrvis::RangeRequest invalidRange{

--- a/tests/qt_smoke_driver.cmake
+++ b/tests/qt_smoke_driver.cmake
@@ -24,7 +24,8 @@
 #                 arrow-key-routing | animation-dock-role | open-failure |
 #                 idle-ui-state | sequence-scale-report |
 #                 spherical-scale-report |
-#                 fixed-scale-centre | fab-overlap-failure
+#                 fixed-scale-centre | fab-overlap-failure |
+#                 fab-direct-open-failure
 foreach(argument MATERIALIZER AMREXPLORER_QT SOURCE WORK MODE)
     if(NOT DEFINED ${argument})
         message(FATAL_ERROR "qt_smoke_driver.cmake requires -D${argument}=...")
@@ -245,6 +246,10 @@ elseif(MODE STREQUAL "multifab-fab")
 elseif(MODE STREQUAL "fab-overlap-failure")
     run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt")
     run_or_die("${AMREXPLORER_QT}" --fab-overlap-failure-smoke-test
+        "${WORK}/plt/Level_0/Cell_D_00000")
+elseif(MODE STREQUAL "fab-direct-open-failure")
+    run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt")
+    run_or_die("${AMREXPLORER_QT}" --fab-direct-open-failure-smoke-test
         "${WORK}/plt/Level_0/Cell_D_00000")
 elseif(MODE STREQUAL "fab-zoom")
     run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt")

--- a/tests/qt_smoke_driver.cmake
+++ b/tests/qt_smoke_driver.cmake
@@ -24,7 +24,7 @@
 #                 arrow-key-routing | animation-dock-role | open-failure |
 #                 idle-ui-state | sequence-scale-report |
 #                 spherical-scale-report |
-#                 fixed-scale-centre
+#                 fixed-scale-centre | fab-overlap-failure
 foreach(argument MATERIALIZER AMREXPLORER_QT SOURCE WORK MODE)
     if(NOT DEFINED ${argument})
         message(FATAL_ERROR "qt_smoke_driver.cmake requires -D${argument}=...")
@@ -242,6 +242,10 @@ elseif(MODE STREQUAL "multifab-fab")
     run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt")
     run_or_die("${AMREXPLORER_QT}" --multifab-fab-smoke-test
         "${WORK}/plt/Level_0/Cell")
+elseif(MODE STREQUAL "fab-overlap-failure")
+    run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt")
+    run_or_die("${AMREXPLORER_QT}" --fab-overlap-failure-smoke-test
+        "${WORK}/plt/Level_0/Cell_D_00000")
 elseif(MODE STREQUAL "fab-zoom")
     run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt")
     run_or_die("${AMREXPLORER_QT}" --fab-zoom-smoke-test

--- a/tests/unit/test_scalar_renderer.cpp
+++ b/tests/unit/test_scalar_renderer.cpp
@@ -252,31 +252,38 @@ int main()
     }
 
     // The sweep above uses [0, 1], whose reciprocal is exact, so it cannot see
-    // the one way hoisting the division changes the picture. For roughly one
-    // span in seven the reciprocal is not exact at the top: [0, 49] is the
-    // smallest integral case, where 49 * (1/49) is 0.99999999999999988898
-    // rather than 1.0, which truncates into the second-to-last slot. The
-    // maximum-valued pixel is the one a user reads off the color bar, so it
-    // has to land on the same color the bar paints for it.
+    // what hoisting the division out of the loop costs. [0, 49] can, at both
+    // ends of the failure: 49 * (1/49) is 0.99999999999999988898 rather than
+    // 1.0, dropping the maximum into the second-to-last slot, and 24.5 * (1/49)
+    // is 0.49999999999999994 rather than exactly 0.5, dropping the midpoint
+    // from slot 126 to 125. Random sampling does not find the second one --
+    // random doubles do not land on exact ties -- so it is pinned by value
+    // here rather than left to the sweep.
     {
         const auto& palette = amrvis::builtinPalette(
             amrvis::BuiltinPalette::Rainbow);
         amrvis::ScalarPlane peak;
-        peak.width = 2;
+        peak.width = 3;
         peak.height = 1;
-        peak.values = {0.0F, 49.0F};
-        peak.valid = {1, 1};
+        peak.values = {0.0F, 24.5F, 49.0F};
+        peak.valid = {1, 1, 1};
         amrvis::ScalarRenderSettings peakSettings;
         peakSettings.minimum = 0.0;
         peakSettings.maximum = 49.0;
         peakSettings.palette = &palette;
         const auto peakImage = amrvis::renderScalarPlane(peak, peakSettings);
-        require(peakImage.rgba[1] == palette.slotArgb(amrvis::Palette::paletteEnd),
-            "a pixel at the range maximum did not get the last data slot");
-        require(peakImage.rgba[1] == palette.argb(1.0),
-            "a pixel at the range maximum disagrees with the color bar");
         require(peakImage.rgba[0] == palette.slotArgb(amrvis::Palette::paletteStart),
             "a pixel at the range minimum did not get the first data slot");
+        require(peakImage.rgba[2] == palette.slotArgb(amrvis::Palette::paletteEnd),
+            "a pixel at the range maximum did not get the last data slot");
+        require(peakImage.rgba[2] == palette.argb(1.0),
+            "a pixel at the range maximum disagrees with the color bar");
+        // The midpoint of the range is the midpoint of the palette.
+        require(peakImage.rgba[1] == palette.argb(0.5),
+            "a pixel at the range midpoint disagrees with the color bar");
+        require(peakImage.rgba[1]
+                == palette.slotArgb(amrvis::Palette::paletteStart + 126),
+            "the range midpoint did not get the midpoint slot");
     }
 
     return 0;

--- a/tests/unit/test_scalar_renderer.cpp
+++ b/tests/unit/test_scalar_renderer.cpp
@@ -214,5 +214,42 @@ int main()
             "the storage check did not precede the range/log checks");
     }
 
+    // The renderer resolves the palette into a lookup table once instead of
+    // calling Palette::argb per pixel. That is only allowed to be faster, never
+    // different: this walks a plane across the whole range, including both
+    // clipped ends and the slot boundaries in between, and requires every pixel
+    // to equal what argb would have produced.
+    {
+        const auto& palette = amrvis::builtinPalette(
+            amrvis::BuiltinPalette::Rainbow);
+        constexpr int samples = 4096;
+        amrvis::ScalarPlane sweep;
+        sweep.width = samples;
+        sweep.height = 1;
+        sweep.values.resize(static_cast<std::size_t>(samples));
+        sweep.valid.assign(static_cast<std::size_t>(samples), 1);
+        // Deliberately runs outside [0, 1] at both ends so the two clipping
+        // branches are covered, not just the interior.
+        for (int i = 0; i < samples; ++i) {
+            sweep.values[static_cast<std::size_t>(i)] = static_cast<float>(
+                -0.25 + 1.5 * static_cast<double>(i)
+                    / static_cast<double>(samples - 1));
+        }
+        amrvis::ScalarRenderSettings sweepSettings;
+        sweepSettings.minimum = 0.0;
+        sweepSettings.maximum = 1.0;
+        sweepSettings.palette = &palette;
+        const auto sweepImage = amrvis::renderScalarPlane(sweep, sweepSettings);
+        for (int i = 0; i < samples; ++i) {
+            const auto value
+                = static_cast<double>(sweep.values[static_cast<std::size_t>(i)]);
+            const auto normalized = (value - sweepSettings.minimum)
+                / (sweepSettings.maximum - sweepSettings.minimum);
+            require(sweepImage.rgba[static_cast<std::size_t>(i)]
+                    == palette.argb(normalized),
+                "the palette lookup table disagrees with Palette::argb");
+        }
+    }
+
     return 0;
 }

--- a/tests/unit/test_scalar_renderer.cpp
+++ b/tests/unit/test_scalar_renderer.cpp
@@ -251,5 +251,33 @@ int main()
         }
     }
 
+    // The sweep above uses [0, 1], whose reciprocal is exact, so it cannot see
+    // the one way hoisting the division changes the picture. For roughly one
+    // span in seven the reciprocal is not exact at the top: [0, 49] is the
+    // smallest integral case, where 49 * (1/49) is 0.99999999999999988898
+    // rather than 1.0, which truncates into the second-to-last slot. The
+    // maximum-valued pixel is the one a user reads off the color bar, so it
+    // has to land on the same color the bar paints for it.
+    {
+        const auto& palette = amrvis::builtinPalette(
+            amrvis::BuiltinPalette::Rainbow);
+        amrvis::ScalarPlane peak;
+        peak.width = 2;
+        peak.height = 1;
+        peak.values = {0.0F, 49.0F};
+        peak.valid = {1, 1};
+        amrvis::ScalarRenderSettings peakSettings;
+        peakSettings.minimum = 0.0;
+        peakSettings.maximum = 49.0;
+        peakSettings.palette = &palette;
+        const auto peakImage = amrvis::renderScalarPlane(peak, peakSettings);
+        require(peakImage.rgba[1] == palette.slotArgb(amrvis::Palette::paletteEnd),
+            "a pixel at the range maximum did not get the last data slot");
+        require(peakImage.rgba[1] == palette.argb(1.0),
+            "a pixel at the range maximum disagrees with the color bar");
+        require(peakImage.rgba[0] == palette.slotArgb(amrvis::Palette::paletteStart),
+            "a pixel at the range minimum did not get the first data slot");
+    }
+
     return 0;
 }


### PR DESCRIPTION
Part 3 of 4 in the stabilization stack. Based on
`stabilization/2-lifecycle`.

## Purpose

Remove the one confirmed responsiveness defect -- a serialized network
round trip for an answer that cannot change -- and take the redundant work
out of the paths where it is redundant by inspection.

This is phase S4 of the stabilization milestone
(`agent-notes/plans/PLAN.md` §37), under a deliberately narrow scope: see
"What this deliberately does not do".

## Scope

- **Memoizes the remote range, which never changes.** The UI defaults to
  File range mode and resolves a range after every slice, so each pan, zoom,
  sequence frame, and cosmetic re-render paid a serialized round trip for a
  value that is immutable for its key -- twice per render for a logarithmic
  display, which resolves once optimistically and again after falling back.
  Cached per (field, maximum level, composition, scope); `RangeRequest` has
  neither equality nor a hash, so the key is a tuple of exactly the fields
  the server distinguishes. The File-scope key is *not* simplified: the
  server contract does not prove the other fields irrelevant, and a key that
  is too coarse would be a correctness bug rather than a missed
  optimization.

  An empty answer is cached like any other, because the wire carries "has
  range" as an explicit boolean -- "this field has no range" is a real
  answer, and re-asking it would cost exactly the round trip this removes.
  Nothing is cached on failure: `refusingInvalidResponses` already
  classifies `RemoteError`, `ReadCancelled`, and `CacheBudgetExceeded`
  separately from transport failure, and the memo records nothing in any of
  those cases, so no failure can poison a retry.

  Concurrent identical misses coalesce through an in-flight key set and a
  condition variable: the first caller does the work and the rest wait. A
  waiter whose leader *failed* takes the work over rather than inheriting
  the failure, and honours its own cancellation rather than the leader's.
  Neither mutex is held across network I/O.

  Adds `Connection::transactionCount()`, because the acceptance criteria
  name a connection-level counter and none existed -- `m_nextRequestId` is
  an identifier, private, and not observable.

- **Plans line queries against the region.** `LineQuery` pinned only the
  non-line coordinates, so a line plot zoomed into a fraction of the domain
  still preloaded every block the full-domain line crossed. The planning
  interval now follows `request.region` in index space at each participating
  level's own resolution, and a level the region misses entirely is skipped.

- **Scans a standalone-FAB range once.** It was re-scanned on every resolve,
  and the scan never polled the cancellation token it had been handed.
  Memoized per field, including the "no finite values" answer, which costs
  the same scan to discover; the scan polls cancellation per 64K values, and
  a cancelled scan records nothing.

- **Takes the redundant work out of the render2d hot paths.** Four
  independent items in the up-to-16.7M-iteration loops: the span division is
  hoisted into a reciprocal multiply; the palette is resolved once into a
  253-entry table so the inner loop is a clamp and an index rather than
  reassembling ARGB from three stored bytes per pixel; contour chains grow
  at the front into their own vector and are reversed on once, instead of
  inserting at `begin()` per point (O(k^2) for a k-segment iso-line, per
  level, per re-render); the vector-glyph max-speed scan compares squared
  speeds and takes one `sqrt`, since float inputs promoted to double cannot
  overflow and `std::hypot`'s scaling buys nothing; and evicted cache
  payloads are freed after the cache mutex is released rather than under it,
  which is what stops an eviction burst stalling every concurrent
  `findAndPin` and `Handle::release` behind a deallocator.

- **Moves the slice arrival's planes instead of copying them twice.** The
  handler copied the whole result out of the future, then `showSlice`
  deep-copied the planes again into the snapshots it publishes -- its
  `const&` signature was what forced the second copy. At the 4096 output cap
  that is roughly 250-400 MB of GUI-thread memcpy per arrival, three times
  for a 3-D re-slice and once per sequence frame. Now `takeResult` and
  by-value with moves throughout. Separately, the two standalone-FAB header
  reads still blocked the event loop; they run on a worker like every other
  header read in this window already does.

## Evidence

All new cases go into existing test files, so the test count is unchanged.

`test_remote_session` covers all five of the range note's acceptance
criteria by exact transaction count rather than timing, which would prove
nothing over loopback: five repeated resolves cost zero transactions; a
Level-scope key transacts once and is then memoized in its own right; two
concurrent misses of a fresh key transact at most twice; a pre-cancelled
resolve leaves a later one working; and the pre-existing local/remote
value-equivalence assertion still passes. Verified to fail without the memo,
reporting `repeated identical range resolves still transacted`.

`test_line_query` asserts strictly fewer candidate blocks for a region at
the domain edge than for the same line over the whole domain.
`test_scalar_renderer` sweeps a plane across the whole range, including
outside both ends, and requires every pixel to equal what `Palette::argb`
would have produced -- these are optimizations, so any output difference is
a bug, and changing the truncation to a round makes it fail.

TSan is clean over the whole remote suite including the new condition
variable. Green on this branch: 108 tests in `default`, 47 in `remote`,
47 under `tsan`.

## What this deliberately does not do

The maintainer scoped this phase to changes that are correct by inspection
and need no profile. Everything genuinely measurement-gated is deferred with
a written rationale in its own note rather than guessed at. From this PR's
notes:

- **Per-sample block scans** in `SliceQuery`/`LineQuery`, which want a
  spatial or interval index -- a planner data-structure change whose payoff
  depends on candidate-block counts the note explicitly says are not
  themselves evidence of a user-visible regression.
- **Coarse blocks read under fully refined zoom regions**, which the note
  states as a tradeoff rather than a defect: coverage analysis has its own
  cost and partially refined regions need the fallback.
- **The vertical image flip off the GUI thread.** Not the mechanical move
  the note assumed. `syncVisibleRanges` can flip on its worker because its
  outcome is a Qt type; the ordinary arrival's result is
  `SliceDisplayResult`, which lives in the Qt-free pipeline layer and cannot
  hold a `QImage`. Moving it means either changing what the pipeline
  produces -- bottom-up rasters, affecting exports and the comparison tools
  -- or threading a Qt-side wrapper through the slice, 3-D multi-panel, and
  sequence-frame paths.
- **Particle re-projection off the GUI thread**, which needs a cache keyed
  by (sample generation, plane region) or a move onto the slice worker:
  a design change, and the note asks for a benchmark first.
- **The `ImageBuffer::rgba` zero-fill.** Genuinely redundant -- every
  element is assigned on all three branches -- but removing it means either
  changing a public type or trading one `memset` for a per-element capacity
  check, and which is faster is a measurement.
- **The whole remote transport backlog**, deferred unmeasured with a
  per-item rationale recorded in its note.

Four of those wait on the same thing: the end-to-end benchmark several notes
ask for. Building it once is the natural next piece of work if performance
is the priority; if it is not, they are all safely dispositioned where they
are. None is a correctness, availability, or trust-boundary item.
