### PR TITLE
index a slice level's blocks for O(1) point lookup

### DIFF
--- a/src/query/SliceQuery.cpp
+++ b/src/query/SliceQuery.cpp
@@ -54,40 +54,59 @@ public:
         }
         const auto a0 = static_cast<std::size_t>(m_axis0);
         const auto a1 = static_cast<std::size_t>(m_axis1);
-        auto hi0 = std::numeric_limits<std::int64_t>::min();
-        auto hi1 = std::numeric_limits<std::int64_t>::min();
         m_lo0 = std::numeric_limits<std::int64_t>::max();
         m_lo1 = std::numeric_limits<std::int64_t>::max();
+        m_hi0 = std::numeric_limits<std::int64_t>::min();
+        m_hi1 = std::numeric_limits<std::int64_t>::min();
         for (const auto& block : blocks) {
             m_lo0 = std::min(m_lo0,
                 static_cast<std::int64_t>(block.validBox.lower[a0]));
             m_lo1 = std::min(m_lo1,
                 static_cast<std::int64_t>(block.validBox.lower[a1]));
-            hi0 = std::max(hi0,
+            m_hi0 = std::max(m_hi0,
                 static_cast<std::int64_t>(block.validBox.upper[a0]));
-            hi1 = std::max(hi1,
+            m_hi1 = std::max(m_hi1,
                 static_cast<std::int64_t>(block.validBox.upper[a1]));
         }
-        const auto span0 = hi0 - m_lo0 + 1;
-        const auto span1 = hi1 - m_lo1 + 1;
-        // Aim for ~one block per tile (sqrt(blocks) tiles per axis), capped so
-        // the bucket array stays bounded no matter how many blocks intersect.
+        const auto span0 = m_hi0 - m_lo0 + 1;
+        const auto span1 = m_hi1 - m_lo1 + 1;
+        // ~sqrt(blocks) tiles per axis, capped so the bucket array is bounded.
+        // llround(sqrt(n)) >= 1 for n >= 1 (the empty case returned above), so
+        // only the upper cap is needed.
         constexpr std::int64_t maxTilesPerAxis = 256;
-        const auto target = std::clamp<std::int64_t>(
-            static_cast<std::int64_t>(std::llround(
-                std::sqrt(static_cast<double>(blocks.size())))),
-            1, maxTilesPerAxis);
+        const auto target = std::min<std::int64_t>(maxTilesPerAxis,
+            std::llround(std::sqrt(static_cast<double>(blocks.size()))));
         m_tile0 = std::max<std::int64_t>(1, (span0 + target - 1) / target);
         m_tile1 = std::max<std::int64_t>(1, (span1 + target - 1) / target);
         m_n0 = static_cast<int>((span0 + m_tile0 - 1) / m_tile0);
         m_n1 = static_cast<int>((span1 + m_tile1 - 1) / m_tile1);
-        m_buckets.assign(
-            static_cast<std::size_t>(m_n0) * static_cast<std::size_t>(m_n1), {});
+        const auto tileCount
+            = static_cast<std::size_t>(m_n0) * static_cast<std::size_t>(m_n1);
+        // Non-overlapping blocks (the level invariant) put ~one block in each
+        // tile, so the fill is O(blocks + tiles). validateMetadata does not
+        // forbid overlap, though, and a degenerate catalog of many large
+        // overlapping boxes would push billions of (block, tile) entries -- an
+        // unbounded, GB-scale allocation off a small header. Cap the total and
+        // fall back to a plain linear scan (bounded memory, identical result)
+        // rather than build an enormous index.
+        const auto maxEntries = 8 * (blocks.size() + tileCount);
+        m_buckets.assign(tileCount, {});
+        std::size_t entries = 0;
         for (std::size_t index = 0; index < blocks.size(); ++index) {
             const auto& box = blocks[index].validBox;
-            for (int t1 = tile1(box.lower[a1]); t1 <= tile1(box.upper[a1]); ++t1) {
-                for (int t0 = tile0(box.lower[a0]);
-                     t0 <= tile0(box.upper[a0]); ++t0) {
+            // Box coordinates are within [m_lo, m_hi], so these tile indices
+            // never overflow the narrowing cast in tile0()/tile1(); the loop
+            // bounds are hoisted out of the inner condition.
+            const auto t0Last = tile0(box.upper[a0]);
+            const auto t1Last = tile1(box.upper[a1]);
+            for (int t1 = tile1(box.lower[a1]); t1 <= t1Last; ++t1) {
+                for (int t0 = tile0(box.lower[a0]); t0 <= t0Last; ++t0) {
+                    if (++entries > maxEntries) {
+                        m_buckets.clear();
+                        m_buckets.shrink_to_fit();
+                        m_linearScan = true;
+                        return;
+                    }
                     m_buckets[bucket(t0, t1)].push_back(static_cast<int>(index));
                 }
             }
@@ -95,25 +114,31 @@ public:
     }
 
     // Index into `blocks` of the block containing `point`, or -1 if none does.
+    // `blocks` must be the same vector the grid was built from.
     [[nodiscard]] int find(const std::vector<LoadedBlock>& blocks,
         const Int3& point, int dimension) const
     {
-        if (m_buckets.empty()) {
+        if (m_linearScan) {
+            for (std::size_t index = 0; index < blocks.size(); ++index) {
+                if (contains(blocks[index].validBox, point, dimension)) {
+                    return static_cast<int>(index);
+                }
+            }
             return -1;
         }
         const auto p0 = static_cast<std::int64_t>(
             point[static_cast<std::size_t>(m_axis0)]);
         const auto p1 = static_cast<std::int64_t>(
             point[static_cast<std::size_t>(m_axis1)]);
-        if (p0 < m_lo0 || p1 < m_lo1) {
+        // Reject out-of-bounds points in int64 *before* tiling. A point far
+        // above the bounding box would otherwise overflow the narrowing cast
+        // in tile0()/tile1() to a negative int and slip past a bare upper-tile
+        // check, indexing m_buckets wildly out of range. The empty-level case
+        // (inverted default bounds, m_hi < m_lo) is rejected here too.
+        if (p0 < m_lo0 || p0 > m_hi0 || p1 < m_lo1 || p1 > m_hi1) {
             return -1;
         }
-        const auto t0 = tile0(p0);
-        const auto t1 = tile1(p1);
-        if (t0 >= m_n0 || t1 >= m_n1) {
-            return -1;
-        }
-        for (const auto index : m_buckets[bucket(t0, t1)]) {
+        for (const auto index : m_buckets[bucket(tile0(p0), tile1(p1))]) {
             if (contains(blocks[static_cast<std::size_t>(index)].validBox,
                     point, dimension)) {
                 return index;
@@ -123,6 +148,8 @@ public:
     }
 
 private:
+    // Precondition: coordinate is within [m_lo, m_hi] on its axis, so the
+    // quotient is in [0, m_n - 1] and the narrowing cast cannot overflow.
     [[nodiscard]] int tile0(std::int64_t coordinate) const noexcept
     {
         return static_cast<int>((coordinate - m_lo0) / m_tile0);
@@ -139,12 +166,16 @@ private:
 
     int m_axis0 = 0;
     int m_axis1 = 1;
+    // Inverted default range so an empty grid rejects every point in find().
     std::int64_t m_lo0 = 0;
     std::int64_t m_lo1 = 0;
+    std::int64_t m_hi0 = -1;
+    std::int64_t m_hi1 = -1;
     std::int64_t m_tile0 = 1;
     std::int64_t m_tile1 = 1;
     int m_n0 = 0;
     int m_n1 = 0;
+    bool m_linearScan = false;
     std::vector<std::vector<int>> m_buckets;
 };
 

--- a/src/query/SliceQuery.cpp
+++ b/src/query/SliceQuery.cpp
@@ -29,6 +29,125 @@ struct LevelBlocks {
     std::vector<LoadedBlock> blocks;
 };
 
+// A uniform bin grid over one level's loaded blocks, on the two plane axes, for
+// O(1)-average point->block lookup. The composited-value lookup below runs once
+// per output pixel (five times per pixel for linear sampling), and a linear scan
+// of every intersecting block per pixel was O(pixels * blocks) -- seconds on a
+// full-resolution view of a block-heavy fine level. Blocks within an AMReX level
+// are non-overlapping, so a point lands in at most one; the grid narrows the scan
+// to the one tile the point falls in.
+//
+// A block that spans several tiles is listed in each, so every block covering a
+// point shares that point's tile and the bucket scan sees all candidates. Scans
+// run in ascending block index (buckets are filled in block order), so a
+// malformed overlapping catalog resolves to the smallest index -- identical to
+// the first-match order of the linear scan this replaces.
+class BlockGrid {
+public:
+    BlockGrid(const std::vector<LoadedBlock>& blocks,
+        const std::array<int, 2>& axes)
+        : m_axis0(axes[0])
+        , m_axis1(axes[1])
+    {
+        if (blocks.empty()) {
+            return;
+        }
+        const auto a0 = static_cast<std::size_t>(m_axis0);
+        const auto a1 = static_cast<std::size_t>(m_axis1);
+        auto hi0 = std::numeric_limits<std::int64_t>::min();
+        auto hi1 = std::numeric_limits<std::int64_t>::min();
+        m_lo0 = std::numeric_limits<std::int64_t>::max();
+        m_lo1 = std::numeric_limits<std::int64_t>::max();
+        for (const auto& block : blocks) {
+            m_lo0 = std::min(m_lo0,
+                static_cast<std::int64_t>(block.validBox.lower[a0]));
+            m_lo1 = std::min(m_lo1,
+                static_cast<std::int64_t>(block.validBox.lower[a1]));
+            hi0 = std::max(hi0,
+                static_cast<std::int64_t>(block.validBox.upper[a0]));
+            hi1 = std::max(hi1,
+                static_cast<std::int64_t>(block.validBox.upper[a1]));
+        }
+        const auto span0 = hi0 - m_lo0 + 1;
+        const auto span1 = hi1 - m_lo1 + 1;
+        // Aim for ~one block per tile (sqrt(blocks) tiles per axis), capped so
+        // the bucket array stays bounded no matter how many blocks intersect.
+        constexpr std::int64_t maxTilesPerAxis = 256;
+        const auto target = std::clamp<std::int64_t>(
+            static_cast<std::int64_t>(std::llround(
+                std::sqrt(static_cast<double>(blocks.size())))),
+            1, maxTilesPerAxis);
+        m_tile0 = std::max<std::int64_t>(1, (span0 + target - 1) / target);
+        m_tile1 = std::max<std::int64_t>(1, (span1 + target - 1) / target);
+        m_n0 = static_cast<int>((span0 + m_tile0 - 1) / m_tile0);
+        m_n1 = static_cast<int>((span1 + m_tile1 - 1) / m_tile1);
+        m_buckets.assign(
+            static_cast<std::size_t>(m_n0) * static_cast<std::size_t>(m_n1), {});
+        for (std::size_t index = 0; index < blocks.size(); ++index) {
+            const auto& box = blocks[index].validBox;
+            for (int t1 = tile1(box.lower[a1]); t1 <= tile1(box.upper[a1]); ++t1) {
+                for (int t0 = tile0(box.lower[a0]);
+                     t0 <= tile0(box.upper[a0]); ++t0) {
+                    m_buckets[bucket(t0, t1)].push_back(static_cast<int>(index));
+                }
+            }
+        }
+    }
+
+    // Index into `blocks` of the block containing `point`, or -1 if none does.
+    [[nodiscard]] int find(const std::vector<LoadedBlock>& blocks,
+        const Int3& point, int dimension) const
+    {
+        if (m_buckets.empty()) {
+            return -1;
+        }
+        const auto p0 = static_cast<std::int64_t>(
+            point[static_cast<std::size_t>(m_axis0)]);
+        const auto p1 = static_cast<std::int64_t>(
+            point[static_cast<std::size_t>(m_axis1)]);
+        if (p0 < m_lo0 || p1 < m_lo1) {
+            return -1;
+        }
+        const auto t0 = tile0(p0);
+        const auto t1 = tile1(p1);
+        if (t0 >= m_n0 || t1 >= m_n1) {
+            return -1;
+        }
+        for (const auto index : m_buckets[bucket(t0, t1)]) {
+            if (contains(blocks[static_cast<std::size_t>(index)].validBox,
+                    point, dimension)) {
+                return index;
+            }
+        }
+        return -1;
+    }
+
+private:
+    [[nodiscard]] int tile0(std::int64_t coordinate) const noexcept
+    {
+        return static_cast<int>((coordinate - m_lo0) / m_tile0);
+    }
+    [[nodiscard]] int tile1(std::int64_t coordinate) const noexcept
+    {
+        return static_cast<int>((coordinate - m_lo1) / m_tile1);
+    }
+    [[nodiscard]] std::size_t bucket(int t0, int t1) const noexcept
+    {
+        return static_cast<std::size_t>(t1) * static_cast<std::size_t>(m_n0)
+            + static_cast<std::size_t>(t0);
+    }
+
+    int m_axis0 = 0;
+    int m_axis1 = 1;
+    std::int64_t m_lo0 = 0;
+    std::int64_t m_lo1 = 0;
+    std::int64_t m_tile0 = 1;
+    std::int64_t m_tile1 = 1;
+    int m_n0 = 0;
+    int m_n1 = 0;
+    std::vector<std::vector<int>> m_buckets;
+};
+
 
 // The index box a physical region covers at one level. Piecewise sampling
 // passes the visible region; linear sampling passes a halo-expanded region
@@ -184,13 +303,21 @@ SliceQueryResult SliceQuery::execute(
         levels.push_back(std::move(levelBlocks));
     }
 
+    // One point->block index per participating level, parallel to `levels`.
+    std::vector<BlockGrid> levelGrids;
+    levelGrids.reserve(levels.size());
+    for (const auto& levelBlocks : levels) {
+        levelGrids.emplace_back(levelBlocks.blocks, axes);
+    }
+
     // The composed piecewise-constant field at a physical point: the finest
     // participating level with a block covering the point's cell wins.
     // Returns the value and the covering level, or nothing when the point
     // is outside every grid.
-    const auto valueAt = [&metadata, &levels](const Real3& position)
+    const auto valueAt = [&metadata, &levels, &levelGrids](const Real3& position)
         -> std::optional<std::pair<double, int>> {
-        for (const auto& levelBlocks : levels) {
+        for (std::size_t entry = 0; entry < levels.size(); ++entry) {
+            const auto& levelBlocks = levels[entry];
             const auto& level =
                 metadata.levels[static_cast<std::size_t>(levelBlocks.levelIndex)];
             Int3 point;
@@ -198,17 +325,19 @@ SliceQueryResult SliceQuery::execute(
                 point[static_cast<std::size_t>(axis)] = physicalToIndex(
                     position[static_cast<std::size_t>(axis)], metadata, level, axis);
             }
-            for (const auto& block : levelBlocks.blocks) {
-                if (!contains(block.validBox, point, metadata.dimension)) {
-                    continue;
-                }
-                const auto offset =
-                    valueOffset(block.data->box, point, metadata.dimension);
-                if (offset >= block.data->values.size()) {
-                    throw std::runtime_error("composed FAB index exceeds loaded block");
-                }
-                return std::pair{block.data->values[offset], levelBlocks.levelIndex};
+            const auto blockIndex = levelGrids[entry].find(
+                levelBlocks.blocks, point, metadata.dimension);
+            if (blockIndex < 0) {
+                continue;
             }
+            const auto& block =
+                levelBlocks.blocks[static_cast<std::size_t>(blockIndex)];
+            const auto offset =
+                valueOffset(block.data->box, point, metadata.dimension);
+            if (offset >= block.data->values.size()) {
+                throw std::runtime_error("composed FAB index exceeds loaded block");
+            }
+            return std::pair{block.data->values[offset], levelBlocks.levelIndex};
         }
         return std::nullopt;
     };

--- a/tests/integration/test_slice_query.cpp
+++ b/tests/integration/test_slice_query.cpp
@@ -6,6 +6,7 @@
 #include <array>
 #include <chrono>
 #include <cmath>
+#include <cstdio>
 #include <cstdlib>
 #include <filesystem>
 #include <fstream>
@@ -483,9 +484,115 @@ int main()
             "ghost MultiFab slice sampled the wrong cell (ghost offset mismatch)");
     }
 
+    // Multi-tile block index + out-of-bounds query point. A 2x2 arrangement of
+    // 1x1 blocks forces the slice compositor's per-level block grid to a real
+    // 2x2 tile layout (every other fixture here has so few blocks the grid
+    // collapses to a single tile, exercising only the linear-scan-equivalent
+    // path). The base index is far negative so a query point far to the
+    // positive side sits >2^31 cells above the grid's lower bound: the pre-fix
+    // narrowing cast in the tile lookup wrapped negative there and indexed the
+    // bucket array out of range (UB/segfault under ASan) where the plain linear
+    // scan safely reported "no block". The grid must reject it in 64-bit before
+    // tiling.
+    const auto gridRoot = std::filesystem::temp_directory_path()
+        / ("amrexplorer-slice-grid-" + std::to_string(unique));
+    std::filesystem::create_directories(gridRoot / "Level_0");
+    constexpr long long base = -2000000000LL;  // near INT_MIN, so lo is negative
+    const auto idx = [](long long v) { return std::to_string(v); };
+    // Header: 2-D, one level, unit cells, domain = cells [base, base+1]^2.
+    std::string header =
+        "HyperCLaw-V1.1\n1\nphi\n2\n0.0\n0\n"
+        + idx(base) + " " + idx(base) + "\n"
+        + idx(base + 2) + " " + idx(base + 2) + "\n"
+        + "\n"
+        + "((" + idx(base) + "," + idx(base) + ") ("
+        + idx(base + 1) + "," + idx(base + 1) + ") (0,0))\n"
+        + "0\n1.0 1.0\n0\n0\n"
+        + "0 4 0.0\n0\n";
+    std::string boxes;
+    std::string fabList;
+    std::string minRows;
+    std::string maxRows;
+    int fabNumber = 0;
+    for (int gj = 0; gj < 2; ++gj) {
+        for (int gi = 0; gi < 2; ++gi) {
+            const auto ci = base + gi;
+            const auto cj = base + gj;
+            header += idx(ci) + " " + idx(ci + 1) + "\n"
+                + idx(cj) + " " + idx(cj + 1) + "\n";
+            const auto box = "((" + idx(ci) + "," + idx(cj) + ") ("
+                + idx(ci) + "," + idx(cj) + ") (0,0))";
+            boxes += box + "\n";
+            char name[32];
+            std::snprintf(name, sizeof(name), "Cell_D_%05d", fabNumber++);
+            fabList += std::string("FabOnDisk: ") + name + " 0\n";
+            const double value = static_cast<double>(gi + gj);
+            minRows += std::to_string(value) + ",\n";
+            maxRows += std::to_string(value) + ",\n";
+            const std::array<double, 1> payload{value};
+            writeFab(gridRoot / "Level_0" / name, box, payload);
+        }
+    }
+    header += "Level_0/Cell\n";
+    writeText(gridRoot / "Header", header);
+    writeText(gridRoot / "Level_0" / "Cell_H",
+        "1\n1\n1\n0\n(4 0\n" + boxes + ")\n4\n" + fabList + "\n"
+        + "4,1\n" + minRows + "\n4,1\n" + maxRows + "\n");
+
+    amrvis::PlotfileDataset gridDataset(
+        gridRoot, amrvis::DatasetId{42}, 1024 * 1024);
+    amrvis::SliceQuery gridQuery(gridDataset);
+
+    // Correctness over the real 2x2 tile grid: every cell resolves to its own
+    // block, phi(i, j) = (i - base) + (j - base).
+    amrvis::SliceRequest inRegion;
+    inRegion.dataset.value = 42;
+    inRegion.field.value = 0;
+    inRegion.normalDirection = 1;
+    inRegion.visibleRegion = {
+        {{static_cast<double>(base), static_cast<double>(base), 0.0}},
+        {{static_cast<double>(base + 2), static_cast<double>(base + 2), 0.0}}};
+    inRegion.maximumLevel = 0;
+    inRegion.outputSize = {2, 2};
+    const auto grid = gridQuery.execute(inRegion);
+    for (int y = 0; y < 2; ++y) {
+        for (int x = 0; x < 2; ++x) {
+            const auto offset = static_cast<std::size_t>(x + 2 * y);
+            require(grid.plane.valid[offset] == 1,
+                "block-grid slice left a hole over a covered cell");
+            require(grid.plane.values[offset]
+                    == static_cast<float>(x + y),
+                "block-grid slice routed a pixel to the wrong block");
+        }
+    }
+
+    // Regression for the tile-index overflow: a region reaching far to the
+    // positive side puts most sample points >2^31 cells above the grid's
+    // negative lower bound. The query must complete (no OOB) and mark those
+    // far points as uncovered rather than crash or read a bogus block.
+    amrvis::SliceRequest farOut;
+    farOut.dataset.value = 42;
+    farOut.field.value = 0;
+    farOut.normalDirection = 1;
+    farOut.visibleRegion = {
+        {{static_cast<double>(base), static_cast<double>(base), 0.0}},
+        {{2.0e9, 2.0e9, 0.0}}};
+    farOut.maximumLevel = 0;
+    farOut.outputSize = {8, 8};
+    const auto reached = gridQuery.execute(farOut);
+    bool sawUncoveredFarPoint = false;
+    for (int offset = 0; offset < 64; ++offset) {
+        if (reached.plane.valid[static_cast<std::size_t>(offset)] == 0) {
+            sawUncoveredFarPoint = true;
+        }
+    }
+    require(sawUncoveredFarPoint,
+        "far-out query point was not reported as uncovered");
+
     std::filesystem::remove_all(root);
     std::filesystem::remove_all(linearRoot);
     std::filesystem::remove_all(linear3dRoot);
     std::filesystem::remove_all(ghostRoot);
+    std::filesystem::remove_all(gridRoot);
     return 0;
 }


### PR DESCRIPTION
The composited-value lookup ran once per output pixel (five times for linear sampling) and linear-scanned every intersecting block each time, so a full-resolution view of a block-heavy fine level was O(pixels x blocks) -- seconds of worker CPU. Bin each level's blocks into a uniform grid on the plane axes and scan only the tile the point falls in; blocks in a level are non-overlapping, and multi-tile blocks are listed in each tile they span, so the result is identical to the linear scan (smallest block index on the impossible overlapping-catalog case).