### PR TITLE
[stabilization] close the low-priority batches and the release-process note

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,9 +1,8 @@
 # Installing AMReXplorer
 
-Two options: build from source, or download a prebuilt AppImage.
-Tested on Ubuntu 24.04 and macOS.
+Build from source. Tested on Ubuntu 24.04 and macOS.
 
-## Option 1: Build from source
+## Build from source
 
 ### Linux (Ubuntu)
 
@@ -86,21 +85,15 @@ Set `-DAMREXPLORER_BUILD_MACOS_APP_BUNDLE=OFF` when configuring to build the pla
 sudo cmake --install build --prefix /usr/local
 ```
 
-## Option 2: Prebuilt AppImage
-
-> **Not yet available.** Prebuilt AppImages will be published on the
-> [GitHub Releases][] page once the first release is tagged.
+## Packaging an AppImage
 
 An AppImage is a self-contained executable that runs on any modern Linux
-distribution without installing packages. To package a source build now, see
-**[Building an AppImage](docs/building.md#building-an-appimage)**. When
-prebuilt images become available:
+distribution without installing packages, which makes it a convenient way to
+move a build to machines you do not administer. You can build one from a source
+build yourself: see
+**[Building an AppImage](docs/building.md#building-an-appimage)**.
 
-1. Download `amrexplorer-*.AppImage` from the [GitHub Releases][] page.
-2. Make it executable: `chmod +x amrexplorer-*.AppImage`
-3. Run it: `./amrexplorer-*.AppImage /path/to/plotfile`
-
-[GitHub Releases]: https://github.com/amrex-codes/amrexplorer/releases
+There is no release pipeline yet, so no prebuilt AppImage is published.
 
 ## Next steps
 

--- a/include/amrexplorer/cache/ByteLruCache.hpp
+++ b/include/amrexplorer/cache/ByteLruCache.hpp
@@ -171,15 +171,30 @@ public:
         }
         evictFor(*m_state, bytes, doomed);
 
+        // Publish first, account second. Both allocating steps -- the LRU node
+        // and the map node -- happen before either byte counter moves, so a
+        // bad_alloc from the map cannot leave pinnedBytes inflated for a pin
+        // that no Handle exists to release. That inflation was permanent:
+        // Handle::release is the only thing that decrements it, and the budget
+        // checks above would eventually reject every insert. Everything after
+        // the emplace is nothrow.
         m_state->lru.push_front(key);
-        Entry entry{std::move(value), bytes, 1, m_state->lru.begin()};
-        m_state->metrics.residentBytes += bytes;
-        m_state->metrics.pinnedBytes += bytes;
-        const auto [inserted, success] = m_state->entries.emplace(key, std::move(entry));
-        if (!success) {
+        std::pair<typename EntryMap::iterator, bool> insertion;
+        try {
+            Entry entry{std::move(value), bytes, 1, m_state->lru.begin()};
+            insertion = m_state->entries.emplace(key, std::move(entry));
+        } catch (...) {
+            m_state->lru.pop_front();
+            throw;
+        }
+        if (!insertion.second) {
+            m_state->lru.pop_front();
             throw std::logic_error("cache insertion failed unexpectedly");
         }
-        return Handle(m_state, std::move(key), inserted->second.value, bytes);
+        m_state->metrics.residentBytes += bytes;
+        m_state->metrics.pinnedBytes += bytes;
+        return Handle(
+            m_state, std::move(key), insertion.first->second.value, bytes);
     }
 
     [[nodiscard]] bool erase(const Key& key)

--- a/include/amrexplorer/core/Geometry.hpp
+++ b/include/amrexplorer/core/Geometry.hpp
@@ -4,6 +4,7 @@
 #include <array>
 #include <cmath>
 #include <cstddef>
+#include <limits>
 
 namespace amrvis {
 
@@ -66,7 +67,17 @@ struct RealBox {
         }
         for (int axis = 0; axis < dimension; ++axis) {
             const auto i = static_cast<std::size_t>(axis);
-            if (!(lower[i] < upper[i])) {
+            // Ordered *and* finite. C++ streams parse "inf", so a corrupt
+            // header can hand us lower = -inf, upper = +inf, which is ordered
+            // and passes an ordering-only test -- and then upper - lower is
+            // inf, and any extent derived from it is inf or NaN. Written as a
+            // pair of comparisons rather than std::isfinite because that is not
+            // constexpr before C++23 and this function is used in constant
+            // expressions. NaN fails the ordering test on its own.
+            constexpr auto infinity
+                = std::numeric_limits<double>::infinity();
+            if (!(lower[i] < upper[i]) || !(lower[i] > -infinity)
+                || !(upper[i] < infinity)) {
                 return false;
             }
         }
@@ -130,10 +141,18 @@ struct RealBox {
         if (!(dx > 0.0)) {
             continue;
         }
-        const auto cells = std::max(1.0,
-            std::round((region.upper[i] - region.lower[i]) / dx));
         const auto domainCells = std::max(0.0,
             std::round((domain.upper[i] - origin) / dx));
+        // Never more cells than the domain holds. Past that the clamp below
+        // collapses to [0, 0], which pins first at zero while upper still
+        // lands at origin + cells*dx -- outside the domain, translating the
+        // view to the corner. The only caller clamps its region into the
+        // domain before calling, so this is not reachable today; the sibling
+        // snapToCellBoundaries clamps its upper edge for the same reason, and
+        // a geometry helper should not depend on its caller for that.
+        const auto cells = std::min(
+            std::max(1.0, std::round((region.upper[i] - region.lower[i]) / dx)),
+            std::max(1.0, domainCells));
         const auto first = std::clamp(
             std::round((region.lower[i] - origin) / dx),
             0.0, std::max(0.0, domainCells - cells));

--- a/include/amrexplorer/pipeline/SliceRangeResolver.hpp
+++ b/include/amrexplorer/pipeline/SliceRangeResolver.hpp
@@ -29,10 +29,22 @@ struct ResolvedRange {
     bool logarithmic;
 };
 
+// Widens a degenerate (minimum == maximum) range just enough to have positive
+// extent, leaving anything else alone. The padding is *relative* to the value:
+// a uniform plane of 1e-7 must not be padded to a range straddling zero, which
+// is what an absolute floor did, and which silently disqualified the plane from
+// logarithmic display. A strictly positive constant under a logarithmic range
+// is widened multiplicatively so it stays positive.
+//
+// One definition, because there were three: two in SliceRangeResolver and one
+// in DisplayCoordinator, and only two of them knew about logarithmic ranges.
+[[nodiscard]] std::pair<double, double> paddedIfDegenerate(
+    double minimum, double maximum, bool logarithmic) noexcept;
+
 // Finite extrema of a plane, padded so minimum < maximum; nullopt when the
 // plane has no finite valid samples.
 [[nodiscard]] std::optional<std::pair<double, double>> finiteRange(
-    const ScalarPlane& plane);
+    const ScalarPlane& plane, bool logarithmic = false);
 
 // The metadata (File/Level) range for the selection, or nullopt when the
 // statistics needed for that mode are unavailable.

--- a/src/core/Metadata.cpp
+++ b/src/core/Metadata.cpp
@@ -166,8 +166,13 @@ std::vector<MetadataIssue> validateMetadata(const DatasetMetadata& metadata)
                     "must contain only cell (0) or node (1) index types");
                 break;
             }
-            if (!(level.cellSize[i] > 0.0)) {
-                add(path + ".cellSize", "must be positive in every active direction");
+            // Positive *and* finite: +inf is positive, parses out of a corrupt
+            // header, and turns every extent computed from it into inf or NaN.
+            // The indexOrigin check below already demanded finiteness.
+            if (!(level.cellSize[i] > 0.0)
+                || !std::isfinite(level.cellSize[i])) {
+                add(path + ".cellSize",
+                    "must be positive and finite in every active direction");
                 break;
             }
             if (!std::isfinite(level.indexOrigin[i])) {

--- a/src/pipeline/DisplayCoordinator.cpp
+++ b/src/pipeline/DisplayCoordinator.cpp
@@ -50,17 +50,7 @@ std::optional<std::pair<double, double>> DisplayCoordinator::sharedVisibleRange(
     if (!std::isfinite(minimum) || !std::isfinite(maximum)) {
         return std::nullopt;
     }
-    if (minimum == maximum) {
-        if (logarithmic && minimum > 0.0) {
-            minimum /= 1.0 + 1.0e-6;
-            maximum *= 1.0 + 1.0e-6;
-        } else {
-            const auto pad = std::max(std::abs(minimum), 1.0) * 1.0e-6;
-            minimum -= pad;
-            maximum += pad;
-        }
-    }
-    return std::pair{minimum, maximum};
+    return paddedIfDegenerate(minimum, maximum, logarithmic);
 }
 
 ImageTransformPolicy DisplayCoordinator::rasterTransformPolicy(

--- a/src/pipeline/SliceRangeResolver.cpp
+++ b/src/pipeline/SliceRangeResolver.cpp
@@ -32,14 +32,21 @@ std::pair<double, double> paddedIfDegenerate(
     // differed only in scale.
     //
     // The floor is the smallest padding that can still separate the two
-    // endpoints in double precision near this magnitude: for a value of zero
-    // that is the smallest normal, and otherwise one ulp is far too small to
-    // survive later arithmetic, so a relative 1e-6 is used with the normal as
-    // a backstop.
+    // endpoints in double precision near this magnitude: one ulp is far too
+    // small to survive later arithmetic, so a relative 1e-6 is used with the
+    // smallest normal as a backstop.
+    //
+    // Zero has no magnitude to be relative to, and the backstop is the wrong
+    // answer there: a uniform plane of zeros -- an ordinary case, not a
+    // pathological one -- would get a range of +/-2.2e-308, which is what the
+    // color bar and the seeded User-range spin boxes then display. Fall back to
+    // the relative constant as an absolute, which is what this returned before
+    // the padding became relative.
     constexpr auto relative = 1.0e-6;
     const auto magnitude = std::abs(minimum);
-    const auto padding = std::max(magnitude * relative,
-        std::numeric_limits<double>::min());
+    const auto padding = magnitude > 0.0
+        ? std::max(magnitude * relative, std::numeric_limits<double>::min())
+        : relative;
     return {minimum - padding, maximum + padding};
 }
 

--- a/src/pipeline/SliceRangeResolver.cpp
+++ b/src/pipeline/SliceRangeResolver.cpp
@@ -15,7 +15,36 @@ public:
 
 } // namespace
 
-std::optional<std::pair<double, double>> finiteRange(const ScalarPlane& plane)
+std::pair<double, double> paddedIfDegenerate(
+    double minimum, double maximum, bool logarithmic) noexcept
+{
+    if (minimum != maximum) {
+        return {minimum, maximum};
+    }
+    if (logarithmic && minimum > 0.0) {
+        return {minimum / (1.0 + 1.0e-6), maximum * (1.0 + 1.0e-6)};
+    }
+    // Relative to the value, not an absolute floor. The old
+    // max(abs(minimum), 1.0) * 1e-6 padded a uniform plane of 1e-7 by 1e-6 --
+    // ten times the value itself, straddling zero, which then disqualified the
+    // plane from logarithmic display. A constant of 5.0 meanwhile stayed
+    // logarithmic, so the same control behaved differently on data that
+    // differed only in scale.
+    //
+    // The floor is the smallest padding that can still separate the two
+    // endpoints in double precision near this magnitude: for a value of zero
+    // that is the smallest normal, and otherwise one ulp is far too small to
+    // survive later arithmetic, so a relative 1e-6 is used with the normal as
+    // a backstop.
+    constexpr auto relative = 1.0e-6;
+    const auto magnitude = std::abs(minimum);
+    const auto padding = std::max(magnitude * relative,
+        std::numeric_limits<double>::min());
+    return {minimum - padding, maximum + padding};
+}
+
+std::optional<std::pair<double, double>> finiteRange(
+    const ScalarPlane& plane, bool logarithmic)
 {
     auto minimum = std::numeric_limits<double>::infinity();
     auto maximum = -std::numeric_limits<double>::infinity();
@@ -33,12 +62,7 @@ std::optional<std::pair<double, double>> finiteRange(const ScalarPlane& plane)
     if (!std::isfinite(minimum) || !std::isfinite(maximum)) {
         return std::nullopt;
     }
-    if (minimum == maximum) {
-        const auto padding = std::max(std::abs(minimum), 1.0) * 1.0e-6;
-        minimum -= padding;
-        maximum += padding;
-    }
-    return std::pair{minimum, maximum};
+    return paddedIfDegenerate(minimum, maximum, logarithmic);
 }
 
 std::optional<ValueRange> selectedMetadataRange(
@@ -145,19 +169,11 @@ std::pair<double, double> resolveRange(
     }
     auto [minimum, maximum] = selectedRange
         ? *selectedRange
-        : finiteRange(plane).value_or(logarithmic
+        : finiteRange(plane, logarithmic).value_or(logarithmic
               ? std::pair{1.0, 10.0}
               : std::pair{0.0, 1.0});
-    if (minimum == maximum) {
-        if (logarithmic && minimum > 0.0) {
-            minimum /= 1.0 + 1.0e-6;
-            maximum *= 1.0 + 1.0e-6;
-        } else {
-            const auto padding = std::max(std::abs(minimum), 1.0) * 1.0e-6;
-            minimum -= padding;
-            maximum += padding;
-        }
-    }
+    std::tie(minimum, maximum)
+        = paddedIfDegenerate(minimum, maximum, logarithmic);
     if (!(minimum < maximum)) {
         throw std::runtime_error("user scalar range must have positive extent");
     }

--- a/src/qt/ColorBarWidget.cpp
+++ b/src/qt/ColorBarWidget.cpp
@@ -56,6 +56,10 @@ ColorBarWidget::ColorBarWidget(QWidget* parent)
     : QWidget(parent)
     , m_numberFormat(defaultNumberFormat())
 {
+    // panelWidth is the floor, not the width: a wide user format (say
+    // "%.10e") produces tick labels past 150 px, and a fixed width clipped
+    // them on screen while exports -- which size themselves with
+    // preferredWidth -- came out fine. Grow to fit whatever the labels need.
     setFixedWidth(panelWidth);
     setMinimumHeight(280);
 }
@@ -72,18 +76,21 @@ void ColorBarWidget::setFieldRange(QString fieldName, double minimum, double max
     m_minimum = minimum;
     m_maximum = maximum;
     m_hasRange = true;
+    applyPreferredWidth();
     update();
 }
 
 void ColorBarWidget::setNumberFormat(QString format)
 {
     m_numberFormat = std::move(format);
+    applyPreferredWidth();
     update();
 }
 
 void ColorBarWidget::setLogarithmic(bool logarithmic)
 {
     m_logarithmic = logarithmic;
+    applyPreferredWidth();
     update();
 }
 
@@ -91,7 +98,13 @@ void ColorBarWidget::clearRange()
 {
     m_fieldName.clear();
     m_hasRange = false;
+    applyPreferredWidth();
     update();
+}
+
+void ColorBarWidget::applyPreferredWidth()
+{
+    setFixedWidth(std::max(panelWidth, preferredWidth()));
 }
 
 void ColorBarWidget::paintBar(QPainter* painter, const QRect& target) const

--- a/src/qt/ColorBarWidget.hpp
+++ b/src/qt/ColorBarWidget.hpp
@@ -17,6 +17,8 @@ public:
 
     // Fixed panel width (including labels); kept constant so exports of the
     // same view always have the same size even when tick labels vary.
+    // Minimum on-screen width; the widget grows past it when the tick
+    // labels need more (see applyPreferredWidth).
     static constexpr int panelWidth = 150;
 
     void setPalette(const amrvis::Palette* palette);
@@ -38,6 +40,10 @@ protected:
     void paintEvent(QPaintEvent* event) override;
 
 private:
+    // Resize to whichever is larger, panelWidth or what the current labels
+    // need, after anything that can change their width.
+    void applyPreferredWidth();
+
     const amrvis::Palette* m_palette = nullptr;
     QString m_fieldName;
     QString m_numberFormat;

--- a/src/qt/DatasetWindow.cpp
+++ b/src/qt/DatasetWindow.cpp
@@ -260,8 +260,17 @@ void DatasetWindow::startLoad()
                 return;
             }
             try {
-                m_levels = watcher->result();
+                // Take the old extracts out of the way before m_levels is
+                // replaced, and only destroy them once the models have been
+                // rebuilt off the new ones. Assigning straight into m_levels
+                // destroys the old extracts while the old LevelTableModels
+                // still reference them; nothing dispatches in between today,
+                // so nothing observes it, but the window is one queued call
+                // away from doing so.
+                auto previous = std::move(m_levels);
+                m_levels = watcher->future().takeResult();
                 populateTabs();
+                previous.clear();
                 m_status->setText(tr("Field: %1").arg(m_request.fieldName));
             } catch (const std::exception& error) {
                 // Report a real failure non-modally through the owner, then

--- a/src/qt/DatasetWindow.cpp
+++ b/src/qt/DatasetWindow.cpp
@@ -260,15 +260,23 @@ void DatasetWindow::startLoad()
                 return;
             }
             try {
-                // Take the old extracts out of the way before m_levels is
-                // replaced, and only destroy them once the models have been
-                // rebuilt off the new ones. Assigning straight into m_levels
-                // destroys the old extracts while the old LevelTableModels
-                // still reference them; nothing dispatches in between today,
-                // so nothing observes it, but the window is one queued call
-                // away from doing so.
-                auto previous = std::move(m_levels);
-                m_levels = watcher->future().takeResult();
+                // Retrieve first, and only then take the old extracts out of
+                // the way, destroying them once the models have been rebuilt
+                // off the new ones. Assigning straight into m_levels destroys
+                // the old extracts while the old LevelTableModels still hold
+                // `const DatasetLevelExtract&` into them; nothing dispatches in
+                // between today, so nothing observes it, but the window is one
+                // queued call away from doing so.
+                //
+                // The retrieval has to come first because it throws: a worker
+                // failure with the old extracts already moved into a local here
+                // would destroy them during unwinding, before the handler below
+                // runs and without populateTabs having rebuilt anything, so
+                // every existing model would be left dangling until the
+                // window's deferred delete. Leaving m_levels alone until the
+                // result is in hand keeps the failure path exactly as it was.
+                auto next = watcher->future().takeResult();
+                auto previous = std::exchange(m_levels, std::move(next));
                 populateTabs();
                 previous.clear();
                 m_status->setText(tr("Field: %1").arg(m_request.fieldName));

--- a/src/qt/FabSelectorDock.cpp
+++ b/src/qt/FabSelectorDock.cpp
@@ -6,6 +6,7 @@
 #include <QInputDialog>
 #include <QItemSelectionModel>
 #include <QKeyEvent>
+#include <QMouseEvent>
 #include <QLineEdit>
 #include <QMessageBox>
 #include <QModelIndex>
@@ -318,6 +319,12 @@ bool FabSelectorDock::eventFilter(QObject* watched, QEvent* event)
 {
     if (watched == m_filter
         && event->type() == QEvent::MouseButtonRelease) {
+        // Left button only. Accepting any button meant a right-click opened
+        // the find-point dialog and swallowed the context menu with it.
+        const auto* mouseEvent = static_cast<QMouseEvent*>(event);
+        if (mouseEvent->button() != Qt::LeftButton) {
+            return false;
+        }
         promptForPoint();
         return true;
     }

--- a/src/qt/ImageView.cpp
+++ b/src/qt/ImageView.cpp
@@ -53,7 +53,21 @@ public:
 
     [[nodiscard]] QRectF boundingRect() const override
     {
-        return m_bounds.adjusted(-m_size, -m_size, m_size, m_size);
+        // The pen is cosmetic, so its width is m_size *device* pixels however
+        // far the view is zoomed out; in item coordinates that is m_size/scale,
+        // which exceeds a bare m_size padding as soon as the scale drops below
+        // one, and edge points then paint outside the declared bounds. Nothing
+        // shows today because the view repaints its whole viewport, but the
+        // contract holds regardless of who is asking.
+        //
+        // A constant multiple rather than the live view scale: boundingRect
+        // must not change without prepareGeometryChange, or the scene's item
+        // index goes stale, and the view scale changes on every zoom. This
+        // covers zoom-out to 1/16, past which the whole raster occupies a
+        // handful of pixels and a point's overspill is not a visible artifact.
+        constexpr qreal smallestCoveredScale = 16.0;
+        const auto padding = m_size * smallestCoveredScale;
+        return m_bounds.adjusted(-padding, -padding, padding, padding);
     }
 
     void paint(QPainter* painter, const QStyleOptionGraphicsItem*, QWidget*) override

--- a/src/qt/IsoWidget.cpp
+++ b/src/qt/IsoWidget.cpp
@@ -113,7 +113,7 @@ void IsoWidget::paintEvent(QPaintEvent* event)
     QPainter painter(this);
     painter.fillRect(event->rect(), viewportBackground());
     if (!m_hasGeometry) {
-        painter.setPen(QColor(0x88, 0x88, 0x88));
+        painter.setPen(viewportForeground());
         painter.drawText(rect(), Qt::AlignCenter, tr("3-D overview"));
         return;
     }

--- a/src/qt/LinePlotWindow.cpp
+++ b/src/qt/LinePlotWindow.cpp
@@ -27,12 +27,18 @@
 namespace amrvis::qt {
 namespace {
 
+// Eight curve colors picked against viewportBackground(), the mid-gray this
+// plot actually fills with. The previous set was chosen for a black background
+// -- white, cyan, yellow and Qt::gray all sit close to 0x888888 in luminance,
+// and the seventh curve in particular was very nearly invisible. These are all
+// darker than the background and mutually distinguishable.
 const std::array<QColor, 8>& curveColors()
 {
     static const std::array<QColor, 8> colors{
-        QColor(Qt::red), QColor(Qt::green), QColor(Qt::cyan), QColor(Qt::yellow),
-        QColor(Qt::magenta), QColor(Qt::white), QColor(Qt::gray),
-        QColor(0x66, 0xB2, 0xFF)};
+        QColor(0xB0, 0x00, 0x00), QColor(0x00, 0x5F, 0x00),
+        QColor(0x00, 0x30, 0xB0), QColor(0x7A, 0x4A, 0x00),
+        QColor(0x8B, 0x00, 0x8B), QColor(0x10, 0x10, 0x10),
+        QColor(0x00, 0x6E, 0x6E), QColor(0x7F, 0x3F, 0xBF)};
     return colors;
 }
 
@@ -270,7 +276,7 @@ void LinePlotWidget::paintEvent(QPaintEvent* /*event*/)
     const auto range = displayedRange();
     m_paintedRange = range;
     if (!range.has_value()) {
-        painter.setPen(Qt::white);
+        painter.setPen(viewportForeground());
         painter.drawText(rect(), Qt::AlignCenter,
             tr("Shift+middle click or horizontal right drag for X, "
                "Shift+right click or vertical right drag for Y"));
@@ -289,13 +295,15 @@ void LinePlotWidget::paintEvent(QPaintEvent* /*event*/)
         return plot.bottom() - (value - yMinimum) / (yMaximum - yMinimum) * plot.height();
     };
 
-    const QPen gridPen(QColor(96, 96, 96));
+    // Darker than the mid-gray fill so the rules read; the previous
+    // 96,96,96 was only a shade off the background.
+    const QPen gridPen(QColor(0x55, 0x55, 0x55));
     constexpr int tickCount = 5;
     const auto drawXTick = [&](double value, const QString& label) {
         const auto x = mapX(value);
         painter.setPen(gridPen);
         painter.drawLine(QPointF(x, plot.top()), QPointF(x, plot.bottom()));
-        painter.setPen(Qt::white);
+        painter.setPen(viewportForeground());
         painter.drawText(QRectF(x - 40.0, plot.bottom() + 4.0, 80.0, 16.0),
             Qt::AlignHCenter | Qt::AlignTop, label);
     };
@@ -325,12 +333,12 @@ void LinePlotWidget::paintEvent(QPaintEvent* /*event*/)
         const auto y = mapY(yValue);
         painter.setPen(gridPen);
         painter.drawLine(QPointF(plot.left(), y), QPointF(plot.right(), y));
-        painter.setPen(Qt::white);
+        painter.setPen(viewportForeground());
         painter.drawText(QRectF(0.0, y - 8.0, plot.left() - 6.0, 16.0),
             Qt::AlignRight | Qt::AlignVCenter,
             formatNumber(yValue, m_numberFormat));
     }
-    painter.setPen(Qt::white);
+    painter.setPen(viewportForeground());
     painter.drawRect(plot);
 
     if (m_curves == nullptr) {

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -3178,6 +3178,13 @@ void MainWindow::requestParticleReload()
     connect(watcher, &QFutureWatcher<std::vector<ParticleSample>>::finished,
         this, [this, watcher, generation, particleGeneration, cancellation] {
             --m_activeRequests;
+            // The one watcher that lacked this: during shutdown the handler
+            // below touches the status bar, the progress widget, and the
+            // overlays, and the other six all return here instead.
+            if (m_closing) {
+                watcher->deleteLater();
+                return;
+            }
             try {
                 auto samples = watcher->future().takeResult();
                 if (generation == m_generation
@@ -3200,6 +3207,10 @@ void MainWindow::requestParticleReload()
                     reportBackgroundError(
                         tr("Particles were not loaded: %1")
                             .arg(exceptionMessage(error)));
+                } else {
+                    // Counted like every other superseded result, which this
+                    // handler alone was not doing.
+                    ++m_staleResults;
                 }
             }
             if (particleGeneration == m_particleGeneration) {

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -913,8 +913,8 @@ MainWindow::MainWindow(QWidget* parent)
         });
     connect(m_levelSelector, qOverload<int>(&QComboBox::currentIndexChanged),
         this, [this](int) { syncMenuChecks(); });
-    connect(m_rangeMode, qOverload<int>(&QComboBox::currentIndexChanged),
-        this, [this](int) { saveSettings(); });
+    // No saveSettings here: range mode is deliberately not persisted (see
+    // saveSettings), so the call only ever rewrote unrelated keys.
     connect(m_logarithmic, &QCheckBox::toggled,
         this, [this](bool) { saveSettings(); });
 
@@ -1539,9 +1539,9 @@ void MainWindow::createMenus()
         if (visible && m_controlsReady) {
             scheduleSliceRequest(false);
         }
-        saveSettings();
+        saveSettings();  // overlay/boxes
     });
-    m_slicePlanesAction = new QAction(tr("&Slice Planes"), this);
+    m_slicePlanesAction = new QAction(tr("Sl&ice Planes"), this);
     m_slicePlanesAction->setCheckable(true);
     m_slicePlanesAction->setEnabled(false);
     connect(m_slicePlanesAction, &QAction::toggled, this,
@@ -1552,7 +1552,7 @@ void MainWindow::createMenus()
     connect(m_contoursAction, &QAction::triggered,
         this, [this] { showContoursDialog(); });
 
-    m_particlesAction = new QAction(tr("&Particles..."), this);
+    m_particlesAction = new QAction(tr("Par&ticles..."), this);
     m_particlesAction->setEnabled(false);
     connect(m_particlesAction, &QAction::triggered,
         this, [this] { showParticlesDialog(); });
@@ -1923,7 +1923,9 @@ void MainWindow::applyContourSettings(
     if (mode == DisplayMode::VelocityVectors) {
         ensureVectorFieldDefaults();
     }
-    saveSettings();
+    // No saveSettings here either: nothing this function sets has a settings
+    // key. Contour mode, count, color, and the vector field choices are all
+    // dataset-dependent, so restoring them across sessions would be wrong.
     const auto involvesVectors = mode == DisplayMode::VelocityVectors
         || previousMode == DisplayMode::VelocityVectors;
     const auto inputsChanged = mode != previousMode || count != previousCount
@@ -3042,6 +3044,12 @@ void MainWindow::configureParticleControls(bool preserveSelection)
         m_particleColors.clear();
         m_particleSeed = 0;
         m_particleSelectionInitialized = false;
+        // The subset and point size reset with everything else. They used to
+        // survive, so a 0.05% subset chosen to make one dense dataset legible
+        // silently decimated the next one -- with no indication that it was a
+        // carried-over setting rather than the data.
+        m_particleFraction = 1.0;
+        m_particlePointSize = defaultParticlePointSize;
     }
     for (std::size_t speciesIndex = 0; speciesIndex < species.size();
          ++speciesIndex) {
@@ -4266,6 +4274,9 @@ void MainWindow::linePlotRequested(PlaneViewState& state, int imageX, int imageY
     setActiveView(state);
     const auto& plane = *state.plane;
     if (!m_controlsReady || !m_dataset || plane.width <= 0 || plane.height <= 0) {
+        // The drag that got here already painted a guide; a request that never
+        // starts still has to take it down.
+        state.view->clearLineGuide();
         return;
     }
     const auto dataset = m_dataset;
@@ -4337,12 +4348,15 @@ void MainWindow::linePlotRequested(PlaneViewState& state, int imageX, int imageY
                 watcher->deleteLater();
                 return;
             }
+            // The drag guide belongs to the request, not to its outcome: a
+            // failed, cancelled, or superseded query used to leave it painted
+            // until the next setImage replaced the whole scene.
+            view->clearLineGuide();
             try {
-                auto result = watcher->result();
+                auto result = watcher->future().takeResult();
                 if (generation != m_generation || cancellation.stop_requested()) {
                     ++m_staleResults;
                 } else {
-                    view->clearLineGuide();
                     appendLinePlotCurve(result.line, fieldName, dimension,
                         primaryFixedAxis, request.axis,
                         request.fixedCoordinates,
@@ -4610,6 +4624,12 @@ void MainWindow::restoreSettings()
         m_syncRubberBandZoomAction->setChecked(
             settings.value(QStringLiteral("zoom/syncRubberBand"), true).toBool());
     }
+    if (m_boxesAction != nullptr) {
+        // Blocked: the toggle handler re-slices, and nothing is loaded yet.
+        const QSignalBlocker boxesBlocker(m_boxesAction);
+        m_boxesAction->setChecked(
+            settings.value(QStringLiteral("overlay/boxes"), false).toBool());
+    }
     if (m_sphericalSupersampleGroup != nullptr) {
         const auto stored = settings.value(
             QStringLiteral("spherical/supersample"), m_sphericalSupersample).toInt();
@@ -4671,6 +4691,11 @@ void MainWindow::saveSettings()
         m_animationPanel->speedValue());
     settings.setValue(QStringLiteral("zoom/syncRubberBand"),
         m_syncRubberBandZoomAction->isChecked());
+    // The grid-box overlay is a display preference like the palette, and the
+    // toggle has always called saveSettings; it just had no key to write, so
+    // it looked persisted and was not.
+    settings.setValue(QStringLiteral("overlay/boxes"),
+        m_boxesAction->isChecked());
     settings.setValue(QStringLiteral("spherical/supersample"),
         m_sphericalSupersample);
     settings.setValue(QStringLiteral("spherical/display"),
@@ -5672,11 +5697,10 @@ void MainWindow::openDatasetImpl(const std::filesystem::path& path,
         m_contoursDialog = nullptr;
         dialog->close();
     }
-    if (m_numberFormatDialog != nullptr) {
-        auto* dialog = m_numberFormatDialog;
-        m_numberFormatDialog = nullptr;
-        dialog->close();
-    }
+    // The Number Format dialog is deliberately *not* closed here. Unlike the
+    // contours dialog above, its setting is dataset-independent and persisted,
+    // so closing it on every open only discarded whatever the user had typed
+    // but not yet applied.
     m_datasetPath = path;
     m_lastBlocksRead = 0;
     m_lastCacheHits = 0;

--- a/src/qt/MainWindow.hpp
+++ b/src/qt/MainWindow.hpp
@@ -901,7 +901,8 @@ private:
     std::unordered_map<std::string, QColor> m_particleColors;
     double m_particleFraction = 1.0;
     std::uint64_t m_particleSeed = 0;
-    int m_particlePointSize = 3;
+    static constexpr int defaultParticlePointSize = 3;
+    int m_particlePointSize = defaultParticlePointSize;
     bool m_particleSelectionInitialized = false;
     bool m_particleLoading = false;
     StopSource m_particleStopSource;

--- a/src/qt/NumberFormat.cpp
+++ b/src/qt/NumberFormat.cpp
@@ -1,6 +1,8 @@
 #include "NumberFormat.hpp"
 
+#include <clocale>
 #include <cstdio>
+#include <cstring>
 
 namespace amrvis::qt {
 
@@ -108,7 +110,24 @@ QString formatNumber(double value, const QString& format)
     if (written < 0 || static_cast<std::size_t>(written) >= sizeof(buffer)) {
         return QString::number(value, 'g', 7);
     }
-    return QString::fromUtf8(buffer, written);
+    auto text = QString::fromUtf8(buffer, written);
+    // snprintf honors LC_NUMERIC, and QApplication calls setlocale(LC_ALL, "")
+    // on Unix, so under a comma locale this path renders "1,5" while both
+    // fallbacks above use QString::number, which is always C-locale. The
+    // readouts have to agree with each other whichever locale the user runs
+    // in, and the C locale is what the rest of the application writes and
+    // parses, so normalize to it. Substituting the decimal point rather than
+    // reaching for snprintf_l keeps this free of platform conditionals; the
+    // validator admits exactly one conversion and no grouping flag, so the
+    // decimal point is the only locale-dependent character that can appear.
+    if (const auto* conventions = std::localeconv(); conventions != nullptr) {
+        const auto* point = conventions->decimal_point;
+        if (point != nullptr && *point != '\0'
+            && std::strcmp(point, ".") != 0) {
+            text.replace(QString::fromUtf8(point), QStringLiteral("."));
+        }
+    }
+    return text;
 }
 
 } // namespace amrvis::qt

--- a/src/qt/NumberFormat.cpp
+++ b/src/qt/NumberFormat.cpp
@@ -60,9 +60,19 @@ bool isValidNumberFormat(const QString& format)
     return specifiers == 1;
 }
 
-QString conversionSpecifier(const QString& format)
+namespace {
+
+// Byte range [start, end) of the single floating conversion in `bytes`, or a
+// start of -1 if there is none. Both the specifier accessor and the formatter
+// need it, and the formatter needs the *position*, not just the text: it splices
+// the rendered number back between the surrounding literals.
+struct ConversionSpan {
+    qsizetype start = -1;
+    qsizetype end = -1;
+};
+
+ConversionSpan conversionSpan(const QByteArray& bytes)
 {
-    const auto bytes = format.toUtf8();
     const auto size = bytes.size();
     for (qsizetype index = 0; index < size; ++index) {
         if (bytes[index] != '%') {
@@ -89,9 +99,36 @@ QString conversionSpecifier(const QString& format)
         if (index < size && (bytes[index] == 'e' || bytes[index] == 'E'
                 || bytes[index] == 'f' || bytes[index] == 'g'
                 || bytes[index] == 'G')) {
-            return QString::fromLatin1(
-                bytes.constData() + start, index - start + 1);
+            return {start, index + 1};
         }
+    }
+    return {};
+}
+
+// Literal text around the conversion. snprintf is no longer run over it, so the
+// "%%" it would have collapsed to "%" is collapsed here instead.
+QString literalText(const char* data, qsizetype size)
+{
+    QByteArray literal;
+    literal.reserve(size);
+    for (qsizetype index = 0; index < size; ++index) {
+        literal.append(data[index]);
+        if (data[index] == '%' && index + 1 < size && data[index + 1] == '%') {
+            ++index;
+        }
+    }
+    return QString::fromUtf8(literal);
+}
+
+} // namespace
+
+QString conversionSpecifier(const QString& format)
+{
+    const auto bytes = format.toUtf8();
+    const auto span = conversionSpan(bytes);
+    if (span.start >= 0) {
+        return QString::fromLatin1(
+            bytes.constData() + span.start, span.end - span.start);
     }
     return defaultNumberFormat();
 }
@@ -102,32 +139,46 @@ QString formatNumber(double value, const QString& format)
         return QString::number(value, 'g', 7);
     }
     const auto bytes = format.toUtf8();
+    const auto span = conversionSpan(bytes);
+    if (span.start < 0) {
+        return QString::number(value, 'g', 7);
+    }
+    // Only the conversion is rendered through snprintf, and only its output is
+    // normalized below. Formatting the whole format string and substituting
+    // across the result corrupts the user's literal text: under a comma locale
+    // the decimal point *is* a comma, so "rho=%.2f, kg/m3" -- which the
+    // validator accepts -- came back as "rho=3.14. kg/m3", with the literal
+    // separator rewritten too. The old comment reasoned that the decimal point
+    // was the only locale-dependent character that could appear, which is true
+    // of the conversion's output and says nothing about the literals around it.
+    const QByteArray specifier(bytes.constData() + span.start,
+        span.end - span.start);
     char buffer[128];
     // The validator guarantees exactly one floating conversion and no other
     // arguments, so a single double is the whole vararg list.
     const auto written = std::snprintf(buffer, sizeof(buffer),
-        bytes.constData(), value);
+        specifier.constData(), value);
     if (written < 0 || static_cast<std::size_t>(written) >= sizeof(buffer)) {
         return QString::number(value, 'g', 7);
     }
-    auto text = QString::fromUtf8(buffer, written);
+    auto number = QString::fromUtf8(buffer, written);
     // snprintf honors LC_NUMERIC, and QApplication calls setlocale(LC_ALL, "")
     // on Unix, so under a comma locale this path renders "1,5" while both
     // fallbacks above use QString::number, which is always C-locale. The
     // readouts have to agree with each other whichever locale the user runs
-    // in, and the C locale is what the rest of the application writes and
-    // parses, so normalize to it. Substituting the decimal point rather than
-    // reaching for snprintf_l keeps this free of platform conditionals; the
-    // validator admits exactly one conversion and no grouping flag, so the
-    // decimal point is the only locale-dependent character that can appear.
+    // in, so normalize to the C locale. Substituting the decimal point rather
+    // than reaching for snprintf_l keeps this free of platform conditionals,
+    // and with only the conversion's own output in hand the substitution can
+    // no longer reach anything the user typed.
     if (const auto* conventions = std::localeconv(); conventions != nullptr) {
         const auto* point = conventions->decimal_point;
         if (point != nullptr && *point != '\0'
             && std::strcmp(point, ".") != 0) {
-            text.replace(QString::fromUtf8(point), QStringLiteral("."));
+            number.replace(QString::fromUtf8(point), QStringLiteral("."));
         }
     }
-    return text;
+    return literalText(bytes.constData(), span.start) + number
+        + literalText(bytes.constData() + span.end, bytes.size() - span.end);
 }
 
 } // namespace amrvis::qt

--- a/src/qt/Theme.hpp
+++ b/src/qt/Theme.hpp
@@ -12,4 +12,13 @@ inline QColor viewportBackground()
     return {0x88, 0x88, 0x88};
 }
 
+// Foreground for text and rules drawn straight onto viewportBackground().
+// Mid-gray on mid-gray is invisible, which is what the Isometric view's
+// placeholder used to be; this is dark enough to read against 0x888888 while
+// staying quieter than the data.
+inline QColor viewportForeground()
+{
+    return {0x20, 0x20, 0x20};
+}
+
 } // namespace amrvis::qt

--- a/src/qt/main.cpp
+++ b/src/qt/main.cpp
@@ -89,6 +89,24 @@ void filterWaylandPopupWarning(QtMsgType type,
 // (~/.local/share); delete ~/.local/share/applications/amrexplorer.desktop and the
 // amrexplorer.png files under ~/.local/share/icons/hicolor to undo. The standalone
 // resources/install-desktop-entry.sh does the same thing by hand.
+// Escapes a path for the inside of a quoted Desktop Entry Exec argument. The
+// spec reserves backslash, double quote, backtick and dollar there, each
+// escaped with a backslash; a path containing any of them previously produced
+// an Exec line that would not parse back to the same path.
+[[nodiscard]] QString desktopExecEscaped(const QString& path)
+{
+    QString escaped;
+    escaped.reserve(path.size());
+    for (const auto character : path) {
+        if (character == QLatin1Char('\\') || character == QLatin1Char('"')
+            || character == QLatin1Char('`') || character == QLatin1Char('$')) {
+            escaped.append(QLatin1Char('\\'));
+        }
+        escaped.append(character);
+    }
+    return escaped;
+}
+
 void ensureDesktopEntry()
 {
 #ifndef Q_OS_LINUX
@@ -158,7 +176,7 @@ void ensureDesktopEntry()
             << "Name=AMReXplorer\n"
             << "GenericName=AMR Visualization\n"
             << "Comment=Demand-driven AMR visualization\n"
-            << "Exec=\"" << execPath << "\" %F\n"
+            << "Exec=\"" << desktopExecEscaped(execPath) << "\" %F\n"
             << "Icon=amrexplorer\n"
             << "StartupWMClass=amrexplorer\n"
             << "Terminal=false\n"
@@ -178,15 +196,25 @@ void ensureDesktopEntry()
             }
         }
     }
-    // Best-effort cache refresh. Detached processes inherit the terminal, so
-    // route them through a shell that discards output (otherwise they print
-    // "Cache file created successfully." on every install). Failures harmless.
-    const auto runSilent = [](const QString& command) {
-        QProcess::startDetached("sh",
-            QStringList{"-c", command + " >/dev/null 2>&1"});
+    // Best-effort cache refresh; failures are harmless. Arguments go through
+    // QProcess as a list rather than being pasted into a shell command: a
+    // single quote anywhere in $HOME used to break the quoting and run
+    // something else entirely. Output is discarded by redirecting the detached
+    // process's channels, not by a shell, since these otherwise print "Cache
+    // file created successfully." on every install.
+    const auto runSilent = [](const QString& program,
+                               const QStringList& arguments) {
+        QProcess process;
+        process.setProgram(program);
+        process.setArguments(arguments);
+        process.setStandardOutputFile(QProcess::nullDevice());
+        process.setStandardErrorFile(QProcess::nullDevice());
+        process.startDetached();
     };
-    runSilent("gtk-update-icon-cache -f '" + hicolorDir + "'");
-    runSilent("update-desktop-database '" + dataDir + "/applications'");
+    runSilent(QStringLiteral("gtk-update-icon-cache"),
+        QStringList{QStringLiteral("-f"), hicolorDir});
+    runSilent(QStringLiteral("update-desktop-database"),
+        QStringList{dataDir + QStringLiteral("/applications")});
 #endif
 }
 
@@ -3314,6 +3342,20 @@ int main(int argc, char* argv[])
                 window.openSequence(paths);
             }
         });
+    } else if (argc >= 2) {
+        // Anything starting with "--" that reached here matched no option, or
+        // matched one with the wrong number of arguments. Both used to fall
+        // through to an empty window with no diagnostic, which reads as the
+        // option having been accepted and done nothing.
+        std::fprintf(stderr,
+            "amrexplorer: unrecognized option '%s'\n\n"
+            "usage: amrexplorer [PLOTFILE...]\n"
+            "       amrexplorer --connect HOST:PORT [--token-stdin] "
+            "REMOTE_PLOTFILE...\n\n"
+            "Open one plotfile directory, or several to play them as a\n"
+            "sequence. See docs/user-guide.md for the remote options.\n",
+            argv[1]);
+        return 2;
     }
     const auto result = application.exec();
     if (smokeServer) {

--- a/src/qt/main.cpp
+++ b/src/qt/main.cpp
@@ -102,15 +102,33 @@ void filterWaylandPopupWarning(QtMsgType type,
 #ifdef Q_OS_LINUX
 [[nodiscard]] QString desktopExecEscaped(const QString& path)
 {
+    // Two layers, applied in the order the reader undoes them. The Exec value
+    // is first unescaped as a desktop-entry string, and only then parsed as an
+    // Exec command line, so the backslashes the quoting rule needs must
+    // themselves survive the string rule -- which is why the spec says a
+    // literal backslash inside a quoted argument takes four of them.
     QString escaped;
     escaped.reserve(path.size());
     for (const auto character : path) {
+        // Exec quoting: reserved inside double quotes.
         if (character == QLatin1Char('\\') || character == QLatin1Char('"')
             || character == QLatin1Char('`') || character == QLatin1Char('$')) {
             escaped.append(QLatin1Char('\\'));
+            escaped.append(character);
+            continue;
+        }
+        // Field codes: a literal percent is written as two. Without this a
+        // path containing, say, "%q" is read as an unknown field code and
+        // desktop-file-validate rejects the entry.
+        if (character == QLatin1Char('%')) {
+            escaped.append(QLatin1String("%%"));
+            continue;
         }
         escaped.append(character);
     }
+    // Desktop-entry string escaping, over the result of the above so the
+    // quoting layer's own backslashes are doubled with the path's.
+    escaped.replace(QLatin1Char('\\'), QLatin1String("\\\\"));
     return escaped;
 }
 #endif

--- a/src/qt/main.cpp
+++ b/src/qt/main.cpp
@@ -93,6 +93,13 @@ void filterWaylandPopupWarning(QtMsgType type,
 // spec reserves backslash, double quote, backtick and dollar there, each
 // escaped with a backslash; a path containing any of them previously produced
 // an Exec line that would not parse back to the same path.
+//
+// Guarded on the same condition as its only caller below. ensureDesktopEntry
+// compiles to an early `return` off Linux, so the call is preprocessed away and
+// an unguarded definition here is an unused static function -- which -Werror
+// turns into a build failure on macOS and Windows, where nothing else in this
+// file would have noticed.
+#ifdef Q_OS_LINUX
 [[nodiscard]] QString desktopExecEscaped(const QString& path)
 {
     QString escaped;
@@ -106,6 +113,7 @@ void filterWaylandPopupWarning(QtMsgType type,
     }
     return escaped;
 }
+#endif
 
 void ensureDesktopEntry()
 {

--- a/tests/unit/test_geometry.cpp
+++ b/tests/unit/test_geometry.cpp
@@ -181,5 +181,46 @@ int main()
             "mixed pan did not snap the nodal y axis");
     }
 
+    // A RealBox is valid only if it is ordered *and* finite. C++ streams parse
+    // "inf", so a corrupt header can present an ordered infinite box; accepting
+    // it means every extent derived from it is infinite, and their differences
+    // NaN.
+    {
+        constexpr auto infinity = std::numeric_limits<double>::infinity();
+        const amrvis::RealBox finite{{{0.0, 0.0, 0.0}}, {{1.0, 1.0, 1.0}}};
+        require(finite.valid(3), "a finite ordered box was rejected");
+
+        amrvis::RealBox upperInfinite = finite;
+        upperInfinite.upper[0] = infinity;
+        require(!upperInfinite.valid(3),
+            "a box with an infinite upper edge was accepted");
+
+        amrvis::RealBox lowerInfinite = finite;
+        lowerInfinite.lower[1] = -infinity;
+        require(!lowerInfinite.valid(3),
+            "a box with an infinite lower edge was accepted");
+
+        // Only the active directions are checked, as before.
+        amrvis::RealBox infiniteInZ = finite;
+        infiniteInZ.upper[2] = infinity;
+        require(infiniteInZ.valid(2),
+            "an inactive direction was checked for finiteness");
+    }
+
+    // snapToNearestCellGrid preserves the span, but never past the domain: with
+    // more cells than the domain holds, the clamp on the first cell collapses
+    // and the upper edge used to land outside.
+    {
+        const amrvis::RealBox unitDomain{{{0.0, 0.0, 0.0}}, {{4.0, 4.0, 0.0}}};
+        const amrvis::Real3 unitCells{{1.0, 1.0, 1.0}};
+        const std::array<int, 2> snapAxes{0, 1};
+        const amrvis::RealBox tooWide{{{-3.0, 0.0, 0.0}}, {{9.0, 4.0, 0.0}}};
+        const auto snapped = amrvis::snapToNearestCellGrid(
+            tooWide, unitDomain, unitCells, snapAxes);
+        require(snapped.lower[0] >= unitDomain.lower[0]
+                && snapped.upper[0] <= unitDomain.upper[0],
+            "a wider-than-domain region snapped outside the domain");
+    }
+
     return 0;
 }

--- a/tests/unit/test_number_format.cpp
+++ b/tests/unit/test_number_format.cpp
@@ -7,6 +7,7 @@
 
 #include <QString>
 
+#include <clocale>
 #include <cstdlib>
 #include <iostream>
 
@@ -81,6 +82,27 @@ int main()
     require(formatNumber(1.0, QStringLiteral("%.130f"))
             == QString::number(1.0, 'g', 7),
         "formatNumber did not fall back on a buffer overflow");
+
+    // snprintf honors LC_NUMERIC, and QApplication sets it from the
+    // environment on Unix, so under a comma locale the formatted path would
+    // render "3,14" while both fallback paths above -- which use
+    // QString::number -- always render a point. Every readout has to agree.
+    // Skipped, with a note, where the locale is not installed: the fix is
+    // wanted on the platforms that have it, and a test that silently passes
+    // for the wrong reason is worse than one that says why.
+    if (std::setlocale(LC_NUMERIC, "de_DE.UTF-8") != nullptr
+        || std::setlocale(LC_NUMERIC, "de_DE") != nullptr) {
+        require(formatNumber(3.14159, QStringLiteral("%.2f"))
+                == QStringLiteral("3.14"),
+            "formatNumber emitted a locale decimal separator");
+        require(formatNumber(1234.5, QStringLiteral("%.1f"))
+                == QStringLiteral("1234.5"),
+            "formatNumber emitted a locale decimal separator");
+        std::setlocale(LC_NUMERIC, "C");
+    } else {
+        std::cerr << "note: no German locale installed; the LC_NUMERIC case "
+                     "did not run\n";
+    }
 
     return 0;
 }

--- a/tests/unit/test_number_format.cpp
+++ b/tests/unit/test_number_format.cpp
@@ -90,6 +90,15 @@ int main()
     // Skipped, with a note, where the locale is not installed: the fix is
     // wanted on the platforms that have it, and a test that silently passes
     // for the wrong reason is worse than one that says why.
+    // Literal text survives in the C locale too, so this half of the contract
+    // is checked whether or not a comma locale is installed.
+    require(formatNumber(3.14159, QStringLiteral("rho=%.2f, kg/m3"))
+            == QStringLiteral("rho=3.14, kg/m3"),
+        "formatNumber altered the literal text around the conversion");
+    require(formatNumber(2.5, QStringLiteral("%.3f,%%"))
+            == QStringLiteral("2.500,%"),
+        "formatNumber mishandled a literal percent");
+
     if (std::setlocale(LC_NUMERIC, "de_DE.UTF-8") != nullptr
         || std::setlocale(LC_NUMERIC, "de_DE") != nullptr) {
         require(formatNumber(3.14159, QStringLiteral("%.2f"))
@@ -98,6 +107,16 @@ int main()
         require(formatNumber(1234.5, QStringLiteral("%.1f"))
                 == QStringLiteral("1234.5"),
             "formatNumber emitted a locale decimal separator");
+        // The normalization must reach the conversion's output and nothing
+        // else. Under a comma locale the decimal separator *is* the comma the
+        // user typed as a literal, so substituting across the whole formatted
+        // string rewrote their text too: this returned "rho=3.14. kg/m3".
+        require(formatNumber(3.14159, QStringLiteral("rho=%.2f, kg/m3"))
+                == QStringLiteral("rho=3.14, kg/m3"),
+            "the decimal-point normalization rewrote literal text");
+        require(formatNumber(2.5, QStringLiteral("%.3f,%%"))
+                == QStringLiteral("2.500,%"),
+            "the decimal-point normalization rewrote a literal separator");
         std::setlocale(LC_NUMERIC, "C");
     } else {
         std::cerr << "note: no German locale installed; the LC_NUMERIC case "

--- a/tests/unit/test_slice_range_resolver.cpp
+++ b/tests/unit/test_slice_range_resolver.cpp
@@ -184,6 +184,17 @@ int main()
             std::pair{5.0, 5.0}, true, plane);
         require(log.first < 5.0 && log.second > 5.0 && log.first > 0.0,
             "degenerate logarithmic range was not ratio-padded");
+        // Zero has no magnitude for the padding to be relative to. Falling back
+        // to the smallest-normal backstop there gives a range of +/-2.2e-308,
+        // which is what the color bar and the seeded User-range spin boxes then
+        // show for a uniform plane of zeros -- an ordinary case. The padding
+        // has to stay the absolute constant.
+        const auto zero = amrvis::resolveRange(noDataset, FieldId{0}, 0,
+            CompositionPolicy::FinestAvailable, RangeMode::User,
+            std::pair{0.0, 0.0}, false, plane);
+        require(nearlyEqual(zero.first, -1.0e-6)
+                && nearlyEqual(zero.second, 1.0e-6),
+            "a degenerate range at zero was not padded by the constant");
     }
     {
         bool threw = false;


### PR DESCRIPTION
Part 4 of 4 in the stabilization stack. Based on
`stabilization/3-responsiveness`.

## Purpose

Burn down the two retained low-priority batches and reconcile the
release-process note, completing phase S5 of the stabilization milestone
(`agent-notes/plans/PLAN.md` §37).

Twenty of the twenty-one batch items land here; UI-polish item 3 (the
one-way Scale button/menu sync) landed in part 2, because the
effective-magnification work depended on having a single scale-state setter.

## Scope

### Robustness batch, items 1-8

- **Finite geometry, not merely ordered.** `RealBox::valid` and the
  `cellSize` check accepted `+inf`, which C++ streams parse out of a corrupt
  header and which turns every extent derived from it into `inf` -- and their
  differences into `NaN`. Written as comparisons rather than `std::isfinite`
  because that is not `constexpr` before C++23 and `valid` is used in
  constant expressions.

- **Relative padding for a degenerate range.** The old
  `max(abs(min), 1.0) * 1e-6` is an absolute floor: a uniform plane of 1e-7
  was padded by 1e-6 -- ten times the value itself -- into a range straddling
  zero, which then silently disqualified the plane from logarithmic display,
  while a constant 5.0 stayed logarithmic. The same control behaved
  differently on data that differed only in scale. Now one shared log-aware
  helper with a denormal-safe relative floor, replacing three copies of this
  arithmetic, one of which had no log-awareness at all.

- **`ByteLruCache::insertAndPin` publishes before it accounts.** Both
  allocating steps happen before either byte counter moves, so a `bad_alloc`
  from the map cannot leave `pinnedBytes` inflated for a pin no `Handle`
  exists to release. That inflation was permanent -- `Handle::release` is
  the only thing that decrements it -- and would eventually reject every
  insert.

- **`snapToNearestCellGrid` never asks for more cells than the domain
  holds.** Past that the clamp collapses and the upper edge lands outside the
  domain. See the judgement calls below: this one is not reachable today.

- **`formatNumber` formats in the C locale.** `snprintf` honours
  `LC_NUMERIC` and `QApplication` calls `setlocale(LC_ALL, "")` on Unix, so
  under a comma locale the success path rendered `1,5` while both fallback
  paths -- which use `QString::number` -- always render `1.5`. Normalizing
  the decimal point rather than reaching for `snprintf_l` keeps this free of
  platform conditionals.

- **Three small lifetime and contract fixes.** The point-cloud bounding rect
  accounts for the cosmetic pen's device-space width; the particle watcher
  gains the `m_closing` guard and stale-result accounting the other six
  watchers have; and the Dataset window rebuilds its models before the old
  extracts are destroyed.

### UI polish batch, items 1-2 and 4-12

- **Colors re-picked against the background these widgets actually fill
  with.** `Theme.hpp` gains `viewportForeground()` beside the existing
  `viewportBackground()`. The Isometric placeholder was `#888888` text on a
  `#888888` fill -- a blank gray panel. The line plot's eight curve colors
  were chosen for a black background per their comment, but the plot fills
  mid-gray: white, cyan, yellow and `Qt::gray` all sit close to it in
  luminance, and the seventh curve was very nearly invisible. All eight are
  now darker than the background and mutually distinguishable, and the grid
  pen moved from `0x60` to `0x55`.

- **The Number Format dialog survives a dataset open.** Its setting is
  dataset-independent and persisted; closing it on every open only discarded
  typed-but-unapplied input.

- **Dead `saveSettings()` calls resolved.** See the judgement calls below.

- **Particle subset and point size reset with the rest of the particle
  state.** They used to survive, so a 0.05% subset chosen to make one dense
  dataset legible silently decimated the next one, with nothing to indicate
  it was a carried-over setting rather than the data.

- **Duplicate View-menu mnemonics removed.** See the judgement calls below.

- **The line-plot drag guide is cleared on every exit**, not only on success,
  so a failed, cancelled, or superseded query no longer leaves it painted
  until the next `setImage`.

- **The FAB Selector filter reacts to the left button only.** Any button
  opened the find-point dialog and swallowed the context menu with it.

- **The color bar grows to fit its labels.** `panelWidth` is a floor rather
  than a fixed width, so a wide user format no longer clips on screen while
  exports -- which size themselves with `preferredWidth` -- came out fine.

- **Unknown CLI options are diagnosed.** Any unrecognized `--flag`,
  `--help` included, opened an empty window with no output, which reads as
  the option having been accepted and done nothing. Prints usage and exits 2.

- **The desktop entry is built with `QProcess` argument lists** rather than
  pasted into `sh -c`, where a single quote anywhere in `$HOME` broke the
  quoting. The `Exec=` line also escapes the four characters the Desktop
  Entry spec reserves inside a quoted argument.

### Release-process note

`INSTALL.md` opened by offering a prebuilt AppImage download and gave
download-and-chmod instructions for it, but the workflow set is CI, style and
codespell -- there is no release builder. It now points at
`docs/building.md` for packaging one yourself and says plainly that no
pipeline exists. Adding and proving that pipeline is the other option and
remains open; nothing in the docs depends on it now.

## Three judgement calls

**Item 4 was not reachable, and was fixed anyway.** The note asked to verify
whether a wider-than-domain region can arise before fixing. It cannot:
`shiftedPanRegion`, the only caller, clamps both edges into the domain before
snapping. The clamp was added regardless -- it is one `std::min`, the sibling
`snapToCellBoundaries` already clamps its upper edge for the same reason, and
a geometry helper in a public header should not depend on its caller for
that.

**The dead `saveSettings()` calls were split rather than answered one way.**
The Boxes overlay is a display preference and users reasonably expect it to
persist, so it got the `overlay/boxes` key it always looked like it had. The
other two calls were deleted: `saveSettings` documents that range mode is
deliberately *not* persisted, and nothing the contour-apply path sets is
dataset-independent enough to restore across sessions.

**The obvious mnemonic fix would have collided.** The note names
`&Palette`/`&Particles...` and `&Scale`/`&Slice Planes`, but Qt mnemonics are
case-insensitive, so `Slice P&lanes` would have collided with `&Level`
instead. The View menu now reads S, L, B, i, P, C, t, D, N with no repeats.

## Evidence

New cases go into existing test files, so the test count is unchanged.
`test_geometry` covers both the finiteness rejection and the snap clamp, and
both were checked to fail without their fix. `test_number_format` asserts the
C-locale result under `de_DE` where the locale exists.

Green on this branch, and this is the tip of the stack, so the full matrix
was run here: `default` (108), `clang` with warnings as errors, `sanitizers`,
`qt-sanitizers`, `remote` (47), and `tsan` (47), plus the tabs, trailing
whitespace and codespell checks.

## One item deferred

Robustness item 9 -- caching the parsed particle header per species, and the
non-zeroing component read buffer -- is deferred for the reasons the note
itself gives. The cache needs invalidation and lifetime rules for
server-opened datasets, and the note is explicit that process-global particle
metadata is the wrong shape; that is a design decision, not a mechanical
change. The buffer is the same trade as the `ImageBuffer::rgba` zero-fill
deferred in part 3. Both want the benchmark that note asks for.
