### PR TITLE
give the palette one label rule and pin its count

### DIFF
--- a/include/amrexplorer/render2d/Palette.hpp
+++ b/include/amrexplorer/render2d/Palette.hpp
@@ -73,7 +73,15 @@ private:
     std::array<Rgb, slotCount> slots_{};
 };
 
-enum class BuiltinPalette { Rainbow, Turbo, Viridis, Plasma, Parula, Coolwarm, Blackbody };
+// Count is a sentinel rather than a palette. It exists so a consumer that
+// enumerates the builtins -- the Qt layer's builtinPalettes array, which drives
+// the menu, the selector and settings restore -- can static_assert that it
+// covers all of them. Without it a new enumerator simply never reaches the UI,
+// and the palette tests still pass because they pin the names, not the count.
+// Add new palettes above it, and handle it in switches by falling through to
+// the default palette.
+enum class BuiltinPalette {
+    Rainbow, Turbo, Viridis, Plasma, Parula, Coolwarm, Blackbody, Count };
 
 // Compiled-in copies of the palette files shipped under palettes/; Rainbow
 // is byte-identical to the legacy default `Palette` file and is the default

--- a/include/amrexplorer/render2d/Palette.hpp
+++ b/include/amrexplorer/render2d/Palette.hpp
@@ -90,8 +90,9 @@ enum class BuiltinPalette {
 // (the Moreland diverging map shared by ParaView/VisIt), and blackbody (a
 // black-body radiation thermal ramp).
 [[nodiscard]] const Palette& builtinPalette(BuiltinPalette palette);
-// The palette's menu label / settings key, without a file extension, e.g.
-// "rainbow".
+// The palette's settings key, without a file extension, e.g. "rainbow". Also
+// the basis for its UI label, which the Qt layer capitalizes -- so this string
+// is what goes on disk and must not change with presentation.
 [[nodiscard]] std::string_view builtinPaletteName(BuiltinPalette palette) noexcept;
 
 } // namespace amrvis

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -309,10 +309,7 @@ MainWindow::MainWindow(QWidget* parent)
     const QFontMetrics paletteFm(m_paletteSelector->font());
     int widestBuiltin = 0;
     for (std::size_t index = 0; index < builtinPalettes.size(); ++index) {
-        auto label = builtinPaletteLabel(index);
-        if (!label.isEmpty()) {
-            label[0] = label[0].toUpper();
-        }
+        const auto label = builtinPaletteLabel(index);
         // Reserve room for the reversed form ("Plasma_r") so the closed
         // selector never elides the "_r" suffix syncPaletteSelector appends.
         widestBuiltin = std::max(widestBuiltin,
@@ -1472,13 +1469,6 @@ void MainWindow::syncPaletteSelector()
         m_paletteSelector->removeItem(custom);
     }
 
-    const auto builtinLabel = [](int index) {
-        auto label = builtinPaletteLabel(static_cast<std::size_t>(index));
-        if (!label.isEmpty()) {
-            label[0] = label[0].toUpper();
-        }
-        return label;
-    };
     // Reversal is a global modifier, so every palette name carries the "_r"
     // suffix (the plasma_r convention) while it is on -- including the closed
     // selector, which shows the active one.
@@ -1490,7 +1480,8 @@ void MainWindow::syncPaletteSelector()
         }
         const auto value = entryData.toInt();
         if (value >= 0) {
-            m_paletteSelector->setItemText(item, builtinLabel(value) + suffix);
+            m_paletteSelector->setItemText(item,
+                builtinPaletteLabel(static_cast<std::size_t>(value)) + suffix);
         } else if (value == -3) {
             // The toggle item shows a check mark while reversal is on.
             m_paletteSelector->setItemText(item,

--- a/src/qt/MainWindow.hpp
+++ b/src/qt/MainWindow.hpp
@@ -170,6 +170,14 @@ public:
     // placeholder naming what failed, never the "Loading..." one it replaced.
     [[nodiscard]] QString viewPlaceholderForTest();
 
+    // Test-only: the builtin palette names as the Palette menu and the palette
+    // selector each show them. Two accessors rather than one because the point
+    // is that the two agree: they are built in different units from the same
+    // helper, and they disagreed for as long as the capitalization was spelled
+    // out at the call sites instead of living in that helper.
+    [[nodiscard]] QStringList paletteMenuLabelsForTest() const;
+    [[nodiscard]] QStringList paletteSelectorLabelsForTest() const;
+
     // Test-only: true when the active view's displayed raster is byte-identical
     // to its plane re-rendered against the current display (color-bar) range —
     // i.e. the raster and color bar agree. See

--- a/src/qt/MainWindowInternal.hpp
+++ b/src/qt/MainWindowInternal.hpp
@@ -139,6 +139,14 @@ inline constexpr std::array<BuiltinPalette, 7> builtinPalettes{
     BuiltinPalette::Plasma, BuiltinPalette::Parula, BuiltinPalette::Coolwarm,
     BuiltinPalette::Blackbody};
 
+// This array is what the Palette menu, the selector and restoreSettings all
+// enumerate, so a palette missing from it exists in render2d and nowhere a user
+// can reach. test_palette pins the seven names but cannot catch that: adding an
+// enumerator leaves this at seven and every name it does check still matches.
+static_assert(builtinPalettes.size()
+        == static_cast<std::size_t>(BuiltinPalette::Count),
+    "every BuiltinPalette must be listed in builtinPalettes");
+
 // The QSettings value for a builtin palette. This string is on disk in every
 // user's settings, and it comes from amrvis::builtinPaletteName(), which
 // render2d documents as the menu label *and* the settings key -- so renaming a
@@ -153,12 +161,19 @@ inline QString builtinPaletteKey(std::size_t index)
     return QString::fromLatin1(name.data(), static_cast<qsizetype>(name.size()));
 }
 
-// The palette's name for the menu and the selector. Identical to the settings
-// key today, and kept apart so it can take presentation rules -- two call
-// sites already capitalize it -- without rewriting anyone's stored settings.
+// The palette's name for the menu and the selector, and the one definition of
+// how it is presented: capitalized, where the settings key above stays
+// lowercase. Kept apart from that key precisely so this rule can live here
+// without rewriting anyone's stored settings. It used to be a pass-through
+// with the capitalization spelled out at two of its three call sites, so the
+// Palette menu showed "rainbow" while the selector showed "Rainbow".
 inline QString builtinPaletteLabel(std::size_t index)
 {
-    return builtinPaletteKey(index);
+    auto label = builtinPaletteKey(index);
+    if (!label.isEmpty()) {
+        label[0] = label[0].toUpper();
+    }
+    return label;
 }
 
 // The single conversion from a rendered ImageBuffer to the QImage the views

--- a/src/qt/MainWindowInternal.hpp
+++ b/src/qt/MainWindowInternal.hpp
@@ -162,8 +162,10 @@ inline QString builtinPaletteKey(std::size_t index)
 }
 
 // The palette's name for the menu and the selector, and the one definition of
-// how it is presented: capitalized, where the settings key above stays
-// lowercase. Kept apart from that key precisely so this rule can live here
+// its capitalization -- where the settings key above stays lowercase. Not the
+// only presentation rule: syncPaletteSelector still appends the "_r" reversal
+// suffix to the selector alone, so with reversal on the two surfaces differ by
+// that suffix. Folding it in here is the remaining half of the job. Kept apart from that key precisely so this rule can live here
 // without rewriting anyone's stored settings. It used to be a pass-through
 // with the capitalization spelled out at two of its three call sites, so the
 // Palette menu showed "rainbow" while the selector showed "Rainbow".

--- a/src/qt/MainWindowTestAccess.cpp
+++ b/src/qt/MainWindowTestAccess.cpp
@@ -95,6 +95,36 @@ void MainWindow::setAnimationDockVisibleForTest(bool visible)
     }
 }
 
+QStringList MainWindow::paletteMenuLabelsForTest() const
+{
+    QStringList labels;
+    if (m_paletteGroup == nullptr) {
+        return labels;
+    }
+    for (const auto* action : m_paletteGroup->actions()) {
+        labels.append(action->text());
+    }
+    return labels;
+}
+
+QStringList MainWindow::paletteSelectorLabelsForTest() const
+{
+    QStringList labels;
+    if (m_paletteSelector == nullptr) {
+        return labels;
+    }
+    for (int item = 0; item < m_paletteSelector->count(); ++item) {
+        const auto entryData = m_paletteSelector->itemData(item);
+        // Skip the separator, the custom-palette entry (-2) and the reverse
+        // toggle (-3): only the builtins have a non-negative index, and only
+        // they are built from the shared label helper.
+        if (entryData.isValid() && entryData.toInt() >= 0) {
+            labels.append(m_paletteSelector->itemText(item));
+        }
+    }
+    return labels;
+}
+
 QString MainWindow::viewPlaceholderForTest()
 {
     QString shared;

--- a/src/qt/main.cpp
+++ b/src/qt/main.cpp
@@ -1576,7 +1576,21 @@ int main(int argc, char* argv[])
         // the selector read "Rainbow". Needs no dataset -- both lists are built
         // during construction.
         const auto menu = window.paletteMenuLabelsForTest();
-        const auto selector = window.paletteSelectorLabelsForTest();
+        auto selector = window.paletteSelectorLabelsForTest();
+        // The reversal suffix is a selector-only presentation rule: with
+        // "Reverse Colormap" on, syncPaletteSelector appends "_r" while the
+        // menu actions keep their original text. That divergence is real and
+        // outside what this case is about, so it is normalized away rather
+        // than asserted on -- the property here is that the two agree on the
+        // *name*. Isolated settings make reversal off anyway; this keeps the
+        // case honest on the platforms where XDG_CONFIG_HOME does not isolate
+        // QSettings, and stops it claiming an invariant the product does not
+        // hold. Unifying the suffix into the shared helper is follow-up work.
+        for (auto& label : selector) {
+            if (label.endsWith(QStringLiteral("_r"))) {
+                label.chop(2);
+            }
+        }
         if (menu.isEmpty() || menu != selector) {
             qCritical("palette menu labels %s do not match the selector's %s",
                 qPrintable(menu.join(QStringLiteral(","))),

--- a/src/qt/main.cpp
+++ b/src/qt/main.cpp
@@ -1567,7 +1567,31 @@ int main(int argc, char* argv[])
             });
     }
 #ifdef AMREXPLORER_QT_TEST_ACCESS
-    else if (argc == 3 && std::string_view(argv[1]) == "--smoke-test") {
+    else if (argc == 2
+        && std::string_view(argv[1]) == "--palette-labels-smoke-test") {
+        // The Palette menu and the palette selector are built in different
+        // translation units from one label helper, and must therefore show the
+        // same names. They did not: the menu used the helper's result raw while
+        // the selector capitalized it by hand, so the menu read "rainbow" where
+        // the selector read "Rainbow". Needs no dataset -- both lists are built
+        // during construction.
+        const auto menu = window.paletteMenuLabelsForTest();
+        const auto selector = window.paletteSelectorLabelsForTest();
+        if (menu.isEmpty() || menu != selector) {
+            qCritical("palette menu labels %s do not match the selector's %s",
+                qPrintable(menu.join(QStringLiteral(","))),
+                qPrintable(selector.join(QStringLiteral(","))));
+            return 1;
+        }
+        // Pinned as a literal rather than derived from the same helper the
+        // widgets used, which would pass whatever that helper produced.
+        if (menu.front() != QStringLiteral("Rainbow")) {
+            qCritical("the first palette is labelled '%s', not 'Rainbow'",
+                qPrintable(menu.front()));
+            return 1;
+        }
+        return 0;
+    } else if (argc == 3 && std::string_view(argv[1]) == "--smoke-test") {
         const std::filesystem::path path(argv[2]);
         QObject::connect(&window, &amrvis::qt::MainWindow::datasetOpenFinished,
             &application, [&application](bool success) {

--- a/src/render2d/BuiltinPalettes.cpp
+++ b/src/render2d/BuiltinPalettes.cpp
@@ -434,6 +434,7 @@ const Palette& builtinPalette(BuiltinPalette palette)
     case BuiltinPalette::Parula: return parula;
     case BuiltinPalette::Coolwarm: return coolwarm;
     case BuiltinPalette::Blackbody: return blackbody;
+    case BuiltinPalette::Count: break;  // sentinel, not a palette
     }
     return rainbow;
 }
@@ -448,6 +449,7 @@ std::string_view builtinPaletteName(BuiltinPalette palette) noexcept
     case BuiltinPalette::Parula: return "parula";
     case BuiltinPalette::Coolwarm: return "coolwarm";
     case BuiltinPalette::Blackbody: return "blackbody";
+    case BuiltinPalette::Count: break;  // sentinel, not a palette
     }
     return "rainbow";
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -426,6 +426,16 @@ if(TARGET amrexplorer_qt)
     add_test(NAME remote_connect_arguments
         COMMAND test_remote_connect_arguments)
 
+    # The Palette menu and the palette selector are built in different
+    # translation units and must agree. Needs no fixture: both lists exist as
+    # soon as the window is constructed.
+    add_test(
+        NAME qt_palette_labels_smoke
+        COMMAND "${CMAKE_COMMAND}" -E env QT_QPA_PLATFORM=offscreen
+            "$<TARGET_FILE:amrexplorer_qt>" --palette-labels-smoke-test
+    )
+    set_tests_properties(qt_palette_labels_smoke PROPERTIES TIMEOUT 30)
+
     add_test(
         NAME qt_remote_slice_smoke
         COMMAND "${CMAKE_COMMAND}" -E env QT_QPA_PLATFORM=offscreen

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -428,10 +428,15 @@ if(TARGET amrexplorer_qt)
 
     # The Palette menu and the palette selector are built in different
     # translation units and must agree. Needs no fixture: both lists exist as
-    # soon as the window is constructed.
+    # soon as the window is constructed -- but it does need an isolated
+    # XDG_CONFIG_HOME, like qt_smoke_driver.cmake gives the fixture-based
+    # cases. Without it the run inherits the developer's real QSettings, and a
+    # persisted "Reverse Colormap" makes the selector read "Rainbow_r" against
+    # the menu's "Rainbow".
     add_test(
         NAME qt_palette_labels_smoke
         COMMAND "${CMAKE_COMMAND}" -E env QT_QPA_PLATFORM=offscreen
+            "XDG_CONFIG_HOME=${CMAKE_CURRENT_BINARY_DIR}/config_palette_labels"
             "$<TARGET_FILE:amrexplorer_qt>" --palette-labels-smoke-test
     )
     set_tests_properties(qt_palette_labels_smoke PROPERTIES TIMEOUT 30)


### PR DESCRIPTION
The Palette menu showed "rainbow" where the selector showed "Rainbow": the capitalization was spelled out at two of the three call sites instead of in builtinPaletteLabel, which exists to hold exactly that. The settings key is untouched.

The rule had no coverage -- removing it left every test green -- so a smoke case now compares the two lists and pins the first name as a literal. A BuiltinPalette::Count sentinel and a static_assert close the other half: a new enumerator that is not listed reached no menu, and the palette tests still passed because they pin names, not the count.