### PR TITLE
reset particle settings when a sequence opens

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -317,9 +317,9 @@ For 3-D data, particles are projected onto each of the three orthogonal slice
 panels. The projection is through the whole volume: a panel shows every selected
 particle, not only those near that slice plane.
 
-Particle settings are not saved between sessions. Species selection, colors, and
-the seed reset when a new dataset is opened; the subset percentage and point
-size persist for the session.
+Particle settings are not saved between sessions. Species selection, colors,
+subset percentage, seed, and point size all reset when a new dataset or sequence
+is opened; they carry across the frames of an open sequence.
 
 ## 2-D spherical coordinates
 

--- a/src/qt/MainWindow.hpp
+++ b/src/qt/MainWindow.hpp
@@ -331,6 +331,11 @@ public:
         std::uint64_t seed = 0);
     [[nodiscard]] std::uint64_t particleSeedForTest() const noexcept;
     [[nodiscard]] double particleFractionForTest() const noexcept;
+    void setParticlePointSizeForTest(int pointSize);
+    [[nodiscard]] int particlePointSizeForTest() const noexcept;
+    // Invalid when the species has no stored color, which is what a reset
+    // leaves behind until the next dataset re-seeds the defaults.
+    [[nodiscard]] QColor particleColorForTest(const std::string& species) const;
     void setParticleColorForTest(
         const std::string& species, const QColor& color);
     [[nodiscard]] bool particleOverlaysUseColorForTest(
@@ -486,8 +491,11 @@ private:
     void showContoursDialog();
     void showParticlesDialog();
     void configureParticleControls(bool preserveSelection);
-    // Drops every particle setting back to its default. Belongs to whichever
-    // path installs a different dataset, so the two that do cannot drift.
+    // Drops every particle setting back to its default: the shared reset for
+    // the two paths that install a different dataset, a plain open and a
+    // sequence open. The teardown in openDatasetImpl clears the runtime state
+    // (samples, progress, generation) separately and deliberately leaves the
+    // settings alone, because a restore reinstalls only what its spec carries.
     void resetParticleSettings();
     void requestParticleReload();
     void updateParticleOverlay(PlaneViewState& state);

--- a/src/qt/MainWindow.hpp
+++ b/src/qt/MainWindow.hpp
@@ -330,6 +330,7 @@ public:
         std::vector<std::string> species, double fraction,
         std::uint64_t seed = 0);
     [[nodiscard]] std::uint64_t particleSeedForTest() const noexcept;
+    [[nodiscard]] double particleFractionForTest() const noexcept;
     void setParticleColorForTest(
         const std::string& species, const QColor& color);
     [[nodiscard]] bool particleOverlaysUseColorForTest(
@@ -485,6 +486,9 @@ private:
     void showContoursDialog();
     void showParticlesDialog();
     void configureParticleControls(bool preserveSelection);
+    // Drops every particle setting back to its default. Belongs to whichever
+    // path installs a different dataset, so the two that do cannot drift.
+    void resetParticleSettings();
     void requestParticleReload();
     void updateParticleOverlay(PlaneViewState& state);
     void updateParticleOverlays();

--- a/src/qt/MainWindowInteraction.cpp
+++ b/src/qt/MainWindowInteraction.cpp
@@ -479,6 +479,20 @@ void MainWindow::showParticlesDialog()
     dialog->show();
 }
 
+void MainWindow::resetParticleSettings()
+{
+    m_selectedParticleSpecies.clear();
+    m_particleColors.clear();
+    m_particleSeed = 0;
+    m_particleSelectionInitialized = false;
+    // The subset and point size reset with everything else. They used to
+    // survive, so a 0.05% subset chosen to make one dense dataset legible
+    // silently decimated the next one -- with no indication that it was a
+    // carried-over setting rather than the data.
+    m_particleFraction = 1.0;
+    m_particlePointSize = defaultParticlePointSize;
+}
+
 void MainWindow::configureParticleControls(bool preserveSelection)
 {
     if (!m_dataset) {
@@ -487,16 +501,7 @@ void MainWindow::configureParticleControls(bool preserveSelection)
     }
     const auto& species = m_dataset->particleSpecies();
     if (!preserveSelection) {
-        m_selectedParticleSpecies.clear();
-        m_particleColors.clear();
-        m_particleSeed = 0;
-        m_particleSelectionInitialized = false;
-        // The subset and point size reset with everything else. They used to
-        // survive, so a 0.05% subset chosen to make one dense dataset legible
-        // silently decimated the next one -- with no indication that it was a
-        // carried-over setting rather than the data.
-        m_particleFraction = 1.0;
-        m_particlePointSize = defaultParticlePointSize;
+        resetParticleSettings();
     }
     for (std::size_t speciesIndex = 0; speciesIndex < species.size();
          ++speciesIndex) {

--- a/src/qt/MainWindowSlice.cpp
+++ b/src/qt/MainWindowSlice.cpp
@@ -1180,15 +1180,19 @@ void MainWindow::prepareSequence(std::size_t frameCount)
     resetFabState();
     m_particleStopSource.request_stop();
     m_particleSamples.clear();
-    // A sequence is a different dataset, so its particle settings start from
-    // defaults exactly as a plain open's do. Clearing only the species left the
-    // subset, seed, point size, and colors behind: a 0.05% subset chosen for a
-    // dense plotfile silently decimated the sequence opened after it.
+    // A sequence is a different dataset, so it starts from defaults exactly as
+    // a plain open does.
     resetParticleSettings();
     m_particleLoading = false;
     m_particleProgress->setVisible(false);
     ++m_particleGeneration;
     m_remoteSequenceConnectionGeneration = 0;
+    // Frame 0 is not installed yet, so m_dataset still describes the outgoing
+    // one. Take the overlay dialogs' menu items down with the dialogs above,
+    // the way a plain open's teardown does; configureSequenceControls and
+    // configureParticleControls bring them back when a frame arrives.
+    m_contoursAction->setEnabled(false);
+    m_particlesAction->setEnabled(false);
 
     m_animationPanel->setSequenceFrameCount(static_cast<int>(frameCount));
     m_animationPanel->setSequenceVisible(true);

--- a/src/qt/MainWindowSlice.cpp
+++ b/src/qt/MainWindowSlice.cpp
@@ -1180,8 +1180,11 @@ void MainWindow::prepareSequence(std::size_t frameCount)
     resetFabState();
     m_particleStopSource.request_stop();
     m_particleSamples.clear();
-    m_selectedParticleSpecies.clear();
-    m_particleSelectionInitialized = false;
+    // A sequence is a different dataset, so its particle settings start from
+    // defaults exactly as a plain open's do. Clearing only the species left the
+    // subset, seed, point size, and colors behind: a 0.05% subset chosen for a
+    // dense plotfile silently decimated the sequence opened after it.
+    resetParticleSettings();
     m_particleLoading = false;
     m_particleProgress->setVisible(false);
     ++m_particleGeneration;
@@ -1197,7 +1200,7 @@ void MainWindow::prepareSequence(std::size_t frameCount)
         linePlotWindow->close();
     }
     // Both overlay dialogs describe the outgoing dataset -- the particles one
-    // lists its species, whose selection state was just reset above, and the
+    // lists its species, whose settings were just reset above, and the
     // contours one lists its fields. openDatasetImpl closes them for a plain
     // open; this path never runs that, so a sequence open would otherwise leave
     // them on screen writing the old dataset's names back on Apply. Frame steps

--- a/src/qt/MainWindowTestAccess.cpp
+++ b/src/qt/MainWindowTestAccess.cpp
@@ -682,6 +682,11 @@ std::uint64_t MainWindow::particleSeedForTest() const noexcept
     return m_particleSeed;
 }
 
+double MainWindow::particleFractionForTest() const noexcept
+{
+    return m_particleFraction;
+}
+
 void MainWindow::setParticleColorForTest(
     const std::string& species, const QColor& color)
 {

--- a/src/qt/MainWindowTestAccess.cpp
+++ b/src/qt/MainWindowTestAccess.cpp
@@ -687,6 +687,23 @@ double MainWindow::particleFractionForTest() const noexcept
     return m_particleFraction;
 }
 
+void MainWindow::setParticlePointSizeForTest(int pointSize)
+{
+    applyParticleSelection(m_selectedParticleSpecies, m_particleFraction,
+        pointSize, m_particleSeed);
+}
+
+int MainWindow::particlePointSizeForTest() const noexcept
+{
+    return m_particlePointSize;
+}
+
+QColor MainWindow::particleColorForTest(const std::string& species) const
+{
+    const auto color = m_particleColors.find(species);
+    return color != m_particleColors.end() ? color->second : QColor();
+}
+
 void MainWindow::setParticleColorForTest(
     const std::string& species, const QColor& color)
 {

--- a/src/qt/main.cpp
+++ b/src/qt/main.cpp
@@ -1890,39 +1890,95 @@ int main(int argc, char* argv[])
         });
     } else if (argc == 4
         && std::string_view(argv[1])
-            == "--particle-sequence-reset-smoke-test") {
-        // Particle settings belong to the dataset they were chosen for. Opening
-        // a sequence installs a different one through prepareSequence, which
-        // bypasses openDatasetImpl, so it owes the same reset a plain open does.
+            == "--particle-settings-reset-smoke-test") {
+        // Particle settings belong to the dataset they were chosen for. Both
+        // paths that install a different one owe the same reset: a plain open,
+        // and a sequence open, which reaches it through prepareSequence rather
+        // than openDatasetImpl. Every setting resets, not just the species --
+        // a subset chosen for a dense plotfile decimates the next one silently.
         const std::filesystem::path first(argv[2]);
         const std::filesystem::path second(argv[3]);
+        const QColor chosenColor(12, 34, 56);
+        // The startup point size is the default this compares against, so the
+        // test does not have to name the constant.
+        const auto defaultPointSize
+            = std::make_shared<int>(window.particlePointSizeForTest());
+        const auto choose = [&window, chosenColor] {
+            window.setParticleSelectionForTest({"Tracer"}, 0.0005, 37);
+            window.setParticlePointSizeForTest(9);
+            window.setParticleColorForTest("Tracer", chosenColor);
+            return window.particleSeedForTest() == 37
+                && window.particleFractionForTest() == 0.0005
+                && window.particlePointSizeForTest() == 9
+                && window.particleColorForTest("Tracer") == chosenColor;
+        };
+        const auto wasReset = [&window, chosenColor, defaultPointSize](
+                                  const char* what) {
+            if (window.particleSeedForTest() == 0
+                && window.particleFractionForTest() == 1.0
+                && window.particlePointSizeForTest() == *defaultPointSize
+                && window.particleColorForTest("Tracer") != chosenColor) {
+                return true;
+            }
+            qCritical("%s inherited particle settings: seed %llu, subset %g, "
+                      "point size %d, colour %s",
+                what,
+                static_cast<unsigned long long>(window.particleSeedForTest()),
+                window.particleFractionForTest(),
+                window.particlePointSizeForTest(),
+                qUtf8Printable(
+                    window.particleColorForTest("Tracer").name(QColor::HexArgb)));
+            return false;
+        };
+        auto phase = std::make_shared<int>(0);
         QObject::connect(&window, &amrvis::qt::MainWindow::initialSliceFinished,
-            &application, [&window, &application, first, second](bool success) {
+            &application,
+            [&window, &application, first, second, phase, choose, wasReset](
+                bool success) {
                 if (!success) {
                     application.exit(1);
                     return;
                 }
-                window.setParticleSelectionForTest({"Tracer"}, 0.0005, 37);
-                if (window.particleSeedForTest() != 37
-                    || window.particleFractionForTest() != 0.0005) {
+                if (*phase == 0) {
+                    if (!choose()) {
+                        qCritical("the particle settings did not take");
+                        application.exit(1);
+                        return;
+                    }
+                    // A plain open of a different plotfile resets them.
+                    *phase = 1;
+                    window.openDataset(second);
+                    return;
+                }
+                if (!wasReset("a plain open")) {
+                    application.exit(1);
+                    return;
+                }
+                if (!choose()) {
                     qCritical("the particle settings did not take");
                     application.exit(1);
                     return;
                 }
+                // prepareSequence resets synchronously; frame 0 then arrives
+                // through a different path, which must not put them back.
                 window.openSequence({first, second});
-                if (window.particleSeedForTest() != 0
-                    || window.particleFractionForTest() != 1.0) {
-                    qCritical("the sequence inherited particle settings: "
-                        "seed %llu, subset %g",
-                        static_cast<unsigned long long>(
-                            window.particleSeedForTest()),
-                        window.particleFractionForTest());
+                if (!wasReset("opening a sequence")) {
+                    application.exit(1);
+                }
+            });
+        QObject::connect(&window,
+            &amrvis::qt::MainWindow::sequenceFrameDisplayed, &application,
+            [&window, &application, wasReset](int index) {
+                if (index != 0) {
+                    return;
+                }
+                if (!wasReset("the first sequence frame")) {
                     application.exit(1);
                     return;
                 }
                 window.close();
                 application.exit(0);
-            }, Qt::SingleShotConnection);
+            });
         QObject::connect(&window, &amrvis::qt::MainWindow::sequenceFrameFailed,
             &application, [&application] { application.exit(1); });
         QTimer::singleShot(15000, &application,

--- a/src/qt/main.cpp
+++ b/src/qt/main.cpp
@@ -1888,6 +1888,48 @@ int main(int argc, char* argv[])
         QTimer::singleShot(0, &window, [&window, first] {
             window.openDataset(first);
         });
+    } else if (argc == 4
+        && std::string_view(argv[1])
+            == "--particle-sequence-reset-smoke-test") {
+        // Particle settings belong to the dataset they were chosen for. Opening
+        // a sequence installs a different one through prepareSequence, which
+        // bypasses openDatasetImpl, so it owes the same reset a plain open does.
+        const std::filesystem::path first(argv[2]);
+        const std::filesystem::path second(argv[3]);
+        QObject::connect(&window, &amrvis::qt::MainWindow::initialSliceFinished,
+            &application, [&window, &application, first, second](bool success) {
+                if (!success) {
+                    application.exit(1);
+                    return;
+                }
+                window.setParticleSelectionForTest({"Tracer"}, 0.0005, 37);
+                if (window.particleSeedForTest() != 37
+                    || window.particleFractionForTest() != 0.0005) {
+                    qCritical("the particle settings did not take");
+                    application.exit(1);
+                    return;
+                }
+                window.openSequence({first, second});
+                if (window.particleSeedForTest() != 0
+                    || window.particleFractionForTest() != 1.0) {
+                    qCritical("the sequence inherited particle settings: "
+                        "seed %llu, subset %g",
+                        static_cast<unsigned long long>(
+                            window.particleSeedForTest()),
+                        window.particleFractionForTest());
+                    application.exit(1);
+                    return;
+                }
+                window.close();
+                application.exit(0);
+            }, Qt::SingleShotConnection);
+        QObject::connect(&window, &amrvis::qt::MainWindow::sequenceFrameFailed,
+            &application, [&application] { application.exit(1); });
+        QTimer::singleShot(15000, &application,
+            [&application] { application.exit(3); });
+        QTimer::singleShot(0, &window, [&window, first] {
+            window.openDataset(first);
+        });
     } else if (argc == 3
         && std::string_view(argv[1]) == "--raster-zoom-smoke-test") {
         // 2-D Visible-range raster/color-bar consistency: after a full-domain

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -805,20 +805,21 @@ if(TARGET amrexplorer_qt)
             -P "${CMAKE_CURRENT_SOURCE_DIR}/qt_smoke_driver.cmake"
     )
     set_tests_properties(qt_particle_dialog_smoke_3d PROPERTIES TIMEOUT 30)
-    # Opening a sequence is a dataset change, so it resets particle settings
-    # rather than carrying the previous dataset's subset and seed into it.
+    # A plain open and a sequence open are both dataset changes, so both reset
+    # every particle setting rather than carrying the previous dataset's
+    # species, subset, seed, point size, and colors into the new one.
     add_test(
-        NAME qt_particle_sequence_reset_smoke_3d
+        NAME qt_particle_settings_reset_smoke_3d
         COMMAND "${CMAKE_COMMAND}"
             "-DMATERIALIZER=$<TARGET_FILE:fixture_materializer>"
             "-DAMREXPLORER_QT=$<TARGET_FILE:amrexplorer_qt>"
             "-DSOURCE=${CMAKE_CURRENT_SOURCE_DIR}/data/plotfile_3d"
-            "-DWORK=${CMAKE_CURRENT_BINARY_DIR}/fixtures_particle_sequence_reset"
-            -DMODE=particle-sequence-reset
+            "-DWORK=${CMAKE_CURRENT_BINARY_DIR}/fixtures_particle_settings_reset_3d"
+            -DMODE=particle-settings-reset
             -P "${CMAKE_CURRENT_SOURCE_DIR}/qt_smoke_driver.cmake"
     )
     set_tests_properties(
-        qt_particle_sequence_reset_smoke_3d PROPERTIES TIMEOUT 30)
+        qt_particle_settings_reset_smoke_3d PROPERTIES TIMEOUT 30)
     # A rubber-band selection in one 3-D panel synchronizes the selected
     # normalized subregion to all three panels by default.
     add_test(

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -805,6 +805,20 @@ if(TARGET amrexplorer_qt)
             -P "${CMAKE_CURRENT_SOURCE_DIR}/qt_smoke_driver.cmake"
     )
     set_tests_properties(qt_particle_dialog_smoke_3d PROPERTIES TIMEOUT 30)
+    # Opening a sequence is a dataset change, so it resets particle settings
+    # rather than carrying the previous dataset's subset and seed into it.
+    add_test(
+        NAME qt_particle_sequence_reset_smoke_3d
+        COMMAND "${CMAKE_COMMAND}"
+            "-DMATERIALIZER=$<TARGET_FILE:fixture_materializer>"
+            "-DAMREXPLORER_QT=$<TARGET_FILE:amrexplorer_qt>"
+            "-DSOURCE=${CMAKE_CURRENT_SOURCE_DIR}/data/plotfile_3d"
+            "-DWORK=${CMAKE_CURRENT_BINARY_DIR}/fixtures_particle_sequence_reset"
+            -DMODE=particle-sequence-reset
+            -P "${CMAKE_CURRENT_SOURCE_DIR}/qt_smoke_driver.cmake"
+    )
+    set_tests_properties(
+        qt_particle_sequence_reset_smoke_3d PROPERTIES TIMEOUT 30)
     # A rubber-band selection in one 3-D panel synchronizes the selected
     # normalized subregion to all three panels by default.
     add_test(

--- a/tests/qt_smoke_driver.cmake
+++ b/tests/qt_smoke_driver.cmake
@@ -12,7 +12,7 @@
 #                 export-quit |
 #                 contour-sync | raster-zoom | rubber-zoom-sync |
 #                 particle-visible-range | particle-dialog |
-#                 particle-sequence-reset |
+#                 particle-settings-reset |
 #                 rubber-zoom-local | rubber-overzoom | pan-zoom |
 #                 range-cache | fab-zoom | cache-budget |
 #                 fixed-scale-1 | fixed-scale-4 | sequence-transform-preserve |
@@ -216,10 +216,10 @@ elseif(MODE STREQUAL "particle-dialog")
     run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt00010" "2.5")
     run_or_die("${AMREXPLORER_QT}" --particle-dialog-smoke-test
         "${WORK}/plt00000" "${WORK}/plt00010")
-elseif(MODE STREQUAL "particle-sequence-reset")
+elseif(MODE STREQUAL "particle-settings-reset")
     run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt00000")
     run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt00010" "2.5")
-    run_or_die("${AMREXPLORER_QT}" --particle-sequence-reset-smoke-test
+    run_or_die("${AMREXPLORER_QT}" --particle-settings-reset-smoke-test
         "${WORK}/plt00000" "${WORK}/plt00010")
 elseif(MODE STREQUAL "raster-zoom")
     run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt")

--- a/tests/qt_smoke_driver.cmake
+++ b/tests/qt_smoke_driver.cmake
@@ -12,6 +12,7 @@
 #                 export-quit |
 #                 contour-sync | raster-zoom | rubber-zoom-sync |
 #                 particle-visible-range | particle-dialog |
+#                 particle-sequence-reset |
 #                 rubber-zoom-local | rubber-overzoom | pan-zoom |
 #                 range-cache | fab-zoom | cache-budget |
 #                 fixed-scale-1 | fixed-scale-4 | sequence-transform-preserve |
@@ -214,6 +215,11 @@ elseif(MODE STREQUAL "particle-dialog")
     run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt00000")
     run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt00010" "2.5")
     run_or_die("${AMREXPLORER_QT}" --particle-dialog-smoke-test
+        "${WORK}/plt00000" "${WORK}/plt00010")
+elseif(MODE STREQUAL "particle-sequence-reset")
+    run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt00000")
+    run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt00010" "2.5")
+    run_or_die("${AMREXPLORER_QT}" --particle-sequence-reset-smoke-test
         "${WORK}/plt00000" "${WORK}/plt00010")
 elseif(MODE STREQUAL "raster-zoom")
     run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt")


### PR DESCRIPTION
prepareSequence cleared the species but kept the subset, seed, point size, and colors, so a 0.05% subset chosen for a dense plotfile silently decimated the sequence opened next. Both dataset-installing paths now share resetParticleSettings.