### PR TITLE
frame a remote rubber-band selection once, flush to the pane

### DIFF
--- a/src/qt/ImageView.cpp
+++ b/src/qt/ImageView.cpp
@@ -621,13 +621,17 @@ void ImageView::zoomBy(qreal factor)
     emit zoomChanged();
 }
 
-void ImageView::zoomToRect(const QRectF& imageRect)
+void ImageView::zoomToRect(const QRectF& imageRect, bool confineScene)
 {
     if (!hasImage() || imageRect.isEmpty()) {
         return;
     }
     m_transformMode = TransformMode::Custom;
-    fitInView(m_item->mapRectToScene(imageRect), Qt::KeepAspectRatio);
+    const auto sceneTarget = m_item->mapRectToScene(imageRect);
+    if (confineScene) {
+        m_scene->setSceneRect(sceneTarget);
+    }
+    fitInView(sceneTarget, Qt::KeepAspectRatio);
 }
 
 void ImageView::panViewport(const QPoint& delta)

--- a/src/qt/ImageView.hpp
+++ b/src/qt/ImageView.hpp
@@ -175,7 +175,14 @@ public:
     void zoomBy(qreal factor);
     // The rect is in image (raster-pixel) coordinates — identical to scene
     // coordinates in the classic scene, offset-corrected on a virtual canvas.
-    void zoomToRect(const QRectF& imageRect);
+    // confineScene additionally shrinks the scene rect to the target, which
+    // keeps the scroll ranges empty: for a zoom whose surroundings are about
+    // to be discarded (a rubber-band selection awaiting its re-slice), the
+    // domain-spanning scroll bars must not appear even transiently — on a
+    // remote session they steal viewport pixels, so the requested raster is
+    // undersized and a second fetch fires when they vanish. The next setImage
+    // restores the scene rect (see applyPlacement).
+    void zoomToRect(const QRectF& imageRect, bool confineScene = false);
     // Scrolls the viewport for Shift+left-drag and the arrow keys. The delta
     // is how far the content moves, matching the sense MainWindow's
     // shiftedPanRegion uses, and is a no-op when the scene already fits the

--- a/src/qt/MainWindow.hpp
+++ b/src/qt/MainWindow.hpp
@@ -224,6 +224,11 @@ public:
     // the same handler used by ImageView::rubberBandSelected.
     void rubberBandZoomActiveViewForTest();
     void rubberBandZoomRectangularActiveViewForTest();
+    void rubberBandZoomTallActiveViewForTest();
+    // Whether the active view's raster is fitted flush to the pane: within
+    // the viewport (no overflow) and touching both borders on the limiting
+    // axis, up to fitInView's built-in margin.
+    [[nodiscard]] bool activeViewRasterSnugForTest() const;
 
     // Test-only: true when every current panel has a strict visible subregion.
     // Used to lock down synchronized 3-D rubber-band zoom.

--- a/src/qt/MainWindowInteraction.cpp
+++ b/src/qt/MainWindowInteraction.cpp
@@ -1261,12 +1261,17 @@ void MainWindow::applyRubberBandZoom(
     state.view->setVirtualCanvas(std::nullopt);
     // Zoom to the requested region mapped back to scene pixels, so the view
     // transform matches the region the requested slice will actually cover.
+    // Confined: the selection becomes a standalone raster with no
+    // domain-spanning scroll bars, so the feedback zoom must not raise them
+    // either — transient scroll bars shrink the viewport, and the remote
+    // request would be sized to the stolen pixels and re-fetched (and
+    // re-framed, visibly) once they vanish.
     const QRectF requestedScene(
         QPointF((visible.lower[xAxis] - region.lower[xAxis]) / xExtent * width,
             (region.upper[yAxis] - visible.upper[yAxis]) / yExtent * height),
         QPointF((visible.upper[xAxis] - region.lower[xAxis]) / xExtent * width,
             (region.upper[yAxis] - visible.lower[yAxis]) / yExtent * height));
-    state.view->zoomToRect(requestedScene.normalized());
+    state.view->zoomToRect(requestedScene.normalized(), true);
     scheduleSliceRequest(state);
 }
 

--- a/src/qt/MainWindowSlice.cpp
+++ b/src/qt/MainWindowSlice.cpp
@@ -746,7 +746,26 @@ std::optional<QRectF> MainWindow::preservedDataWindow(
     if (window.isEmpty()) {
         return std::nullopt;
     }
-    return window;
+    // Clamped to the raster that actually arrived. The window is the *viewport*
+    // mapped through the old plane, and after a rubber-band zoom the viewport
+    // shows more than the selection: the feedback zoom fits the selection with
+    // KeepAspectRatio, which pads the slack axis. Framing that padded window
+    // over a raster that stops at the selection leaves the raster short of the
+    // pane -- the gap that only the next pan corrected, by refitting.
+    //
+    // There is nothing outside the raster to show anyway, so clamping is the
+    // whole fix, and it is a no-op for the case this function exists for: a
+    // density change mid-view preserves a window that lies *inside* the new
+    // raster. Local rubber-band zooms never reach here at all, since their
+    // density is unchanged -- which is why they never showed the gap.
+    const QRectF rasterBounds(0.0, 0.0,
+        static_cast<double>(incoming.width),
+        static_cast<double>(incoming.height));
+    const auto clamped = window.intersected(rasterBounds);
+    if (clamped.isEmpty()) {
+        return std::nullopt;
+    }
+    return clamped;
 }
 
 std::optional<QRectF> MainWindow::sphericalReframe(

--- a/src/qt/MainWindowTestAccess.cpp
+++ b/src/qt/MainWindowTestAccess.cpp
@@ -313,6 +313,48 @@ void MainWindow::rubberBandZoomRectangularActiveViewForTest()
         QRectF(0.275 * width, 0.35 * height, 0.45 * width, 0.2 * height));
 }
 
+void MainWindow::rubberBandZoomTallActiveViewForTest()
+{
+    if (m_activeView == nullptr || m_activeView->plane->width <= 0
+        || m_activeView->plane->height <= 0) {
+        return;
+    }
+    // The transpose of the rectangular selection above. A wide and a tall
+    // selection err on opposite sides when the arrival is framed through a
+    // padded window, so a framing regression needs both signs covered.
+    const auto width = static_cast<double>(m_activeView->plane->width);
+    const auto height = static_cast<double>(m_activeView->plane->height);
+    rubberBandZoom(*m_activeView,
+        QRectF(0.35 * width, 0.275 * height, 0.2 * width, 0.45 * height));
+}
+
+bool MainWindow::activeViewRasterSnugForTest() const
+{
+    if (m_activeView == nullptr || m_activeView->view == nullptr
+        || !m_activeView->view->hasImage()
+        || m_activeView->view->viewport() == nullptr) {
+        return false;
+    }
+    const auto* view = m_activeView->view;
+    const auto shown = view->mapFromScene(
+        view->imageSceneRect()).boundingRect();
+    const auto viewport = view->viewport()->rect();
+    // A raster fitted to the pane touches both borders on its limiting axis
+    // and never spills past the pane. fitInView keeps a hardcoded 2-pixel
+    // margin per side, hence the tolerances: one pixel of overflow for
+    // round-off, six pixels of slack (the 2x2 margin plus rounding) before
+    // the limiting axis counts as falling short of the pane. Six is
+    // deliberate: framing the arrival through a window that was itself
+    // produced by a fitInView applies the margin twice, which reads as
+    // eight-plus pixels of slack and must fail here.
+    if (!viewport.adjusted(-1, -1, 1, 1).contains(shown)) {
+        return false;
+    }
+    const auto slackX = viewport.width() - shown.width();
+    const auto slackY = viewport.height() - shown.height();
+    return std::min(slackX, slackY) <= 6;
+}
+
 bool MainWindow::allViewsRubberBandZoomedForTest()
 {
     const auto views = currentViews();

--- a/src/qt/main.cpp
+++ b/src/qt/main.cpp
@@ -607,6 +607,34 @@ std::optional<ViewportDifference> viewportDifference(
     return difference;
 }
 
+// The sequence preserve smokes assert that the *data window* survives the
+// step: rubberBandZoomActiveViewForTest selects the domain's centered half,
+// and after the density change the view must still show exactly that window.
+// They used to assert the transform differed from a fresh fit instead, but
+// that proxy only held while the rubber-band feedback disturbed the viewport
+// (transient scroll bars): once the arrival is framed cleanly, preserving a
+// window that the raster covers exactly *is* numerically a fit, while a
+// broken preserve (refit to the whole frame) still moves the window and
+// fails here.
+bool centeredHalfWindowPreserved(const amrvis::qt::MainWindow& window)
+{
+    const auto domain = window.datasetPhysicalDomainForTest();
+    const auto shown = window.activeViewVisibleDataWindowForTest();
+    if (domain.isEmpty() || shown.isEmpty()) {
+        return false;
+    }
+    const QRectF expected(
+        domain.left() + 0.25 * domain.width(),
+        domain.top() + 0.25 * domain.height(),
+        0.5 * domain.width(), 0.5 * domain.height());
+    const auto tolerance
+        = 0.02 * std::max(domain.width(), domain.height());
+    return std::abs(shown.left() - expected.left()) <= tolerance
+        && std::abs(shown.top() - expected.top()) <= tolerance
+        && std::abs(shown.right() - expected.right()) <= tolerance
+        && std::abs(shown.bottom() - expected.bottom()) <= tolerance;
+}
+
 #endif // AMREXPLORER_QT_TEST_ACCESS
 
 } // namespace
@@ -1450,14 +1478,39 @@ int main(int argc, char* argv[])
                     application.exit(2);
                     return;
                 }
+                // Three settles: the wide selection, the reset back to the
+                // whole domain, the tall selection. The wide and tall
+                // selections err on opposite sides of the pane when the
+                // arrival's framing regresses, so both must end snug — and
+                // already at the first settle: the transient-scroll-bar
+                // double fetch showed a mis-framed raster there before its
+                // correction arrived.
+                auto step = std::make_shared<int>(0);
                 QObject::connect(&window,
                     &amrvis::qt::MainWindow::interactiveSlicesSettled,
-                    &application, [&window, &application] {
-                        application.exit(window.activeViewIsZoomedForTest()
-                                && window.activeViewHasPhysicalAspectForTest(
+                    &application, [&window, &application, step] {
+                        switch ((*step)++) {
+                        case 0:
+                            if (!window.activeViewIsZoomedForTest()
+                                || !window.activeViewHasPhysicalAspectForTest(
                                     9.0 / 4.0)
-                            ? 0 : 1);
-                    }, Qt::SingleShotConnection);
+                                || !window.activeViewRasterSnugForTest()) {
+                                application.exit(1);
+                                return;
+                            }
+                            window.resetZoomAllViewsForTest();
+                            return;
+                        case 1:
+                            window.rubberBandZoomTallActiveViewForTest();
+                            return;
+                        default:
+                            application.exit(window.activeViewIsZoomedForTest()
+                                    && window.activeViewHasPhysicalAspectForTest(
+                                        4.0 / 9.0)
+                                    && window.activeViewRasterSnugForTest()
+                                ? 0 : 1);
+                        }
+                    });
                 window.rubberBandZoomRectangularActiveViewForTest();
             });
         QTimer::singleShot(15000, &application,
@@ -3567,7 +3620,7 @@ int main(int argc, char* argv[])
                     application.exit(
                         *zoomSettled
                             && window.activeViewIsZoomedForTest()
-                            && !window.activeViewIsFitToWindowForTest()
+                            && centeredHalfWindowPreserved(window)
                         ? 0 : 1);
                 }
             });
@@ -3595,7 +3648,7 @@ int main(int argc, char* argv[])
                 } else if (index == 1) {
                     application.exit(
                         window.activeViewIsZoomedForTest()
-                            && !window.activeViewIsFitToWindowForTest()
+                            && centeredHalfWindowPreserved(window)
                         ? 0 : 1);
                 }
             });


### PR DESCRIPTION
A remote rubber-band zoom showed a mis-framed intermediate raster before settling. Two stacked defects: preservedDataWindow framed the arrival through the padded feedback viewport, leaving the raster short of the pane (fixed by clamping the window to the raster's bounds), and the feedback zoom transiently raised both scroll bars, so the request was sized to the shrunken viewport and re-fetched once they vanished (fixed by confining the scene to the selection during the feedback).

The rubber-aspect smoke now asserts flush framing for a wide and a tall selection; the sequence preserve smokes assert the preserved data window directly, since a clean preserve is numerically a fresh fit.