### PR TITLE
pin LC_NUMERIC to "C" so plotfiles open in every locale

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,12 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install --yes cmake desktop-file-utils ninja-build qt6-base-dev ${{ matrix.package }}
+          sudo apt-get install --yes cmake desktop-file-utils locales ninja-build qt6-base-dev ${{ matrix.package }}
+          # qt_comma_locale_open needs a comma-decimal locale. The runner image
+          # ships no language packs, so generate one: without it the test falls
+          # back to building a locale with localedef, and if that ever stops
+          # working it would skip and CI would stay green over the regression.
+          sudo locale-gen de_DE.UTF-8
 
       - name: Configure
         run: cmake --preset default -DAMREXPLORER_WARNINGS_AS_ERRORS=ON
@@ -185,7 +190,10 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install --yes cmake g++ ninja-build qt6-base-dev
+          sudo apt-get install --yes cmake g++ locales ninja-build qt6-base-dev
+          # See the linux job: qt_comma_locale_open needs a comma locale, and a
+          # skip here would be a silent green over the LC_NUMERIC regression.
+          sudo locale-gen de_DE.UTF-8
 
       - name: Configure
         run: cmake --preset qt-sanitizers -DAMREXPLORER_WARNINGS_AS_ERRORS=ON

--- a/src/qt/NumberFormat.cpp
+++ b/src/qt/NumberFormat.cpp
@@ -162,14 +162,15 @@ QString formatNumber(double value, const QString& format)
         return QString::number(value, 'g', 7);
     }
     auto number = QString::fromUtf8(buffer, written);
-    // snprintf honors LC_NUMERIC, and QApplication calls setlocale(LC_ALL, "")
-    // on Unix, so under a comma locale this path renders "1,5" while both
-    // fallbacks above use QString::number, which is always C-locale. The
-    // readouts have to agree with each other whichever locale the user runs
-    // in, so normalize to the C locale. Substituting the decimal point rather
-    // than reaching for snprintf_l keeps this free of platform conditionals,
-    // and with only the conversion's own output in hand the substitution can
-    // no longer reach anything the user typed.
+    // Belt-and-braces since main() pins LC_NUMERIC to "C" after constructing
+    // QApplication: with that pin in place snprintf already renders "1.5", and
+    // this substitution finds nothing to do. It is kept because this is a
+    // library function -- nothing stops it being called from a process that
+    // has not pinned the locale, and the readouts have to agree with the
+    // QString::number fallbacks above, which are always C-locale, whichever
+    // locale is in force. Substituting the decimal point rather than reaching
+    // for snprintf_l keeps it free of platform conditionals, and with only the
+    // conversion's own output in hand it cannot reach anything the user typed.
     if (const auto* conventions = std::localeconv(); conventions != nullptr) {
         const auto* point = conventions->decimal_point;
         if (point != nullptr && *point != '\0'

--- a/src/qt/main.cpp
+++ b/src/qt/main.cpp
@@ -629,9 +629,28 @@ int main(int argc, char* argv[])
     // This is pinned here, once, rather than fixed at the call site, because
     // the call site is not the class of bug: the next strtod, atof or
     // printf("%f") anyone adds re-opens the same hole, and only a pin closes
-    // it by construction. Placement is deliberate -- immediately after the
-    // constructor that moves the locale, before any window or worker thread
-    // exists to observe either value.
+    // it by construction.
+    //
+    // The placement is forced rather than merely chosen. Qt moves the locale
+    // inside the constructor above (QCoreApplicationPrivate::initLocale), and
+    // that runs once behind a static guard, so pinning earlier is simply
+    // overwritten; pinning later only widens the window in which the wrong
+    // locale is live. Immediately after is the earliest point that holds.
+    //
+    // It is not, however, "before any thread exists". No *application* window
+    // or worker does, but the constructor has already started Qt's own --
+    // QDBusConnection always, and with a platform theme or a non-offscreen
+    // platform also the xcb/wayland event threads and glib's pango/gdbus/pool
+    // threads (measured: 2 threads offscreen, 10 under wayland with the gtk3
+    // theme). glibc marks setlocale MT-Unsafe, so this call is not provably
+    // race-free against threads the application does not control. It is the
+    // best available placement, not a safe one in the formal sense.
+    //
+    // The gtk3 platform theme is the one plausible defeater and it is not one:
+    // gtk_init does call setlocale(LC_ALL, "") of its own, but theme creation
+    // is eager inside the constructor above, so it happens before this line,
+    // and GTK's call is one-shot -- opening a native dialog later cannot undo
+    // the pin.
     //
     // Nothing user-visible is lost. QLocale is independent of the C locale, so
     // QLocale::system() still reports the user's real locale and separators;

--- a/src/qt/main.cpp
+++ b/src/qt/main.cpp
@@ -34,6 +34,7 @@
 #include <array>
 #include <atomic>
 #include <chrono>
+#include <clocale>
 #include <cmath>
 #include <cstdio>
 #include <cstdlib>
@@ -618,6 +619,27 @@ int main(int argc, char* argv[])
                        "qt.qpa.services.warning=false"));
 
     QApplication application(argc, argv);
+    // Undo, for numeric conversion only, what QApplication just did. Qt calls
+    // setlocale(LC_ALL, "") on Unix, which hands the C locale to the
+    // environment -- and the C locale is what strtod, printf("%f") and atof
+    // consult. The plotfile reader parses per-block statistics with strtod, so
+    // under any comma-decimal locale strtod("0.5") stopped at the '.' and *no
+    // plotfile opened at all*: LC_ALL=en_DK.utf8 failed 49 of 115 tests.
+    //
+    // This is pinned here, once, rather than fixed at the call site, because
+    // the call site is not the class of bug: the next strtod, atof or
+    // printf("%f") anyone adds re-opens the same hole, and only a pin closes
+    // it by construction. Placement is deliberate -- immediately after the
+    // constructor that moves the locale, before any window or worker thread
+    // exists to observe either value.
+    //
+    // Nothing user-visible is lost. QLocale is independent of the C locale, so
+    // QLocale::system() still reports the user's real locale and separators;
+    // only the C conversion functions are pinned. C++ iostreams were never
+    // affected either -- they consult the C++ global locale, which stays "C"
+    // -- which is why the reader's other numeric fields, and AMReX's readers,
+    // never broke. See agent-notes comma-locale-breaks-every-open.
+    std::setlocale(LC_NUMERIC, "C");
     // Advertise the desktop entry name and WM class as "amrexplorer" so Linux
     // docks/taskbars can match the running window to amrexplorer.desktop and
     // resolve its icon from the icon theme (setWindowIcon alone only sets the

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -962,6 +962,22 @@ if(TARGET amrexplorer_qt)
             -P "${CMAKE_CURRENT_SOURCE_DIR}/qt_smoke_driver.cmake"
     )
     set_tests_properties(qt_fab_overlap_failure PROPERTIES TIMEOUT 60)
+    # The LC_NUMERIC pin, end to end: under a comma-decimal locale the reader's
+    # strtod stops at the '.' in "0.5" and nothing opens, so an ordinary slice
+    # smoke test is the whole regression. Skips visibly (never silently) when no
+    # comma locale is installed and localedef cannot build one.
+    add_test(
+        NAME qt_comma_locale_open
+        COMMAND "${CMAKE_COMMAND}"
+            "-DMATERIALIZER=$<TARGET_FILE:fixture_materializer>"
+            "-DAMREXPLORER_QT=$<TARGET_FILE:amrexplorer_qt>"
+            "-DSOURCE=${CMAKE_CURRENT_SOURCE_DIR}/data/plotfile_2d"
+            "-DWORK=${CMAKE_CURRENT_BINARY_DIR}/fixtures_comma_locale"
+            -P "${CMAKE_CURRENT_SOURCE_DIR}/qt_locale_smoke_driver.cmake"
+    )
+    set_tests_properties(qt_comma_locale_open PROPERTIES
+        SKIP_REGULAR_EXPRESSION "AMREXPLORER_LOCALE_SKIP"
+        TIMEOUT 120)
     add_test(
         NAME qt_fab_direct_open_failure
         COMMAND "${CMAKE_COMMAND}"

--- a/tests/qt_locale_smoke_driver.cmake
+++ b/tests/qt_locale_smoke_driver.cmake
@@ -1,0 +1,80 @@
+# Runs a Qt smoke test under a comma-decimal locale.
+#
+# The application pins LC_NUMERIC to "C" after constructing QApplication,
+# because Qt's setlocale(LC_ALL, "") otherwise hands the C locale to the
+# environment and the plotfile reader's strtod stops at the '.' in "0.5" --
+# under which no plotfile opens at all. This exercises that pin end to end:
+# without it the slice smoke test fails to open its fixture.
+#
+# Expected -D arguments: MATERIALIZER, AMREXPLORER_QT, SOURCE, WORK.
+#
+# Skips -- visibly, via ctest's SKIP_RETURN_CODE, never silently -- when no
+# comma locale can be obtained. A silent pass is what let this defect hide:
+# low-priority-robustness item 5 recorded "no German locale installed" and
+# stopped there, when localedef needs no root.
+foreach(argument MATERIALIZER AMREXPLORER_QT SOURCE WORK)
+    if(NOT DEFINED ${argument})
+        message(FATAL_ERROR "qt_locale_smoke_driver.cmake requires -D${argument}=...")
+    endif()
+endforeach()
+
+# An installed comma locale, if there is one.
+set(commaLocale "")
+execute_process(COMMAND locale -a
+    OUTPUT_VARIABLE installedLocales
+    ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
+foreach(candidate de_DE.UTF-8 de_DE.utf8 en_DK.UTF-8 en_DK.utf8 fr_FR.UTF-8 fr_FR.utf8)
+    if(installedLocales MATCHES "(^|\n)${candidate}(\n|$)")
+        set(commaLocale "${candidate}")
+        break()
+    endif()
+endforeach()
+
+# Otherwise build one. --no-archive plus LOCPATH needs no root.
+set(localeRoot "${WORK}/locales")
+if(commaLocale STREQUAL "")
+    file(MAKE_DIRECTORY "${localeRoot}")
+    execute_process(
+        COMMAND localedef -i de_DE -f UTF-8 --no-archive "${localeRoot}/de_DE.UTF-8"
+        RESULT_VARIABLE localedefResult ERROR_QUIET OUTPUT_QUIET)
+    if(localedefResult STREQUAL "0")
+        set(commaLocale "de_DE.UTF-8")
+        set(ENV{LOCPATH} "${localeRoot}")
+    endif()
+endif()
+
+if(commaLocale STREQUAL "")
+    # The registration sets SKIP_REGULAR_EXPRESSION on this marker, so ctest
+    # reports "Skipped" rather than a green pass. A cmake -P script cannot
+    # choose its own exit code, which rules out SKIP_RETURN_CODE here.
+    message(STATUS
+        "AMREXPLORER_LOCALE_SKIP: no comma-decimal locale installed and "
+        "localedef could not build one; the LC_NUMERIC pin was NOT exercised")
+    return()
+endif()
+
+message(STATUS "exercising the LC_NUMERIC pin under ${commaLocale}")
+
+set(ENV{QT_QPA_PLATFORM} offscreen)
+file(REMOVE_RECURSE "${WORK}/config")
+set(ENV{XDG_CONFIG_HOME} "${WORK}/config")
+
+execute_process(COMMAND "${MATERIALIZER}" "${SOURCE}" "${WORK}/plt"
+    RESULT_VARIABLE materializeResult
+    OUTPUT_VARIABLE materializeOutput ERROR_VARIABLE materializeError)
+if(NOT materializeResult STREQUAL "0")
+    message(FATAL_ERROR
+        "fixture materialization failed: ${materializeOutput}${materializeError}")
+endif()
+
+# LC_ALL so the whole environment, not just LC_NUMERIC, is the comma locale --
+# which is what a user in that locale actually has.
+set(ENV{LC_ALL} "${commaLocale}")
+execute_process(COMMAND "${AMREXPLORER_QT}" --slice-smoke-test "${WORK}/plt"
+    RESULT_VARIABLE smokeResult
+    OUTPUT_VARIABLE smokeOutput ERROR_VARIABLE smokeError)
+if(NOT smokeResult STREQUAL "0")
+    message(FATAL_ERROR
+        "the slice smoke test failed under ${commaLocale} (${smokeResult}): "
+        "the LC_NUMERIC pin is not holding\n${smokeOutput}${smokeError}")
+endif()

--- a/tests/qt_locale_smoke_driver.cmake
+++ b/tests/qt_locale_smoke_driver.cmake
@@ -70,7 +70,15 @@ endif()
 # LC_ALL so the whole environment, not just LC_NUMERIC, is the comma locale --
 # which is what a user in that locale actually has.
 set(ENV{LC_ALL} "${commaLocale}")
+# TIMEOUT because the regression this guards does not exit: a metadata-open
+# failure never reaches the slice stage, so initialSliceFinished -- which is
+# what the smoke test quits on -- is never emitted and the app hangs. Without a
+# timeout here ctest kills the test at its own 120 s limit and reports a bare
+# Timeout, with the child's streams still captured into the variables below, so
+# neither the app's error nor this driver's message ever reaches the log. Thirty
+# seconds is ~100x the passing runtime.
 execute_process(COMMAND "${AMREXPLORER_QT}" --slice-smoke-test "${WORK}/plt"
+    TIMEOUT 30
     RESULT_VARIABLE smokeResult
     OUTPUT_VARIABLE smokeOutput ERROR_VARIABLE smokeError)
 if(NOT smokeResult STREQUAL "0")

--- a/tests/qt_locale_smoke_driver.cmake
+++ b/tests/qt_locale_smoke_driver.cmake
@@ -8,8 +8,8 @@
 #
 # Expected -D arguments: MATERIALIZER, AMREXPLORER_QT, SOURCE, WORK.
 #
-# Skips -- visibly, via ctest's SKIP_RETURN_CODE, never silently -- when no
-# comma locale can be obtained. A silent pass is what let this defect hide:
+# Skips -- visibly, via ctest's SKIP_REGULAR_EXPRESSION, never silently -- when
+# no comma locale can be obtained. A silent pass is what let this defect hide:
 # low-priority-robustness item 5 recorded "no German locale installed" and
 # stopped there, when localedef needs no root.
 foreach(argument MATERIALIZER AMREXPLORER_QT SOURCE WORK)

--- a/tests/unit/test_number_format.cpp
+++ b/tests/unit/test_number_format.cpp
@@ -99,8 +99,21 @@ int main()
             == QStringLiteral("2.500,%"),
         "formatNumber mishandled a literal percent");
 
-    if (std::setlocale(LC_NUMERIC, "de_DE.UTF-8") != nullptr
-        || std::setlocale(LC_NUMERIC, "de_DE") != nullptr) {
+    // Several candidates, not just de_DE: the runners here and on CI have no
+    // German locale but do have en_DK, so trying only de_DE meant this branch
+    // printed its note and passed green everywhere it mattered. A silent skip
+    // is how the far larger sibling bug -- strtod failing on "0.5", so no
+    // plotfile opened at all under a comma locale -- stayed hidden.
+    const char* commaLocales[] = {"de_DE.UTF-8", "de_DE", "en_DK.UTF-8",
+        "en_DK.utf8", "fr_FR.UTF-8", "fr_FR.utf8"};
+    bool commaLocaleSet = false;
+    for (const auto* candidate : commaLocales) {
+        if (std::setlocale(LC_NUMERIC, candidate) != nullptr) {
+            commaLocaleSet = true;
+            break;
+        }
+    }
+    if (commaLocaleSet) {
         require(formatNumber(3.14159, QStringLiteral("%.2f"))
                 == QStringLiteral("3.14"),
             "formatNumber emitted a locale decimal separator");

--- a/tests/unit/test_number_format.cpp
+++ b/tests/unit/test_number_format.cpp
@@ -132,8 +132,8 @@ int main()
             "the decimal-point normalization rewrote a literal separator");
         std::setlocale(LC_NUMERIC, "C");
     } else {
-        std::cerr << "note: no German locale installed; the LC_NUMERIC case "
-                     "did not run\n";
+        std::cerr << "note: no comma-decimal locale installed (tried de_DE, "
+                     "en_DK, fr_FR); the LC_NUMERIC case did not run\n";
     }
 
     return 0;


### PR DESCRIPTION
QApplication calls setlocale(LC_ALL, "") on Unix, which hands the C locale to the environment -- and the C locale is what strtod, atof and printf("%f") consult. The plotfile reader parses per-block statistics with strtod, so under any comma-decimal locale strtod("0.5") stopped at the '.', the caller's end-of-token check failed, and the open died with "malformed plotfile Header while reading per-block minima". Not a degraded render: no plotfile opened at all, for most of continental Europe. LC_ALL=en_DK.utf8 failed 50 of 116 tests against 0 under LC_ALL=C.

Pin the numeric category back to "C" immediately after the constructor that moved it, before any window or worker exists to observe either value. This is deliberately not a fix to readStatisticValue: that call site is not the class of bug, and the next strtod, atof or printf("%f") anyone adds would re-open the same hole. The pin closes it by construction.

Nothing user-visible is lost. QLocale is independent of the C locale, so QLocale::system() still reports the user's real locale and separators; only the C conversion functions are pinned. C++ iostreams were never affected -- they consult the C++ global locale, which stays "C" -- which is why the reader's other numeric fields never broke, and why AMReX, whose readers use iostreams throughout, does not have this bug. strtod is kept where it is: it was chosen because it accepts the inf/nan tokens iostreams reject, which is the fix for nonfinite-header-statistics-unopenable.

qt_comma_locale_open runs an ordinary slice smoke test under a comma locale, which is the whole regression -- without the pin the fixture does not open. It fails with the pin reverted. Where no comma locale is installed it builds one with localedef --no-archive plus LOCPATH, and if that also fails it reports a ctest *skip*, never a silent pass: low-priority-robustness item 5 recorded "no German locale installed" and stopped there, which is how this stayed hidden.

The NumberFormat normalization stays as belt-and-braces, with its comment corrected -- it is a library function that may be called from a process which has not pinned the locale, and it must still agree with the QString::number fallbacks beside it.