### PR TITLE
bound every text header reader against crafted input

### DIFF
--- a/include/amrexplorer/data/LocalDatasetSession.hpp
+++ b/include/amrexplorer/data/LocalDatasetSession.hpp
@@ -15,8 +15,9 @@ class PlotfileDataset;
 
 class LocalDatasetSession final : public DatasetSession {
 public:
-    explicit LocalDatasetSession(
-        std::shared_ptr<PlotfileDataset> dataset, std::string fileVersion = {});
+    // The file version comes from the dataset's own metadata read; nothing
+    // re-opens the Header for it.
+    explicit LocalDatasetSession(std::shared_ptr<PlotfileDataset> dataset);
     LocalDatasetSession(const std::filesystem::path& path, DatasetId id,
         std::uint64_t cacheBudgetBytes, StopToken cancellation = {});
     LocalDatasetSession(std::filesystem::path dataRoot, DatasetId id,

--- a/include/amrexplorer/io/PlotfileDataset.hpp
+++ b/include/amrexplorer/io/PlotfileDataset.hpp
@@ -32,6 +32,9 @@ public:
 
     [[nodiscard]] const DatasetMetadata& metadata() const noexcept;
     [[nodiscard]] const MetadataReadMetrics& metadataReadMetrics() const noexcept;
+    // The Header's version line, as the bounded metadata read already parsed
+    // it. Exposed so no caller has to open and re-read the Header for it.
+    [[nodiscard]] const std::string& fileVersion() const noexcept;
     [[nodiscard]] DatasetId id() const noexcept;
     [[nodiscard]] const std::vector<ParticleSpeciesMetadata>& particleSpecies()
         const noexcept;

--- a/include/amrexplorer/io/PlotfileDataset.hpp
+++ b/include/amrexplorer/io/PlotfileDataset.hpp
@@ -32,8 +32,15 @@ public:
 
     [[nodiscard]] const DatasetMetadata& metadata() const noexcept;
     [[nodiscard]] const MetadataReadMetrics& metadataReadMetrics() const noexcept;
-    // The Header's version line, as the bounded metadata read already parsed
-    // it. Exposed so no caller has to open and re-read the Header for it.
+    // The Header's version *token* -- its first whitespace-delimited word --
+    // as the bounded metadata read already parsed it. Exposed so no caller has
+    // to open and re-read the Header for it.
+    //
+    // Narrower than the whole first line, which is what the session used to
+    // re-read with its own getline. AMReX writes the version alone on that
+    // line ("HyperCLaw-V1.1"), so the two agree on every real plotfile; they
+    // differ only where a Header carries something after it, and this is the
+    // string the UI's Format field and the wire catalog show.
     [[nodiscard]] const std::string& fileVersion() const noexcept;
     [[nodiscard]] DatasetId id() const noexcept;
     [[nodiscard]] const std::vector<ParticleSpeciesMetadata>& particleSpecies()

--- a/include/amrexplorer/io/detail/FabHeaderParsing.hpp
+++ b/include/amrexplorer/io/detail/FabHeaderParsing.hpp
@@ -19,6 +19,7 @@
 #include <limits>
 #include <sstream>
 #include <string>
+#include <system_error>
 #include <string_view>
 #include <vector>
 
@@ -39,10 +40,11 @@ inline constexpr std::size_t maximumHeaderLineBytes = 16U * 1024U;
 // before any count or cap can reject it.
 inline constexpr std::size_t maximumHeaderTokenBytes = 4U * 1024U;
 
-// The largest speculative reserve any header parse may take. Beyond this the
-// container simply grows as records are parsed, which costs amortized copying
-// and nothing else -- so this is the point where an optimization stops being
-// worth a crafted-input risk.
+// The most *records* a header parse may reserve before it has parsed any. A
+// count, not a byte quantity: what it costs depends on the element, and the
+// callers span 36-byte IntBox through std::string, so 65,536 records is about
+// 2.4 MB of boxes or ~4 MB of field metadata. Named for what it bounds so the
+// next caller with a fatter element knows what it is choosing.
 //
 // It exists because the file's own size is *not* trustworthy evidence on its
 // own: std::filesystem::file_size reports the apparent size, so `truncate -s
@@ -50,7 +52,7 @@ inline constexpr std::size_t maximumHeaderTokenBytes = 4U * 1024U;
 // one filesystem block, and a bound derived from it alone is forgeable at
 // almost no cost. The size still tightens the bound for ordinary files; this
 // cap is what makes it hold for hostile ones.
-inline constexpr std::size_t maximumSpeculativeReserve = 64U * 1024U;
+inline constexpr std::size_t maximumSpeculativeRecords = 64U * 1024U;
 
 // How many entries to reserve for a count a header declares. A declared count
 // is a claim; the file's size is evidence against it, since a header cannot
@@ -59,13 +61,35 @@ inline constexpr std::size_t maximumSpeculativeReserve = 64U * 1024U;
 // under-reserving costs one reallocation while over-reserving is the whole
 // attack. That asymmetry is also why the per-record floors callers pass sit
 // below the true minimum rather than being tuned to it.
+//
+// A zero floor reserves nothing rather than dividing by it. The floor is often
+// derived from a parsed count -- a component count may legitimately be zero --
+// and a caller should not have to know that passing one through would be a
+// division by zero rather than a bound.
 [[nodiscard]] inline std::size_t evidenceBoundedCount(std::uint64_t declared,
     std::uintmax_t fileBytes, std::uint64_t minimumBytesPerRecord)
 {
+    if (minimumBytesPerRecord == 0) {
+        return 0;
+    }
     const auto describable
         = static_cast<std::uint64_t>(fileBytes) / minimumBytesPerRecord;
     return static_cast<std::size_t>(std::min({declared, describable,
-        static_cast<std::uint64_t>(maximumSpeculativeReserve)}));
+        static_cast<std::uint64_t>(maximumSpeculativeRecords)}));
+}
+
+// The same rule when the file's size could not be determined. Callers disagreed
+// about what a failed stat means -- one skipped the reserve, another failed the
+// open -- so the rule states it once: no evidence, no speculative reserve. The
+// parse then decides whether the file is readable, which is its job, not this
+// helper's.
+[[nodiscard]] inline std::size_t evidenceBoundedCount(std::uint64_t declared,
+    std::uintmax_t fileBytes, std::uint64_t minimumBytesPerRecord,
+    const std::error_code& sizeError)
+{
+    return sizeError
+        ? 0
+        : evidenceBoundedCount(declared, fileBytes, minimumBytesPerRecord);
 }
 
 // std::getline with a ceiling, and otherwise its semantics: false when nothing

--- a/include/amrexplorer/io/detail/FabHeaderParsing.hpp
+++ b/include/amrexplorer/io/detail/FabHeaderParsing.hpp
@@ -12,6 +12,7 @@
 #include <algorithm>
 #include <array>
 #include <cctype>
+#include <charconv>
 #include <cstddef>
 #include <cstdint>
 #include <iomanip>
@@ -199,6 +200,70 @@ template <typename Error>
             throw Error(std::string(subject) + " " + std::string(description)
                 + " exceeds the supported length");
         }
+    }
+    return value;
+}
+
+// The longest run a numeric field may occupy. A 64-bit value needs 20 digits
+// and a sign; this leaves room for padding without leaving room for a run
+// whose only purpose is to be long.
+inline constexpr std::size_t maximumHeaderNumberBytes = 128;
+
+// An integer field, bounded, and stopping exactly where operator>> stopped.
+//
+// That last part is why this cannot reuse readBoundedToken: header integers sit
+// inside punctuation -- "((0,0) (7,7) (0,0))" -- and must end at the comma or
+// the paren, where a whitespace-delimited token would swallow "0,0)" whole and
+// then fail to convert it. So the digits are accumulated directly, and the
+// first character that cannot extend the value ends the field, as before.
+//
+// The bound is not a libstdc++ detail. That implementation happens to
+// accumulate an integer rather than a buffer, so an enormous digit run costs it
+// nothing -- but libc++ resizes and doubles a std::string per digit, so on
+// macOS the same run allocates it whole. A ceiling here holds on both.
+//
+// Two deliberate differences from the extraction it replaces, both narrowing:
+// a sign is rejected for unsigned fields, where operator>> would wrap "-1" into
+// a huge count of exactly the kind these bounds exist to refuse; and an
+// out-of-range value throws rather than silently saturating.
+template <typename Error, typename Integer>
+[[nodiscard]] Integer readBoundedInteger(std::istream& input,
+    std::string_view subject, std::string_view description,
+    std::size_t limit = maximumHeaderNumberBytes)
+{
+    input >> std::ws;
+    std::string token;
+    for (;;) {
+        const auto next = input.peek();
+        if (next == std::char_traits<char>::eof()) {
+            break;
+        }
+        const auto character = static_cast<char>(next);
+        const bool isDigit = character >= '0' && character <= '9';
+        const bool isSign = (character == '-' || character == '+')
+            && token.empty();
+        if (!isDigit && !isSign) {
+            break;
+        }
+        if (token.size() >= limit) {
+            throw Error(std::string(subject) + " " + std::string(description)
+                + " exceeds the supported length");
+        }
+        token.push_back(character);
+        (void)input.get();
+    }
+    // from_chars rejects a leading '+', which operator>> accepts; skip it so
+    // the only grammar changes are the two narrowing ones described above.
+    const auto* begin = token.data();
+    const auto* end = token.data() + token.size();
+    if (!token.empty() && token.front() == '+') {
+        ++begin;
+    }
+    Integer value{};
+    const auto [stopped, error] = std::from_chars(begin, end, value);
+    if (begin == end || error != std::errc{} || stopped != end) {
+        throw Error("malformed " + std::string(subject) + " while reading "
+            + std::string(description));
     }
     return value;
 }

--- a/include/amrexplorer/io/detail/FabHeaderParsing.hpp
+++ b/include/amrexplorer/io/detail/FabHeaderParsing.hpp
@@ -46,25 +46,39 @@ inline constexpr std::size_t maximumHeaderTokenBytes = 4U * 1024U;
 // remaining file into the string before the parse can reject it. An overlong
 // line is malformed by definition, so it throws the caller's error type rather
 // than returning a truncated one that might parse.
+//
+// Reads through the stream buffer rather than istream::get(), which builds a
+// sentry per character. Measured over a 2.4 MB, 100,000-line Header: 10.1 ms
+// through get(), 5.0 ms this way, against std::getline's 1.34 ms. Real Headers
+// carry a handful of components, so the absolute cost is small either way --
+// but the ceiling is the only reason to leave getline behind, and paying 7x
+// for it was not part of that bargain. The remaining gap buys the bound.
+//
+// The stream-state handling is what makes this a drop-in, and it is written
+// out rather than inherited because sbumpc sets no state of its own:
+//   - nothing read at end of input: eofbit *and* failbit, as getline sets when
+//     it extracts nothing, so a caller's `while (readBoundedLine(...))` ends;
+//   - characters read, then end of input: eofbit only, so the final line of a
+//     file with no trailing newline is returned rather than discarded;
+//   - a stream that is not good() on entry: failbit, matching the sentry
+//     get() would have constructed and failed.
 template <typename Error>
 [[nodiscard]] bool readBoundedLine(std::istream& input, std::string& line,
     std::size_t limit = maximumHeaderLineBytes)
 {
     line.clear();
+    if (!input.good()) {
+        input.setstate(std::ios::failbit);
+        return false;
+    }
+    auto* buffer = input.rdbuf();
     for (;;) {
-        const auto character = input.get();
+        const auto character = buffer->sbumpc();
         if (character == std::char_traits<char>::eof()) {
-            // istream::get() sets failbit *and* eofbit when it runs out;
-            // std::getline sets failbit only if it extracted nothing. Drop the
-            // failbit when characters were read, so this really is a drop-in.
-            // Both current callers happen not to notice -- they only call
-            // tellg(), whose sentry sets failbit for an eof stream regardless
-            // -- but a caller that checks the stream would see the difference.
-            if (line.empty()) {
-                return false;
-            }
-            input.clear(input.rdstate() & ~std::ios::failbit);
-            return true;
+            input.setstate(line.empty()
+                    ? (std::ios::eofbit | std::ios::failbit)
+                    : std::ios::eofbit);
+            return !line.empty();
         }
         if (character == '\n') {
             return true;
@@ -95,8 +109,15 @@ template <typename Error>
     std::string_view subject, std::string_view description,
     std::size_t limit = maximumHeaderTokenBytes)
 {
+    // width() is an int, and a limit past INT_MAX would narrow to zero or
+    // negative -- which operator>> reads as "no width", making the extraction
+    // unbounded and the check below dead. That is the exact behaviour this
+    // helper exists to prevent, so clamp instead of narrowing, and compare
+    // against what was actually applied.
+    const auto effectiveLimit = std::min<std::size_t>(limit,
+        static_cast<std::size_t>(std::numeric_limits<int>::max()));
     std::string value;
-    input >> std::setw(static_cast<int>(limit)) >> value;
+    input >> std::setw(static_cast<int>(effectiveLimit)) >> value;
     if (!input) {
         throw Error("malformed " + std::string(subject) + " while reading "
             + std::string(description));
@@ -104,7 +125,7 @@ template <typename Error>
     // good() is false when the extraction stopped at end of file, which is one
     // of the two ways a complete token ends -- and peeking a stream that is not
     // good() would set failbit on a stream the caller may still be reading.
-    if (value.size() >= limit && input.good()) {
+    if (value.size() >= effectiveLimit && input.good()) {
         const auto next = input.peek();
         if (next != std::char_traits<char>::eof()
             && std::isspace(static_cast<unsigned char>(next)) == 0) {

--- a/include/amrexplorer/io/detail/FabHeaderParsing.hpp
+++ b/include/amrexplorer/io/detail/FabHeaderParsing.hpp
@@ -39,6 +39,35 @@ inline constexpr std::size_t maximumHeaderLineBytes = 16U * 1024U;
 // before any count or cap can reject it.
 inline constexpr std::size_t maximumHeaderTokenBytes = 4U * 1024U;
 
+// The largest speculative reserve any header parse may take. Beyond this the
+// container simply grows as records are parsed, which costs amortized copying
+// and nothing else -- so this is the point where an optimization stops being
+// worth a crafted-input risk.
+//
+// It exists because the file's own size is *not* trustworthy evidence on its
+// own: std::filesystem::file_size reports the apparent size, so `truncate -s
+// 80M` on a short crafted header yields 80 MB of "evidence" while occupying
+// one filesystem block, and a bound derived from it alone is forgeable at
+// almost no cost. The size still tightens the bound for ordinary files; this
+// cap is what makes it hold for hostile ones.
+inline constexpr std::size_t maximumSpeculativeReserve = 64U * 1024U;
+
+// How many entries to reserve for a count a header declares. A declared count
+// is a claim; the file's size is evidence against it, since a header cannot
+// describe more records than its bytes allow. Both are advisory, and the cap
+// above is the backstop: every caller is *reserving*, never sizing, so
+// under-reserving costs one reallocation while over-reserving is the whole
+// attack. That asymmetry is also why the per-record floors callers pass sit
+// below the true minimum rather than being tuned to it.
+[[nodiscard]] inline std::size_t evidenceBoundedCount(std::uint64_t declared,
+    std::uintmax_t fileBytes, std::uint64_t minimumBytesPerRecord)
+{
+    const auto describable
+        = static_cast<std::uint64_t>(fileBytes) / minimumBytesPerRecord;
+    return static_cast<std::size_t>(std::min({declared, describable,
+        static_cast<std::uint64_t>(maximumSpeculativeReserve)}));
+}
+
 // std::getline with a ceiling, and otherwise its semantics: false when nothing
 // could be read, the line without its terminator otherwise, and the stream left
 // positioned just past the newline. The ceiling is the point: a file that opens
@@ -72,8 +101,21 @@ template <typename Error>
         return false;
     }
     auto* buffer = input.rdbuf();
+    // An unformatted input function turns a streambuf exception into badbit
+    // and rethrows only when the caller asked for it; sbumpc does neither, so
+    // that translation is done here rather than quietly dropped. (A null rdbuf
+    // needs no guard: both constructing a stream with one and swapping one in
+    // set badbit, so good() is already false above -- verified, not assumed.)
+    const auto next = [buffer, &input] {
+        try {
+            return buffer->sbumpc();
+        } catch (...) {
+            input.setstate(std::ios::badbit);
+            throw;
+        }
+    };
     for (;;) {
-        const auto character = buffer->sbumpc();
+        const auto character = next();
         if (character == std::char_traits<char>::eof()) {
             input.setstate(line.empty()
                     ? (std::ios::eofbit | std::ios::failbit)
@@ -109,12 +151,13 @@ template <typename Error>
     std::string_view subject, std::string_view description,
     std::size_t limit = maximumHeaderTokenBytes)
 {
-    // width() is an int, and a limit past INT_MAX would narrow to zero or
-    // negative -- which operator>> reads as "no width", making the extraction
-    // unbounded and the check below dead. That is the exact behaviour this
-    // helper exists to prevent, so clamp instead of narrowing, and compare
-    // against what was actually applied.
-    const auto effectiveLimit = std::min<std::size_t>(limit,
+    // width() is an int, and operator>> reads any non-positive width as "no
+    // width" -- unbounded extraction, with the length check below then dead.
+    // Both ends therefore need clamping, not just the top: a limit past
+    // INT_MAX narrows to zero or negative, and a limit of zero is already
+    // there. Either way the helper would silently become the thing it exists
+    // to prevent, so the applied width is what the check compares against.
+    const auto effectiveLimit = std::clamp<std::size_t>(limit, 1,
         static_cast<std::size_t>(std::numeric_limits<int>::max()));
     std::string value;
     input >> std::setw(static_cast<int>(effectiveLimit)) >> value;

--- a/include/amrexplorer/io/detail/FabHeaderParsing.hpp
+++ b/include/amrexplorer/io/detail/FabHeaderParsing.hpp
@@ -11,12 +11,15 @@
 
 #include <algorithm>
 #include <array>
+#include <cctype>
 #include <cstddef>
 #include <cstdint>
+#include <iomanip>
 #include <istream>
 #include <limits>
 #include <sstream>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace amrvis::detail {
@@ -25,11 +28,16 @@ namespace amrvis::detail {
 // opaque, so it is read from a stream that has no idea where the text ends.
 // Real ones are a few hundred bytes -- a FAB's "FAB " plus a RealDescriptor, a
 // Box and a component count; a plotfile's version string -- and this ceiling
-// leaves two orders of magnitude of room. Named for headers generally though
-// both callers are currently FAB-path: the plotfile text readers are the
-// follow-up in text-header-readers-unbounded, and renaming this twice to say
-// so would be churn.
+// leaves two orders of magnitude of room. Named for headers generally, and now
+// genuinely shared: the FAB path and the plotfile text readers both bound their
+// lines here.
 inline constexpr std::size_t maximumHeaderLineBytes = 16U * 1024U;
+
+// The same idea for a whitespace-delimited token: a version string, a component
+// name, a FAB filename. Extraction with >> is otherwise unbounded -- it reads to
+// the next whitespace -- so one enormous whitespace-free run is allocated whole
+// before any count or cap can reject it.
+inline constexpr std::size_t maximumHeaderTokenBytes = 4U * 1024U;
 
 // std::getline with a ceiling, and otherwise its semantics: false when nothing
 // could be read, the line without its terminator otherwise, and the stream left
@@ -66,6 +74,45 @@ template <typename Error>
         }
         line.push_back(static_cast<char>(character));
     }
+}
+
+// operator>>(std::string) with a ceiling, and with the truncation hazard the
+// ceiling introduces handled here once rather than at each call site.
+//
+// width() is how the standard bounds the extraction, but it does not fail it:
+// >> sets failbit only when it extracts *nothing*, so an over-long token would
+// leave its tail in the stream to be read as the next field, and every field
+// after it would shift. That converts an out-of-memory failure into a silent
+// misparse, which is worse. A token this long is malformed, so say so.
+//
+// Reaching the limit is not by itself proof of truncation, and the difference
+// is what the stream position tells: what follows a complete token is
+// whitespace or end of file, and anything else is the rest of a token that did
+// not fit. Without that check a well-formed token of exactly the limit is
+// refused along with the truncated ones.
+template <typename Error>
+[[nodiscard]] std::string readBoundedToken(std::istream& input,
+    std::string_view subject, std::string_view description,
+    std::size_t limit = maximumHeaderTokenBytes)
+{
+    std::string value;
+    input >> std::setw(static_cast<int>(limit)) >> value;
+    if (!input) {
+        throw Error("malformed " + std::string(subject) + " while reading "
+            + std::string(description));
+    }
+    // good() is false when the extraction stopped at end of file, which is one
+    // of the two ways a complete token ends -- and peeking a stream that is not
+    // good() would set failbit on a stream the caller may still be reading.
+    if (value.size() >= limit && input.good()) {
+        const auto next = input.peek();
+        if (next != std::char_traits<char>::eof()
+            && std::isspace(static_cast<unsigned char>(next)) == 0) {
+            throw Error(std::string(subject) + " " + std::string(description)
+                + " exceeds the supported length");
+        }
+    }
+    return value;
 }
 
 // Every integer in the text, in order; any non-numeric characters act as

--- a/src/data/LocalDatasetSession.cpp
+++ b/src/data/LocalDatasetSession.cpp
@@ -8,7 +8,6 @@
 
 #include <algorithm>
 #include <cmath>
-#include <fstream>
 #include <limits>
 #include <stdexcept>
 #include <type_traits>
@@ -17,21 +16,6 @@
 
 namespace amrvis {
 namespace {
-
-std::string readFileVersion(
-    const std::filesystem::path& path, StopToken cancellation)
-{
-    if (cancellation.stop_requested()) {
-        throw ReadCancelled();
-    }
-    std::ifstream header(path / "Header");
-    std::string version;
-    std::getline(header, version);
-    while (!version.empty() && version.back() == '\r') {
-        version.pop_back();
-    }
-    return version;
-}
 
 std::optional<ValueRange> compositeMetadataRange(const DatasetMetadata& metadata,
     const RangeRequest& request)
@@ -62,12 +46,12 @@ std::optional<ValueRange> compositeMetadataRange(const DatasetMetadata& metadata
 } // namespace
 
 LocalDatasetSession::LocalDatasetSession(
-    std::shared_ptr<PlotfileDataset> dataset, std::string fileVersion)
+    std::shared_ptr<PlotfileDataset> dataset)
     : m_id(dataset ? dataset->id() : DatasetId{})
     , m_metadata(dataset ? dataset->metadata() : DatasetMetadata{})
     , m_metadataMetrics(
           dataset ? dataset->metadataReadMetrics() : MetadataReadMetrics{})
-    , m_fileVersion(std::move(fileVersion))
+    , m_fileVersion(dataset ? dataset->fileVersion() : std::string{})
     , m_particleSpecies(
           dataset ? dataset->particleSpecies()
                   : std::vector<ParticleSpeciesMetadata>{})
@@ -81,8 +65,7 @@ LocalDatasetSession::LocalDatasetSession(
 LocalDatasetSession::LocalDatasetSession(const std::filesystem::path& path,
     DatasetId id, std::uint64_t cacheBudgetBytes, StopToken cancellation)
     : LocalDatasetSession(std::make_shared<PlotfileDataset>(
-          path, id, cacheBudgetBytes, cancellation),
-          readFileVersion(path, cancellation))
+          path, id, cacheBudgetBytes, cancellation))
 {
 }
 
@@ -90,8 +73,7 @@ LocalDatasetSession::LocalDatasetSession(std::filesystem::path dataRoot,
     DatasetId id, std::uint64_t cacheBudgetBytes,
     PlotfileMetadataResult metadata, StopToken cancellation)
     : LocalDatasetSession(std::make_shared<PlotfileDataset>(dataRoot, id,
-          cacheBudgetBytes, metadata, cancellation),
-          metadata.fileVersion)
+          cacheBudgetBytes, std::move(metadata), cancellation))
 {
 }
 

--- a/src/io/plotfile/ParticleReader.cpp
+++ b/src/io/plotfile/ParticleReader.cpp
@@ -62,12 +62,10 @@ T readRequired(std::istream& input, std::string_view description)
         return detail::readBoundedToken<ParticleReadError>(
             input, "particle Header", description);
     } else {
-        T value{};
-        if (!(input >> value)) {
-            throw ParticleReadError("malformed particle Header while reading "
-                + std::string(description));
-        }
-        return value;
+        static_assert(std::is_integral_v<T>,
+            "particle Header fields are strings or integers");
+        return detail::readBoundedInteger<ParticleReadError, T>(
+            input, "particle Header", description);
     }
 }
 
@@ -167,7 +165,13 @@ ParsedHeader parseHeader(const std::filesystem::path& path,
         || result.metadata.realComponentCount > maximumComponents) {
         throw ParticleReadError("particle real component count is outside supported bounds");
     }
+    // Both component-name loops run up to maximumComponents times, and
+    // discoverParticleSpecies calls this once per subdirectory at every open,
+    // so a cancelled open must not wait them out.
     for (int i = 0; i < result.metadata.realComponentCount; ++i) {
+        if (cancellation.stop_requested()) {
+            throw ReadCancelled();
+        }
         (void)readRequired<std::string>(input, "real component name");
     }
     result.metadata.intComponentCount
@@ -178,6 +182,9 @@ ParsedHeader parseHeader(const std::filesystem::path& path,
             "particle integer component count is outside supported bounds");
     }
     for (int i = 0; i < result.metadata.intComponentCount; ++i) {
+        if (cancellation.stop_requested()) {
+            throw ReadCancelled();
+        }
         (void)readRequired<std::string>(input, "integer component name");
     }
     const auto checkpointFlag = readRequired<int>(input, "checkpoint flag");

--- a/src/io/plotfile/ParticleReader.cpp
+++ b/src/io/plotfile/ParticleReader.cpp
@@ -207,26 +207,26 @@ ParsedHeader parseHeader(const std::filesystem::path& path,
         throw ParticleReadError(
             "particle grid total is outside supported bounds");
     }
-    // The cap above rejects the absurd; this bounds what is merely large. A
-    // declared count is a claim, and the file's own size is the evidence
-    // against it: every grid record still to come needs at least "0 0 0\n" --
-    // three numbers, two separators, a newline -- so the Header cannot
-    // describe more than its bytes allow. Without this a Header of a few
-    // dozen bytes could still reserve the cap's worth, a quarter of a
-    // gigabyte, which is the same trade the point reserve below refuses to
-    // make.
+    // The cap above rejects the absurd; the shared rule bounds what is merely
+    // large. Every grid record still to come needs at least "0 0 0\n" -- three
+    // numbers, two separators, a newline -- so that is this table's per-record
+    // floor. Reserving straight from the declared count let a Header of a few
+    // dozen bytes take a quarter of a gigabyte.
+    //
+    // This used to be written out here with its own fallback rule, which had
+    // already drifted from the plotfile reader's copy. It now calls the one
+    // definition, which also brings the absolute reserve cap: a sparse header
+    // can forge any apparent size, so the file's size alone is not a bound.
     constexpr std::uint64_t minimumBytesPerGridRecord = 6;
     std::error_code headerSizeError;
     const auto headerBytes = std::filesystem::file_size(path, headerSizeError);
+    // No reserve at all when the size is unknown: this is an optimization, and
+    // the safe answer for an optimization that cannot be bounded is to skip it
+    // rather than take the largest allocation the cap still permits.
     if (!headerSizeError) {
-        const auto describableGrids
-            = static_cast<std::uint64_t>(headerBytes) / minimumBytesPerGridRecord;
-        result.grids.reserve(
-            static_cast<std::size_t>(std::min(totalGrids, describableGrids)));
+        result.grids.reserve(detail::evidenceBoundedCount(
+            totalGrids, headerBytes, minimumBytesPerGridRecord));
     }
-    // No fallback reserve when the size is unknown: this is an optimization,
-    // and the safe answer for an optimization that cannot be bounded is to
-    // skip it, not to take the largest allocation the cap still permits.
     std::uint64_t recordedParticles = 0;
     for (int level = 0; level <= result.finestLevel; ++level) {
         for (int grid = 0; grid < gridCounts[static_cast<std::size_t>(level)]; ++grid) {

--- a/src/io/plotfile/ParticleReader.cpp
+++ b/src/io/plotfile/ParticleReader.cpp
@@ -214,7 +214,7 @@ ParsedHeader parseHeader(const std::filesystem::path& path,
     // describe more than its bytes allow. Without this a Header of a few
     // dozen bytes could still reserve the cap's worth, a quarter of a
     // gigabyte, which is the same trade the point reserve below refuses to
-    // make. A failure to stat falls back to the count, which the cap bounds.
+    // make.
     constexpr std::uint64_t minimumBytesPerGridRecord = 6;
     std::error_code headerSizeError;
     const auto headerBytes = std::filesystem::file_size(path, headerSizeError);
@@ -514,6 +514,14 @@ std::vector<ParticleSpeciesMetadata> discoverParticleSpecies(
         // narrow deliberately, since an out-of-memory machine is not something
         // to swallow.
         std::ifstream probe(headerPath);
+        // Checked before the read, not caught after it: the plotfile root's
+        // subdirectories include every Level_N, none of which has a Header, so
+        // routing that outcome through a throw would cost one exception per
+        // level on every dataset open for a result that is entirely expected.
+        // The catch stays for the genuinely malformed case below.
+        if (!probe) {
+            continue;
+        }
         std::string version;
         try {
             version = detail::readBoundedToken<ParticleReadError>(

--- a/src/io/plotfile/ParticleReader.cpp
+++ b/src/io/plotfile/ParticleReader.cpp
@@ -1,4 +1,5 @@
 #include <amrexplorer/io/ParticleReader.hpp>
+#include <amrexplorer/io/detail/FabHeaderParsing.hpp>
 
 #include <algorithm>
 #include <array>
@@ -6,7 +7,6 @@
 #include <cmath>
 #include <cstring>
 #include <fstream>
-#include <iomanip>
 #include <limits>
 #include <map>
 #include <optional>
@@ -52,36 +52,23 @@ struct SelectedParticle {
     std::uint64_t id = 0;
 };
 
-// Longest string token a Header may contain -- a version string or a component
-// name. Extracting a string with >> is otherwise unbounded: it reads until
-// whitespace, so a Header holding one enormous whitespace-free run allocates
-// all of it before any count or cap is consulted. width() is how the standard
-// bounds that, and it is reset by the extraction.
-constexpr int maximumHeaderTokenBytes = 4096;
-
+// String tokens -- the version string, a component name -- are bounded and
+// length-checked by the shared helper, which owns the width()-plus-reject shape
+// this function used to carry by hand.
 template <typename T>
 T readRequired(std::istream& input, std::string_view description)
 {
-    T value{};
     if constexpr (std::is_same_v<T, std::string>) {
-        input >> std::setw(maximumHeaderTokenBytes);
-    }
-    if (!(input >> value)) {
-        throw ParticleReadError(
-            "malformed particle Header while reading " + std::string(description));
-    }
-    if constexpr (std::is_same_v<T, std::string>) {
-        // width() stops the extraction but does not fail it: >> sets failbit
-        // only when it extracts nothing, so hitting the limit would leave the
-        // rest of the token in the stream to be read as the next field, and
-        // every field after it would shift. Bounding the allocation must not
-        // buy that -- a token this long is malformed, so say so.
-        if (value.size() >= static_cast<std::size_t>(maximumHeaderTokenBytes)) {
-            throw ParticleReadError("particle Header " + std::string(description)
-                + " exceeds the supported length");
+        return detail::readBoundedToken<ParticleReadError>(
+            input, "particle Header", description);
+    } else {
+        T value{};
+        if (!(input >> value)) {
+            throw ParticleReadError("malformed particle Header while reading "
+                + std::string(description));
         }
+        return value;
     }
-    return value;
 }
 
 std::uint64_t checkedProduct(
@@ -140,8 +127,8 @@ void skipChunk(std::istream& input, std::size_t recordCount,
     }
 }
 
-ParsedHeader parseHeader(
-    const std::filesystem::path& path, const std::string& species)
+ParsedHeader parseHeader(const std::filesystem::path& path,
+    const std::string& species, StopToken cancellation)
 {
     std::ifstream input(path);
     if (!input) {
@@ -243,6 +230,13 @@ ParsedHeader parseHeader(
     std::uint64_t recordedParticles = 0;
     for (int level = 0; level <= result.finestLevel; ++level) {
         for (int grid = 0; grid < gridCounts[static_cast<std::size_t>(level)]; ++grid) {
+            // Up to ten million records per level: the one stretch of a Header
+            // parse long enough that a user who cancels must not wait it out.
+            // Polled per record, like the DATA-file stat loop in
+            // readParticleSample.
+            if (cancellation.stop_requested()) {
+                throw ReadCancelled();
+            }
             GridRecord record;
             record.level = level;
             record.fileNumber = readRequired<int>(input, "particle data file number");
@@ -514,22 +508,25 @@ std::vector<ParticleSpeciesMetadata> discoverParticleSpecies(
             continue;
         }
         const auto headerPath = entry.path() / "Header";
-        // Bounded like every other Header token: this runs before the try
-        // below, and its catch is deliberately narrow -- a malformed species
-        // is skipped, an out-of-memory machine is not something to swallow --
-        // so an unbounded read here would take the whole open down.
+        // Bounded like every other Header token, through the same helper the
+        // real parse uses. An unreadable, empty or over-long probe is just a
+        // directory that is not a species, so it is skipped -- the catch stays
+        // narrow deliberately, since an out-of-memory machine is not something
+        // to swallow.
         std::ifstream probe(headerPath);
         std::string version;
-        probe >> std::setw(maximumHeaderTokenBytes);
-        if (!(probe >> version)
-            || version.size() >= static_cast<std::size_t>(
-                   maximumHeaderTokenBytes)
-            || !version.starts_with("Version_")) {
+        try {
+            version = detail::readBoundedToken<ParticleReadError>(
+                probe, "particle Header", "version");
+        } catch (const ParticleReadError&) {
+            continue;
+        }
+        if (!version.starts_with("Version_")) {
             continue;
         }
         try {
-            result.push_back(parseHeader(
-                headerPath, entry.path().filename().string()).metadata);
+            result.push_back(parseHeader(headerPath,
+                entry.path().filename().string(), cancellation).metadata);
         } catch (const ParticleReadError&) {
             continue;
         }
@@ -553,7 +550,8 @@ ParticleSample readParticleSample(
         throw ReadCancelled();
     }
     const auto speciesPath = plotfile / species;
-    const auto header = parseHeader(speciesPath / "Header", species);
+    const auto header
+        = parseHeader(speciesPath / "Header", species, cancellation);
     if (!header.checkpoint) {
         throw ParticleReadError(
             "non-checkpoint particle data is unsupported because it has no "

--- a/src/io/plotfile/ParticleReader.cpp
+++ b/src/io/plotfile/ParticleReader.cpp
@@ -220,13 +220,8 @@ ParsedHeader parseHeader(const std::filesystem::path& path,
     constexpr std::uint64_t minimumBytesPerGridRecord = 6;
     std::error_code headerSizeError;
     const auto headerBytes = std::filesystem::file_size(path, headerSizeError);
-    // No reserve at all when the size is unknown: this is an optimization, and
-    // the safe answer for an optimization that cannot be bounded is to skip it
-    // rather than take the largest allocation the cap still permits.
-    if (!headerSizeError) {
-        result.grids.reserve(detail::evidenceBoundedCount(
-            totalGrids, headerBytes, minimumBytesPerGridRecord));
-    }
+    result.grids.reserve(detail::evidenceBoundedCount(
+        totalGrids, headerBytes, minimumBytesPerGridRecord, headerSizeError));
     std::uint64_t recordedParticles = 0;
     for (int level = 0; level <= result.finestLevel; ++level) {
         for (int grid = 0; grid < gridCounts[static_cast<std::size_t>(level)]; ++grid) {

--- a/src/io/plotfile/PlotfileDataset.cpp
+++ b/src/io/plotfile/PlotfileDataset.cpp
@@ -87,6 +87,11 @@ const MetadataReadMetrics& PlotfileDataset::metadataReadMetrics() const noexcept
     return m_metadataResult.metrics;
 }
 
+const std::string& PlotfileDataset::fileVersion() const noexcept
+{
+    return m_metadataResult.fileVersion;
+}
+
 DatasetId PlotfileDataset::id() const noexcept
 {
     return m_id;

--- a/src/io/plotfile/PlotfileMetadataReader.cpp
+++ b/src/io/plotfile/PlotfileMetadataReader.cpp
@@ -15,6 +15,7 @@
 #include <string>
 #include <string_view>
 #include <system_error>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -25,15 +26,24 @@ constexpr int maximumComponents = 100'000;
 constexpr int maximumLevels = 1'000;
 constexpr int maximumGridsPerLevel = 10'000'000;
 
+// Every Header field goes through here. String fields -- the file version, the
+// FabOnDisk prefix and filename, the level data path -- are bounded and
+// length-checked by the shared helper; the numeric ones need no ceiling because
+// >> stops at the first character that cannot extend the value.
 template <typename T>
 T readRequired(std::istream& input, std::string_view description)
 {
-    T value{};
-    if (!(input >> value)) {
-        throw MetadataReadError("malformed plotfile Header while reading "
-            + std::string(description));
+    if constexpr (std::is_same_v<T, std::string>) {
+        return detail::readBoundedToken<MetadataReadError>(
+            input, "plotfile Header", description);
+    } else {
+        T value{};
+        if (!(input >> value)) {
+            throw MetadataReadError("malformed plotfile Header while reading "
+                + std::string(description));
+        }
+        return value;
     }
-    return value;
 }
 
 // Reads one VisMF min/max statistic, which -- unlike the geometry fields --
@@ -57,6 +67,15 @@ double readStatisticValue(std::istream& input, std::string_view description)
              && next != ','
              && std::isspace(static_cast<unsigned char>(next)) == 0;
          next = input.peek()) {
+        // The loop is delimited by the file's own content, so a run without a
+        // comma or whitespace would otherwise accumulate without limit. Unlike
+        // a name or a path, a numeric token has no legitimate length anywhere
+        // near this ceiling, so hitting it needs no complete-versus-truncated
+        // distinction -- it is malformed either way.
+        if (token.size() >= detail::maximumHeaderTokenBytes) {
+            throw MetadataReadError("plotfile Header "
+                + std::string(description) + " exceeds the supported length");
+        }
         token.push_back(static_cast<char>(input.get()));
     }
     const char* begin = token.c_str();
@@ -79,10 +98,13 @@ std::string trim(std::string value)
     return value.substr(first, last - first + 1);
 }
 
+// The function that walks a plotfile Header, so its ceiling matters most: a
+// Header that never supplies a newline would otherwise accumulate the whole
+// remaining file into one line before the parse could reject it.
 std::string readNonEmptyLine(std::istream& input, std::string_view description)
 {
     std::string line;
-    while (std::getline(input, line)) {
+    while (detail::readBoundedLine<MetadataReadError>(input, line)) {
         line = trim(std::move(line));
         if (!line.empty()) {
             return line;
@@ -238,7 +260,27 @@ detail::VisMfIndex detail::readVisMfIndex(
         throw MetadataReadError("VisMF BoxArray size is outside supported bounds");
     }
     const auto boxCount = static_cast<std::size_t>(boxArrayHeader.front());
-    index.boxes.reserve(boxCount);
+    // The cap above rejects the absurd; the file's own size bounds what is
+    // merely large. A declared count is a claim, and the Header cannot describe
+    // more entries than its bytes allow: the shortest legal BoxArray entry is
+    // "((0)(0)(0))", eleven bytes at one dimension and more at two or three,
+    // and the shortest legal location record is "FabOnDisk: a 0", fourteen.
+    // Reserving from the declared count alone let a Header of a few dozen bytes
+    // claim ten million boxes plus ten million names and offsets -- roughly
+    // 750 MB -- before a single entry was parsed, which is the same trade the
+    // particle grid table already refuses to make. Both reserves are
+    // optimizations, so under-reserving a legitimate file costs one
+    // reallocation and nothing else; that is why the floors here sit below the
+    // true minimums rather than being tuned to them.
+    constexpr std::uint64_t minimumBytesPerBoxEntry = 8;
+    constexpr std::uint64_t minimumBytesPerLocationRecord = 12;
+    const auto evidenceBoundedCount = [headerSize](std::uint64_t declared,
+                                          std::uint64_t bytesPerRecord) {
+        return static_cast<std::size_t>(std::min(
+            declared, static_cast<std::uint64_t>(headerSize) / bytesPerRecord));
+    };
+    index.boxes.reserve(evidenceBoundedCount(
+        static_cast<std::uint64_t>(boxCount), minimumBytesPerBoxEntry));
     for (std::size_t box = 0; box < boxCount; ++box) {
         if (cancellation.stop_requested()) {
             throw ReadCancelled();
@@ -253,8 +295,10 @@ detail::VisMfIndex detail::readVisMfIndex(
     if (locationCount != boxCount) {
         throw MetadataReadError("VisMF location count does not match BoxArray size");
     }
-    index.fileNames.reserve(boxCount);
-    index.fileOffsets.reserve(boxCount);
+    const auto reservableLocations = evidenceBoundedCount(
+        static_cast<std::uint64_t>(boxCount), minimumBytesPerLocationRecord);
+    index.fileNames.reserve(reservableLocations);
+    index.fileOffsets.reserve(reservableLocations);
     for (std::size_t block = 0; block < boxCount; ++block) {
         if (cancellation.stop_requested()) {
             throw ReadCancelled();

--- a/src/io/plotfile/PlotfileMetadataReader.cpp
+++ b/src/io/plotfile/PlotfileMetadataReader.cpp
@@ -46,6 +46,25 @@ T readRequired(std::istream& input, std::string_view description)
     }
 }
 
+// How many entries to reserve for a count the file declares. A declared count
+// is a claim; the file's own size is the evidence against it, because a header
+// cannot describe more entries than its bytes allow. Reserving from the claim
+// alone let a header of a few dozen bytes take hundreds of megabytes before a
+// single entry was parsed -- the trade the particle grid table already refuses
+// to make.
+//
+// Every caller is reserving, never sizing, so under-reserving a legitimate file
+// costs one reallocation and nothing else. That asymmetry is why the per-record
+// floors callers pass sit *below* the true minimum rather than being tuned to
+// it: too low only forgoes some of the optimization, while too high would drop
+// a real file's reserve on the floor.
+[[nodiscard]] std::size_t evidenceBoundedCount(std::uint64_t declared,
+    std::uintmax_t fileBytes, std::uint64_t minimumBytesPerRecord)
+{
+    return static_cast<std::size_t>(std::min(
+        declared, static_cast<std::uint64_t>(fileBytes) / minimumBytesPerRecord));
+}
+
 // Reads one VisMF min/max statistic, which -- unlike the geometry fields --
 // may be non-finite. AMReX's FArrayBox::min/max propagate +/-inf (and can
 // leave a NaN) from an overflowed run, and its plotfile headers carry those
@@ -261,26 +280,14 @@ detail::VisMfIndex detail::readVisMfIndex(
     }
     const auto boxCount = static_cast<std::size_t>(boxArrayHeader.front());
     // The cap above rejects the absurd; the file's own size bounds what is
-    // merely large. A declared count is a claim, and the Header cannot describe
-    // more entries than its bytes allow: the shortest legal BoxArray entry is
-    // "((0)(0)(0))", eleven bytes at one dimension and more at two or three,
-    // and the shortest legal location record is "FabOnDisk: a 0", fourteen.
-    // Reserving from the declared count alone let a Header of a few dozen bytes
-    // claim ten million boxes plus ten million names and offsets -- roughly
-    // 750 MB -- before a single entry was parsed, which is the same trade the
-    // particle grid table already refuses to make. Both reserves are
-    // optimizations, so under-reserving a legitimate file costs one
-    // reallocation and nothing else; that is why the floors here sit below the
-    // true minimums rather than being tuned to them.
+    // merely large. The shortest legal BoxArray entry is "((0)(0)(0))", eleven
+    // bytes at one dimension and more at two or three, and the shortest legal
+    // location record is "FabOnDisk: a 0", fourteen.
     constexpr std::uint64_t minimumBytesPerBoxEntry = 8;
     constexpr std::uint64_t minimumBytesPerLocationRecord = 12;
-    const auto evidenceBoundedCount = [headerSize](std::uint64_t declared,
-                                          std::uint64_t bytesPerRecord) {
-        return static_cast<std::size_t>(std::min(
-            declared, static_cast<std::uint64_t>(headerSize) / bytesPerRecord));
-    };
     index.boxes.reserve(evidenceBoundedCount(
-        static_cast<std::uint64_t>(boxCount), minimumBytesPerBoxEntry));
+        static_cast<std::uint64_t>(boxCount), headerSize,
+        minimumBytesPerBoxEntry));
     for (std::size_t box = 0; box < boxCount; ++box) {
         if (cancellation.stop_requested()) {
             throw ReadCancelled();
@@ -296,7 +303,8 @@ detail::VisMfIndex detail::readVisMfIndex(
         throw MetadataReadError("VisMF location count does not match BoxArray size");
     }
     const auto reservableLocations = evidenceBoundedCount(
-        static_cast<std::uint64_t>(boxCount), minimumBytesPerLocationRecord);
+        static_cast<std::uint64_t>(boxCount), headerSize,
+        minimumBytesPerLocationRecord);
     index.fileNames.reserve(reservableLocations);
     index.fileOffsets.reserve(reservableLocations);
     for (std::size_t block = 0; block < boxCount; ++block) {
@@ -421,7 +429,12 @@ PlotfileMetadataResult PlotfileMetadataReader::read(
     }
 
     input.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
-    metadata->fields.reserve(static_cast<std::size_t>(componentCount));
+    // Each component is one name on its own line, so two bytes is the shortest
+    // one a Header can carry.
+    constexpr std::uint64_t minimumBytesPerComponentName = 2;
+    metadata->fields.reserve(evidenceBoundedCount(
+        static_cast<std::uint64_t>(componentCount), headerSize,
+        minimumBytesPerComponentName));
     for (int component = 0; component < componentCount; ++component) {
         auto name = readNonEmptyLine(input, "component name");
         metadata->fields.push_back({name, Centering::Cell, {std::move(name)}});
@@ -493,7 +506,15 @@ PlotfileMetadataResult PlotfileMetadataReader::read(
 
         auto& level = metadata->levels[levelIndex];
         level.step = headerStep;
-        level.boxes.reserve(static_cast<std::size_t>(gridCount));
+        // The same claim-versus-evidence trade as the VisMF BoxArray, and the
+        // more reachable one: this is the top-level Header, the first file any
+        // open reads. A grid record is a physical bound per axis, so the
+        // shortest one a Header can carry is "0 0\n" -- four bytes at one
+        // dimension, more above it.
+        constexpr std::uint64_t minimumBytesPerGridRecord = 4;
+        level.boxes.reserve(evidenceBoundedCount(
+            static_cast<std::uint64_t>(gridCount), headerSize,
+            minimumBytesPerGridRecord));
         for (int grid = 0; grid < gridCount; ++grid) {
             if (cancellation.stop_requested()) {
                 throw ReadCancelled();

--- a/src/io/plotfile/PlotfileMetadataReader.cpp
+++ b/src/io/plotfile/PlotfileMetadataReader.cpp
@@ -30,22 +30,33 @@ constexpr int maximumGridsPerLevel = 10'000'000;
 // FabOnDisk prefix and filename, the level data path -- are bounded and
 // length-checked by the shared helper.
 //
-// The numeric ones are not, and they do not divide the way one would guess.
-// Integer extraction is genuinely bounded: libstdc++ stops accumulating once
-// the digits cannot extend the value, and a multi-megabyte digit run allocates
-// nothing (measured). `double` is not: the whole run is a syntactically valid
-// float prefix, so num_get buffers all of it -- 67 MB for a 20 MB run of
-// digits, a 3.2x amplification, before the value overflows and the extraction
-// fails. `time`, the physical bounds, the cell sizes and the grid bounds all
-// read through that path. Bounding it means routing through readBoundedToken
-// and strtod, the shape readStatisticValue already uses; it is tracked with
-// the rest of the remaining allocation work rather than done here.
+// The numeric ones do not divide the way one would guess. Integer extraction
+// is genuinely bounded -- libstdc++ stops accumulating once the digits cannot
+// extend the value, and a multi-megabyte run allocates nothing (measured) --
+// so it goes straight to operator>>. `double` is not: every digit of a long
+// run is a syntactically valid continuation, so num_get buffers all of it, 67
+// MB for a 20 MB run, before the value overflows and the extraction fails.
+// `time`, the physical bounds, the cell sizes and every grid bound read that
+// way, so double goes through a bounded token and strtod instead -- the shape
+// readStatisticValue uses, minus its tolerance for inf/nan, which the geometry
+// fields have no reason to accept.
 template <typename T>
 T readRequired(std::istream& input, std::string_view description)
 {
     if constexpr (std::is_same_v<T, std::string>) {
         return detail::readBoundedToken<MetadataReadError>(
             input, "plotfile Header", description);
+    } else if constexpr (std::is_same_v<T, double>) {
+        const auto token = detail::readBoundedToken<MetadataReadError>(
+            input, "plotfile Header", description);
+        const char* begin = token.c_str();
+        char* end = nullptr;
+        const double value = std::strtod(begin, &end);
+        if (token.empty() || end != begin + token.size()) {
+            throw MetadataReadError("malformed plotfile Header while reading "
+                + std::string(description));
+        }
+        return value;
     } else {
         T value{};
         if (!(input >> value)) {
@@ -54,25 +65,6 @@ T readRequired(std::istream& input, std::string_view description)
         }
         return value;
     }
-}
-
-// How many entries to reserve for a count the file declares. A declared count
-// is a claim; the file's own size is the evidence against it, because a header
-// cannot describe more entries than its bytes allow. Reserving from the claim
-// alone let a header of a few dozen bytes take hundreds of megabytes before a
-// single entry was parsed -- the trade the particle grid table already refuses
-// to make.
-//
-// Every caller is reserving, never sizing, so under-reserving a legitimate file
-// costs one reallocation and nothing else. That asymmetry is why the per-record
-// floors callers pass sit *below* the true minimum rather than being tuned to
-// it: too low only forgoes some of the optimization, while too high would drop
-// a real file's reserve on the floor.
-[[nodiscard]] std::size_t evidenceBoundedCount(std::uint64_t declared,
-    std::uintmax_t fileBytes, std::uint64_t minimumBytesPerRecord)
-{
-    return static_cast<std::size_t>(std::min(
-        declared, static_cast<std::uint64_t>(fileBytes) / minimumBytesPerRecord));
 }
 
 // Reads one VisMF min/max statistic, which -- unlike the geometry fields --
@@ -213,7 +205,8 @@ void requireContainedPath(const std::string& value, std::string_view what)
 // full before the count was cross-checked).
 std::vector<std::vector<double>> readRealMatrix(
     std::istream& input, std::string_view description,
-    std::uint64_t expectedRows, std::uint64_t expectedColumns)
+    std::uint64_t expectedRows, std::uint64_t expectedColumns,
+    std::uintmax_t fileBytes, StopToken cancellation)
 {
     const auto rows = readRequired<std::uint64_t>(input, description);
     char comma = '\0';
@@ -226,16 +219,36 @@ std::vector<std::vector<double>> readRealMatrix(
             "BoxArray size and component count");
     }
 
-    std::vector<std::vector<double>> matrix(
-        static_cast<std::size_t>(rows),
-        std::vector<double>(static_cast<std::size_t>(columns)));
-    for (auto& row : matrix) {
-        for (auto& value : row) {
-            value = readStatisticValue(input, description);
+    // Grown as values parse rather than sized up front. The shape check above
+    // constrains each factor against something real -- rows against the boxes
+    // already parsed, columns against the declared component count -- but not
+    // their *product*, and the product is the allocation. A 35 KB header
+    // declaring 1000 boxes and 100,000 components asked for 800 MB before a
+    // single statistic was read, and scaling the box list to a ~350 KB header
+    // reached ~8 GB. Growing instead means the memory tracks the values the
+    // file actually contains: a header that runs out faults on the first
+    // missing one.
+    constexpr std::uint64_t minimumBytesPerValue = 2;  // "0,"
+    std::vector<std::vector<double>> matrix;
+    matrix.reserve(detail::evidenceBoundedCount(
+        rows, fileBytes, minimumBytesPerValue * std::max<std::uint64_t>(1, columns)));
+    for (std::uint64_t row = 0; row < rows; ++row) {
+        std::vector<double> values;
+        values.reserve(detail::evidenceBoundedCount(
+            columns, fileBytes, minimumBytesPerValue));
+        for (std::uint64_t column = 0; column < columns; ++column) {
+            // The longest loop in the parse: rows x columns iterations, run
+            // twice for a v1/v3 header. Nothing else here polls often enough
+            // to make a cancelled open responsive.
+            if (cancellation.stop_requested()) {
+                throw ReadCancelled();
+            }
+            values.push_back(readStatisticValue(input, description));
             if (!(input >> comma) || comma != ',') {
                 throw MetadataReadError("malformed comma-separated VisMF matrix");
             }
         }
+        matrix.push_back(std::move(values));
     }
     return matrix;
 }
@@ -295,7 +308,7 @@ detail::VisMfIndex detail::readVisMfIndex(
     // location record is "FabOnDisk: a 0", fourteen.
     constexpr std::uint64_t minimumBytesPerBoxEntry = 8;
     constexpr std::uint64_t minimumBytesPerLocationRecord = 12;
-    index.boxes.reserve(evidenceBoundedCount(
+    index.boxes.reserve(detail::evidenceBoundedCount(
         static_cast<std::uint64_t>(boxCount), headerSize,
         minimumBytesPerBoxEntry));
     for (std::size_t box = 0; box < boxCount; ++box) {
@@ -312,7 +325,7 @@ detail::VisMfIndex detail::readVisMfIndex(
     if (locationCount != boxCount) {
         throw MetadataReadError("VisMF location count does not match BoxArray size");
     }
-    const auto reservableLocations = evidenceBoundedCount(
+    const auto reservableLocations = detail::evidenceBoundedCount(
         static_cast<std::uint64_t>(boxCount), headerSize,
         minimumBytesPerLocationRecord);
     index.fileNames.reserve(reservableLocations);
@@ -333,10 +346,12 @@ detail::VisMfIndex detail::readVisMfIndex(
     if (index.version == 1 || index.version == 3) {
         index.minimum = readRealMatrix(input, "per-block minima",
             static_cast<std::uint64_t>(boxCount),
-            static_cast<std::uint64_t>(index.components));
+            static_cast<std::uint64_t>(index.components), headerSize,
+            cancellation);
         index.maximum = readRealMatrix(input, "per-block maxima",
             static_cast<std::uint64_t>(boxCount),
-            static_cast<std::uint64_t>(index.components));
+            static_cast<std::uint64_t>(index.components), headerSize,
+            cancellation);
         index.hasPerBlockStatistics = true;
         if (index.minimum.size() != boxCount || index.maximum.size() != boxCount) {
             throw MetadataReadError("VisMF statistics do not match BoxArray size");
@@ -345,7 +360,12 @@ detail::VisMfIndex detail::readVisMfIndex(
         index.minimum.push_back({});
         index.maximum.push_back({});
         char comma = '\0';
+        // Up to maximumComponents iterations each, so both poll: a declared
+        // count drives the loop and only the values themselves end it.
         for (int component = 0; component < index.components; ++component) {
+            if (cancellation.stop_requested()) {
+                throw ReadCancelled();
+            }
             index.minimum.front().push_back(
                 readStatisticValue(input, "FabArray minimum"));
             if (!(input >> comma) || comma != ',') {
@@ -353,6 +373,9 @@ detail::VisMfIndex detail::readVisMfIndex(
             }
         }
         for (int component = 0; component < index.components; ++component) {
+            if (cancellation.stop_requested()) {
+                throw ReadCancelled();
+            }
             index.maximum.front().push_back(
                 readStatisticValue(input, "FabArray maximum"));
             if (!(input >> comma) || comma != ',') {
@@ -442,10 +465,15 @@ PlotfileMetadataResult PlotfileMetadataReader::read(
     // Each component is one name on its own line, so two bytes is the shortest
     // one a Header can carry.
     constexpr std::uint64_t minimumBytesPerComponentName = 2;
-    metadata->fields.reserve(evidenceBoundedCount(
+    metadata->fields.reserve(detail::evidenceBoundedCount(
         static_cast<std::uint64_t>(componentCount), headerSize,
         minimumBytesPerComponentName));
     for (int component = 0; component < componentCount; ++component) {
+        // Driven by a declared count up to maximumComponents, so it polls for
+        // the same reason the statistics loops do.
+        if (cancellation.stop_requested()) {
+            throw ReadCancelled();
+        }
         auto name = readNonEmptyLine(input, "component name");
         metadata->fields.push_back({name, Centering::Cell, {std::move(name)}});
     }
@@ -522,7 +550,7 @@ PlotfileMetadataResult PlotfileMetadataReader::read(
         // shortest one a Header can carry is "0 0\n" -- four bytes at one
         // dimension, more above it.
         constexpr std::uint64_t minimumBytesPerGridRecord = 4;
-        level.boxes.reserve(evidenceBoundedCount(
+        level.boxes.reserve(detail::evidenceBoundedCount(
             static_cast<std::uint64_t>(gridCount), headerSize,
             minimumBytesPerGridRecord));
         for (int grid = 0; grid < gridCount; ++grid) {

--- a/src/io/plotfile/PlotfileMetadataReader.cpp
+++ b/src/io/plotfile/PlotfileMetadataReader.cpp
@@ -28,8 +28,18 @@ constexpr int maximumGridsPerLevel = 10'000'000;
 
 // Every Header field goes through here. String fields -- the file version, the
 // FabOnDisk prefix and filename, the level data path -- are bounded and
-// length-checked by the shared helper; the numeric ones need no ceiling because
-// >> stops at the first character that cannot extend the value.
+// length-checked by the shared helper.
+//
+// The numeric ones are not, and they do not divide the way one would guess.
+// Integer extraction is genuinely bounded: libstdc++ stops accumulating once
+// the digits cannot extend the value, and a multi-megabyte digit run allocates
+// nothing (measured). `double` is not: the whole run is a syntactically valid
+// float prefix, so num_get buffers all of it -- 67 MB for a 20 MB run of
+// digits, a 3.2x amplification, before the value overflows and the extraction
+// fails. `time`, the physical bounds, the cell sizes and the grid bounds all
+// read through that path. Bounding it means routing through readBoundedToken
+// and strtod, the shape readStatisticValue already uses; it is tracked with
+// the rest of the remaining allocation work rather than done here.
 template <typename T>
 T readRequired(std::istream& input, std::string_view description)
 {

--- a/src/io/plotfile/PlotfileMetadataReader.cpp
+++ b/src/io/plotfile/PlotfileMetadataReader.cpp
@@ -52,7 +52,17 @@ T readRequired(std::istream& input, std::string_view description)
         const char* begin = token.c_str();
         char* end = nullptr;
         const double value = std::strtod(begin, &end);
-        if (token.empty() || end != begin + token.size()) {
+        // strtod and operator>> do not accept the same grammar, and bounding
+        // the read must not quietly widen it. strtod takes "nan", "inf",
+        // "infinity" and an overflowing exponent, all of which num_get
+        // refuses; rejecting non-finite results restores that exactly.
+        //
+        // Deliberately *not* errno == ERANGE: strtod raises it for underflow
+        // too, where operator>> accepts the result -- including a legitimate
+        // denormal like 4.9e-324. Measured on all of nan, inf, -inf, infinity,
+        // 1e999, 1e-999, 4.9e-324 and 0.5, this predicate agrees with the
+        // extraction it replaced on every one.
+        if (end != begin + token.size() || !std::isfinite(value)) {
             throw MetadataReadError("malformed plotfile Header while reading "
                 + std::string(description));
         }
@@ -231,15 +241,21 @@ std::vector<std::vector<double>> readRealMatrix(
     constexpr std::uint64_t minimumBytesPerValue = 2;  // "0,"
     std::vector<std::vector<double>> matrix;
     matrix.reserve(detail::evidenceBoundedCount(
-        rows, fileBytes, minimumBytesPerValue * std::max<std::uint64_t>(1, columns)));
+        rows, fileBytes, minimumBytesPerValue * columns));
     for (std::uint64_t row = 0; row < rows; ++row) {
+        // Polled per row as well as per value: a header may declare zero
+        // components, and then the inner loop never runs while this one still
+        // iterates once per box -- up to ten million times, with the poll
+        // below never reached.
+        if (cancellation.stop_requested()) {
+            throw ReadCancelled();
+        }
         std::vector<double> values;
         values.reserve(detail::evidenceBoundedCount(
             columns, fileBytes, minimumBytesPerValue));
         for (std::uint64_t column = 0; column < columns; ++column) {
             // The longest loop in the parse: rows x columns iterations, run
-            // twice for a v1/v3 header. Nothing else here polls often enough
-            // to make a cancelled open responsive.
+            // twice for a v1/v3 header.
             if (cancellation.stop_requested()) {
                 throw ReadCancelled();
             }
@@ -353,9 +369,11 @@ detail::VisMfIndex detail::readVisMfIndex(
             static_cast<std::uint64_t>(index.components), headerSize,
             cancellation);
         index.hasPerBlockStatistics = true;
-        if (index.minimum.size() != boxCount || index.maximum.size() != boxCount) {
-            throw MetadataReadError("VisMF statistics do not match BoxArray size");
-        }
+        // The shape check that used to live here is gone rather than kept as
+        // reassurance: readRealMatrix now returns only after appending exactly
+        // `rows` rows, having already refused any rows != boxCount, so it
+        // could not fail. A check that cannot fail reads like a live invariant
+        // and is worse than none.
     } else if (index.version == 4) {
         index.minimum.push_back({});
         index.maximum.push_back({});

--- a/src/io/plotfile/PlotfileMetadataReader.cpp
+++ b/src/io/plotfile/PlotfileMetadataReader.cpp
@@ -30,16 +30,20 @@ constexpr int maximumGridsPerLevel = 10'000'000;
 // FabOnDisk prefix and filename, the level data path -- are bounded and
 // length-checked by the shared helper.
 //
-// The numeric ones do not divide the way one would guess. Integer extraction
-// is genuinely bounded -- libstdc++ stops accumulating once the digits cannot
-// extend the value, and a multi-megabyte run allocates nothing (measured) --
-// so it goes straight to operator>>. `double` is not: every digit of a long
-// run is a syntactically valid continuation, so num_get buffers all of it, 67
-// MB for a 20 MB run, before the value overflows and the extraction fails.
-// `time`, the physical bounds, the cell sizes and every grid bound read that
-// way, so double goes through a bounded token and strtod instead -- the shape
-// readStatisticValue uses, minus its tolerance for inf/nan, which the geometry
-// fields have no reason to accept.
+// The numeric ones are bounded too, each by the helper that keeps its own
+// delimiters. `double` reads a whitespace-delimited token and converts with
+// strtod, because every digit of a long run is a valid continuation and
+// num_get buffers all of it -- 67 MB for a 20 MB run, measured. Integers stop
+// at the first character that cannot extend the value, because header integers
+// sit inside "((0,0) (7,7))" and a whitespace-delimited read would swallow the
+// punctuation.
+//
+// Integers were briefly left unbounded on the grounds that libstdc++
+// accumulates a value rather than a buffer, which measured as allocating
+// nothing. That reasoning does not travel: libc++ buffers and doubles a string
+// per digit, so the same run allocates in full on macOS, which this project
+// supports and builds in CI. The bound belongs in the reader, not in an
+// assumption about one standard library.
 template <typename T>
 T readRequired(std::istream& input, std::string_view description)
 {
@@ -68,12 +72,10 @@ T readRequired(std::istream& input, std::string_view description)
         }
         return value;
     } else {
-        T value{};
-        if (!(input >> value)) {
-            throw MetadataReadError("malformed plotfile Header while reading "
-                + std::string(description));
-        }
-        return value;
+        static_assert(std::is_integral_v<T>,
+            "readRequired handles strings, doubles and integers");
+        return detail::readBoundedInteger<MetadataReadError, T>(
+            input, "plotfile Header", description);
     }
 }
 
@@ -132,10 +134,19 @@ std::string trim(std::string value)
 // The function that walks a plotfile Header, so its ceiling matters most: a
 // Header that never supplies a newline would otherwise accumulate the whole
 // remaining file into one line before the parse could reject it.
-std::string readNonEmptyLine(std::istream& input, std::string_view description)
+std::string readNonEmptyLine(std::istream& input, std::string_view description,
+    StopToken cancellation = {})
 {
     std::string line;
     while (detail::readBoundedLine<MetadataReadError>(input, line)) {
+        // Each line is individually bounded, but how many blank ones precede
+        // the field is the file's decision: a Header of nothing but newlines
+        // spins here once per byte. Every other loop a declared count drives
+        // polls; this one is driven by content and needs it for the same
+        // reason.
+        if (cancellation.stop_requested()) {
+            throw ReadCancelled();
+        }
         line = trim(std::move(line));
         if (!line.empty()) {
             return line;
@@ -299,7 +310,7 @@ detail::VisMfIndex detail::readVisMfIndex(
     }
     input.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
 
-    const auto ghostValues = parseIntegers(readNonEmptyLine(input, "VisMF ghost width"));
+    const auto ghostValues = parseIntegers(readNonEmptyLine(input, "VisMF ghost width", cancellation));
     if (ghostValues.size() == 1) {
         index.ghostWidth = {{ghostValues[0], ghostValues[0], ghostValues[0]}};
     } else if (ghostValues.size() >= static_cast<std::size_t>(dimension)) {
@@ -312,7 +323,7 @@ detail::VisMfIndex detail::readVisMfIndex(
     }
 
     const auto boxArrayHeader = parseIntegers(
-        readNonEmptyLine(input, "VisMF BoxArray header"));
+        readNonEmptyLine(input, "VisMF BoxArray header", cancellation));
     if (boxArrayHeader.empty() || boxArrayHeader.front() < 0
         || boxArrayHeader.front() > maximumGridsPerLevel) {
         throw MetadataReadError("VisMF BoxArray size is outside supported bounds");
@@ -333,7 +344,7 @@ detail::VisMfIndex detail::readVisMfIndex(
         }
         index.boxes.push_back(readAmrexBox(input, dimension, "VisMF BoxArray entry"));
     }
-    if (readNonEmptyLine(input, "VisMF BoxArray terminator") != ")") {
+    if (readNonEmptyLine(input, "VisMF BoxArray terminator", cancellation) != ")") {
         throw MetadataReadError("malformed VisMF BoxArray terminator");
     }
 
@@ -408,7 +419,7 @@ detail::VisMfIndex detail::readVisMfIndex(
         // the FabOnDisk list and after each per-block min/max matrix).
         // readNonEmptyLine skips blank lines, mirroring how AMReX reads the
         // descriptor with operator>>. Version 4 emits no separator.
-        index.realDescriptor = readNonEmptyLine(input, "VisMF RealDescriptor");
+        index.realDescriptor = readNonEmptyLine(input, "VisMF RealDescriptor", cancellation);
     }
     return index;
 }
@@ -492,7 +503,7 @@ PlotfileMetadataResult PlotfileMetadataReader::read(
         if (cancellation.stop_requested()) {
             throw ReadCancelled();
         }
-        auto name = readNonEmptyLine(input, "component name");
+        auto name = readNonEmptyLine(input, "component name", cancellation);
         metadata->fields.push_back({name, Centering::Cell, {std::move(name)}});
     }
 

--- a/src/io/plotfile/StandaloneMetadataReader.cpp
+++ b/src/io/plotfile/StandaloneMetadataReader.cpp
@@ -41,7 +41,9 @@ int inferMultiFabDimension(const std::filesystem::path& headerPath)
         throw MetadataReadError("cannot open MultiFab header '" + headerPath.string() + "'");
     }
     std::string line;
-    while (std::getline(input, line)) {
+    // Bounded like every other header line: a MultiFab header with no newline
+    // would otherwise be accumulated whole before the "((" search rejected it.
+    while (detail::readBoundedLine<MetadataReadError>(input, line)) {
         const auto boxStart = line.find("((");
         if (boxStart != std::string::npos) {
             return inferBoxDimension(line.substr(boxStart));

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -244,22 +244,17 @@ add_test(NAME plotfile_header COMMAND test_plotfile_header)
 # must stay its own executable: the counting would otherwise apply to every
 # other case sharing the binary.
 #
-# That replacement routes every allocation through plain malloc/free, which
-# takes the whole binary out from under AddressSanitizer's allocator -- no
-# redzones, no use-after-free detection. The parse paths it exercises are
-# covered under ASan by vismf_index and plotfile_header, so nothing is lost by
-# excluding it there, whereas leaving it in would advertise sanitizer coverage
-# this target cannot provide.
+# It runs under the sanitizers like everything else. Replacing operator new was
+# briefly thought to take the binary out from under ASan; it does not. ASan
+# interposes malloc/free at the libc level, so an operator new built on malloc
+# still allocates from ASan's allocator with its redzones intact -- verified by
+# compiling this shape under -fsanitize=address and watching it report a
+# heap-buffer-overflow. Only new/delete-mismatch detection is lost, and this
+# file pairs them by construction.
 add_executable(test_header_allocation_bounds unit/test_header_allocation_bounds.cpp)
 target_link_libraries(test_header_allocation_bounds
     PRIVATE amrexplorer::data amrexplorer::io amrexplorer::warnings)
-if(AMREXPLORER_ENABLE_SANITIZERS)
-    message(STATUS
-        "header_allocation_bounds is excluded under sanitizers: it replaces "
-        "global operator new, which disables ASan's heap instrumentation")
-else()
-    add_test(NAME header_allocation_bounds COMMAND test_header_allocation_bounds)
-endif()
+add_test(NAME header_allocation_bounds COMMAND test_header_allocation_bounds)
 
 add_executable(test_particle_header unit/test_particle_header.cpp)
 target_link_libraries(test_particle_header PRIVATE amrexplorer::io amrexplorer::warnings)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -240,6 +240,14 @@ add_executable(test_plotfile_header unit/test_plotfile_header.cpp)
 target_link_libraries(test_plotfile_header PRIVATE amrexplorer::io amrexplorer::warnings)
 add_test(NAME plotfile_header COMMAND test_plotfile_header)
 
+# Replaces global operator new to measure what a crafted Header reserves, so it
+# must stay its own executable: the counting would otherwise apply to every
+# other case sharing the binary.
+add_executable(test_header_allocation_bounds unit/test_header_allocation_bounds.cpp)
+target_link_libraries(test_header_allocation_bounds
+    PRIVATE amrexplorer::io amrexplorer::warnings)
+add_test(NAME header_allocation_bounds COMMAND test_header_allocation_bounds)
+
 add_executable(test_particle_header unit/test_particle_header.cpp)
 target_link_libraries(test_particle_header PRIVATE amrexplorer::io amrexplorer::warnings)
 add_test(NAME particle_header COMMAND test_particle_header)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -243,10 +243,23 @@ add_test(NAME plotfile_header COMMAND test_plotfile_header)
 # Replaces global operator new to measure what a crafted Header reserves, so it
 # must stay its own executable: the counting would otherwise apply to every
 # other case sharing the binary.
+#
+# That replacement routes every allocation through plain malloc/free, which
+# takes the whole binary out from under AddressSanitizer's allocator -- no
+# redzones, no use-after-free detection. The parse paths it exercises are
+# covered under ASan by vismf_index and plotfile_header, so nothing is lost by
+# excluding it there, whereas leaving it in would advertise sanitizer coverage
+# this target cannot provide.
 add_executable(test_header_allocation_bounds unit/test_header_allocation_bounds.cpp)
 target_link_libraries(test_header_allocation_bounds
-    PRIVATE amrexplorer::io amrexplorer::warnings)
-add_test(NAME header_allocation_bounds COMMAND test_header_allocation_bounds)
+    PRIVATE amrexplorer::data amrexplorer::io amrexplorer::warnings)
+if(AMREXPLORER_ENABLE_SANITIZERS)
+    message(STATUS
+        "header_allocation_bounds is excluded under sanitizers: it replaces "
+        "global operator new, which disables ASan's heap instrumentation")
+else()
+    add_test(NAME header_allocation_bounds COMMAND test_header_allocation_bounds)
+endif()
 
 add_executable(test_particle_header unit/test_particle_header.cpp)
 target_link_libraries(test_particle_header PRIVATE amrexplorer::io amrexplorer::warnings)

--- a/tests/integration/test_remote_server.cpp
+++ b/tests/integration/test_remote_server.cpp
@@ -224,6 +224,29 @@ void writeCraftedGridTable(const std::filesystem::path& root)
         "could not write crafted grid-table Header");
 }
 
+// A plotfile Header whose component-name line never ends. The reader walks a
+// Header as text, so without a ceiling this line is accumulated whole before
+// any parse can look at it -- and in the long-lived server that allocation is
+// charged to a session rather than to a process that can simply die. Two
+// hundred kilobytes is enough to tell the two behaviours apart by the error
+// text: bounded, the reader names the length; unbounded, it swallows the line
+// and fails later on the field after it.
+//
+// Deliberately does not begin with "Version_", so particle species discovery
+// skips this directory and the crafted Header is read only when it is opened
+// as a dataset in its own right.
+void writeCraftedPlotfileHeader(const std::filesystem::path& root)
+{
+    const auto crafted = root / "CraftedHeader";
+    std::filesystem::create_directories(crafted);
+    std::ofstream header(crafted / "Header");
+    require(static_cast<bool>(header),
+        "could not create crafted plotfile Header");
+    header << "HyperCLaw-V1.1\n1\n" << std::string(200000, 'x') << '\n';
+    require(static_cast<bool>(header),
+        "could not write crafted plotfile Header");
+}
+
 } // namespace
 
 int main(int argc, char* argv[])
@@ -237,6 +260,7 @@ int main(int argc, char* argv[])
     }
     writeOversizedParticleHeader(argv[1]);
     writeCraftedGridTable(argv[1]);
+    writeCraftedPlotfileHeader(argv[1]);
 
     ServerOptions options;
     options.workerCount = 2;
@@ -391,6 +415,35 @@ int main(int argc, char* argv[])
             && codec::fromWire(*envelope->payload.AsErrorResponse()).code
                 == ErrorCode::InvalidRequest,
         "a crafted particle species was not refused by name");
+
+    // A crafted plotfile Header opened as a dataset of its own. The property is
+    // the one the bounds exist for: the server refuses it on the Header's
+    // length rather than accumulating the line, and the session it was sent on
+    // keeps working afterwards. The message check is what makes this
+    // discriminating -- an unbounded reader would swallow the 200 KB line and
+    // fail on the next field instead.
+    {
+        envelope = exchange(socket, 14,
+            codec::toWire(OpenDatasetData{
+                (std::filesystem::path(argv[1]) / "CraftedHeader").string(),
+                16ULL * 1024ULL * 1024ULL}),
+            hello.maximumFrameBytes);
+        require(codec::inspect(*envelope).payload == PayloadKind::ErrorResponse,
+            "a crafted plotfile Header was opened as a dataset");
+        const auto rejection
+            = codec::fromWire(*envelope->payload.AsErrorResponse());
+        require(rejection.message.find("exceeds the supported length")
+                != std::string::npos,
+            "a crafted plotfile Header was rejected for the wrong reason");
+
+        // ...and the server keeps serving: the dataset opened before the
+        // crafted one is still usable on the same connection.
+        envelope = exchange(socket, 15, codec::toWire(smallPage),
+            hello.maximumFrameBytes);
+        require(codec::inspect(*envelope).payload
+                == PayloadKind::DatasetPageResponse,
+            "the server stopped serving after refusing a crafted Header");
+    }
 
     SliceRequest request;
     request.dataset = opened.id;
@@ -927,5 +980,7 @@ int main(int argc, char* argv[])
         std::filesystem::path(argv[1]) / "Oversized");
     std::filesystem::remove_all(
         std::filesystem::path(argv[1]) / "GridBomb");
+    std::filesystem::remove_all(
+        std::filesystem::path(argv[1]) / "CraftedHeader");
     return 0;
 }

--- a/tests/integration/test_remote_server.cpp
+++ b/tests/integration/test_remote_server.cpp
@@ -432,6 +432,12 @@ int main(int argc, char* argv[])
             "a crafted plotfile Header was opened as a dataset");
         const auto rejection
             = codec::fromWire(*envelope->payload.AsErrorResponse());
+        // What this case can and cannot show: it pins that the server refuses
+        // a crafted Header and keeps serving, on a typed code rather than on
+        // prose. It cannot show that the refusal was *cheap* -- the message is
+        // the same whether or not the file was accumulated first -- so the
+        // allocation itself is measured in header_allocation_bounds instead.
+        //
         // The code first, like every other refusal case here: without it this
         // passes on any error that happens to carry the phrase, including a
         // cancellation or an authorization failure.

--- a/tests/integration/test_remote_server.cpp
+++ b/tests/integration/test_remote_server.cpp
@@ -432,6 +432,11 @@ int main(int argc, char* argv[])
             "a crafted plotfile Header was opened as a dataset");
         const auto rejection
             = codec::fromWire(*envelope->payload.AsErrorResponse());
+        // The code first, like every other refusal case here: without it this
+        // passes on any error that happens to carry the phrase, including a
+        // cancellation or an authorization failure.
+        require(rejection.code == ErrorCode::DatasetOpenFailure,
+            "a crafted plotfile Header was not refused as an open failure");
         require(rejection.message.find("exceeds the supported length")
                 != std::string::npos,
             "a crafted plotfile Header was rejected for the wrong reason");

--- a/tests/unit/test_header_allocation_bounds.cpp
+++ b/tests/unit/test_header_allocation_bounds.cpp
@@ -32,7 +32,8 @@
 
 namespace {
 
-std::atomic<std::size_t> g_allocatedBytes{0};
+std::atomic<std::size_t> g_liveBytes{0};
+std::atomic<std::size_t> g_peakBytes{0};
 
 int g_failures = 0;
 
@@ -56,20 +57,52 @@ void require(bool condition, const char* message)
 // route std::vector's allocation to operator new(size_t, align_val_t), the
 // counter would stop seeing the reserve, and every case here would pass with
 // the bounds reverted -- failing open, silently.
+// One per element type any case here measures, since an assert that covers
+// only some of them leaves the rest free to fail open.
 static_assert(alignof(amrvis::IntBox) <= __STDCPP_DEFAULT_NEW_ALIGNMENT__,
     "IntBox is over-aligned, so vector routes around the counted operator new "
     "and these allocation bounds are no longer measured");
 static_assert(alignof(double) <= __STDCPP_DEFAULT_NEW_ALIGNMENT__,
     "double is over-aligned, so the statistics matrix is no longer measured");
+static_assert(alignof(amrvis::FieldMetadata) <= __STDCPP_DEFAULT_NEW_ALIGNMENT__,
+    "FieldMetadata is over-aligned, so the component-count case is no longer "
+    "measured");
+static_assert(alignof(std::string) <= __STDCPP_DEFAULT_NEW_ALIGNMENT__,
+    "std::string is over-aligned, so the FabOnDisk name reserve is no longer "
+    "measured");
+// Live bytes and their high-water mark, not a running total. The property
+// under test is how much a crafted parse *holds*, and this PR deliberately
+// replaces up-front sizing with growth by reallocation past the reserve cap --
+// so a cumulative counter would charge every doubling's new buffer while the
+// old one is freed moments later, and eventually fail a bound that is working.
+// The size is stashed ahead of the block so the unsized deletes can return it.
+struct AllocationHeader {
+    std::size_t bytes;
+};
+constexpr std::size_t headerBytes = sizeof(AllocationHeader) < alignof(std::max_align_t)
+    ? alignof(std::max_align_t)
+    : sizeof(AllocationHeader);
+
+void recordPeak(std::size_t live)
+{
+    auto previous = g_peakBytes.load(std::memory_order_relaxed);
+    while (live > previous
+        && !g_peakBytes.compare_exchange_weak(previous, live,
+               std::memory_order_relaxed)) {
+    }
+}
+
 void* operator new(std::size_t bytes)
 {
-    g_allocatedBytes.fetch_add(bytes, std::memory_order_relaxed);
-    // malloc(0) may return null, which would look like exhaustion here.
-    void* const memory = std::malloc(bytes == 0 ? 1 : bytes);
-    if (memory == nullptr) {
+    void* const block = std::malloc(bytes + headerBytes);
+    if (block == nullptr) {
         throw std::bad_alloc();
     }
-    return memory;
+    static_cast<AllocationHeader*>(block)->bytes = bytes;
+    const auto live
+        = g_liveBytes.fetch_add(bytes, std::memory_order_relaxed) + bytes;
+    recordPeak(live);
+    return static_cast<char*>(block) + headerBytes;
 }
 
 void* operator new[](std::size_t bytes)
@@ -79,22 +112,28 @@ void* operator new[](std::size_t bytes)
 
 void operator delete(void* memory) noexcept
 {
-    std::free(memory);
+    if (memory == nullptr) {
+        return;
+    }
+    auto* const block = static_cast<char*>(memory) - headerBytes;
+    g_liveBytes.fetch_sub(reinterpret_cast<AllocationHeader*>(block)->bytes,
+        std::memory_order_relaxed);
+    std::free(block);
 }
 
 void operator delete[](void* memory) noexcept
 {
-    std::free(memory);
+    operator delete(memory);
 }
 
 void operator delete(void* memory, std::size_t) noexcept
 {
-    std::free(memory);
+    operator delete(memory);
 }
 
 void operator delete[](void* memory, std::size_t) noexcept
 {
-    std::free(memory);
+    operator delete(memory);
 }
 
 // The budget must sit above what a crafted parse legitimately needs -- a
@@ -109,7 +148,10 @@ template <typename Parse>
 void requireBoundedAllocation(Parse parse, const char* what,
     std::size_t allowedBytes = defaultAllowedBytes)
 {
-    const auto before = g_allocatedBytes.load(std::memory_order_relaxed);
+    // The peak is measured against what was already live when the case began,
+    // so the number reported is what this parse added at its worst moment.
+    const auto before = g_liveBytes.load(std::memory_order_relaxed);
+    g_peakBytes.store(before, std::memory_order_relaxed);
     bool threw = false;
     try {
         parse();
@@ -121,8 +163,7 @@ void requireBoundedAllocation(Parse parse, const char* what,
         ++g_failures;
         return;  // one failure per case; require(threw) below would add another
     }
-    const auto used
-        = g_allocatedBytes.load(std::memory_order_relaxed) - before;
+    const auto used = g_peakBytes.load(std::memory_order_relaxed) - before;
     require(threw, what);
     // The positive control. Every one of these parses allocates *something*;
     // a zero means the replaced operator new stopped being the allocator this

--- a/tests/unit/test_header_allocation_bounds.cpp
+++ b/tests/unit/test_header_allocation_bounds.cpp
@@ -16,6 +16,7 @@
 // boxCount real boxes have been read out of the file, so by then the file is
 // genuinely as large as the count claims; its bound is defensive rather than
 // load-bearing.
+#include <amrexplorer/core/Geometry.hpp>
 #include <amrexplorer/io/PlotfileMetadataReader.hpp>
 #include <amrexplorer/io/detail/VisMfIndex.hpp>
 
@@ -48,6 +49,17 @@ void require(bool condition, const char* message)
 // allocator that did not produce it. The aligned overloads are deliberately
 // left to the library -- they pair with the library's aligned delete, and
 // nothing on this path uses them.
+//
+// "Nothing on this path uses them" is the assumption the measurement rests on,
+// so it is asserted rather than trusted: an over-aligned element type would
+// route std::vector's allocation to operator new(size_t, align_val_t), the
+// counter would stop seeing the reserve, and every case here would pass with
+// the bounds reverted -- failing open, silently.
+static_assert(alignof(amrvis::IntBox) <= __STDCPP_DEFAULT_NEW_ALIGNMENT__,
+    "IntBox is over-aligned, so vector routes around the counted operator new "
+    "and these allocation bounds are no longer measured");
+static_assert(alignof(double) <= __STDCPP_DEFAULT_NEW_ALIGNMENT__,
+    "double is over-aligned, so the statistics matrix is no longer measured");
 void* operator new(std::size_t bytes)
 {
     g_allocatedBytes.fetch_add(bytes, std::memory_order_relaxed);

--- a/tests/unit/test_header_allocation_bounds.cpp
+++ b/tests/unit/test_header_allocation_bounds.cpp
@@ -84,6 +84,39 @@ void operator delete[](void* memory, std::size_t) noexcept
     std::free(memory);
 }
 
+// The budget must sit above what a crafted parse legitimately needs -- a
+// handful of small vectors and a stream buffer, well under 100 KB -- and below
+// what the unbounded reserve would take, which differs per case: ten million
+// IntBox is ~360 MB, while a hundred thousand FieldMetadata is only ~7 MB. A
+// single generous budget would leave the component case passing either way, so
+// each caller states its own.
+constexpr std::size_t defaultAllowedBytes = 8U * 1024U * 1024U;
+
+template <typename Parse>
+void requireBoundedAllocation(Parse parse, const char* what,
+    std::size_t allowedBytes = defaultAllowedBytes)
+{
+    const auto before = g_allocatedBytes.load(std::memory_order_relaxed);
+    bool threw = false;
+    try {
+        parse();
+    } catch (const amrvis::MetadataReadError&) {
+        threw = true;
+    } catch (const std::exception& other) {
+        std::cerr << "FAILED: " << what << " threw the wrong exception: "
+                  << other.what() << '\n';
+        ++g_failures;
+    }
+    const auto used
+        = g_allocatedBytes.load(std::memory_order_relaxed) - before;
+    require(threw, what);
+    if (used >= allowedBytes) {
+        std::cerr << "FAILED: " << what << " allocated " << used
+                  << " bytes; the reserve is not bounded by the file's size\n";
+        ++g_failures;
+    }
+}
+
 int main()
 {
     const auto scratch = std::filesystem::temp_directory_path()
@@ -101,32 +134,43 @@ int main()
                   ")\n";
     }
 
-    // Everything before this point -- iostreams, the filesystem calls, the
-    // static initializers -- is excluded by taking the baseline here.
-    const auto before = g_allocatedBytes.load(std::memory_order_relaxed);
-    bool threw = false;
-    try {
-        (void)amrvis::detail::readVisMfIndex(path, 2);
-    } catch (const amrvis::MetadataReadError&) {
-        threw = true;
-    } catch (const std::exception& other) {
-        std::cerr << "FAILED: the crafted Header threw the wrong exception: "
-                  << other.what() << '\n';
-        ++g_failures;
-    }
-    const auto used = g_allocatedBytes.load(std::memory_order_relaxed) - before;
+    requireBoundedAllocation([&path] { (void)amrvis::detail::readVisMfIndex(path, 2); },
+        "a VisMF BoxArray shorter than its declared count");
 
-    require(threw, "a BoxArray shorter than its declared count was not rejected");
-    // Two orders of magnitude of headroom over what the parse actually needs
-    // (a handful of small vectors and the stream buffer), and two below what
-    // the unbounded reserve would take.
-    constexpr std::size_t allowedBytes = 8U * 1024U * 1024U;
-    if (used >= allowedBytes) {
-        std::cerr << "FAILED: parsing a 42-byte Header that claims ten million "
-                     "boxes allocated " << used << " bytes; the reserve is not "
-                     "bounded by the file's size\n";
-        ++g_failures;
+    // The same claim in the top-level plotfile Header, which is the first file
+    // any open reads and the one the server reads on every session. Its
+    // per-level grid count carries the same ten-million cap, so a Header that
+    // declares it and then supplies no grid bounds asks for the same ~360 MB
+    // before failing on the first one it cannot read.
+    const auto plotfile = scratch / "claims_ten_million_grids";
+    std::filesystem::create_directories(plotfile);
+    {
+        std::ofstream stream(plotfile / "Header", std::ios::binary);
+        stream << "HyperCLaw-V1.1\n"      // file version
+                  "1\ndensity\n"          // one component
+                  "2\n0.0\n0\n"           // dimension, time, finest level
+                  "0.0\n0.0\n1.0\n1.0\n"  // physical bounds
+                  "((0,0) (7,7) (0,0))\n" // level 0 domain
+                  "0\n"                   // level step
+                  "0.125 0.125\n"         // cell sizes
+                  "0\n0\n"                // coordinate system, boundary width
+                  "0 10000000 0.0 0\n";   // level record claiming ten million
     }
+    requireBoundedAllocation(
+        [&plotfile] { (void)amrvis::PlotfileMetadataReader{}.read(plotfile); },
+        "a plotfile Header level record shorter than its declared grid count");
+
+    // A component count is the same shape of claim, one line per name.
+    const auto components = scratch / "claims_many_components";
+    std::filesystem::create_directories(components);
+    {
+        std::ofstream stream(components / "Header", std::ios::binary);
+        stream << "HyperCLaw-V1.1\n100000\ndensity\n";
+    }
+    requireBoundedAllocation(
+        [&components] { (void)amrvis::PlotfileMetadataReader{}.read(components); },
+        "a plotfile Header shorter than its declared component count",
+        1024U * 1024U);
 
     std::error_code removeError;
     std::filesystem::remove_all(scratch, removeError);

--- a/tests/unit/test_header_allocation_bounds.cpp
+++ b/tests/unit/test_header_allocation_bounds.cpp
@@ -17,6 +17,7 @@
 // genuinely as large as the count claims; its bound is defensive rather than
 // load-bearing.
 #include <amrexplorer/core/Geometry.hpp>
+#include <amrexplorer/data/LocalDatasetSession.hpp>
 #include <amrexplorer/io/PlotfileMetadataReader.hpp>
 #include <amrexplorer/io/detail/VisMfIndex.hpp>
 
@@ -118,10 +119,23 @@ void requireBoundedAllocation(Parse parse, const char* what,
         std::cerr << "FAILED: " << what << " threw the wrong exception: "
                   << other.what() << '\n';
         ++g_failures;
+        return;  // one failure per case; require(threw) below would add another
     }
     const auto used
         = g_allocatedBytes.load(std::memory_order_relaxed) - before;
     require(threw, what);
+    // The positive control. Every one of these parses allocates *something*;
+    // a zero means the replaced operator new stopped being the allocator this
+    // binary uses -- a shared build, an LTO or allocator change -- at which
+    // point every case below passes with the bounds reverted, which is the
+    // silent-green failure this file exists to avoid.
+    if (used == 0) {
+        std::cerr << "FAILED: " << what
+                  << " allocated nothing, so the counted operator new is not "
+                     "in effect and these bounds are not being measured\n";
+        ++g_failures;
+        return;
+    }
     if (used >= allowedBytes) {
         std::cerr << "FAILED: " << what << " allocated " << used
                   << " bytes; the reserve is not bounded by the file's size\n";
@@ -183,6 +197,84 @@ int main()
         [&components] { (void)amrvis::PlotfileMetadataReader{}.read(components); },
         "a plotfile Header shorter than its declared component count",
         1024U * 1024U);
+
+    // Forged evidence. std::filesystem::file_size reports the *apparent* size,
+    // so extending a short crafted header makes it claim megabytes it does not
+    // occupy -- one filesystem block, on any filesystem with sparse support.
+    // The file-size bound alone is therefore defeatable at almost no cost,
+    // which is what the absolute reserve cap is for. 4 MB of apparent size
+    // would otherwise vouch for ~500,000 boxes, or ~18 MB of IntBox.
+    const auto sparse = scratch / "sparse_claims_ten_million_H";
+    {
+        std::ofstream stream(sparse, std::ios::binary);
+        stream << "1\n1\n2\n0\n"
+                  "(10000000 0\n"
+                  "((0,0) (1,3) (0,0))\n"
+                  ")\n";
+    }
+    std::error_code resizeError;
+    std::filesystem::resize_file(sparse, 4u * 1024u * 1024u, resizeError);
+    require(!resizeError, "could not extend the sparse header fixture");
+    requireBoundedAllocation(
+        [&sparse] { (void)amrvis::detail::readVisMfIndex(sparse, 2); },
+        "a sparse header forging four megabytes of apparent size");
+
+    // The statistics matrix: both factors pass their own checks, and it is
+    // their product that allocates. Ten real boxes and a declared 100,000
+    // components claim a million doubles from a header with none of them.
+    const auto matrix = scratch / "claims_wide_matrix_H";
+    {
+        std::ofstream stream(matrix, std::ios::binary);
+        stream << "1\n1\n100000\n0\n"
+                  "(10 0\n";
+        for (int box = 0; box < 10; ++box) {
+            stream << "((" << box << ",0) (" << box << ",3) (0,0))\n";
+        }
+        stream << ")\n10\n";
+        for (int box = 0; box < 10; ++box) {
+            stream << "FabOnDisk: Cell_D_00000 " << box * 4096 << '\n';
+        }
+        stream << "\n10,100000\n";  // shape matches; no values follow
+    }
+    requireBoundedAllocation(
+        [&matrix] { (void)amrvis::detail::readVisMfIndex(matrix, 2); },
+        "a statistics matrix whose declared shape has no values behind it");
+
+    // The first line of the Header, which is where the session used to re-read
+    // the file version with an unbounded getline *before* the bounded parser
+    // saw anything. The remote server's open path ran that read, so the
+    // crafted-Header case in test_remote_server could not see it: the refusal
+    // message was identical whether or not the file had been slurped first.
+    // Measuring is what distinguishes them, so it is measured here.
+    const auto firstLine = scratch / "long_first_line";
+    std::filesystem::create_directories(firstLine);
+    {
+        std::ofstream stream(firstLine / "Header", std::ios::binary);
+        stream << std::string(4u * 1024u * 1024u, 'V') << "\n1\ndensity\n";
+    }
+    // Through LocalDatasetSession, not the reader: the reader bounds the
+    // version token either way, and it was the session that opened the Header a
+    // second time to re-read that line. Calling the reader here would measure
+    // the wrong path and pass whether or not the second read exists.
+    requireBoundedAllocation(
+        [&firstLine] {
+            (void)amrvis::LocalDatasetSession(firstLine, amrvis::DatasetId{1},
+                16ULL * 1024ULL * 1024ULL);
+        },
+        "a Header whose first line is a four-megabyte run");
+
+    // The top-level Header's numeric fields: `double` extraction buffers the
+    // whole digit run, so a long one amplifies by ~3.2x before it even fails.
+    const auto digits = scratch / "long_double_run";
+    std::filesystem::create_directories(digits);
+    {
+        std::ofstream stream(digits / "Header", std::ios::binary);
+        stream << "HyperCLaw-V1.1\n1\ndensity\n2\n" << std::string(4u * 1024u * 1024u, '9')
+               << '\n';
+    }
+    requireBoundedAllocation(
+        [&digits] { (void)amrvis::PlotfileMetadataReader{}.read(digits); },
+        "a Header whose time field is a four-megabyte digit run");
 
     std::error_code removeError;
     std::filesystem::remove_all(scratch, removeError);

--- a/tests/unit/test_header_allocation_bounds.cpp
+++ b/tests/unit/test_header_allocation_bounds.cpp
@@ -1,0 +1,139 @@
+// The reserve bounds in readVisMfIndex are invisible to an ordinary parse test.
+// A crafted BoxArray count is rejected either way -- the boxes it promises are
+// not in the file -- and the exception says nothing about how much memory was
+// taken to produce it. The defect was never the rejection; it was that a Header
+// of a few dozen bytes could make the reader reserve a quarter of a gigabyte
+// before parsing a single entry, which in the long-lived server is a cost every
+// session pays rather than one process.
+//
+// So this measures instead: global operator new is replaced to count the bytes
+// requested, and the crafted parse must stay far below what its declared count
+// would take. Without the file-size evidence bound, ten million boxes is about
+// 360 MB of IntBox reserved from 42 bytes of text.
+//
+// The BoxArray reserve is the one measured because it is the only one reachable
+// before any evidence has been parsed. The location table's reserve comes after
+// boxCount real boxes have been read out of the file, so by then the file is
+// genuinely as large as the count claims; its bound is defensive rather than
+// load-bearing.
+#include <amrexplorer/io/PlotfileMetadataReader.hpp>
+#include <amrexplorer/io/detail/VisMfIndex.hpp>
+
+#include <atomic>
+#include <cstddef>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <new>
+#include <system_error>
+
+namespace {
+
+std::atomic<std::size_t> g_allocatedBytes{0};
+
+int g_failures = 0;
+
+void require(bool condition, const char* message)
+{
+    if (!condition) {
+        std::cerr << "FAILED: " << message << '\n';
+        ++g_failures;
+    }
+}
+
+} // namespace
+
+// Replaced as a matched pair over malloc/free, so nothing is released by an
+// allocator that did not produce it. The aligned overloads are deliberately
+// left to the library -- they pair with the library's aligned delete, and
+// nothing on this path uses them.
+void* operator new(std::size_t bytes)
+{
+    g_allocatedBytes.fetch_add(bytes, std::memory_order_relaxed);
+    // malloc(0) may return null, which would look like exhaustion here.
+    void* const memory = std::malloc(bytes == 0 ? 1 : bytes);
+    if (memory == nullptr) {
+        throw std::bad_alloc();
+    }
+    return memory;
+}
+
+void* operator new[](std::size_t bytes)
+{
+    return operator new(bytes);
+}
+
+void operator delete(void* memory) noexcept
+{
+    std::free(memory);
+}
+
+void operator delete[](void* memory) noexcept
+{
+    std::free(memory);
+}
+
+void operator delete(void* memory, std::size_t) noexcept
+{
+    std::free(memory);
+}
+
+void operator delete[](void* memory, std::size_t) noexcept
+{
+    std::free(memory);
+}
+
+int main()
+{
+    const auto scratch = std::filesystem::temp_directory_path()
+        / "amrexplorer_header_allocation_test";
+    std::filesystem::create_directories(scratch);
+    const auto path = scratch / "claims_ten_million_H";
+
+    // A well-formed prefix whose BoxArray header claims the per-level maximum
+    // (the cap itself accepts exactly ten million) and then supplies one box.
+    {
+        std::ofstream stream(path, std::ios::binary);
+        stream << "1\n1\n2\n0\n"
+                  "(10000000 0\n"
+                  "((0,0) (1,3) (0,0))\n"
+                  ")\n";
+    }
+
+    // Everything before this point -- iostreams, the filesystem calls, the
+    // static initializers -- is excluded by taking the baseline here.
+    const auto before = g_allocatedBytes.load(std::memory_order_relaxed);
+    bool threw = false;
+    try {
+        (void)amrvis::detail::readVisMfIndex(path, 2);
+    } catch (const amrvis::MetadataReadError&) {
+        threw = true;
+    } catch (const std::exception& other) {
+        std::cerr << "FAILED: the crafted Header threw the wrong exception: "
+                  << other.what() << '\n';
+        ++g_failures;
+    }
+    const auto used = g_allocatedBytes.load(std::memory_order_relaxed) - before;
+
+    require(threw, "a BoxArray shorter than its declared count was not rejected");
+    // Two orders of magnitude of headroom over what the parse actually needs
+    // (a handful of small vectors and the stream buffer), and two below what
+    // the unbounded reserve would take.
+    constexpr std::size_t allowedBytes = 8U * 1024U * 1024U;
+    if (used >= allowedBytes) {
+        std::cerr << "FAILED: parsing a 42-byte Header that claims ten million "
+                     "boxes allocated " << used << " bytes; the reserve is not "
+                     "bounded by the file's size\n";
+        ++g_failures;
+    }
+
+    std::error_code removeError;
+    std::filesystem::remove_all(scratch, removeError);
+
+    if (g_failures != 0) {
+        std::cerr << g_failures << " header_allocation_bounds test failure(s)\n";
+        return 1;
+    }
+    return 0;
+}

--- a/tests/unit/test_plotfile_header.cpp
+++ b/tests/unit/test_plotfile_header.cpp
@@ -225,6 +225,22 @@ int main()
         "out-of-order grid records were not rejected",
         "out of order");
 
+    // Integer fields are bounded too, and stop where they always did. The
+    // ceiling matters on libc++, which buffers a digit run rather than
+    // accumulating a value, so an enormous one allocates in full there.
+    expectHeaderRejected(scratch / "long_component_count",
+        "HyperCLaw-V1.1\n" + std::string(5000, '9') + "\ndensity\n",
+        "an over-long component count was not rejected",
+        "exceeds the supported length");
+    // ...and the delimiters are unchanged: a Box packs its integers against
+    // commas and parens, which a whitespace-delimited read would swallow. The
+    // baseline plotfile above already proves the positive case; this pins the
+    // negative one, where the value is followed by punctuation it must not eat.
+    expectHeaderRejected(scratch / "negative_component_count",
+        "HyperCLaw-V1.1\n-3\ndensity\n",
+        "a negative component count was not rejected",
+        "component count");
+
     // Bounding the numeric fields must not widen what they accept. strtod
     // takes "nan", "inf" and an overflowing exponent where operator>> refuses
     // all three, and `time` is not among the fields validateMetadata checks

--- a/tests/unit/test_plotfile_header.cpp
+++ b/tests/unit/test_plotfile_header.cpp
@@ -203,6 +203,34 @@ int main()
         "out-of-order grid records were not rejected",
         "out of order");
 
+    // Crafted input, bounded rather than allocated: the reader walks this file
+    // as text, so without a ceiling one enormous line or token is accumulated
+    // whole before any parse can reject it. Kilobyte-scale input then forces an
+    // allocation limited only by the file's length -- and in the long-lived
+    // server that cost lands on every session, not one process. Each case must
+    // fault with a MetadataReadError, never a std::bad_alloc.
+    expectHeaderRejected(scratch / "long_version",
+        std::string(5000, 'V') + "\n1\ndensity\n2\n0.0\n0\n",
+        "an over-long version token was not rejected",
+        "exceeds the supported length");
+    expectHeaderRejected(scratch / "long_component_name",
+        "HyperCLaw-V1.1\n1\n" + std::string(20000, 'c') + "\n",
+        "an over-long component-name line was not rejected",
+        "header line exceeds the supported length");
+    expectHeaderRejected(scratch / "long_data_path",
+        headerThroughBoundaryWidth()
+            + "0 1 0.0 0\n0.0 1.0 0.0 1.0\n" + std::string(5000, 'p') + "\n",
+        "an over-long level data path was not rejected",
+        "exceeds the supported length");
+    // The unterminated variant, which is the shape the line bound exists for:
+    // a line that never ends makes plain getline accumulate the whole rest of
+    // the file before the parse can look at it. Ends at EOF rather than at a
+    // newline, so it also covers the bound's end-of-input path.
+    expectHeaderRejected(scratch / "no_newline",
+        "HyperCLaw-V1.1\n1\n" + std::string(30000, 'z'),
+        "an unterminated over-long line was not rejected",
+        "header line exceeds the supported length");
+
     std::error_code removeError;
     std::filesystem::remove_all(scratch, removeError);
 

--- a/tests/unit/test_plotfile_header.cpp
+++ b/tests/unit/test_plotfile_header.cpp
@@ -225,6 +225,44 @@ int main()
         "out-of-order grid records were not rejected",
         "out of order");
 
+    // Bounding the numeric fields must not widen what they accept. strtod
+    // takes "nan", "inf" and an overflowing exponent where operator>> refuses
+    // all three, and `time` is not among the fields validateMetadata checks
+    // for finiteness -- so without an explicit rejection a Header declaring
+    // time = nan would open and carry a NaN into the metadata, the wire
+    // catalog and the UI. Non-finite values stay legal only in VisMF block
+    // statistics, where AMReX genuinely writes them.
+    for (const auto* value : {"nan", "inf", "-inf", "1e999"}) {
+        const auto dir = scratch / (std::string("nonfinite_time_") + value);
+        expectHeaderRejected(dir,
+            "HyperCLaw-V1.1\n1\ndensity\n2\n" + std::string(value) + "\n0\n",
+            "a non-finite time field was not rejected",
+            "time");
+    }
+    // The other direction: a denormal is finite and must still parse, which is
+    // why the check is isfinite rather than errno -- strtod reports ERANGE for
+    // underflow, where the extraction this replaced accepted the value.
+    {
+        const auto dir = scratch / "denormal_time";
+        writeValidPlotfile(dir);
+        writeFile(dir / "Header",
+            "HyperCLaw-V1.1\n1\ndensity\n2\n4.9e-324\n1\n"
+            "0.0\n0.0\n1.0\n1.0\n2\n"
+            "((0,0) (7,7) (0,0))\n((0,0) (15,15) (0,0))\n0\n0\n"
+            "0.125 0.125\n0.0625 0.0625\n0\n0\n"
+            "0 1 0.0 0\n0.0 1.0 0.0 1.0\nLevel_0/Cell\n"
+            "1 1 0.0 0\n0.0 1.0 0.0 1.0\nLevel_1/Cell\n");
+        try {
+            const auto result = amrvis::PlotfileMetadataReader{}.read(dir);
+            require(result.metadata->levels.size() == 2,
+                "a denormal time field parsed to the wrong shape");
+        } catch (const std::exception& error) {
+            std::cerr << "FAILED: a denormal time field was rejected: "
+                      << error.what() << '\n';
+            ++g_failures;
+        }
+    }
+
     // Crafted input, bounded rather than allocated: the reader walks this file
     // as text, so without a ceiling one enormous line or token is accumulated
     // whole before any parse can reject it. Kilobyte-scale input then forces an

--- a/tests/unit/test_plotfile_header.cpp
+++ b/tests/unit/test_plotfile_header.cpp
@@ -175,6 +175,28 @@ int main()
         }
     }
 
+    // Forward compatibility meets the new ceilings: an AMReX Header may carry
+    // content past what this reader consumes, and that content is not the
+    // reader's to validate. A trailing section holding a line far longer than
+    // maximumHeaderLineBytes must therefore still parse -- the bounds apply to
+    // fields the parser actually reads, not to the whole file.
+    {
+        const auto dir = scratch / "valid_extra_long";
+        writeValidPlotfile(dir);
+        writeFile(dir / "Header",
+            validHeaderBody() + std::string(30000, 'z') + "\n");
+        try {
+            const auto result = amrvis::PlotfileMetadataReader{}.read(dir);
+            require(result.metadata->levels.size() == 2,
+                "a Header with an over-long trailing line parsed to the wrong shape");
+        } catch (const std::exception& error) {
+            std::cerr << "FAILED: an over-long line in trailing content the "
+                         "reader never consumes was rejected: "
+                      << error.what() << '\n';
+            ++g_failures;
+        }
+    }
+
     // Truncation: the Header ends before a required field. Each case names the
     // first field the reader cannot read.
     expectHeaderRejected(scratch / "trunc_version",

--- a/tests/unit/test_plotfile_header.cpp
+++ b/tests/unit/test_plotfile_header.cpp
@@ -246,8 +246,10 @@ int main()
         "exceeds the supported length");
     // The unterminated variant, which is the shape the line bound exists for:
     // a line that never ends makes plain getline accumulate the whole rest of
-    // the file before the parse can look at it. Ends at EOF rather than at a
-    // newline, so it also covers the bound's end-of-input path.
+    // the file before the parse can look at it. This trips the ceiling at
+    // 16 KiB and never reaches end of input, so it does *not* cover the
+    // bound's end-of-input path -- see the unterminated-descriptor case in
+    // test_vismf_index for that.
     expectHeaderRejected(scratch / "no_newline",
         "HyperCLaw-V1.1\n1\n" + std::string(30000, 'z'),
         "an unterminated over-long line was not rejected",

--- a/tests/unit/test_vismf_index.cpp
+++ b/tests/unit/test_vismf_index.cpp
@@ -433,6 +433,7 @@ void testAcceptsTrailingContent(const std::filesystem::path& path)
         "\n"
         "((8, (64 11 52 0 1 12 0 1023)),(8, (8 7 6 5 4 3 2 1)))\n"
         "a future section this reader does not consume\n"
+        + std::string(30000, 'z') + "\n"
         "999\n");
     const auto index = readHeader(path, 2, "2+trailing");
     require(index.version == 2, "trailing-content version mismatch");

--- a/tests/unit/test_vismf_index.cpp
+++ b/tests/unit/test_vismf_index.cpp
@@ -500,6 +500,35 @@ void testRejectsOverlongLine(const std::filesystem::path& path)
         "header line exceeds the supported length");
 }
 
+void testAcceptsUnterminatedDescriptor(const std::filesystem::path& path)
+{
+    // A file whose final line has no trailing newline. The RealDescriptor is
+    // the last field a v2 _H carries and is read as a line, so this is the one
+    // shape that exercises the bounded reader's end-of-input-with-content
+    // branch -- the one that returns the partial line instead of discarding
+    // it, and clears the failbit that would otherwise make it look like a
+    // failed read. Nothing else in the suite reaches it: every other case
+    // either ends on a newline or trips the length ceiling first. A reader
+    // that got this wrong would reject every Header written without a final
+    // newline.
+    writeHeader(path,
+        "2\n1\n2\n0\n"
+        "(2 0\n"
+        "((0,0) (1,3) (0,0))\n"
+        "((2,0) (3,3) (0,0))\n"
+        ")\n"
+        "2\n"
+        "FabOnDisk: Cell_D_00000 0\n"
+        "FabOnDisk: Cell_D_00000 4096\n"
+        "\n"
+        "((8, (64 11 52 0 1 12 0 1023)),(8, (8 7 6 5 4 3 2 1)))");
+    const auto index = readHeader(path, 2, "2-unterminated");
+    require(index.realDescriptor == kRealDescriptor,
+        "a RealDescriptor without a trailing newline was not read whole");
+    require(index.boxes.size() == 2,
+        "unterminated-descriptor box count mismatch");
+}
+
 void testRejectsOverlongMultiFabLine(const std::filesystem::path& path)
 {
     // readMultiFab infers the dimension by scanning the header for the first
@@ -568,6 +597,7 @@ int main()
     testRejectsOverlongFabName(scratch / "long_name_H");
     testAcceptsMaximumLengthFabName(scratch / "limit_name_H");
     testRejectsOverlongLine(scratch / "long_line_H");
+    testAcceptsUnterminatedDescriptor(scratch / "unterminated_H");
     testRejectsOverlongMultiFabLine(scratch / "long_multifab_line_H");
     testRejectsOverlongStatistic(scratch / "long_statistic_H");
 

--- a/tests/unit/test_vismf_index.cpp
+++ b/tests/unit/test_vismf_index.cpp
@@ -462,6 +462,83 @@ void testRejectsV4MissingComma(const std::filesystem::path& path)
         "malformed FabArray minima");
 }
 
+// A _H header is walked as text, so without ceilings one enormous line or
+// whitespace-free run is accumulated whole before any parse can reject it.
+// These cases pin each ceiling: the reject must be a MetadataReadError naming
+// the length, not a bad_alloc and not a silent misparse of a truncated token.
+void testRejectsOverlongFabName(const std::filesystem::path& path)
+{
+    expectRejected(path, version2Body(std::string(5000, 'f')), 2,
+        "an over-long FAB filename was not rejected",
+        "exceeds the supported length");
+}
+
+void testAcceptsMaximumLengthFabName(const std::filesystem::path& path)
+{
+    // The other half of the bound, and the reason it is not a plain length
+    // test: a complete token of exactly the limit is well formed, and refusing
+    // it along with the truncated ones would be wrong. What separates the two
+    // is the character that follows -- whitespace or end of file for a complete
+    // token, more token for a truncated one -- so this header must parse, and
+    // the name must arrive whole rather than clipped.
+    const std::string name(4096, 'f');
+    writeHeader(path, version2Body(name));
+    const auto index = readHeader(path, 2, "2-maximum-length-name");
+    require(index.fileNames.size() == 2, "maximum-length name box count mismatch");
+    require(index.fileNames.front() == name,
+        "a FAB filename of exactly the token limit was not read whole");
+}
+
+void testRejectsOverlongLine(const std::filesystem::path& path)
+{
+    // The ghost-width line, read whole before it is parsed for integers.
+    expectRejected(path,
+        "1\n1\n2\n" + std::string(20000, '0') + "\n",
+        2,
+        "an over-long header line was not rejected",
+        "header line exceeds the supported length");
+}
+
+void testRejectsOverlongMultiFabLine(const std::filesystem::path& path)
+{
+    // readMultiFab infers the dimension by scanning the header for the first
+    // BoxArray entry, one line at a time -- the same unbounded read as the
+    // plotfile path's, through a different reader, so it needs its own case.
+    // inferMultiFabDimension runs before readVisMfIndex, so this pins that
+    // scan rather than the index parse that follows it.
+    writeHeader(path, "2\n1\n2\n0\n" + std::string(20000, 'q') + "\n");
+    bool threw = false;
+    try {
+        (void)amrvis::StandaloneMetadataReader{}.readMultiFab(path);
+    } catch (const amrvis::MetadataReadError& error) {
+        threw = true;
+        if (std::string(error.what()).find("header line exceeds the supported "
+                                           "length") == std::string::npos) {
+            std::cerr << "FAILED: an over-long MultiFab header line was "
+                         "rejected for the wrong reason: " << error.what()
+                      << '\n';
+            ++g_failures;
+            return;
+        }
+    } catch (const std::exception& other) {
+        std::cerr << "FAILED: an over-long MultiFab header line threw the "
+                     "wrong exception: " << other.what() << '\n';
+        ++g_failures;
+        return;
+    }
+    require(threw, "an over-long MultiFab header line was not rejected");
+}
+
+void testRejectsOverlongStatistic(const std::filesystem::path& path)
+{
+    // A statistic is accumulated character by character up to its comma, so a
+    // run without one is unbounded input. The ceiling makes it malformed.
+    expectRejected(path,
+        std::string(kV1Prefix) + "2,2\n" + std::string(5000, '9') + ",\n", 2,
+        "an over-long statistic token was not rejected",
+        "exceeds the supported length");
+}
+
 } // namespace
 
 int main()
@@ -487,6 +564,11 @@ int main()
     testRejectsTruncatedBoxArray(scratch / "trunc_boxarray_H");
     testRejectsMissingDescriptor(scratch / "missing_descriptor_H");
     testAcceptsTrailingContent(scratch / "trailing_H");
+    testRejectsOverlongFabName(scratch / "long_name_H");
+    testAcceptsMaximumLengthFabName(scratch / "limit_name_H");
+    testRejectsOverlongLine(scratch / "long_line_H");
+    testRejectsOverlongMultiFabLine(scratch / "long_multifab_line_H");
+    testRejectsOverlongStatistic(scratch / "long_statistic_H");
 
     std::error_code removeError;
     std::filesystem::remove_all(scratch, removeError);


### PR DESCRIPTION
A plotfile Header is walked as text, so an unterminated line or a whitespace-free run was accumulated whole before any parse could reject it -- in the long-lived server, at a session's expense rather than a process's. readBoundedToken now sits beside readBoundedLine and owns the width()-plus-reject shape both readers carried by hand, and readVisMfIndex reserves against the Header's own size instead of a declared count.

Each bound has a regression that was confirmed to fail without it. The reserve needed its own executable: it is invisible to a parse test, so that one counts bytes through a replaced operator new.