### PR TITLE
make the particles dialog modeless with an Apply button

### DIFF
--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -1263,6 +1263,7 @@ void MainWindow::createMenus()
         [this](bool visible) { m_isoWidget->setSlicePlanesVisible(visible); });
 
     m_contoursAction = new QAction(tr("&Contours..."), this);
+    m_contoursAction->setObjectName(QStringLiteral("contoursAction"));
     m_contoursAction->setEnabled(false);
     connect(m_contoursAction, &QAction::triggered,
         this, [this] { showContoursDialog(); });

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -1268,6 +1268,7 @@ void MainWindow::createMenus()
         this, [this] { showContoursDialog(); });
 
     m_particlesAction = new QAction(tr("Par&ticles..."), this);
+    m_particlesAction->setObjectName(QStringLiteral("particlesAction"));
     m_particlesAction->setEnabled(false);
     connect(m_particlesAction, &QAction::triggered,
         this, [this] { showParticlesDialog(); });

--- a/src/qt/MainWindow.hpp
+++ b/src/qt/MainWindow.hpp
@@ -779,6 +779,7 @@ private:
     DatasetWindow* m_datasetWindow = nullptr;
     SetContoursDialog* m_contoursDialog = nullptr;
     QDialog* m_numberFormatDialog = nullptr;
+    QDialog* m_particlesDialog = nullptr;
     UserGuideDialog* m_userGuideDialog = nullptr;
     QComboBox* m_fieldSelector = nullptr;
     QComboBox* m_levelSelector = nullptr;

--- a/src/qt/MainWindowDataset.cpp
+++ b/src/qt/MainWindowDataset.cpp
@@ -1162,6 +1162,13 @@ void MainWindow::openDatasetImpl(const std::filesystem::path& path,
         m_contoursDialog = nullptr;
         dialog->close();
     }
+    // The particles dialog lists this dataset's species; the next one has its
+    // own. (A sequence frame switch keeps it open -- the species are the same.)
+    if (m_particlesDialog != nullptr) {
+        auto* dialog = m_particlesDialog;
+        m_particlesDialog = nullptr;
+        dialog->close();
+    }
     // The Number Format dialog is deliberately *not* closed here. Unlike the
     // contours dialog above, its setting is dataset-independent and persisted,
     // so closing it on every open only discarded whatever the user had typed

--- a/src/qt/MainWindowInteraction.cpp
+++ b/src/qt/MainWindowInteraction.cpp
@@ -303,17 +303,28 @@ void MainWindow::updateOverlays()
 
 void MainWindow::showParticlesDialog()
 {
+    if (m_particlesDialog != nullptr) {
+        m_particlesDialog->raise();
+        m_particlesDialog->activateWindow();
+        return;
+    }
     if (!m_dataset || m_dataset->particleSpecies().empty()) {
         return;
     }
-    QDialog dialog(this);
-    dialog.setWindowTitle(tr("Particles"));
-    auto* layout = new QVBoxLayout(&dialog);
+    // Modeless, like the contours dialog: settings are worth trying against the
+    // image, and a modal dialog made every attempt a reopen -- and dimmed the
+    // main window while it was up on Linux.
+    auto* dialog = new QDialog(this);
+    dialog->setObjectName(QStringLiteral("particlesDialog"));
+    dialog->setAttribute(Qt::WA_DeleteOnClose);
+    dialog->setWindowTitle(tr("Particles"));
+    dialog->setWindowFlags(Qt::Window);
+    auto* layout = new QVBoxLayout(dialog);
     layout->addWidget(new QLabel(
         tr("Select particle species to draw. Sampling hashes the persistent "
            "particle ID/CPU identity, so the same particles remain selected "
            "across plotfile frames."),
-        &dialog));
+        dialog));
 
     struct SpeciesControls {
         std::string name;
@@ -322,17 +333,19 @@ void MainWindow::showParticlesDialog()
         QSpinBox* alpha = nullptr;
         QColor color;
     };
-    std::vector<SpeciesControls> speciesControls;
-    speciesControls.reserve(m_dataset->particleSpecies().size());
+    // The dialog outlives this call now, so the per-species state has to as
+    // well; the button handlers keep it alive by shared ownership.
+    auto speciesControls = std::make_shared<std::vector<SpeciesControls>>();
+    speciesControls->reserve(m_dataset->particleSpecies().size());
     auto* speciesGrid = new QGridLayout;
-    speciesGrid->addWidget(new QLabel(tr("Show"), &dialog), 0, 0);
-    speciesGrid->addWidget(new QLabel(tr("Species"), &dialog), 0, 1);
-    speciesGrid->addWidget(new QLabel(tr("Color"), &dialog), 0, 2);
-    speciesGrid->addWidget(new QLabel(tr("Alpha"), &dialog), 0, 3);
+    speciesGrid->addWidget(new QLabel(tr("Show"), dialog), 0, 0);
+    speciesGrid->addWidget(new QLabel(tr("Species"), dialog), 0, 1);
+    speciesGrid->addWidget(new QLabel(tr("Color"), dialog), 0, 2);
+    speciesGrid->addWidget(new QLabel(tr("Alpha"), dialog), 0, 3);
     for (std::size_t speciesIndex = 0;
          speciesIndex < m_dataset->particleSpecies().size(); ++speciesIndex) {
         const auto& species = m_dataset->particleSpecies()[speciesIndex];
-        auto* check = new QCheckBox(&dialog);
+        auto* check = new QCheckBox(dialog);
         check->setChecked(!m_particleSelectionInitialized
             || std::find(m_selectedParticleSpecies.begin(),
                 m_selectedParticleSpecies.end(), species.name)
@@ -341,13 +354,13 @@ void MainWindow::showParticlesDialog()
             tr("%1 (%2 particles)")
                 .arg(QString::fromStdString(species.name))
                 .arg(species.particleCount),
-            &dialog);
+            dialog);
         auto color = m_particleColors.contains(species.name)
             ? m_particleColors.at(species.name)
             : defaultParticleColor(speciesIndex);
-        auto* colorButton = new QPushButton(&dialog);
+        auto* colorButton = new QPushButton(dialog);
         updateColorButton(*colorButton, color);
-        auto* alpha = new QSpinBox(&dialog);
+        auto* alpha = new QSpinBox(dialog);
         alpha->setRange(0, 100);
         alpha->setSuffix(tr("%"));
         alpha->setValue(qRound(color.alphaF() * 100.0));
@@ -356,29 +369,28 @@ void MainWindow::showParticlesDialog()
         speciesGrid->addWidget(name, row, 1);
         speciesGrid->addWidget(colorButton, row, 2);
         speciesGrid->addWidget(alpha, row, 3);
-        speciesControls.push_back(
+        speciesControls->push_back(
             {species.name, check, colorButton, alpha, color});
     }
-    for (auto& controls : speciesControls) {
-        auto* controlsPtr = &controls;
-        connect(controls.colorButton, &QPushButton::clicked, &dialog,
-            [&dialog, controlsPtr] {
-                auto chosen = QColorDialog::getColor(controlsPtr->color, &dialog,
+    for (std::size_t index = 0; index < speciesControls->size(); ++index) {
+        connect((*speciesControls)[index].colorButton, &QPushButton::clicked,
+            dialog, [dialog, speciesControls, index] {
+                auto& controls = (*speciesControls)[index];
+                auto chosen = QColorDialog::getColor(controls.color, dialog,
                     QObject::tr("Particle color"));
                 if (!chosen.isValid()) {
                     return;
                 }
-                chosen.setAlpha(controlsPtr->color.alpha());
-                controlsPtr->color = chosen;
-                updateColorButton(
-                    *controlsPtr->colorButton, controlsPtr->color);
+                chosen.setAlpha(controls.color.alpha());
+                controls.color = chosen;
+                updateColorButton(*controls.colorButton, controls.color);
             });
     }
     layout->addLayout(speciesGrid);
 
     auto* fractionRow = new QHBoxLayout;
-    fractionRow->addWidget(new QLabel(tr("Visible subset:"), &dialog));
-    auto* fraction = new QDoubleSpinBox(&dialog);
+    fractionRow->addWidget(new QLabel(tr("Visible subset:"), dialog));
+    auto* fraction = new QDoubleSpinBox(dialog);
     fraction->setRange(0.01, 100.0);
     fraction->setDecimals(2);
     fraction->setSuffix(tr("%"));
@@ -388,8 +400,8 @@ void MainWindow::showParticlesDialog()
     layout->addLayout(fractionRow);
 
     auto* seedRow = new QHBoxLayout;
-    seedRow->addWidget(new QLabel(tr("Sampling seed:"), &dialog));
-    auto* seed = new QLineEdit(QString::number(m_particleSeed), &dialog);
+    seedRow->addWidget(new QLabel(tr("Sampling seed:"), dialog));
+    auto* seed = new QLineEdit(QString::number(m_particleSeed), dialog);
     seed->setValidator(new QRegularExpressionValidator(
         QRegularExpression(QStringLiteral("[0-9]{1,20}")), seed));
     seed->setToolTip(tr(
@@ -399,8 +411,8 @@ void MainWindow::showParticlesDialog()
     layout->addLayout(seedRow);
 
     auto* sizeRow = new QHBoxLayout;
-    sizeRow->addWidget(new QLabel(tr("Point size:"), &dialog));
-    auto* pointSize = new QSpinBox(&dialog);
+    sizeRow->addWidget(new QLabel(tr("Point size:"), dialog));
+    auto* pointSize = new QSpinBox(dialog);
     pointSize->setRange(1, 12);
     pointSize->setValue(m_particlePointSize);
     sizeRow->addWidget(pointSize);
@@ -410,40 +422,50 @@ void MainWindow::showParticlesDialog()
     if (m_dataset->metadata().dimension == 3) {
         layout->addWidget(new QLabel(
             tr("In 3-D, points are projected onto each orthogonal view."),
-            &dialog));
+            dialog));
     }
-    auto* buttons = new QDialogButtonBox(
-        QDialogButtonBox::Ok | QDialogButtonBox::Cancel, &dialog);
-    connect(buttons, &QDialogButtonBox::accepted, &dialog, [&dialog, seed] {
-        bool valid = false;
-        static_cast<void>(seed->text().toULongLong(&valid));
-        if (valid) {
-            dialog.accept();
-        } else {
-            QMessageBox::warning(&dialog, QObject::tr("Invalid seed"),
-                QObject::tr(
-                    "The sampling seed must be an integer from 0 through "
-                    "18446744073709551615."));
-        }
-    });
-    connect(buttons, &QDialogButtonBox::rejected, &dialog, &QDialog::reject);
+    auto* buttons = new QDialogButtonBox(QDialogButtonBox::Ok
+        | QDialogButtonBox::Apply | QDialogButtonBox::Cancel, dialog);
+    buttons->setObjectName(QStringLiteral("particlesDialogButtons"));
+    connect(buttons, &QDialogButtonBox::clicked, dialog,
+        [this, dialog, buttons, speciesControls, fraction, seed, pointSize](
+            QAbstractButton* button) {
+            const auto role = buttons->buttonRole(button);
+            if (role != QDialogButtonBox::AcceptRole
+                && role != QDialogButtonBox::ApplyRole) {
+                dialog->reject();
+                return;
+            }
+            bool valid = false;
+            const auto seedValue = seed->text().toULongLong(&valid);
+            if (!valid) {
+                QMessageBox::warning(dialog, QObject::tr("Invalid seed"),
+                    QObject::tr(
+                        "The sampling seed must be an integer from 0 through "
+                        "18446744073709551615."));
+                return;
+            }
+            std::vector<std::string> selectedSpecies;
+            for (auto& controls : *speciesControls) {
+                if (controls.enabled->isChecked()) {
+                    selectedSpecies.push_back(controls.name);
+                }
+                controls.color.setAlphaF(
+                    static_cast<float>(controls.alpha->value()) / 100.0F);
+                m_particleColors[controls.name] = controls.color;
+            }
+            applyParticleSelection(std::move(selectedSpecies),
+                fraction->value() / 100.0, pointSize->value(), seedValue);
+            if (role == QDialogButtonBox::AcceptRole) {
+                dialog->accept();
+            }
+        });
     layout->addWidget(buttons);
-    if (dialog.exec() != QDialog::Accepted) {
-        return;
-    }
-
-    std::vector<std::string> selectedSpecies;
-    for (auto& controls : speciesControls) {
-        if (controls.enabled->isChecked()) {
-            selectedSpecies.push_back(controls.name);
-        }
-        controls.color.setAlphaF(
-            static_cast<float>(controls.alpha->value()) / 100.0F);
-        m_particleColors[controls.name] = controls.color;
-    }
-    const auto seedValue = seed->text().toULongLong();
-    applyParticleSelection(std::move(selectedSpecies),
-        fraction->value() / 100.0, pointSize->value(), seedValue);
+    connect(dialog, &QDialog::finished, this, [this] {
+        m_particlesDialog = nullptr;
+    });
+    m_particlesDialog = dialog;
+    dialog->show();
 }
 
 void MainWindow::configureParticleControls(bool preserveSelection)
@@ -1846,6 +1868,11 @@ void MainWindow::closeEvent(QCloseEvent* event)
     if (m_contoursDialog != nullptr) {
         auto* dialog = m_contoursDialog;
         m_contoursDialog = nullptr;
+        dialog->close();
+    }
+    if (m_particlesDialog != nullptr) {
+        auto* dialog = m_particlesDialog;
+        m_particlesDialog = nullptr;
         dialog->close();
     }
     if (m_numberFormatDialog != nullptr) {

--- a/src/qt/MainWindowInteraction.cpp
+++ b/src/qt/MainWindowInteraction.cpp
@@ -431,9 +431,14 @@ void MainWindow::showParticlesDialog()
         [this, dialog, buttons, speciesControls, fraction, seed, pointSize](
             QAbstractButton* button) {
             const auto role = buttons->buttonRole(button);
+            if (role == QDialogButtonBox::RejectRole) {
+                dialog->reject();
+                return;
+            }
+            // Only Ok and Apply act; anything added later (a Reset, a Help)
+            // must not be treated as a Cancel and dismiss the dialog.
             if (role != QDialogButtonBox::AcceptRole
                 && role != QDialogButtonBox::ApplyRole) {
-                dialog->reject();
                 return;
             }
             bool valid = false;

--- a/src/qt/MainWindowInteraction.cpp
+++ b/src/qt/MainWindowInteraction.cpp
@@ -355,15 +355,21 @@ void MainWindow::showParticlesDialog()
                 .arg(QString::fromStdString(species.name))
                 .arg(species.particleCount),
             dialog);
-        auto color = m_particleColors.contains(species.name)
+        const auto stored = m_particleColors.contains(species.name)
             ? m_particleColors.at(species.name)
             : defaultParticleColor(speciesIndex);
+        // The spin box owns opacity and the swatch shows the hue alone. Held
+        // together, an Apply that folded the alpha into the swatch would leave
+        // it disagreeing with the spin box beside it until the next color pick,
+        // which would then bake that alpha into the newly picked color.
+        auto color = stored;
+        color.setAlpha(255);
         auto* colorButton = new QPushButton(dialog);
         updateColorButton(*colorButton, color);
         auto* alpha = new QSpinBox(dialog);
         alpha->setRange(0, 100);
         alpha->setSuffix(tr("%"));
-        alpha->setValue(qRound(color.alphaF() * 100.0));
+        alpha->setValue(qRound(stored.alphaF() * 100.0));
         const auto row = static_cast<int>(speciesIndex + 1);
         speciesGrid->addWidget(check, row, 0, Qt::AlignHCenter);
         speciesGrid->addWidget(name, row, 1);
@@ -381,7 +387,6 @@ void MainWindow::showParticlesDialog()
                 if (!chosen.isValid()) {
                     return;
                 }
-                chosen.setAlpha(controls.color.alpha());
                 controls.color = chosen;
                 updateColorButton(*controls.colorButton, controls.color);
             });
@@ -451,13 +456,14 @@ void MainWindow::showParticlesDialog()
                 return;
             }
             std::vector<std::string> selectedSpecies;
-            for (auto& controls : *speciesControls) {
+            for (const auto& controls : *speciesControls) {
                 if (controls.enabled->isChecked()) {
                     selectedSpecies.push_back(controls.name);
                 }
-                controls.color.setAlphaF(
+                auto applied = controls.color;
+                applied.setAlphaF(
                     static_cast<float>(controls.alpha->value()) / 100.0F);
-                m_particleColors[controls.name] = controls.color;
+                m_particleColors[controls.name] = applied;
             }
             applyParticleSelection(std::move(selectedSpecies),
                 fraction->value() / 100.0, pointSize->value(), seedValue);

--- a/src/qt/MainWindowSlice.cpp
+++ b/src/qt/MainWindowSlice.cpp
@@ -1196,6 +1196,15 @@ void MainWindow::prepareSequence(std::size_t frameCount)
     if (linePlotWindow != nullptr) {
         linePlotWindow->close();
     }
+    // The particles dialog lists the outgoing dataset's species, and the state
+    // it edits was just reset above. openDatasetImpl closes it for a plain
+    // open; this path never runs that, so a sequence open would otherwise leave
+    // it on screen writing the old species names back on Apply.
+    auto* particlesDialog = m_particlesDialog;
+    m_particlesDialog = nullptr;
+    if (particlesDialog != nullptr) {
+        particlesDialog->close();
+    }
 }
 
 void MainWindow::openRemoteSequence(std::string host, std::uint16_t port,

--- a/src/qt/MainWindowSlice.cpp
+++ b/src/qt/MainWindowSlice.cpp
@@ -1196,14 +1196,21 @@ void MainWindow::prepareSequence(std::size_t frameCount)
     if (linePlotWindow != nullptr) {
         linePlotWindow->close();
     }
-    // The particles dialog lists the outgoing dataset's species, and the state
-    // it edits was just reset above. openDatasetImpl closes it for a plain
+    // Both overlay dialogs describe the outgoing dataset -- the particles one
+    // lists its species, whose selection state was just reset above, and the
+    // contours one lists its fields. openDatasetImpl closes them for a plain
     // open; this path never runs that, so a sequence open would otherwise leave
-    // it on screen writing the old species names back on Apply.
+    // them on screen writing the old dataset's names back on Apply. Frame steps
+    // do not come through here, so both survive stepping, as intended.
     auto* particlesDialog = m_particlesDialog;
     m_particlesDialog = nullptr;
     if (particlesDialog != nullptr) {
         particlesDialog->close();
+    }
+    auto* contoursDialog = m_contoursDialog;
+    m_contoursDialog = nullptr;
+    if (contoursDialog != nullptr) {
+        contoursDialog->close();
     }
 }
 

--- a/src/qt/SetContoursDialog.cpp
+++ b/src/qt/SetContoursDialog.cpp
@@ -77,6 +77,7 @@ SetContoursDialog::SetContoursDialog(const std::vector<std::string>& fieldNames,
     bool is3D, QWidget* parent)
     : QDialog(parent)
 {
+    setObjectName(QStringLiteral("setContoursDialog"));
     setWindowTitle(tr("Set Contours"));
     setWindowFlags(Qt::Window);
 

--- a/src/qt/main.cpp
+++ b/src/qt/main.cpp
@@ -1734,19 +1734,23 @@ int main(int argc, char* argv[])
         // main window, must survive Apply, and must not stack up copies of
         // itself when the menu item is chosen again. It also belongs to the
         // dataset whose species it lists, so opening a sequence -- which never
-        // runs openDatasetImpl -- must take it down.
+        // runs openDatasetImpl -- must take it down, as it must the contours
+        // dialog beside it.
         const std::filesystem::path first(argv[2]);
         const std::filesystem::path second(argv[3]);
-        // The dialog closes with WA_DeleteOnClose, so a just-closed one can
-        // still be a child of the window; the live dialog is the visible one.
-        const auto liveDialog = [&window]() -> QDialog* {
-            for (auto* candidate :
-                window.findChildren<QDialog*>(QStringLiteral("particlesDialog"))) {
+        // Both close with WA_DeleteOnClose, so a just-closed one can still be a
+        // child of the window; the live dialog is the visible one.
+        const auto liveNamedDialog
+            = [&window](const QString& name) -> QDialog* {
+            for (auto* candidate : window.findChildren<QDialog*>(name)) {
                 if (candidate->isVisible()) {
                     return candidate;
                 }
             }
             return nullptr;
+        };
+        const auto liveDialog = [liveNamedDialog]() {
+            return liveNamedDialog(QStringLiteral("particlesDialog"));
         };
         auto* poll = new QTimer(&window);
         poll->setInterval(10);
@@ -1801,7 +1805,8 @@ int main(int argc, char* argv[])
         // Let the Apply read finish rather than tearing the window down around
         // a live worker, then check the rest of the dialog's lifecycle.
         QObject::connect(poll, &QTimer::timeout, &application,
-            [&window, &application, poll, attempts, liveDialog, first, second] {
+            [&window, &application, poll, attempts, liveDialog, liveNamedDialog,
+                first, second] {
                 if (++*attempts > 500) {
                     qCritical("the particle read started by Apply never settled");
                     application.exit(1);
@@ -1833,10 +1838,32 @@ int main(int argc, char* argv[])
                     application.exit(1);
                     return;
                 }
-                // The species it lists belong to the outgoing dataset.
+                // The contours dialog is the other one bound to this dataset.
+                auto* contoursAction = window.findChild<QAction*>(
+                    QStringLiteral("contoursAction"));
+                if (contoursAction == nullptr || !contoursAction->isEnabled()) {
+                    qCritical("the contours menu item is missing or disabled");
+                    application.exit(1);
+                    return;
+                }
+                contoursAction->trigger();
+                const auto contoursName = QStringLiteral("setContoursDialog");
+                if (liveNamedDialog(contoursName) == nullptr) {
+                    qCritical("the contours dialog did not open");
+                    application.exit(1);
+                    return;
+                }
+                // The species and fields they list belong to the outgoing
+                // dataset, which a sequence open replaces.
                 window.openSequence({first, second});
                 if (liveDialog() != nullptr) {
                     qCritical("opening a sequence left the dialog on screen");
+                    application.exit(1);
+                    return;
+                }
+                if (liveNamedDialog(contoursName) != nullptr) {
+                    qCritical(
+                        "opening a sequence left the contours dialog on screen");
                     application.exit(1);
                     return;
                 }

--- a/src/qt/main.cpp
+++ b/src/qt/main.cpp
@@ -6,6 +6,8 @@
 #include <QAction>
 #include <QApplication>
 #include <QComboBox>
+#include <QDialog>
+#include <QDialogButtonBox>
 #include <QDir>
 #include <QFile>
 #include <QFileInfo>
@@ -16,6 +18,7 @@
 #include <QLoggingCategory>
 #include <QMouseEvent>
 #include <QPainter>
+#include <QPointer>
 #include <QProcess>
 #include <QPushButton>
 #include <QStandardPaths>
@@ -1720,6 +1723,66 @@ int main(int argc, char* argv[])
                             ? 0 : 1);
                     }, Qt::SingleShotConnection);
                 window.enableVisibleRasterForTest();
+            });
+        QTimer::singleShot(0, &window, [&window, path] {
+            window.openDataset(path);
+        });
+    } else if (argc == 3
+        && std::string_view(argv[1]) == "--particle-dialog-smoke-test") {
+        // The particles dialog is modeless with an Apply button: settings are
+        // meant to be tried against the image, so the dialog must not block the
+        // main window, must survive Apply, and must not stack up copies of
+        // itself when the menu item is chosen again.
+        const std::filesystem::path path(argv[2]);
+        QObject::connect(&window, &amrvis::qt::MainWindow::initialSliceFinished,
+            &application, [&window, &application](bool success) {
+                if (!success) {
+                    application.exit(1);
+                    return;
+                }
+                auto* action = window.findChild<QAction*>(
+                    QStringLiteral("particlesAction"));
+                if (action == nullptr || !action->isEnabled()) {
+                    qCritical("the particles menu item is missing or disabled");
+                    application.exit(1);
+                    return;
+                }
+                action->trigger();
+                action->trigger();
+                const auto dialogs = window.findChildren<QDialog*>(
+                    QStringLiteral("particlesDialog"));
+                if (dialogs.size() != 1) {
+                    qCritical("expected one particles dialog, found %lld",
+                        static_cast<long long>(dialogs.size()));
+                    application.exit(1);
+                    return;
+                }
+                const QPointer<QDialog> dialog = dialogs.front();
+                if (!dialog->isVisible() || dialog->isModal()
+                    || QApplication::activeModalWidget() != nullptr) {
+                    qCritical("the particles dialog blocks the main window");
+                    application.exit(1);
+                    return;
+                }
+                auto* buttons = dialog->findChild<QDialogButtonBox*>(
+                    QStringLiteral("particlesDialogButtons"));
+                if (buttons == nullptr
+                    || buttons->button(QDialogButtonBox::Apply) == nullptr) {
+                    qCritical("the particles dialog has no Apply button");
+                    application.exit(1);
+                    return;
+                }
+                buttons->button(QDialogButtonBox::Apply)->click();
+                // Apply draws the checked species and leaves the dialog up.
+                if (dialog.isNull() || !dialog->isVisible()
+                    || !window.particleLoadingForTest()) {
+                    qCritical("Apply did not draw, or closed the dialog");
+                    application.exit(1);
+                    return;
+                }
+                buttons->button(QDialogButtonBox::Ok)->click();
+                application.exit(
+                    !dialog.isNull() && dialog->isVisible() ? 1 : 0);
             });
         QTimer::singleShot(0, &window, [&window, path] {
             window.openDataset(path);

--- a/src/qt/main.cpp
+++ b/src/qt/main.cpp
@@ -1727,15 +1727,32 @@ int main(int argc, char* argv[])
         QTimer::singleShot(0, &window, [&window, path] {
             window.openDataset(path);
         });
-    } else if (argc == 3
+    } else if (argc == 4
         && std::string_view(argv[1]) == "--particle-dialog-smoke-test") {
         // The particles dialog is modeless with an Apply button: settings are
         // meant to be tried against the image, so the dialog must not block the
         // main window, must survive Apply, and must not stack up copies of
-        // itself when the menu item is chosen again.
-        const std::filesystem::path path(argv[2]);
+        // itself when the menu item is chosen again. It also belongs to the
+        // dataset whose species it lists, so opening a sequence -- which never
+        // runs openDatasetImpl -- must take it down.
+        const std::filesystem::path first(argv[2]);
+        const std::filesystem::path second(argv[3]);
+        // The dialog closes with WA_DeleteOnClose, so a just-closed one can
+        // still be a child of the window; the live dialog is the visible one.
+        const auto liveDialog = [&window]() -> QDialog* {
+            for (auto* candidate :
+                window.findChildren<QDialog*>(QStringLiteral("particlesDialog"))) {
+                if (candidate->isVisible()) {
+                    return candidate;
+                }
+            }
+            return nullptr;
+        };
+        auto* poll = new QTimer(&window);
+        poll->setInterval(10);
+        auto attempts = std::make_shared<int>(0);
         QObject::connect(&window, &amrvis::qt::MainWindow::initialSliceFinished,
-            &application, [&window, &application](bool success) {
+            &application, [&window, &application, poll](bool success) {
                 if (!success) {
                     application.exit(1);
                     return;
@@ -1757,7 +1774,7 @@ int main(int argc, char* argv[])
                     application.exit(1);
                     return;
                 }
-                const QPointer<QDialog> dialog = dialogs.front();
+                auto* dialog = dialogs.front();
                 if (!dialog->isVisible() || dialog->isModal()
                     || QApplication::activeModalWidget() != nullptr) {
                     qCritical("the particles dialog blocks the main window");
@@ -1774,18 +1791,62 @@ int main(int argc, char* argv[])
                 }
                 buttons->button(QDialogButtonBox::Apply)->click();
                 // Apply draws the checked species and leaves the dialog up.
-                if (dialog.isNull() || !dialog->isVisible()
-                    || !window.particleLoadingForTest()) {
+                if (!dialog->isVisible() || !window.particleLoadingForTest()) {
                     qCritical("Apply did not draw, or closed the dialog");
                     application.exit(1);
                     return;
                 }
+                poll->start();
+            }, Qt::SingleShotConnection);
+        // Let the Apply read finish rather than tearing the window down around
+        // a live worker, then check the rest of the dialog's lifecycle.
+        QObject::connect(poll, &QTimer::timeout, &application,
+            [&window, &application, poll, attempts, liveDialog, first, second] {
+                if (++*attempts > 500) {
+                    qCritical("the particle read started by Apply never settled");
+                    application.exit(1);
+                    return;
+                }
+                if (window.particleLoadingForTest()) {
+                    return;
+                }
+                poll->stop();
+                auto* dialog = liveDialog();
+                if (dialog == nullptr) {
+                    qCritical("the dialog did not survive the particle read");
+                    application.exit(1);
+                    return;
+                }
+                auto* buttons = dialog->findChild<QDialogButtonBox*>(
+                    QStringLiteral("particlesDialogButtons"));
                 buttons->button(QDialogButtonBox::Ok)->click();
-                application.exit(
-                    !dialog.isNull() && dialog->isVisible() ? 1 : 0);
+                if (liveDialog() != nullptr) {
+                    qCritical("Ok did not close the dialog");
+                    application.exit(1);
+                    return;
+                }
+                auto* action = window.findChild<QAction*>(
+                    QStringLiteral("particlesAction"));
+                action->trigger();
+                if (liveDialog() == nullptr) {
+                    qCritical("the dialog did not reopen");
+                    application.exit(1);
+                    return;
+                }
+                // The species it lists belong to the outgoing dataset.
+                window.openSequence({first, second});
+                if (liveDialog() != nullptr) {
+                    qCritical("opening a sequence left the dialog on screen");
+                    application.exit(1);
+                    return;
+                }
+                window.close();
+                application.exit(0);
             });
-        QTimer::singleShot(0, &window, [&window, path] {
-            window.openDataset(path);
+        QTimer::singleShot(15000, &application,
+            [&application] { application.exit(3); });
+        QTimer::singleShot(0, &window, [&window, first] {
+            window.openDataset(first);
         });
     } else if (argc == 3
         && std::string_view(argv[1]) == "--raster-zoom-smoke-test") {

--- a/src/qt/main.cpp
+++ b/src/qt/main.cpp
@@ -18,7 +18,6 @@
 #include <QLoggingCategory>
 #include <QMouseEvent>
 #include <QPainter>
-#include <QPointer>
 #include <QProcess>
 #include <QPushButton>
 #include <QStandardPaths>
@@ -1808,6 +1807,9 @@ int main(int argc, char* argv[])
             [&window, &application, poll, attempts, liveDialog, liveNamedDialog,
                 first, second] {
                 if (++*attempts > 500) {
+                    // exit() only flags the loop, so stop the timer too rather
+                    // than report the same stall on every tick until it unwinds.
+                    poll->stop();
                     qCritical("the particle read started by Apply never settled");
                     application.exit(1);
                     return;
@@ -1824,6 +1826,12 @@ int main(int argc, char* argv[])
                 }
                 auto* buttons = dialog->findChild<QDialogButtonBox*>(
                     QStringLiteral("particlesDialogButtons"));
+                if (buttons == nullptr
+                    || buttons->button(QDialogButtonBox::Ok) == nullptr) {
+                    qCritical("the particles dialog has no Ok button");
+                    application.exit(1);
+                    return;
+                }
                 buttons->button(QDialogButtonBox::Ok)->click();
                 if (liveDialog() != nullptr) {
                     qCritical("Ok did not close the dialog");
@@ -1832,6 +1840,11 @@ int main(int argc, char* argv[])
                 }
                 auto* action = window.findChild<QAction*>(
                     QStringLiteral("particlesAction"));
+                if (action == nullptr || !action->isEnabled()) {
+                    qCritical("the particles menu item did not come back");
+                    application.exit(1);
+                    return;
+                }
                 action->trigger();
                 if (liveDialog() == nullptr) {
                     qCritical("the dialog did not reopen");

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -792,6 +792,19 @@ if(TARGET amrexplorer_qt)
     )
     set_tests_properties(
         qt_particle_visible_range_smoke_3d PROPERTIES TIMEOUT 30)
+    # The particles dialog is modeless: it must not block the main window, one
+    # instance is reused, and Apply draws without closing it.
+    add_test(
+        NAME qt_particle_dialog_smoke_3d
+        COMMAND "${CMAKE_COMMAND}"
+            "-DMATERIALIZER=$<TARGET_FILE:fixture_materializer>"
+            "-DAMREXPLORER_QT=$<TARGET_FILE:amrexplorer_qt>"
+            "-DSOURCE=${CMAKE_CURRENT_SOURCE_DIR}/data/plotfile_3d"
+            "-DWORK=${CMAKE_CURRENT_BINARY_DIR}/fixtures_particle_dialog_3d"
+            -DMODE=particle-dialog
+            -P "${CMAKE_CURRENT_SOURCE_DIR}/qt_smoke_driver.cmake"
+    )
+    set_tests_properties(qt_particle_dialog_smoke_3d PROPERTIES TIMEOUT 30)
     # A rubber-band selection in one 3-D panel synchronizes the selected
     # normalized subregion to all three panels by default.
     add_test(

--- a/tests/qt_smoke_driver.cmake
+++ b/tests/qt_smoke_driver.cmake
@@ -211,8 +211,10 @@ elseif(MODE STREQUAL "particle-visible-range")
     run_or_die("${AMREXPLORER_QT}" --particle-visible-range-smoke-test
         "${WORK}/plt")
 elseif(MODE STREQUAL "particle-dialog")
-    run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt")
-    run_or_die("${AMREXPLORER_QT}" --particle-dialog-smoke-test "${WORK}/plt")
+    run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt00000")
+    run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt00010" "2.5")
+    run_or_die("${AMREXPLORER_QT}" --particle-dialog-smoke-test
+        "${WORK}/plt00000" "${WORK}/plt00010")
 elseif(MODE STREQUAL "raster-zoom")
     run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt")
     run_or_die("${AMREXPLORER_QT}" --raster-zoom-smoke-test "${WORK}/plt")

--- a/tests/qt_smoke_driver.cmake
+++ b/tests/qt_smoke_driver.cmake
@@ -11,7 +11,7 @@
 #                 multifab-fab | quit | quit-on-failure | window-close-pool |
 #                 export-quit |
 #                 contour-sync | raster-zoom | rubber-zoom-sync |
-#                 particle-visible-range |
+#                 particle-visible-range | particle-dialog |
 #                 rubber-zoom-local | rubber-overzoom | pan-zoom |
 #                 range-cache | fab-zoom | cache-budget |
 #                 fixed-scale-1 | fixed-scale-4 | sequence-transform-preserve |
@@ -210,6 +210,9 @@ elseif(MODE STREQUAL "particle-visible-range")
     run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt")
     run_or_die("${AMREXPLORER_QT}" --particle-visible-range-smoke-test
         "${WORK}/plt")
+elseif(MODE STREQUAL "particle-dialog")
+    run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt")
+    run_or_die("${AMREXPLORER_QT}" --particle-dialog-smoke-test "${WORK}/plt")
 elseif(MODE STREQUAL "raster-zoom")
     run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt")
     run_or_die("${AMREXPLORER_QT}" --raster-zoom-smoke-test "${WORK}/plt")


### PR DESCRIPTION
It ran modal, so trying a setting meant reopening it, and on Linux it dimmed the main window. Now it follows the contours dialog: one instance, Apply redraws without closing, and it closes when the dataset it describes goes away.