### PR TITLE
install where users can actually write, and say so

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,12 +21,11 @@ option(AMREXPLORER_ENABLE_SANITIZERS "Enable AddressSanitizer and UndefinedBehav
 option(AMREXPLORER_ENABLE_TSAN "Enable ThreadSanitizer (mutually exclusive with AMREXPLORER_ENABLE_SANITIZERS)" OFF)
 option(AMREXPLORER_FORCE_FETCH_FLATBUFFERS
     "Skip installed FlatBuffers discovery and use the pinned fallback" OFF)
-# Off under the sanitizers, where it is both pointless and a hazard: their
-# runtimes pull in libgcc_s.so.1 and libstdc++.so.6 anyway, so -static-libgcc
-# buys nothing and the process ends up carrying a statically linked libstdc++
-# inside the executable alongside the shared one behind libasan -- two unwinders
-# and two copies of the runtime's state. The portability this option exists for
-# only concerns release and remote builds.
+# Off under the sanitizers, where it is both pointless and a hazard: every
+# sanitizer runtime pulls in libgcc_s.so.1, so -static-libgcc buys nothing, and
+# libubsan pulls libstdc++.so.6 too -- the process would then carry a statically
+# linked copy inside the executable alongside that one. The portability this
+# option exists for only concerns release and remote builds.
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux"
         AND NOT AMREXPLORER_ENABLE_SANITIZERS
         AND NOT AMREXPLORER_ENABLE_TSAN)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,46 @@ option(AMREXPLORER_ENABLE_SANITIZERS "Enable AddressSanitizer and UndefinedBehav
 option(AMREXPLORER_ENABLE_TSAN "Enable ThreadSanitizer (mutually exclusive with AMREXPLORER_ENABLE_SANITIZERS)" OFF)
 option(AMREXPLORER_FORCE_FETCH_FLATBUFFERS
     "Skip installed FlatBuffers discovery and use the pinned fallback" OFF)
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    set(amrexplorer_static_cxx_default ON)
+else()
+    set(amrexplorer_static_cxx_default OFF)
+endif()
+option(AMREXPLORER_SERVER_STATIC_CXX_RUNTIME
+    "Link amrexplorer-server against a static libstdc++/libgcc"
+    ${amrexplorer_static_cxx_default})
+unset(amrexplorer_static_cxx_default)
+
+# CMake would default the install prefix to /usr/local, which essentially
+# nobody who builds this can write to: the users are HPC users without root and
+# desktop users who would otherwise reach for sudo. Default to the per-user
+# location each platform actually uses instead.
+#
+# Only when the caller did not choose one. Packagers always pass a prefix (or
+# stage through DESTDIR), so this cannot surprise them; it only replaces the
+# default nobody wanted.
+if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT
+        AND NOT WIN32 AND DEFINED ENV{HOME})
+    if(APPLE AND AMREXPLORER_BUILD_MACOS_APP_BUNDLE)
+        # The GUI installs as a .app bundle at the prefix root (BUNDLE
+        # DESTINATION .), so here the prefix *is* the applications folder.
+        # amrexplorer-server lands in a bin/ beside it, which is unusual for
+        # macOS but harmless -- the server is a headless HPC tool and those
+        # machines are not Macs.
+        set(amrexplorer_default_prefix "$ENV{HOME}/Applications")
+    else()
+        # ~/.local is the XDG user prefix, and the choice is load-bearing
+        # rather than cosmetic: ~/.local/share is $XDG_DATA_HOME, which is
+        # where the desktop entry and icons below have to land to be found at
+        # all. Installed under $HOME directly they are inert -- nothing
+        # searches $HOME/share. ~/.local/bin is also on PATH by default on most
+        # distributions.
+        set(amrexplorer_default_prefix "$ENV{HOME}/.local")
+    endif()
+    set(CMAKE_INSTALL_PREFIX "${amrexplorer_default_prefix}" CACHE PATH
+        "Install path prefix, prepended onto install directories" FORCE)
+    unset(amrexplorer_default_prefix)
+endif()
 
 if(AMREXPLORER_ENABLE_SERVER_TEST_HOOKS
     AND NOT AMREXPLORER_BUILD_TESTS)
@@ -59,11 +99,26 @@ check_cxx_source_compiles([=[
 ]=] AMREXPLORER_HAS_REQUIRED_CXX20_SUPPORT)
 
 if(NOT AMREXPLORER_HAS_REQUIRED_CXX20_SUPPORT)
+    # The remedy matters more than the diagnosis here. This fails most often on
+    # HPC login nodes, where the OS is several years old and /usr/bin/c++ is
+    # too, but a perfectly good compiler is one `module load` away -- so say so
+    # rather than leaving the reader to conclude the machine is unsupported.
     message(FATAL_ERROR
         "AMReXplorer requires a compiler and standard library with C++20 support "
         "(including <compare> and defaulted comparisons). "
         "The configured compiler is ${CMAKE_CXX_COMPILER_ID} "
-        "${CMAKE_CXX_COMPILER_VERSION} at ${CMAKE_CXX_COMPILER}.")
+        "${CMAKE_CXX_COMPILER_VERSION} at ${CMAKE_CXX_COMPILER}.\n"
+        "\n"
+        "On an HPC system this usually means CMake picked up the system "
+        "compiler in /usr/bin rather than a module-provided one. Load a newer "
+        "toolchain and point CMake at it in a fresh build directory, for "
+        "example:\n"
+        "    module load gcc\n"
+        "    cmake --preset remote -DCMAKE_CXX_COMPILER=g++\n"
+        "On Cray systems (Perlmutter, Frontier) the compiler wrapper is CC:\n"
+        "    cmake --preset remote -DCMAKE_CXX_COMPILER=CC\n"
+        "CMAKE_CXX_COMPILER is only read when a build directory is first "
+        "configured, so change it in a new directory or delete CMakeCache.txt.")
 endif()
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,15 +31,23 @@ option(AMREXPLORER_SERVER_STATIC_CXX_RUNTIME
     ${amrexplorer_static_cxx_default})
 unset(amrexplorer_static_cxx_default)
 
+option(AMREXPLORER_USER_INSTALL_PREFIX
+    "Default the install prefix to the platform's per-user location" OFF)
+
 # CMake would default the install prefix to /usr/local, which essentially
 # nobody who builds this can write to: the users are HPC users without root and
 # desktop users who would otherwise reach for sudo. Default to the per-user
 # location each platform actually uses instead.
 #
-# Only when the caller did not choose one. Packagers always pass a prefix (or
-# stage through DESTDIR), so this cannot surprise them; it only replaces the
-# default nobody wanted.
-if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT
+# Opt-in, and set by the presets rather than unconditionally, because changing
+# a cached prefix is not free for packagers: DESTDIR is *prepended* to the
+# prefix rather than replacing it, so a DESTDIR-only staging install with this
+# forced on would produce stage/home/<builder>/.local/bin/... and bake the
+# builder's home directory into the package. Packagers invoke cmake directly
+# rather than through a preset, so they keep CMake's own default and DESTDIR
+# behaves as documented.
+if(AMREXPLORER_USER_INSTALL_PREFIX
+        AND CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT
         AND NOT WIN32 AND DEFINED ENV{HOME})
     if(APPLE AND AMREXPLORER_BUILD_MACOS_APP_BUNDLE)
         # The GUI installs as a .app bundle at the prefix root (BUNDLE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,10 +54,15 @@ option(AMREXPLORER_USER_INSTALL_PREFIX
 # builder's home directory into the package. Packagers invoke cmake directly
 # rather than through a preset, so they keep CMake's own default and DESTDIR
 # behaves as documented.
+# DEFINED is not enough: HOME set but empty would yield a prefix of "/.local".
 if(AMREXPLORER_USER_INSTALL_PREFIX
         AND CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT
-        AND NOT WIN32 AND DEFINED ENV{HOME})
-    if(APPLE AND AMREXPLORER_BUILD_MACOS_APP_BUNDLE)
+        AND NOT WIN32 AND NOT "$ENV{HOME}" STREQUAL "")
+    # Gated on the GUI actually being built, not just on the bundle option,
+    # which defaults to ${APPLE} independently of it. A server-only build on a
+    # Mac (`cmake --preset remote`) otherwise took the bundle branch and
+    # installed ~/Applications/bin/amrexplorer-server with no .app anywhere.
+    if(APPLE AND AMREXPLORER_ENABLE_QT AND AMREXPLORER_BUILD_MACOS_APP_BUNDLE)
         # The GUI installs as a .app bundle at the prefix root (BUNDLE
         # DESTINATION .), so here the prefix *is* the applications folder.
         # amrexplorer-server lands in a bin/ beside it, which is unusual for
@@ -134,7 +139,9 @@ if(NOT AMREXPLORER_HAS_REQUIRED_CXX20_SUPPORT)
         "\n"
         "On an HPC system this usually means CMake picked up the system "
         "compiler in /usr/bin rather than a module-provided one. Load a newer "
-        "toolchain and point CMake at it, for example:\n"
+        "toolchain and re-run the configure you just ran, adding --fresh and "
+        "the compiler -- keeping your own preset, since the one below is only "
+        "an example:\n"
         "    module load gcc\n"
         "    cmake --preset remote --fresh -DCMAKE_CXX_COMPILER=g++\n"
         "On Cray systems (Perlmutter, Frontier) the compiler wrapper is CC:\n"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,15 @@ option(AMREXPLORER_ENABLE_SANITIZERS "Enable AddressSanitizer and UndefinedBehav
 option(AMREXPLORER_ENABLE_TSAN "Enable ThreadSanitizer (mutually exclusive with AMREXPLORER_ENABLE_SANITIZERS)" OFF)
 option(AMREXPLORER_FORCE_FETCH_FLATBUFFERS
     "Skip installed FlatBuffers discovery and use the pinned fallback" OFF)
-if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+# Off under the sanitizers, where it is both pointless and a hazard: their
+# runtimes pull in libgcc_s.so.1 and libstdc++.so.6 anyway, so -static-libgcc
+# buys nothing and the process ends up carrying a statically linked libstdc++
+# inside the executable alongside the shared one behind libasan -- two unwinders
+# and two copies of the runtime's state. The portability this option exists for
+# only concerns release and remote builds.
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux"
+        AND NOT AMREXPLORER_ENABLE_SANITIZERS
+        AND NOT AMREXPLORER_ENABLE_TSAN)
     set(amrexplorer_static_cxx_default ON)
 else()
     set(amrexplorer_static_cxx_default OFF)
@@ -58,11 +66,18 @@ if(AMREXPLORER_USER_INSTALL_PREFIX
         set(amrexplorer_default_prefix "$ENV{HOME}/Applications")
     else()
         # ~/.local is the XDG user prefix, and the choice is load-bearing
-        # rather than cosmetic: ~/.local/share is $XDG_DATA_HOME, which is
-        # where the desktop entry and icons below have to land to be found at
-        # all. Installed under $HOME directly they are inert -- nothing
+        # rather than cosmetic: ~/.local/share is the *default* $XDG_DATA_HOME,
+        # which is where the desktop entry and icons below have to land to be
+        # found at all. Installed under $HOME directly they are inert -- nothing
         # searches $HOME/share. ~/.local/bin is also on PATH by default on most
         # distributions.
+        #
+        # A user who has moved XDG_DATA_HOME elsewhere gets the installed entry
+        # in a directory their desktop does not search. The application's own
+        # ensureDesktopEntry (src/qt/main.cpp) writes through
+        # QStandardPaths::GenericDataLocation and so honours the variable, which
+        # means the menu entry still appears -- the two disagree only about
+        # which copy is the live one, and the runtime one wins.
         set(amrexplorer_default_prefix "$ENV{HOME}/.local")
     endif()
     set(CMAKE_INSTALL_PREFIX "${amrexplorer_default_prefix}" CACHE PATH
@@ -119,14 +134,16 @@ if(NOT AMREXPLORER_HAS_REQUIRED_CXX20_SUPPORT)
         "\n"
         "On an HPC system this usually means CMake picked up the system "
         "compiler in /usr/bin rather than a module-provided one. Load a newer "
-        "toolchain and point CMake at it in a fresh build directory, for "
-        "example:\n"
+        "toolchain and point CMake at it, for example:\n"
         "    module load gcc\n"
-        "    cmake --preset remote -DCMAKE_CXX_COMPILER=g++\n"
+        "    cmake --preset remote --fresh -DCMAKE_CXX_COMPILER=g++\n"
         "On Cray systems (Perlmutter, Frontier) the compiler wrapper is CC:\n"
-        "    cmake --preset remote -DCMAKE_CXX_COMPILER=CC\n"
-        "CMAKE_CXX_COMPILER is only read when a build directory is first "
-        "configured, so change it in a new directory or delete CMakeCache.txt.")
+        "    cmake --preset remote --fresh -DCMAKE_CXX_COMPILER=CC\n"
+        "--fresh matters: this configure has already written a cache naming the "
+        "old compiler, and CMake normally clears such a cache and retries "
+        "within the same run -- but the error above aborts before it can, so "
+        "without --fresh the next attempt fails identically and only a third "
+        "would succeed.")
 endif()
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -68,7 +68,8 @@
       "displayName": "Headless Debug with ASan and UBSan",
       "binaryDir": "${sourceDir}/build-sanitizers",
       "cacheVariables": {
-        "AMREXPLORER_ENABLE_SANITIZERS": "ON"
+        "AMREXPLORER_ENABLE_SANITIZERS": "ON",
+        "AMREXPLORER_SERVER_STATIC_CXX_RUNTIME": "OFF"
       }
     },
     {
@@ -90,7 +91,8 @@
       "cacheVariables": {
         "AMREXPLORER_ENABLE_TSAN": "ON",
         "AMREXPLORER_ENABLE_REMOTE": "ON",
-        "AMREXPLORER_ENABLE_SERVER_TEST_HOOKS": "OFF"
+        "AMREXPLORER_ENABLE_SERVER_TEST_HOOKS": "OFF",
+        "AMREXPLORER_SERVER_STATIC_CXX_RUNTIME": "OFF"
       }
     },
     {
@@ -99,7 +101,8 @@
       "displayName": "Qt Debug with ASan and UBSan (offscreen smoke tests)",
       "binaryDir": "${sourceDir}/build-qt-sanitizers",
       "cacheVariables": {
-        "AMREXPLORER_ENABLE_SANITIZERS": "ON"
+        "AMREXPLORER_ENABLE_SANITIZERS": "ON",
+        "AMREXPLORER_SERVER_STATIC_CXX_RUNTIME": "OFF"
       }
     },
     {

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -16,7 +16,8 @@
         "AMREXPLORER_ENABLE_QT": "ON",
         "AMREXPLORER_ENABLE_VTK": "OFF",
         "AMREXPLORER_BUILD_TESTS": "ON",
-        "AMREXPLORER_ENABLE_SERVER_TEST_HOOKS": "OFF"
+        "AMREXPLORER_ENABLE_SERVER_TEST_HOOKS": "OFF",
+        "AMREXPLORER_USER_INSTALL_PREFIX": "ON"
       }
     },
     {
@@ -78,7 +79,8 @@
       "cacheVariables": {
         "AMREXPLORER_ENABLE_REMOTE": "ON",
         "AMREXPLORER_BUILD_TESTS": "ON",
-        "AMREXPLORER_ENABLE_SERVER_TEST_HOOKS": "OFF"
+        "AMREXPLORER_ENABLE_SERVER_TEST_HOOKS": "OFF",
+        "AMREXPLORER_USER_INSTALL_PREFIX": "ON"
       }
     },
     {
@@ -105,7 +107,9 @@
       "name": "windows",
       "displayName": "Windows MSVC Release build (mirrors the CI job)",
       "generator": "Visual Studio 17 2022",
-      "architecture": { "value": "x64" },
+      "architecture": {
+        "value": "x64"
+      },
       "binaryDir": "${sourceDir}/build-windows",
       "condition": {
         "type": "equals",

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -79,8 +79,7 @@
       "cacheVariables": {
         "AMREXPLORER_ENABLE_REMOTE": "ON",
         "AMREXPLORER_BUILD_TESTS": "ON",
-        "AMREXPLORER_ENABLE_SERVER_TEST_HOOKS": "OFF",
-        "AMREXPLORER_USER_INSTALL_PREFIX": "ON"
+        "AMREXPLORER_ENABLE_SERVER_TEST_HOOKS": "OFF"
       }
     },
     {

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -10,9 +10,9 @@ The build produces two programs:
 
 ## Requirements
 
-CMake 3.25 or newer, a C++20 compiler (GCC recommended), and Qt 6.4 or newer
-for the application. Check CMake first — enterprise distributions and HPC login nodes
-often ship an older one:
+CMake 3.25 or newer, a C++20 compiler (GCC or Clang recommended), and Qt 6.4 or
+newer for the application. Check CMake first — enterprise distributions and HPC
+login nodes often ship an older one:
 
 ```bash
 cmake --version
@@ -95,16 +95,14 @@ cmake --install build --prefix /opt/amrexplorer
 Build the server only, with a GNU toolchain:
 
 ```bash
-module load gcc
+module load gcc            # or gcc-native on a Cray system
 module load cmake          # if the system cmake is older than 3.25
 cmake --preset remote --fresh -DCMAKE_CXX_COMPILER=g++
 cmake --build --preset remote
 cmake --install build-remote --prefix ${HOME}
 ```
 
-That installs one file, `${HOME}/bin/amrexplorer-server`. On Cray systems such
-as Perlmutter and Frontier the GNU module may be named `gcc` or `gcc-native`,
-and either `g++` or the `CC` wrapper works.
+That installs one file, `${HOME}/bin/amrexplorer-server`.
 
 Use `--fresh` whenever you change the compiler; without it a build directory
 keeps the one it was first configured with.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -81,8 +81,9 @@ cmake --install build
 ```
 
 No `sudo` needed: this installs to `~/.local` on Linux and `~/Applications` on
-macOS. On Linux it also adds a desktop entry, so AMReXplorer appears in your
-application menu.
+macOS. On Linux the application lands at `~/.local/bin/amrexplorer`, and a
+desktop entry puts it in your application menu. If `~/.local/bin` did not exist
+before, log out and back in for it to be on your `PATH`.
 
 Choose somewhere else with `--prefix`:
 
@@ -104,8 +105,8 @@ cmake --install build-remote --prefix ${HOME}
 
 That installs one file, `${HOME}/bin/amrexplorer-server`.
 
-Use `--fresh` whenever you change the compiler; without it a build directory
-keeps the one it was first configured with.
+Use `--fresh` whenever you change the compiler; without it the configure fails
+again with the same message and has to be run twice.
 
 If your `${HOME}` is shared between machines, give each its own prefix so one
 build does not overwrite another:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,37 +1,24 @@
 # Installing AMReXplorer
 
-Build from source. Tested on Ubuntu 24.04 and 26.04, and on macOS; for Windows
-see [below](#windows). There are no prebuilt binaries yet.
+Build from source. Tested on Ubuntu 24.04 and 26.04, and on macOS.
 
-The build produces two independent executables.
+The build produces two programs:
 
-`amrexplorer` is the application. On its own it opens plotfiles stored on the
-machine it runs on, which is the ordinary case and needs nothing further.
+- `amrexplorer` — the application. Opens plotfiles on the machine it runs on.
+- `amrexplorer-server` — optional. Run it where the data lives, typically an HPC
+  login node, and connect to it from `amrexplorer` over an SSH tunnel.
 
-`amrexplorer-server` is optional. Run it on the machine where the data lives —
-typically an HPC login node — and connect to it from `amrexplorer` over an SSH
-tunnel, for datasets too large or too awkward to copy back. If you only ever
-open local files you can ignore it; a desktop build produces it anyway, and it
-costs nothing to leave alone.
+## Requirements
 
-| | needs at run time | typical home |
-| --- | --- | --- |
-| `amrexplorer` | Qt 6 and its dependencies | your desktop or laptop |
-| `amrexplorer-server` | the C and C++ system libraries — on Linux usually the C library alone, see [HPC](#hpc-systems-the-server-only) | an HPC login node |
-
-They install and move independently.
-
-## Dependencies
-
-CMake 3.25 or newer, a C++20 compiler, and Qt 6 for the desktop application.
-The CMake floor is worth checking before anything else — every command below
-uses presets, and `--fresh` needs 3.24 — because enterprise distributions and
-HPC login nodes often ship an older one:
+CMake 3.25 or newer, a C++20 compiler (GCC recommended), and Qt 6 for the
+application. Check CMake first — enterprise distributions and HPC login nodes
+often ship an older one:
 
 ```bash
 cmake --version
-module load cmake     # on an HPC system, if it is too old
 ```
+
+## Dependencies
 
 ### Linux (Ubuntu)
 
@@ -59,12 +46,8 @@ brew install cmake ninja qt
 ### Windows
 
 Windows is covered only in continuous integration: MSVC 2022 with Qt 6.8, using
-the `windows` preset, building and running the test suite on every change.
-
-None of the developers uses Windows or has tested a build on a Windows machine,
-so there is no guidance here on installing Qt, choosing an install location, or
-anything else specific to the platform. The CI job is evidence that the code
-compiles and the tests pass; it is not a supported installation path.
+the `windows` preset. None of the developers uses Windows or has tested a build
+on one, so there is no guidance here for it.
 
 ### Optional
 
@@ -75,11 +58,6 @@ sudo apt install ffmpeg   # Ubuntu
 brew install ffmpeg       # macOS
 ```
 
-FlatBuffers is found automatically: CMake uses an installed package when there
-is one and otherwise fetches the pinned version. Point `CMAKE_PREFIX_PATH` at an
-installed package for offline or package-managed builds, or set
-`-DAMREXPLORER_FORCE_FETCH_FLATBUFFERS=ON` to force the pinned fallback.
-
 ## Build
 
 ```bash
@@ -89,16 +67,12 @@ cmake --preset default
 cmake --build --preset default
 ```
 
-Run it straight from the build tree, without installing:
+Run it from the build tree without installing:
 
 ```bash
-./build/src/qt/amrexplorer /path/to/plotfile                      # Linux
-open build/src/qt/amrexplorer.app                                 # macOS
+./build/src/qt/amrexplorer /path/to/plotfile     # Linux
+open build/src/qt/amrexplorer.app                # macOS
 ```
-
-On macOS the build is an `.app` bundle; to pass a plotfile on the command line
-use `./build/src/qt/amrexplorer.app/Contents/MacOS/amrexplorer`, or configure
-with `-DAMREXPLORER_BUILD_MACOS_APP_BUNDLE=OFF` for a plain executable.
 
 ## Install
 
@@ -106,116 +80,43 @@ with `-DAMREXPLORER_BUILD_MACOS_APP_BUNDLE=OFF` for a plain executable.
 cmake --install build
 ```
 
-No `sudo`, and no prefix to choose: the default is the per-user location for
-your platform — `~/.local` on Linux, and `~/Applications` on macOS when building
-the `.app` bundle, which is the default there. (CMake's own default is
-`/usr/local`, which most people building this cannot write to.) Building on
-macOS with `-DAMREXPLORER_BUILD_MACOS_APP_BUNDLE=OFF` produces a plain
-executable rather than a bundle, and installs to `~/.local` like Linux.
-
-On Linux that installs:
-
-```
-~/.local/bin/amrexplorer
-~/.local/bin/amrexplorer-server
-~/.local/share/applications/amrexplorer.desktop
-~/.local/share/icons/hicolor/{16,32,64,128,256}x*/apps/amrexplorer.png
-```
-
-`~/.local/bin` is on `PATH` by default on most distributions, and the desktop
-entry and icons make AMReXplorer appear in your application menu. The
-application also writes its own desktop entry on first run, so the menu entry
-works even if you skip installing and just copy the executable somewhere.
-
-On macOS it installs `~/Applications/amrexplorer.app`, plus
-`~/Applications/bin/amrexplorer-server`.
+No `sudo` needed: this installs to `~/.local` on Linux and `~/Applications` on
+macOS. On Linux it also adds a desktop entry, so AMReXplorer appears in your
+application menu.
 
 Choose somewhere else with `--prefix`:
 
 ```bash
-cmake --install build --prefix /opt/amrexplorer      # needs write access
+cmake --install build --prefix /opt/amrexplorer
 ```
 
-## HPC systems: the server only
+## HPC systems
 
-On a cluster you want the server and nothing else. Use the `remote` preset,
-which builds no Qt and installs exactly one file:
-
-```bash
-cmake --preset remote
-cmake --build --preset remote
-cmake --install build-remote --prefix ${HOME}
-# -> ${HOME}/bin/amrexplorer-server
-```
-
-Three things are worth knowing.
-
-**The system compiler is usually too old.** HPC login nodes run an OS several
-years old, and `/usr/bin/c++` with it, so a default configure often fails on
-C++20 support. The compiler you want is a module away:
+Build the server only, with a GNU toolchain:
 
 ```bash
 module load gcc
+module load cmake          # if the system cmake is older than 3.25
 cmake --preset remote --fresh -DCMAKE_CXX_COMPILER=g++
+cmake --build --preset remote
+cmake --install build-remote --prefix ${HOME}
 ```
 
-On Cray systems such as Perlmutter and Frontier, use the compiler wrapper:
+That installs one file, `${HOME}/bin/amrexplorer-server`. On Cray systems such
+as Perlmutter and Frontier, use `PrgEnv-gnu` and `-DCMAKE_CXX_COMPILER=CC`.
 
-```bash
-cmake --preset remote --fresh -DCMAKE_CXX_COMPILER=CC
-```
+Use `--fresh` whenever you change the compiler; without it a build directory
+keeps the one it was first configured with.
 
-`--fresh` is not optional after a failed configure. That configure has already
-written a cache naming the old compiler, and while CMake normally clears such a
-cache and retries within the same run, the C++20 error aborts before it can — so
-without `--fresh` the next attempt fails identically, naming the old compiler
-again, and only a third would succeed.
-
-The same applies to any other preset: keep whichever one you were using and add
-`--fresh` and `-DCMAKE_CXX_COMPILER=...` to it. `--preset remote` above is the
-HPC case, not part of the fix.
-
-Configuring with an unsupported compiler fails with a message naming the
-compiler it found and repeating these commands.
-
-**The binary is easy to move.** On Linux the server links the C++ runtime
-statically and depends only on the C library, so you can build it once and copy
-it where you like — including to machines where the compiler module you built
-with is not loaded. It does need a glibc no older than the machine that built
-it, so build on the cluster rather than carrying a binary from your laptop.
-Packagers who want the system runtime should configure with
-`-DAMREXPLORER_SERVER_STATIC_CXX_RUNTIME=OFF`.
-
-**Beware a shared home directory.** Several centres share `${HOME}` across
-machines. Installing to the same `${HOME}/bin` from two clusters overwrites one
-build with the other, and the survivor may not run on both. Give each system its
-own prefix:
+If your `${HOME}` is shared between machines, give each its own prefix so one
+build does not overwrite another:
 
 ```bash
 cmake --install build-remote --prefix ${HOME}/perlmutter
 ```
 
-See the **[User Guide](docs/user-guide.md)** for connecting the desktop
-application to a running server over an SSH tunnel.
-
-## Development tools
-
-`amrexplorer-render-equivalence`, which compares local and remote rendering, is
-built but not installed by default. Install it deliberately with:
-
-```bash
-cmake --install build --component tools
-```
-
-## Packaging an AppImage
-
-An AppImage is a self-contained executable that runs on any modern Linux
-distribution without installing packages, which makes it a convenient way to
-move a build to machines you do not administer. Build one from a source build
-yourself: see
-**[Building an AppImage](docs/building.md#building-an-appimage)**.
-
-There is no release pipeline yet, so no prebuilt AppImage is published.
+See the **[User Guide](docs/user-guide.md)** for connecting the application to a
+running server over an SSH tunnel.
 
 ## Next steps
 
@@ -223,6 +124,9 @@ See the **[AMReXplorer User Guide](docs/user-guide.md)** for opening plotfiles,
 navigating 2-D and 3-D data, selecting AMR levels, animation, export, and
 troubleshooting. The same guide is bundled in the application under **Help >
 User Guide...**.
+
+Developers and packagers: see **[docs/building.md](docs/building.md)** for build
+options, presets, the compiler matrix, and packaging an AppImage.
 
 ## Existing installations
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,55 +1,76 @@
 # Installing AMReXplorer
 
-Build from source. Tested on Ubuntu 24.04 and macOS.
+Build from source. Tested on Ubuntu 24.04 and 26.04, and on macOS; for Windows
+see [below](#windows). There are no prebuilt binaries yet.
 
-## Build from source
+The build produces two independent executables.
+
+`amrexplorer` is the application. On its own it opens plotfiles stored on the
+machine it runs on, which is the ordinary case and needs nothing further.
+
+`amrexplorer-server` is optional. Run it on the machine where the data lives —
+typically an HPC login node — and connect to it from `amrexplorer` over an SSH
+tunnel, for datasets too large or too awkward to copy back. If you only ever
+open local files you can ignore it; a desktop build produces it anyway, and it
+costs nothing to leave alone.
+
+| | needs at run time | typical home |
+| --- | --- | --- |
+| `amrexplorer` | Qt 6 and its dependencies | your desktop or laptop |
+| `amrexplorer-server` | the C system library, nothing else | an HPC login node |
+
+They install and move independently.
+
+## Dependencies
 
 ### Linux (Ubuntu)
-
-Install the dependencies:
 
 ```bash
 sudo apt install g++ cmake ninja-build qt6-base-dev
 ```
 
-### Linux (all distros)
+### Linux (any distribution)
 
-Install the dependencies with [Spack](https://github.com/spack/spack):
+With [Spack](https://github.com/spack/spack):
+
 ```bash
 spack install qt-base
 spack load qt-base
-cmake --preset default
-cmake --build --preset default
-./build/src/qt/amrexplorer /path/to/plotfile
 ```
-
-Remote support and the headless `amrexplorer-server` executable are included
-in normal desktop builds. CMake uses an installed FlatBuffers CMake package
-when one is available, otherwise it fetches the project's pinned FlatBuffers
-version. Package-managed and offline builds can point `CMAKE_PREFIX_PATH` at an
-installed FlatBuffers package. Set `-DAMREXPLORER_FORCE_FETCH_FLATBUFFERS=ON`
-to test or explicitly select the pinned fallback.
 
 ### macOS
 
-Install the dependencies with [Homebrew][]:
+With [Homebrew](https://brew.sh):
 
 ```bash
 brew install cmake ninja qt
 ```
 
-[Homebrew]: https://brew.sh
+### Windows
 
-**Optional:** `ffmpeg` is needed to encode animation exports (MP4).
+Windows is covered only in continuous integration: MSVC 2022 with Qt 6.8, using
+the `windows` preset, building and running the test suite on every change.
+
+None of the developers uses Windows or has tested a build on a Windows machine,
+so there is no guidance here on installing Qt, choosing an install location, or
+anything else specific to the platform. The CI job is evidence that the code
+compiles and the tests pass; it is not a supported installation path.
+
+### Optional
+
+`ffmpeg` is needed only to encode animation exports (MP4):
 
 ```bash
-# Ubuntu
-sudo apt install ffmpeg
-# macOS
-brew install ffmpeg
+sudo apt install ffmpeg   # Ubuntu
+brew install ffmpeg       # macOS
 ```
 
-Build (both platforms):
+FlatBuffers is found automatically: CMake uses an installed package when there
+is one and otherwise fetches the pinned version. Point `CMAKE_PREFIX_PATH` at an
+installed package for offline or package-managed builds, or set
+`-DAMREXPLORER_FORCE_FETCH_FLATBUFFERS=ON` to force the pinned fallback.
+
+## Build
 
 ```bash
 git clone https://github.com/amrex-codes/amrexplorer.git
@@ -58,39 +79,119 @@ cmake --preset default
 cmake --build --preset default
 ```
 
-On Linux, the executable is `build/src/qt/amrexplorer`. Run it with a plotfile:
+Run it straight from the build tree, without installing:
 
 ```bash
-./build/src/qt/amrexplorer /path/to/plotfile
+./build/src/qt/amrexplorer /path/to/plotfile                      # Linux
+open build/src/qt/amrexplorer.app                                 # macOS
 ```
 
-On macOS, the default build is `build/src/qt/amrexplorer.app`. It can be opened
-from Finder, launched with `open build/src/qt/amrexplorer.app`, or run with a
-plotfile from the command line:
+On macOS the build is an `.app` bundle; to pass a plotfile on the command line
+use `./build/src/qt/amrexplorer.app/Contents/MacOS/amrexplorer`, or configure
+with `-DAMREXPLORER_BUILD_MACOS_APP_BUNDLE=OFF` for a plain executable.
+
+## Install
 
 ```bash
-./build/src/qt/amrexplorer.app/Contents/MacOS/amrexplorer /path/to/plotfile
+cmake --install build
 ```
 
-Install it for the current user with:
+No `sudo`, and no prefix to choose: the default is the per-user location for
+your platform — `~/.local` on Linux, `~/Applications` on macOS. (CMake's own
+default is `/usr/local`, which most people building this cannot write to.)
 
-```bash
-cmake --install build --prefix "$HOME/Applications"
+On Linux that installs:
+
+```
+~/.local/bin/amrexplorer
+~/.local/bin/amrexplorer-server
+~/.local/share/applications/amrexplorer.desktop
+~/.local/share/icons/hicolor/{16,32,64,128,256}x*/apps/amrexplorer.png
 ```
 
-Set `-DAMREXPLORER_BUILD_MACOS_APP_BUNDLE=OFF` when configuring to build the plain
-`amrexplorer` executable on macOS instead. On Linux, install system-wide with:
+`~/.local/bin` is on `PATH` by default on most distributions, and the desktop
+entry and icons make AMReXplorer appear in your application menu. The
+application also writes its own desktop entry on first run, so the menu entry
+works even if you skip installing and just copy the executable somewhere.
+
+On macOS it installs `~/Applications/amrexplorer.app`, plus
+`~/Applications/bin/amrexplorer-server`.
+
+Choose somewhere else with `--prefix`:
 
 ```bash
-sudo cmake --install build --prefix /usr/local
+cmake --install build --prefix /opt/amrexplorer      # needs write access
+```
+
+## HPC systems: the server only
+
+On a cluster you want the server and nothing else. Use the `remote` preset,
+which builds no Qt and installs exactly one file:
+
+```bash
+cmake --preset remote
+cmake --build --preset remote
+cmake --install build-remote --prefix ${HOME}
+# -> ${HOME}/bin/amrexplorer-server
+```
+
+Three things are worth knowing.
+
+**The system compiler is usually too old.** HPC login nodes run an OS several
+years old, and `/usr/bin/c++` with it, so a default configure often fails on
+C++20 support. The compiler you want is a module away. Point CMake at it in a
+*fresh* build directory — `CMAKE_CXX_COMPILER` is only read when a directory is
+first configured:
+
+```bash
+module load gcc
+cmake --preset remote -DCMAKE_CXX_COMPILER=g++
+```
+
+On Cray systems such as Perlmutter and Frontier, use the compiler wrapper:
+
+```bash
+cmake --preset remote -DCMAKE_CXX_COMPILER=CC
+```
+
+Configuring with an unsupported compiler fails with a message naming the
+compiler it found and repeating these commands.
+
+**The binary is easy to move.** On Linux the server links the C++ runtime
+statically and depends only on the C library, so you can build it once and copy
+it where you like — including to machines where the compiler module you built
+with is not loaded. It does need a glibc no older than the machine that built
+it, so build on the cluster rather than carrying a binary from your laptop.
+Packagers who want the system runtime should configure with
+`-DAMREXPLORER_SERVER_STATIC_CXX_RUNTIME=OFF`.
+
+**Beware a shared home directory.** Several centres share `${HOME}` across
+machines. Installing to the same `${HOME}/bin` from two clusters overwrites one
+build with the other, and the survivor may not run on both. Give each system its
+own prefix:
+
+```bash
+cmake --install build-remote --prefix ${HOME}/perlmutter
+```
+
+See the **[User Guide](docs/user-guide.md)** for connecting the desktop
+application to a running server over an SSH tunnel.
+
+## Development tools
+
+`amrexplorer-render-equivalence`, which compares local and remote rendering, is
+built but not installed by default. Install it deliberately with:
+
+```bash
+cmake --install build --component tools
 ```
 
 ## Packaging an AppImage
 
 An AppImage is a self-contained executable that runs on any modern Linux
 distribution without installing packages, which makes it a convenient way to
-move a build to machines you do not administer. You can build one from a source
-build yourself: see
+move a build to machines you do not administer. Build one from a source build
+yourself: see
 **[Building an AppImage](docs/building.md#building-an-appimage)**.
 
 There is no release pipeline yet, so no prebuilt AppImage is published.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -23,6 +23,16 @@ They install and move independently.
 
 ## Dependencies
 
+CMake 3.25 or newer, a C++20 compiler, and Qt 6 for the desktop application.
+The CMake floor is worth checking before anything else — every command below
+uses presets, and `--fresh` needs 3.24 — because enterprise distributions and
+HPC login nodes often ship an older one:
+
+```bash
+cmake --version
+module load cmake     # on an HPC system, if it is too old
+```
+
 ### Linux (Ubuntu)
 
 ```bash
@@ -160,6 +170,10 @@ written a cache naming the old compiler, and while CMake normally clears such a
 cache and retries within the same run, the C++20 error aborts before it can — so
 without `--fresh` the next attempt fails identically, naming the old compiler
 again, and only a third would succeed.
+
+The same applies to any other preset: keep whichever one you were using and add
+`--fresh` and `-DCMAKE_CXX_COMPILER=...` to it. `--preset remote` above is the
+HPC case, not part of the fix.
 
 Configuring with an unsupported compiler fails with a message naming the
 compiler it found and repeating these commands.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -17,7 +17,7 @@ costs nothing to leave alone.
 | | needs at run time | typical home |
 | --- | --- | --- |
 | `amrexplorer` | Qt 6 and its dependencies | your desktop or laptop |
-| `amrexplorer-server` | the C system library, nothing else | an HPC login node |
+| `amrexplorer-server` | the C and C++ system libraries — on Linux usually the C library alone, see [HPC](#hpc-systems-the-server-only) | an HPC login node |
 
 They install and move independently.
 
@@ -97,8 +97,11 @@ cmake --install build
 ```
 
 No `sudo`, and no prefix to choose: the default is the per-user location for
-your platform — `~/.local` on Linux, `~/Applications` on macOS. (CMake's own
-default is `/usr/local`, which most people building this cannot write to.)
+your platform — `~/.local` on Linux, and `~/Applications` on macOS when building
+the `.app` bundle, which is the default there. (CMake's own default is
+`/usr/local`, which most people building this cannot write to.) Building on
+macOS with `-DAMREXPLORER_BUILD_MACOS_APP_BUNDLE=OFF` produces a plain
+executable rather than a bundle, and installs to `~/.local` like Linux.
 
 On Linux that installs:
 
@@ -139,20 +142,24 @@ Three things are worth knowing.
 
 **The system compiler is usually too old.** HPC login nodes run an OS several
 years old, and `/usr/bin/c++` with it, so a default configure often fails on
-C++20 support. The compiler you want is a module away. Point CMake at it in a
-*fresh* build directory — `CMAKE_CXX_COMPILER` is only read when a directory is
-first configured:
+C++20 support. The compiler you want is a module away:
 
 ```bash
 module load gcc
-cmake --preset remote -DCMAKE_CXX_COMPILER=g++
+cmake --preset remote --fresh -DCMAKE_CXX_COMPILER=g++
 ```
 
 On Cray systems such as Perlmutter and Frontier, use the compiler wrapper:
 
 ```bash
-cmake --preset remote -DCMAKE_CXX_COMPILER=CC
+cmake --preset remote --fresh -DCMAKE_CXX_COMPILER=CC
 ```
+
+`--fresh` is not optional after a failed configure. That configure has already
+written a cache naming the old compiler, and while CMake normally clears such a
+cache and retries within the same run, the C++20 error aborts before it can — so
+without `--fresh` the next attempt fails identically, naming the old compiler
+again, and only a third would succeed.
 
 Configuring with an unsupported compiler fails with a message naming the
 compiler it found and repeating these commands.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -10,8 +10,8 @@ The build produces two programs:
 
 ## Requirements
 
-CMake 3.25 or newer, a C++20 compiler (GCC recommended), and Qt 6 for the
-application. Check CMake first — enterprise distributions and HPC login nodes
+CMake 3.25 or newer, a C++20 compiler (GCC recommended), and Qt 6.4 or newer
+for the application. Check CMake first — enterprise distributions and HPC login nodes
 often ship an older one:
 
 ```bash
@@ -103,7 +103,8 @@ cmake --install build-remote --prefix ${HOME}
 ```
 
 That installs one file, `${HOME}/bin/amrexplorer-server`. On Cray systems such
-as Perlmutter and Frontier, use `PrgEnv-gnu` and `-DCMAKE_CXX_COMPILER=CC`.
+as Perlmutter and Frontier the GNU module may be named `gcc` or `gcc-native`,
+and either `g++` or the `CC` wrapper works.
 
 Use `--fresh` whenever you change the compiler; without it a build directory
 keeps the one it was first configured with.

--- a/docs/building.md
+++ b/docs/building.md
@@ -77,6 +77,27 @@ cmake --install build --prefix "$HOME/Applications"
 Configure with `-DAMREXPLORER_BUILD_MACOS_APP_BUNDLE=OFF` to retain the plain
 `build/src/qt/amrexplorer` executable layout.
 
+## Install options
+
+The presets set `AMREXPLORER_USER_INSTALL_PREFIX=ON`, which defaults
+`CMAKE_INSTALL_PREFIX` to `~/.local` (or `~/Applications` for a macOS bundle).
+Configuring without a preset leaves CMake's own default, so packaging with
+`DESTDIR` alone is unaffected; pass `-DCMAKE_INSTALL_PREFIX` explicitly as usual.
+
+`amrexplorer-render-equivalence`, which compares local and remote rendering, is
+built but not installed by default:
+
+```bash
+cmake --install build --component tools
+```
+
+On Linux the server links the C++ runtime statically so it can be copied between
+machines without the compiler module it was built under. This applies to GNU and
+Clang builds, is skipped under the sanitizers, and falls back to the shared
+runtime with a warning where `libstdc++.a` is missing (Fedora and RHEL package it
+as `libstdc++-static`). Packagers who want the system runtime should configure
+with `-DAMREXPLORER_SERVER_STATIC_CXX_RUNTIME=OFF`.
+
 ## Building an AppImage
 
 From the repository root on Linux, build AMReXplorer and install it into an

--- a/docs/building.md
+++ b/docs/building.md
@@ -126,6 +126,7 @@ application.
 |---|---|---|
 | Ubuntu 24.04 | GCC | GitHub CI (full Qt) |
 | Ubuntu 24.04 | Clang | GitHub CI (full Qt) |
+| Ubuntu 26.04 | GCC 15 | Developer machines (full Qt) |
 | macOS 15 | AppleClang | GitHub CI (full Qt) |
 | Windows Server 2022 | MSVC 2022 | GitHub CI (full Qt) |
 

--- a/docs/building.md
+++ b/docs/building.md
@@ -79,8 +79,11 @@ Configure with `-DAMREXPLORER_BUILD_MACOS_APP_BUNDLE=OFF` to retain the plain
 
 ## Install options
 
-The presets set `AMREXPLORER_USER_INSTALL_PREFIX=ON`, which defaults
-`CMAKE_INSTALL_PREFIX` to `~/.local` (or `~/Applications` for a macOS bundle).
+The `default` preset sets `AMREXPLORER_USER_INSTALL_PREFIX=ON`, and `clang`,
+`headless` and `remote` inherit it; the `debug`, `sanitizers`, `tsan`,
+`qt-sanitizers` and `windows` presets do not, and keep CMake's default. Where it
+is on, `CMAKE_INSTALL_PREFIX` defaults to `~/.local` (or `~/Applications` for a
+macOS bundle).
 Configuring without a preset leaves CMake's own default, so packaging with
 `DESTDIR` alone is unaffected; pass `-DCMAKE_INSTALL_PREFIX` explicitly as usual.
 
@@ -93,10 +96,12 @@ cmake --install build --component tools
 
 On Linux the server links the C++ runtime statically so it can be copied between
 machines without the compiler module it was built under. This applies to GNU and
-Clang builds, is skipped under the sanitizers, and falls back to the shared
-runtime with a warning where `libstdc++.a` is missing (Fedora and RHEL package it
-as `libstdc++-static`). Packagers who want the system runtime should configure
-with `-DAMREXPLORER_SERVER_STATIC_CXX_RUNTIME=OFF`.
+Clang builds, and falls back to the shared runtime — reporting why at configure
+time — under the sanitizers, where `libstdc++.a` is missing (Fedora and RHEL
+package it as `libstdc++-static`), and when `CMAKE_TRY_COMPILE_TARGET_TYPE` is
+not `EXECUTABLE`, which cross-compiling toolchain files set so that the link
+cannot be tested. Packagers who want the system runtime should configure with
+`-DAMREXPLORER_SERVER_STATIC_CXX_RUNTIME=OFF`.
 
 ## Building an AppImage
 

--- a/tools/amrexplorer_server/CMakeLists.txt
+++ b/tools/amrexplorer_server/CMakeLists.txt
@@ -25,6 +25,13 @@ target_compile_definitions(amrexplorer_server
 if(AMREXPLORER_SERVER_STATIC_CXX_RUNTIME
         AND CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
     include(CheckCXXSourceCompiles)
+    # Re-probed on every configure. check_cxx_source_compiles caches its result,
+    # so a tree first configured on a machine without libstdc++.a would keep the
+    # warning and the dynamic fallback for ever -- installing the package and
+    # reconfiguring would change nothing, and the only way out would be to
+    # delete the build directory. A warning that names a package to install has
+    # to be actionable without that.
+    unset(AMREXPLORER_STATIC_CXX_RUNTIME_LINKS CACHE)
     set(CMAKE_REQUIRED_LINK_OPTIONS -static-libstdc++ -static-libgcc)
     check_cxx_source_compiles([=[
         #include <stdexcept>

--- a/tools/amrexplorer_server/CMakeLists.txt
+++ b/tools/amrexplorer_server/CMakeLists.txt
@@ -28,10 +28,17 @@ target_compile_definitions(amrexplorer_server
 # would still get the flags. Guarding where they are applied makes the
 # behaviour right in every tree, including hand-configured ones that no preset
 # covers.
+#
+# The compiler is not checked by identity. A GNU|Clang gate looked like a safety
+# net but was the opposite: the option's default has no compiler clause, so on a
+# Linux login node running oneAPI (IntelLLVM), NVHPC, Cray or XL the cache said
+# ON while the flags were quietly dropped -- exactly the toolchains this exists
+# for, failing silently, with INSTALL.md still promising a copyable binary. The
+# probe below is the real test: a toolchain that cannot link this way fails it
+# and gets the warning.
 if(AMREXPLORER_SERVER_STATIC_CXX_RUNTIME
         AND NOT AMREXPLORER_ENABLE_SANITIZERS
-        AND NOT AMREXPLORER_ENABLE_TSAN
-        AND CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+        AND NOT AMREXPLORER_ENABLE_TSAN)
     include(CheckCXXSourceCompiles)
     # Re-probed on every configure. check_cxx_source_compiles caches its result,
     # so a tree first configured on a machine without libstdc++.a would keep the
@@ -69,6 +76,16 @@ if(AMREXPLORER_SERVER_STATIC_CXX_RUNTIME
             "get a freely copyable server, or set "
             "-DAMREXPLORER_SERVER_STATIC_CXX_RUNTIME=OFF to silence this.")
     endif()
+elseif(AMREXPLORER_SERVER_STATIC_CXX_RUNTIME)
+    # Asked for, and vetoed above. Say so: the veto leaves the cache reading ON
+    # and AMREXPLORER_STATIC_CXX_RUNTIME_LINKS possibly reading 1 from an earlier
+    # configure, both describing a build that ignores them, and silence there is
+    # how the stale-cache defect went unnoticed in the first place.
+    message(STATUS
+        "amrexplorer-server: linking the shared C++ runtime despite "
+        "AMREXPLORER_SERVER_STATIC_CXX_RUNTIME=ON, because a sanitizer is "
+        "enabled. Their runtimes load libstdc++.so.6 and libgcc_s.so.1 anyway, "
+        "so a static copy inside the executable would only add a second one.")
 endif()
 
 install(TARGETS amrexplorer_server RUNTIME DESTINATION bin)

--- a/tools/amrexplorer_server/CMakeLists.txt
+++ b/tools/amrexplorer_server/CMakeLists.txt
@@ -29,16 +29,20 @@ target_compile_definitions(amrexplorer_server
 # behaviour right in every tree, including hand-configured ones that no preset
 # covers.
 #
-# The compiler is not checked by identity. A GNU|Clang gate looked like a safety
-# net but was the opposite: the option's default has no compiler clause, so on a
-# Linux login node running oneAPI (IntelLLVM), NVHPC, Cray or XL the cache said
-# ON while the flags were quietly dropped -- exactly the toolchains this exists
-# for, failing silently, with INSTALL.md still promising a copyable binary. The
-# probe below is the real test: a toolchain that cannot link this way fails it
-# and gets the warning.
+# Restricted to the GNU and Clang families, whose handling of these flags is
+# known, and *not* silently. Both halves matter, and each was learned the hard
+# way. A probe alone is not enough: a driver that accepts an unknown switch and
+# ignores it makes the probe succeed while still linking libstdc++ dynamically,
+# so the build would claim a copyable binary and not have one. An allowlist
+# alone is not enough either: when this was a bare condition the flags simply
+# vanished on other toolchains while the cache still read ON and INSTALL.md
+# still promised the static link. So: restrict, and say so when the restriction
+# bites. GNU is what we recommend and test; Clang is included because the clang
+# preset and the CI job build with it.
 if(AMREXPLORER_SERVER_STATIC_CXX_RUNTIME
         AND NOT AMREXPLORER_ENABLE_SANITIZERS
-        AND NOT AMREXPLORER_ENABLE_TSAN)
+        AND NOT AMREXPLORER_ENABLE_TSAN
+        AND CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
     include(CheckCXXSourceCompiles)
     # Re-probed on every configure. check_cxx_source_compiles caches its result,
     # so a tree first configured on a machine without libstdc++.a would keep the
@@ -76,6 +80,17 @@ if(AMREXPLORER_SERVER_STATIC_CXX_RUNTIME
             "get a freely copyable server, or set "
             "-DAMREXPLORER_SERVER_STATIC_CXX_RUNTIME=OFF to silence this.")
     endif()
+elseif(AMREXPLORER_SERVER_STATIC_CXX_RUNTIME
+        AND NOT AMREXPLORER_ENABLE_SANITIZERS
+        AND NOT AMREXPLORER_ENABLE_TSAN)
+    message(STATUS
+        "amrexplorer-server: linking the shared C++ runtime, because this "
+        "build uses ${CMAKE_CXX_COMPILER_ID} and only the GNU and Clang "
+        "families are known to honour -static-libstdc++ rather than accept and "
+        "ignore it. The server will need a matching libstdc++.so.6 wherever it "
+        "runs, which on an HPC system means the compiler module it was built "
+        "under. Build with GNU (module load gcc, or PrgEnv-gnu) for a freely "
+        "copyable server.")
 elseif(AMREXPLORER_SERVER_STATIC_CXX_RUNTIME)
     # Asked for, and vetoed above. Say so: the veto leaves the cache reading ON
     # and AMREXPLORER_STATIC_CXX_RUNTIME_LINKS possibly reading 1 from an earlier

--- a/tools/amrexplorer_server/CMakeLists.txt
+++ b/tools/amrexplorer_server/CMakeLists.txt
@@ -22,7 +22,15 @@ target_compile_definitions(amrexplorer_server
 # in by an otherwise complete C++ toolchain. Enabling this blind would turn a
 # working desktop build into a link failure, since the server is built by the
 # default preset too. Fall back to the shared runtime with a warning instead.
+# The sanitizer conditions are repeated here rather than left to the option's
+# default, because a default only applies to a build tree's first configure: a
+# directory configured before that default changed keeps ON in its cache and
+# would still get the flags. Guarding where they are applied makes the
+# behaviour right in every tree, including hand-configured ones that no preset
+# covers.
 if(AMREXPLORER_SERVER_STATIC_CXX_RUNTIME
+        AND NOT AMREXPLORER_ENABLE_SANITIZERS
+        AND NOT AMREXPLORER_ENABLE_TSAN
         AND CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
     include(CheckCXXSourceCompiles)
     # Re-probed on every configure. check_cxx_source_compiles caches its result,

--- a/tools/amrexplorer_server/CMakeLists.txt
+++ b/tools/amrexplorer_server/CMakeLists.txt
@@ -39,10 +39,23 @@ target_compile_definitions(amrexplorer_server
 # still promised the static link. So: restrict, and say so when the restriction
 # bites. GNU is what we recommend and test; Clang is included because the clang
 # preset and the CI job build with it.
+#
+# The probe needs try_compile to build an executable. Toolchain files set
+# CMAKE_TRY_COMPILE_TARGET_TYPE to STATIC_LIBRARY when cross-compiling, and CMake
+# then hands the link options to `ar`, which rejects them -- the probe fails on a
+# machine where the flags work perfectly well, and the warning tells the user to
+# install a package they already have.
+set(amrexplorer_static_runtime_probeable TRUE)
+if(DEFINED CMAKE_TRY_COMPILE_TARGET_TYPE
+        AND NOT CMAKE_TRY_COMPILE_TARGET_TYPE STREQUAL "EXECUTABLE")
+    set(amrexplorer_static_runtime_probeable FALSE)
+endif()
+
 if(AMREXPLORER_SERVER_STATIC_CXX_RUNTIME
         AND NOT AMREXPLORER_ENABLE_SANITIZERS
         AND NOT AMREXPLORER_ENABLE_TSAN
-        AND CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+        AND CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang"
+        AND amrexplorer_static_runtime_probeable)
     include(CheckCXXSourceCompiles)
     # Re-probed on every configure. check_cxx_source_compiles caches its result,
     # so a tree first configured on a machine without libstdc++.a would keep the
@@ -51,7 +64,11 @@ if(AMREXPLORER_SERVER_STATIC_CXX_RUNTIME
     # delete the build directory. A warning that names a package to install has
     # to be actionable without that.
     unset(AMREXPLORER_STATIC_CXX_RUNTIME_LINKS CACHE)
-    set(CMAKE_REQUIRED_LINK_OPTIONS -static-libstdc++ -static-libgcc)
+    # Appended and restored, not overwritten: a toolchain file may have put its
+    # own link options here, and dropping them would make the probe test
+    # something other than this build.
+    set(amrexplorer_saved_link_options "${CMAKE_REQUIRED_LINK_OPTIONS}")
+    list(APPEND CMAKE_REQUIRED_LINK_OPTIONS -static-libstdc++ -static-libgcc)
     check_cxx_source_compiles([=[
         #include <stdexcept>
         #include <string>
@@ -65,7 +82,8 @@ if(AMREXPLORER_SERVER_STATIC_CXX_RUNTIME
             }
         }
     ]=] AMREXPLORER_STATIC_CXX_RUNTIME_LINKS)
-    unset(CMAKE_REQUIRED_LINK_OPTIONS)
+    set(CMAKE_REQUIRED_LINK_OPTIONS "${amrexplorer_saved_link_options}")
+    unset(amrexplorer_saved_link_options)
 
     if(AMREXPLORER_STATIC_CXX_RUNTIME_LINKS)
         target_link_options(amrexplorer_server
@@ -80,6 +98,16 @@ if(AMREXPLORER_SERVER_STATIC_CXX_RUNTIME
             "get a freely copyable server, or set "
             "-DAMREXPLORER_SERVER_STATIC_CXX_RUNTIME=OFF to silence this.")
     endif()
+elseif(AMREXPLORER_SERVER_STATIC_CXX_RUNTIME
+        AND NOT AMREXPLORER_ENABLE_SANITIZERS
+        AND NOT AMREXPLORER_ENABLE_TSAN
+        AND NOT amrexplorer_static_runtime_probeable)
+    message(STATUS
+        "amrexplorer-server: linking the shared C++ runtime, because "
+        "CMAKE_TRY_COMPILE_TARGET_TYPE is ${CMAKE_TRY_COMPILE_TARGET_TYPE} and "
+        "the static-runtime link cannot be tested that way. Nothing is wrong "
+        "with the toolchain; set -DAMREXPLORER_SERVER_STATIC_CXX_RUNTIME=OFF to "
+        "silence this.")
 elseif(AMREXPLORER_SERVER_STATIC_CXX_RUNTIME
         AND NOT AMREXPLORER_ENABLE_SANITIZERS
         AND NOT AMREXPLORER_ENABLE_TSAN)
@@ -99,8 +127,10 @@ elseif(AMREXPLORER_SERVER_STATIC_CXX_RUNTIME)
     message(STATUS
         "amrexplorer-server: linking the shared C++ runtime despite "
         "AMREXPLORER_SERVER_STATIC_CXX_RUNTIME=ON, because a sanitizer is "
-        "enabled. Their runtimes load libstdc++.so.6 and libgcc_s.so.1 anyway, "
-        "so a static copy inside the executable would only add a second one.")
+        "enabled. Every sanitizer runtime pulls in libgcc_s.so.1, so "
+        "-static-libgcc achieves nothing, and libubsan pulls libstdc++.so.6 as "
+        "well -- a statically linked copy inside the executable would then be "
+        "the second one in the process.")
 endif()
 
 install(TARGETS amrexplorer_server RUNTIME DESTINATION bin)

--- a/tools/amrexplorer_server/CMakeLists.txt
+++ b/tools/amrexplorer_server/CMakeLists.txt
@@ -7,4 +7,20 @@ target_compile_features(amrexplorer_server PRIVATE cxx_std_20)
 target_compile_definitions(amrexplorer_server
     PRIVATE AMREXPLORER_VERSION="${PROJECT_VERSION}")
 
+# The server's whole portability story is that it needs nothing but the C++
+# runtime -- four shared libraries against the GUI's forty-three. Linking that
+# runtime statically removes the most fragile of them: HPC users build under a
+# `module load gcc`, and the resulting binary then fails for anyone who has not
+# loaded that same module, because the module's libstdc++.so.6 is not on the
+# default search path. Static here leaves only glibc, so "build once on the
+# login node, copy it where you like" actually holds.
+#
+# Off outside Linux, and overridable: a distro packager wants the system
+# runtime, and should configure with -DAMREXPLORER_SERVER_STATIC_CXX_RUNTIME=OFF.
+if(AMREXPLORER_SERVER_STATIC_CXX_RUNTIME
+        AND CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+    target_link_options(amrexplorer_server
+        PRIVATE -static-libstdc++ -static-libgcc)
+endif()
+
 install(TARGETS amrexplorer_server RUNTIME DESTINATION bin)

--- a/tools/amrexplorer_server/CMakeLists.txt
+++ b/tools/amrexplorer_server/CMakeLists.txt
@@ -98,6 +98,21 @@ if(AMREXPLORER_SERVER_STATIC_CXX_RUNTIME
             "get a freely copyable server, or set "
             "-DAMREXPLORER_SERVER_STATIC_CXX_RUNTIME=OFF to silence this.")
     endif()
+# Each condition names its own reason rather than relying on the order of the
+# branches: the toolchain test used to sit after the try-compile one, so a
+# compiler that failed both was told "nothing is wrong with the toolchain".
+elseif(AMREXPLORER_SERVER_STATIC_CXX_RUNTIME
+        AND NOT AMREXPLORER_ENABLE_SANITIZERS
+        AND NOT AMREXPLORER_ENABLE_TSAN
+        AND NOT CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+    message(STATUS
+        "amrexplorer-server: linking the shared C++ runtime, because this "
+        "build uses ${CMAKE_CXX_COMPILER_ID} and only the GNU and Clang "
+        "families are known to honour -static-libstdc++ rather than accept and "
+        "ignore it. The server will need a matching libstdc++.so.6 wherever it "
+        "runs, which on an HPC system means the compiler module it was built "
+        "under. Build with GNU (module load gcc, or PrgEnv-gnu) for a freely "
+        "copyable server.")
 elseif(AMREXPLORER_SERVER_STATIC_CXX_RUNTIME
         AND NOT AMREXPLORER_ENABLE_SANITIZERS
         AND NOT AMREXPLORER_ENABLE_TSAN
@@ -108,17 +123,6 @@ elseif(AMREXPLORER_SERVER_STATIC_CXX_RUNTIME
         "the static-runtime link cannot be tested that way. Nothing is wrong "
         "with the toolchain; set -DAMREXPLORER_SERVER_STATIC_CXX_RUNTIME=OFF to "
         "silence this.")
-elseif(AMREXPLORER_SERVER_STATIC_CXX_RUNTIME
-        AND NOT AMREXPLORER_ENABLE_SANITIZERS
-        AND NOT AMREXPLORER_ENABLE_TSAN)
-    message(STATUS
-        "amrexplorer-server: linking the shared C++ runtime, because this "
-        "build uses ${CMAKE_CXX_COMPILER_ID} and only the GNU and Clang "
-        "families are known to honour -static-libstdc++ rather than accept and "
-        "ignore it. The server will need a matching libstdc++.so.6 wherever it "
-        "runs, which on an HPC system means the compiler module it was built "
-        "under. Build with GNU (module load gcc, or PrgEnv-gnu) for a freely "
-        "copyable server.")
 elseif(AMREXPLORER_SERVER_STATIC_CXX_RUNTIME)
     # Asked for, and vetoed above. Say so: the veto leaves the cache reading ON
     # and AMREXPLORER_STATIC_CXX_RUNTIME_LINKS possibly reading 1 from an earlier

--- a/tools/amrexplorer_server/CMakeLists.txt
+++ b/tools/amrexplorer_server/CMakeLists.txt
@@ -17,10 +17,43 @@ target_compile_definitions(amrexplorer_server
 #
 # Off outside Linux, and overridable: a distro packager wants the system
 # runtime, and should configure with -DAMREXPLORER_SERVER_STATIC_CXX_RUNTIME=OFF.
+# Probed rather than assumed: the static libstdc++ is a separate package on
+# several distributions (Fedora's libstdc++-static, for one) and is not pulled
+# in by an otherwise complete C++ toolchain. Enabling this blind would turn a
+# working desktop build into a link failure, since the server is built by the
+# default preset too. Fall back to the shared runtime with a warning instead.
 if(AMREXPLORER_SERVER_STATIC_CXX_RUNTIME
         AND CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
-    target_link_options(amrexplorer_server
-        PRIVATE -static-libstdc++ -static-libgcc)
+    include(CheckCXXSourceCompiles)
+    set(CMAKE_REQUIRED_LINK_OPTIONS -static-libstdc++ -static-libgcc)
+    check_cxx_source_compiles([=[
+        #include <stdexcept>
+        #include <string>
+
+        int main()
+        {
+            try {
+                throw std::runtime_error(std::string("probe"));
+            } catch (const std::exception& error) {
+                return error.what() == nullptr ? 1 : 0;
+            }
+        }
+    ]=] AMREXPLORER_STATIC_CXX_RUNTIME_LINKS)
+    unset(CMAKE_REQUIRED_LINK_OPTIONS)
+
+    if(AMREXPLORER_STATIC_CXX_RUNTIME_LINKS)
+        target_link_options(amrexplorer_server
+            PRIVATE -static-libstdc++ -static-libgcc)
+    else()
+        message(WARNING
+            "A static libstdc++/libgcc is not available with this toolchain, so "
+            "amrexplorer-server will link the shared C++ runtime. The binary "
+            "then requires a matching libstdc++.so.6 wherever it runs, which "
+            "matters on HPC systems where it was built under a compiler module. "
+            "Install the static runtime (Fedora and RHEL: libstdc++-static) to "
+            "get a freely copyable server, or set "
+            "-DAMREXPLORER_SERVER_STATIC_CXX_RUNTIME=OFF to silence this.")
+    endif()
 endif()
 
 install(TARGETS amrexplorer_server RUNTIME DESTINATION bin)

--- a/tools/render_equivalence/CMakeLists.txt
+++ b/tools/render_equivalence/CMakeLists.txt
@@ -11,4 +11,12 @@ target_link_libraries(amrexplorer_render_equivalence
 )
 target_compile_features(amrexplorer_render_equivalence PRIVATE cxx_std_20)
 
-install(TARGETS amrexplorer_render_equivalence RUNTIME DESTINATION bin)
+# Not installed by default: this is a local/remote render comparison tool for
+# development, documented nowhere a user would look, and it was landing in
+# everyone's bin/ beside the two executables they asked for. Still installable
+# deliberately, for comparison work on a machine without a build tree:
+#     cmake --install build --component tools
+install(TARGETS amrexplorer_render_equivalence
+    RUNTIME DESTINATION bin
+    COMPONENT tools
+    EXCLUDE_FROM_ALL)


### PR DESCRIPTION
Five related changes to the install story, all aimed at the same audience: people who build from source and cannot write to /usr/local.

**Default the install prefix per platform.** CMake's default is /usr/local, which essentially nobody who builds this can write to, so `cmake --install build` failed and the reflex after that is sudo. Default instead to ~/.local on Linux and ~/Applications on macOS, guarded on
CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT so it only replaces the default nobody wanted -- packagers always pass a prefix or stage through DESTDIR and are untouched. ~/.local is not a matter of taste: ~/.local/share is $XDG_DATA_HOME, so the desktop entry and icons land where the desktop actually searches. Under $HOME directly they were inert, since nothing reads $HOME/share.

**Stop installing a development tool into everyone's bin.** amrexplorer-render-equivalence compares local and remote rendering, is documented nowhere a user would look, and was landing beside the two executables they asked for. It is now COMPONENT tools EXCLUDE_FROM_ALL, still installable on purpose with --component tools.

**Link the server's C++ runtime statically on Linux.** The server's portability story is that it needs nothing but the C runtime -- four shared libraries against the GUI's forty-three. HPC users build under `module load gcc`, and the result then fails for anyone without that module loaded, the module's libstdc++.so.6 not being on the default search path. Static leaves libm and libc only, and no GLIBCXX/CXXABI symbol requirements at all, so "build once, copy it where you like" holds. Overridable with
-DAMREXPLORER_SERVER_STATIC_CXX_RUNTIME=OFF for distribution packagers.

**Tell HPC users how to get a working compiler.** Login nodes run an old OS and an old /usr/bin/c++, so the C++20 check fails -- but a usable compiler is one module away. The failure now names the compiler it found and then says what to do about it, including the Cray wrapper (-DCMAKE_CXX_COMPILER=CC) and the fact that CMAKE_CXX_COMPILER is only read when a directory is first configured.

**Rework INSTALL.md** around what people actually do: the two executables and what each needs at run time, install with no prefix argument, and a section for HPC covering the compiler modules, the copyable server binary and its remaining glibc floor, and shared-$HOME collisions between clusters. Records Ubuntu 26.04 alongside 24.04 as tested, and adds it to the compiler matrix marked as developer machines rather than CI, which still runs 24.04.

Verified: a fresh configure defaults to ~/.local; the default install produces two executables plus the desktop entry and icons on Linux and one executable for the remote preset; --component tools produces only the comparison tool; the server links libm and libc alone; and the C++20 message renders as documented. All four presets stay green, sanitizers and TSan included.