### PR TITLE
keep the test accessors and smoke branches out of release builds

### DIFF
--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -24,7 +24,6 @@ add_executable(amrexplorer_qt
     MainWindowInteraction.cpp
     MainWindowInternal.hpp
     MainWindowSlice.cpp
-    MainWindowTestAccess.cpp
     NumberFormat.cpp
     NumberFormat.hpp
     QtErrorText.hpp
@@ -44,6 +43,17 @@ add_executable(amrexplorer_qt
     ${CMAKE_SOURCE_DIR}/resources/user-guide.qrc
 )
 set_target_properties(amrexplorer_qt PROPERTIES OUTPUT_NAME amrexplorer AUTOMOC ON AUTORCC ON)
+
+# MainWindowTestAccess.cpp defines the ~70 ForTest accessors the offscreen
+# smoke tests reach through, and main.cpp's "--...-smoke-test" branches are
+# their only callers. Both are gated on the same definition, so a release build
+# carries neither -- the same shape AMREXPLORER_ENABLE_SERVER_TEST_HOOKS uses
+# for the remote library. The smoke tests run against this executable, so they
+# need AMREXPLORER_BUILD_TESTS=ON, which is the default and what CI configures.
+if(AMREXPLORER_BUILD_TESTS)
+    target_sources(amrexplorer_qt PRIVATE MainWindowTestAccess.cpp)
+    target_compile_definitions(amrexplorer_qt PRIVATE AMREXPLORER_QT_TEST_ACCESS)
+endif()
 
 if(APPLE AND AMREXPLORER_BUILD_MACOS_APP_BUNDLE)
     set(amrexplorer_macos_icon "${CMAKE_SOURCE_DIR}/resources/amrexplorer.icns")

--- a/src/qt/main.cpp
+++ b/src/qt/main.cpp
@@ -247,6 +247,12 @@ void ensureDesktopEntry()
 #endif
 }
 
+// Everything from here to the end of the namespace serves the smoke-test
+// branches in main() and nothing else, so it is gated with them: without this
+// a release build compiles a few hundred lines it cannot reach, and -Werror
+// reports every one of them as unused.
+#ifdef AMREXPLORER_QT_TEST_ACCESS
+
 bool rangeSelectorMatches(
     const amrvis::qt::MainWindow& window, bool metadataRangesAvailable)
 {
@@ -601,6 +607,8 @@ std::optional<ViewportDifference> viewportDifference(
     return difference;
 }
 
+#endif // AMREXPLORER_QT_TEST_ACCESS
+
 } // namespace
 
 int main(int argc, char* argv[])
@@ -683,6 +691,15 @@ int main(int argc, char* argv[])
     std::shared_ptr<amrvis::remote::Server> smokeServer;
     std::optional<std::thread> smokeServerThread;
     std::optional<std::thread> smokePeerThread;
+    // The option chain below carries two kinds of branch. The production
+    // options -- --connect, and the bare plotfile paths at the end -- always
+    // compile. The ~55 "--...-smoke-test" branches drive the offscreen test
+    // harness through MainWindow's ForTest accessors, so they compile only
+    // where those accessors do, and the release binary carries neither. The
+    // chain is split into two guarded runs because --connect sits between
+    // them; the trailing `else` of the first run attaches to it, so removing
+    // the run leaves --connect as the leading `if`.
+#ifdef AMREXPLORER_QT_TEST_ACCESS
     if ((argc == 8 || argc == 10)
         && std::string_view(argv[1])
             == "--fixed-scale-local-remote-repro") {
@@ -1521,7 +1538,9 @@ int main(int argc, char* argv[])
                     "127.0.0.1", server->port(), {path, path},
                     server->token());
             });
-    } else if (argc >= 2
+    } else
+#endif
+    if (argc >= 2
         && std::string_view(argv[1]) == "--connect") {
         std::vector<std::string_view> arguments;
         arguments.reserve(static_cast<std::size_t>(argc - 2));
@@ -1546,7 +1565,9 @@ int main(int argc, char* argv[])
                         request.endpoint.token);
                 }
             });
-    } else if (argc == 3 && std::string_view(argv[1]) == "--smoke-test") {
+    }
+#ifdef AMREXPLORER_QT_TEST_ACCESS
+    else if (argc == 3 && std::string_view(argv[1]) == "--smoke-test") {
         const std::filesystem::path path(argv[2]);
         QObject::connect(&window, &amrvis::qt::MainWindow::datasetOpenFinished,
             &application, [&application](bool success) {
@@ -3655,7 +3676,9 @@ int main(int argc, char* argv[])
         QTimer::singleShot(0, &window, [&window, first, second] {
             window.openSequence({first, second});
         });
-    } else if (argc >= 2 && !std::string_view(argv[1]).starts_with("--")) {
+    }
+#endif
+    else if (argc >= 2 && !std::string_view(argv[1]).starts_with("--")) {
         // One or more plotfile paths: a single path opens a dataset, two or
         // more open a plotfile sequence (matching the GUI's Open Plotfile
         // Sequence, which also takes plotfile directories).


### PR DESCRIPTION
MainWindowTestAccess.cpp compiled into every binary, and it could not be gated alone: main.cpp calls its accessors from the ~55 --...-smoke-test branches, and much of its anonymous namespace serves only those. All three now sit behind AMREXPLORER_QT_TEST_ACCESS, which follows AMREXPLORER_BUILD_TESTS.

Two guarded runs rather than one, because --connect sits between them and inherits the first run's trailing else. An unrecognized smoke option now reaches the usage diagnostic instead of silently working.