### PR TITLE
retire a connection under the lock that rejects the response

### DIFF
--- a/src/remote/Connection.cpp
+++ b/src/remote/Connection.cpp
@@ -1,6 +1,9 @@
 #include <amrexplorer/remote/Connection.hpp>
 
 #include "Codec.hpp"
+#ifdef AMREXPLORER_SERVER_TEST_HOOKS
+#include "ServerTestHooks.hpp"
+#endif
 
 #include <algorithm>
 #include <atomic>
@@ -431,8 +434,7 @@ private:
                         "remote server changed protocol major version");
                 }
                 std::shared_ptr<Pending> pending;
-                bool minorVersionMismatch = false;
-                bool payloadMismatch = false;
+                const char* protocolViolation = nullptr;
                 {
                     std::scoped_lock lock(m_stateMutex);
                     const auto found = m_pending.find(info.requestId);
@@ -441,30 +443,50 @@ private:
                             "remote response has an unknown request ID");
                     }
                     pending = found->second;
-                    minorVersionMismatch
-                        = pending->expected != PayloadKind::HelloResponse
+                    if (pending->expected != PayloadKind::HelloResponse
                         && info.protocolMinorVersion
-                            != m_selectedMinorVersion;
-                    payloadMismatch = info.payload != pending->expected
-                        && info.payload != PayloadKind::ErrorResponse;
+                            != m_selectedMinorVersion) {
+                        protocolViolation
+                            = "remote server changed protocol minor version";
+                    } else if (info.payload != pending->expected
+                        && info.payload != PayloadKind::ErrorResponse) {
+                        protocolViolation
+                            = "remote response has an unexpected payload type";
+                    }
                     m_pending.erase(found);
                     if (pending->countsAgainstBudget) {
                         --m_outstandingRequests;
                     }
+                    if (protocolViolation != nullptr) {
+                        // Retire under the same lock that recognizes the
+                        // violation, so detection and retirement are atomic.
+                        // Setting m_connected below -- even immediately before
+                        // waking the caller -- would leave a window in which an
+                        // independent thread sharing this connection observes
+                        // connected() == true and reuses one that has already
+                        // seen a semantically impossible response.
+                        m_connected = false;
+                        // The catch handler fills the reason only when it is
+                        // empty, so this early write wins and has to carry the
+                        // real one.
+                        if (m_disconnectReason.empty()) {
+                            m_disconnectReason = protocolViolation;
+                        }
+                    }
                 }
-                if (minorVersionMismatch) {
-                    pending->promise.set_exception(std::make_exception_ptr(
-                        std::runtime_error(
-                            "remote server changed protocol minor version")));
-                    throw std::runtime_error(
-                        "remote server changed protocol minor version");
-                }
-                if (payloadMismatch) {
-                    pending->promise.set_exception(std::make_exception_ptr(
-                        std::runtime_error(
-                            "remote response has an unexpected payload type")));
-                    throw std::runtime_error(
-                        "remote response has an unexpected payload type");
+                if (protocolViolation != nullptr) {
+                    pending->promise.set_exception(
+                        std::make_exception_ptr(
+                            std::runtime_error(protocolViolation)));
+#ifdef AMREXPLORER_SERVER_TEST_HOOKS
+                    // The caller is awake and this thread has not unwound: the
+                    // window the retirement above closes. A test stalls here to
+                    // observe it.
+                    testing::notifyAfterViolationWake();
+#endif
+                    // Still throw: the handler below also fails the other
+                    // outstanding requests and stops the lifecycle.
+                    throw std::runtime_error(protocolViolation);
                 }
                 pending->promise.set_value(std::move(envelope));
             }

--- a/src/remote/ServerTestHooks.cpp
+++ b/src/remote/ServerTestHooks.cpp
@@ -10,6 +10,7 @@ namespace {
 std::mutex hookMutex;
 BeforeResponseWrite beforeResponseWrite;
 WriteChunkLimit writeChunkLimitHook;
+AfterViolationWake afterViolationWake;
 thread_local bool inResponseWrite = false;
 
 } // namespace
@@ -34,6 +35,32 @@ void notifyBeforeResponseWrite(std::uint64_t requestId)
     }
     if (hook) {
         hook(requestId);
+    }
+}
+
+void setAfterViolationWake(AfterViolationWake hook)
+{
+    std::scoped_lock lock(hookMutex);
+    afterViolationWake = std::move(hook);
+}
+
+void clearAfterViolationWake()
+{
+    setAfterViolationWake({});
+}
+
+void notifyAfterViolationWake()
+{
+    AfterViolationWake hook;
+    {
+        std::scoped_lock lock(hookMutex);
+        hook = afterViolationWake;
+    }
+    // Copied out and invoked unlocked, like the hooks around it: this one is
+    // meant to block, and holding the installer's mutex while it did would
+    // deadlock whoever tries to clear it.
+    if (hook) {
+        hook();
     }
 }
 

--- a/src/remote/ServerTestHooks.hpp
+++ b/src/remote/ServerTestHooks.hpp
@@ -6,7 +6,10 @@
 
 namespace amrvis::remote::testing {
 
-// Internal synchronization seam, compiled only into test-enabled builds.
+// Internal synchronization seams for the remote client and server, compiled
+// only into test-enabled builds. The option that controls them is still named
+// AMREXPLORER_ENABLE_SERVER_TEST_HOOKS for the benefit of existing CI
+// invocations; it covers both sides of the protocol.
 using BeforeResponseWrite = std::function<void(std::uint64_t)>;
 
 void setBeforeResponseWrite(BeforeResponseWrite hook);
@@ -31,6 +34,24 @@ void clearWriteChunkLimit();
 // drives its own client sockets from its own threads in this same process, and
 // pacing those would throttle the test rather than the server.
 [[nodiscard]] std::size_t writeChunkLimit(std::size_t requested);
+
+// Client-side seam, consulted by Connection's receive loop immediately after a
+// protocol violation has woken the caller waiting on that request, and before
+// the reader thread unwinds. That is the one instant at which the two halves
+// of retirement can be observed apart: an implementation that marks the
+// connection disconnected while unwinding, rather than under the lock that
+// recognized the violation, still reports connected() == true here. A hook that
+// blocks holds the instant open for as long as the test needs, which is what
+// turns a load-dependent race into a deterministic assertion.
+//
+// Invoked on the reader thread with no connection lock held, so a hook may call
+// back into the connection. It must return before the connection is destroyed:
+// the destructor joins the reader.
+using AfterViolationWake = std::function<void()>;
+
+void setAfterViolationWake(AfterViolationWake hook);
+void clearAfterViolationWake();
+void notifyAfterViolationWake();
 
 class ResponseWriteScope {
 public:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -197,6 +197,10 @@ if(TARGET amrexplorer_remote)
             amrexplorer::warnings
             Threads::Threads
     )
+    if(AMREXPLORER_ENABLE_SERVER_TEST_HOOKS)
+        target_compile_definitions(test_remote_connection
+            PRIVATE AMREXPLORER_SERVER_TEST_HOOKS)
+    endif()
     add_test(NAME remote_connection
         COMMAND test_remote_connection "${remote_server_fixture_dir}")
     set_tests_properties(remote_connection PROPERTIES

--- a/tests/integration/test_remote_connection.cpp
+++ b/tests/integration/test_remote_connection.cpp
@@ -1,4 +1,7 @@
 #include "../../src/remote/Codec.hpp"
+#ifdef AMREXPLORER_SERVER_TEST_HOOKS
+#include "../../src/remote/ServerTestHooks.hpp"
+#endif
 
 #include <amrexplorer/cache/ByteLruCache.hpp>
 #include <amrexplorer/data/ViewData.hpp>
@@ -337,6 +340,65 @@ int main(int argc, char* argv[])
     require(!wrongPayloadConnection.connected(),
         "wrong response payload did not fail the connection");
     wrongPayloadPeer.get();
+
+#ifdef AMREXPLORER_SERVER_TEST_HOOKS
+    // The same guarantee as the case above, made deterministic. That one only
+    // fails when the reader happens to be descheduled between waking the caller
+    // and unwinding; this one stalls the reader at exactly that point, so a
+    // client that retires while unwinding rather than under the lock that
+    // recognized the violation fails it on every run.
+    //
+    // Reachability is not hypothetical: openRemoteSequence shares one
+    // connection between overlapping foreground and prefetch loads and gates
+    // reuse on connected(), so a second loader inside this window would write
+    // to a connection that has already seen an impossible response.
+    {
+        auto retirementListener = listenOnLoopback(0);
+        auto retirementPeer = std::async(std::launch::async, [&] {
+            auto peer = acceptConnection(retirementListener.socket);
+            static_cast<void>(acceptHello(peer));
+            const auto frame = readFrame(peer, defaultMaximumFrameBytes);
+            require(frame.has_value(), "client omitted ping request");
+            const auto requestEnvelope = codec::decode(*frame);
+            const auto requestInfo = codec::inspect(*requestEnvelope);
+            codec::fb::DatasetClosedT wrong;
+            wrong.dataset_id = 1;
+            writeFrame(peer,
+                codec::encode(requestInfo.requestId, std::move(wrong)),
+                defaultMaximumFrameBytes);
+        });
+
+        std::promise<void> insideWindowPromise;
+        auto insideWindow = insideWindowPromise.get_future();
+        std::promise<void> releaseReaderPromise;
+        auto releaseReader = releaseReaderPromise.get_future();
+        testing::setAfterViolationWake([&] {
+            insideWindowPromise.set_value();
+            releaseReader.wait();
+        });
+
+        // Generous, because the reader is deliberately held: a timeout here
+        // would retire the connection through close() and mask the defect.
+        ConnectionOptions heldReader;
+        heldReader.requestTimeout = 30s;
+        Connection retirementConnection(
+            "127.0.0.1", retirementListener.port, heldReader);
+        auto retirementCall = std::async(std::launch::async,
+            [&] { retirementConnection.ping(); });
+
+        require(insideWindow.wait_for(5s) == std::future_status::ready,
+            "reader never reached the protocol-violation window");
+        require(!retirementConnection.connected(),
+            "connection was still reusable inside the retirement window");
+        releaseReaderPromise.set_value();
+        require(throwsWithin(retirementCall, 5s),
+            "held wrong payload left its caller waiting");
+        // Join the reader out of the hook before the captured futures die.
+        retirementConnection.close();
+        testing::clearAfterViolationWake();
+        retirementPeer.get();
+    }
+#endif
 
     auto delayedRangeListener = listenOnLoopback(0);
     auto delayedRangePeer = std::async(std::launch::async, [&] {

--- a/tests/integration/test_remote_connection.cpp
+++ b/tests/integration/test_remote_connection.cpp
@@ -245,6 +245,11 @@ int main(int argc, char* argv[])
         "non-negotiated response minor version was accepted");
     require(!wrongMinorVersionConnection.connected(),
         "non-negotiated response minor version did not fail the connection");
+    // Join this reader before moving on: the assertion above only proves the
+    // caller was woken, so the reader can still be short of unwinding, at the
+    // point where the hook-enabled case below would let it consume the
+    // process-global violation hook installed for that case's connection.
+    wrongMinorVersionConnection.close();
     wrongMinorVersionPeer.get();
 
     StopSource preCancelled;
@@ -339,6 +344,8 @@ int main(int argc, char* argv[])
         "wrong response payload left its caller waiting");
     require(!wrongPayloadConnection.connected(),
         "wrong response payload did not fail the connection");
+    // Join this reader too, for the reason above.
+    wrongPayloadConnection.close();
     wrongPayloadPeer.get();
 
 #ifdef AMREXPLORER_SERVER_TEST_HOOKS


### PR DESCRIPTION
Connection's receive loop recognizes a payload or minor-version mismatch inside a scoped block holding m_stateMutex, but woke the waiting caller from outside it and marked the connection disconnected only in the handler that catches the resulting throw. So the caller's future became ready before m_connected became false. connected() reads that flag under the same mutex, which the reader thread has not yet re-acquired -- it is still unwinding -- and under load the reader can be descheduled in between. The caller observes its exception, asks connected(), and is told true.

Inside that window ensureConnected() passes, so a caller can write to a connection that has already seen a semantically impossible response. That is the trust-boundary guarantee the wire validation exists to provide, and it held only after a delay no caller could observe.

Ordinary session calls are contained: refusingInvalidResponses catches the plain runtime_error a mismatch produces and closes the connection before rethrowing, so a caller on that thread cannot see the window. The remote sequence path is not. openRemoteSequence puts one shared_ptr in a SharedRemoteConnection deliberately shared between overlapping foreground and prefetch loads, and gates reuse on connected() alone, so a second loader can reuse a condemned connection. It also already flaked CI: the wrong-payload retirement check in remote_connection failed twice under load, on unrelated machines, while the assertion above it -- that the caller stopped waiting -- passed both times.

Set m_connected and the disconnect reason where the violation is recognized, under the lock already held there, so detection and retirement are atomic. Moving the write to just before the caller is woken would fix the ordering this started from but leave a window between the lock release and the retirement, during which an independent thread could still observe connected() == true -- which is exactly the prefetch path above. Same-lock is strictly better and costs nothing. The two mismatch branches collapse onto one string, so the reason is written once instead of three times.

Two details the shape depends on. The throw still propagates: the catch handler also fails the other outstanding requests and stops the lifecycle, so retiring early and returning would strand them. And the early write carries the real reason, because the handler fills m_disconnectReason only when empty and the early write wins.

Cover it with a client-side test hook. The window is two statements of a private receive loop, so the existing case can only catch this when the reader happens to be descheduled at the right instant -- it passed 13 consecutive runs before this branch. AfterViolationWake joins BeforeResponseWrite and WriteChunkLimit in ServerTestHooks, compiled in only under AMREXPLORER_ENABLE_SERVER_TEST_HOOKS, which already builds into amrexplorer_remote rather than just the server executable and is already passed by the three CI jobs that run remote_connection. The new case installs a hook that blocks at exactly that point and asserts connected() == false while the reader is held. Mutation-verified: disabling the in-lock retirement fails it every run, and the pre-existing assertion still passes under the same mutation, which is the point.

The option, its macro, and the file name still say "server" while the seam now covers both sides. Renaming would touch three CI lines, five preset entries, two file names and every guard, so it is left for its own change; the header says what the option actually covers.

Verified: remote 47/47 with the hooks both on and off, so the guarded paths compile either way; tsan 47/47 with the hooks on, no race and no suppression; remote_connection green over repeated runs in both presets. Note that the remote and tsan presets set the option OFF while CI turns it ON, so a local run without -DAMREXPLORER_ENABLE_SERVER_TEST_HOOKS=ON skips every hook-gated case.