### PR TITLE
gate the fixed-scale flicker smoke on quiescence, not a fixed delay

### DIFF
--- a/src/qt/MainWindow.hpp
+++ b/src/qt/MainWindow.hpp
@@ -214,6 +214,9 @@ public:
     // window it implies) needs before it measures. Pair it with a settle to
     // absorb a request that only queues its successor.
     [[nodiscard]] int slicesInFlightForTest() const;
+    // True while a slice request is queued behind the debounce but not yet on a
+    // worker; a settle-driven wait must treat this as "not converged".
+    [[nodiscard]] bool sliceRequestPendingForTest() const;
     // Test-only: send a real Shift+left drag through the active view's
     // viewport, exercising the same event path as interactive panning.
     void shiftDragActiveViewForTest(int dx, int dy);

--- a/src/qt/MainWindowTestAccess.cpp
+++ b/src/qt/MainWindowTestAccess.cpp
@@ -270,7 +270,11 @@ int MainWindow::slicesInFlightForTest() const
 
 bool MainWindow::sliceRequestPendingForTest() const
 {
-    return m_sliceDebounce != nullptr && m_sliceDebounce->isActive();
+    // The debounce timer is normally active while a request is queued, but some
+    // paths stop it without clearing the queue (see openDataset), so check the
+    // pending views too -- the header promises "queued behind the debounce".
+    return (m_sliceDebounce != nullptr && m_sliceDebounce->isActive())
+        || m_pendingAllViews || !m_pendingViews.empty();
 }
 
 bool MainWindow::allViewsFixedScaleRasterCoversViewportForTest() const

--- a/src/qt/MainWindowTestAccess.cpp
+++ b/src/qt/MainWindowTestAccess.cpp
@@ -268,6 +268,11 @@ int MainWindow::slicesInFlightForTest() const
     return slicesInFlight();
 }
 
+bool MainWindow::sliceRequestPendingForTest() const
+{
+    return m_sliceDebounce != nullptr && m_sliceDebounce->isActive();
+}
+
 bool MainWindow::allViewsFixedScaleRasterCoversViewportForTest() const
 {
     const auto check = [](const PlaneViewState& state) {

--- a/src/qt/main.cpp
+++ b/src/qt/main.cpp
@@ -1106,21 +1106,47 @@ int main(int argc, char* argv[])
         // selection is re-rendered fitted to the pane exactly as for local
         // data.
         auto phase = std::make_shared<int>(0);
-        auto settles = std::make_shared<int>(0);
+        auto sawSettle = std::make_shared<bool>(false);
+        // Each step of the sequence is judged only once the demand loop has
+        // gone quiet for this interval (several remote render round-trips), not
+        // on a fixed delay from the first settle. A slow runner's convergence
+        // jitter -- an extra late settle after a legitimate fetch -- then just
+        // re-arms the wait instead of failing the check, while the flicker this
+        // guards against never goes quiet at all and is caught by the watchdog.
+        auto* quiet = new QTimer(&application);
+        quiet->setSingleShot(true);
+        quiet->setInterval(2000);
         QObject::connect(&window,
             &amrvis::qt::MainWindow::initialSliceFinished,
             &application,
-            [&window, &application, phase, settles](bool success) {
+            [&window, &application, phase, sawSettle, quiet](bool success) {
                 if (!success) {
                     application.exit(2);
                     return;
                 }
+                // Every settle marks activity and (re)arms quiescence; the phase
+                // machine below advances only after the loop settles and stays
+                // quiet.
                 QObject::connect(&window,
                     &amrvis::qt::MainWindow::interactiveSlicesSettled,
-                    &application,
-                    [&window, &application, phase, settles] {
-                        ++*settles;
+                    &application, [sawSettle, quiet] {
+                        *sawSettle = true;
+                        quiet->start();
+                    });
+                QObject::connect(quiet, &QTimer::timeout, &application,
+                    [&window, &application, phase, sawSettle] {
+                        // A timeout before this step produced any settle (the gap
+                        // between issuing an input and its fetch arriving) is not
+                        // quiescence -- keep waiting.
+                        if (!*sawSettle) {
+                            return;
+                        }
+                        *sawSettle = false;
                         if (*phase == 0) {
+                            // Fixed scale converged: the raster backs the whole
+                            // viewport and the demand loop stays quiet, rather
+                            // than re-issuing itself endlessly through the
+                            // as-needed scroll bars.
                             *phase = 1;
                             if (!window.fixedScaleStateMatchesForTest(32)
                                 || !window
@@ -1128,33 +1154,17 @@ int main(int argc, char* argv[])
                                 application.exit(1);
                                 return;
                             }
-                            // A quiet period several render round-trips long:
-                            // any settle in here means the demand feeds back
-                            // on itself.
-                            const auto armed = *settles;
-                            QTimer::singleShot(2000, &application,
-                                [&window, &application, phase, settles,
-                                    armed] {
-                                    if (*settles != armed
-                                        || !window
-                        .allViewsFixedScaleRasterCoversViewportForTest()) {
-                                        application.exit(1);
-                                        return;
-                                    }
-                                    *phase = 2;
-                                    // Five cells' worth of pixels at 32x,
-                                    // sent through the real Shift+left mouse
-                                    // event path: the newly visible cells must
-                                    // be fetched, giving exactly one settle.
-                                    window.shiftDragActiveViewForTest(-160, 0);
-                                });
+                            // Five cells' worth of pixels at 32x through the real
+                            // Shift+left mouse event path: the newly visible
+                            // cells are fetched, then the loop is quiet again.
+                            window.shiftDragActiveViewForTest(-160, 0);
                             return;
                         }
-                        if (*phase == 2) {
-                            *phase = 3;
-                            // The scrolled fixed scale keeps the fetched
-                            // raster under the whole viewport, with the
-                            // domain-spanning scroll bars present.
+                        if (*phase == 1) {
+                            // The scrolled fixed scale keeps the fetched raster
+                            // under the whole viewport, with the domain-spanning
+                            // scroll bars present.
+                            *phase = 2;
                             if (!window.fixedScaleStateMatchesForTest(32)
                                 || !window
                         .allViewsFixedScaleRasterCoversViewportForTest()
@@ -1166,11 +1176,9 @@ int main(int argc, char* argv[])
                             window.rubberBandZoomActiveViewForTest();
                             return;
                         }
-                        if (*phase == 3) {
-                            *phase = 4;
-                            // The re-rendered selection stands alone, fitted
-                            // to the pane without scroll bars, as for local
-                            // data.
+                        if (*phase == 2) {
+                            // The re-rendered selection stands alone, fitted to
+                            // the pane without scroll bars, as for local data.
                             application.exit(
                                 window.activeViewIsZoomedForTest()
                                     && !window
@@ -1180,7 +1188,9 @@ int main(int argc, char* argv[])
                     });
                 window.selectFixedScaleForTest(32);
             });
-        QTimer::singleShot(15000, &application,
+        // Longer than three quiescence windows plus convergence, so only a demand
+        // loop that never settles (the flicker regression) reaches it.
+        QTimer::singleShot(20000, &application,
             [&application] { application.exit(4); });
         QTimer::singleShot(0, &window,
             [&window, path = std::string(argv[2]), server = smokeServer] {

--- a/src/qt/main.cpp
+++ b/src/qt/main.cpp
@@ -1100,96 +1100,108 @@ int main(int argc, char* argv[])
         // the demand-driven fixed scale must settle with the viewport fully
         // backed by fetched raster, stay quiet with no input (the demand used
         // to re-issue itself endlessly through the as-needed scrollbars,
-        // flickering through one remote render per flip), refetch exactly
-        // once when the virtual scroll bars pan to unfetched cells, and drop
-        // the domain-spanning scroll bars on a rubber-band zoom, whose
-        // selection is re-rendered fitted to the pane exactly as for local
-        // data.
+        // flickering through one remote render per flip), refetch when the
+        // virtual scroll bars pan to unfetched cells, and drop the
+        // domain-spanning scroll bars on a rubber-band zoom, whose selection is
+        // re-rendered fitted to the pane exactly as for local data. The step
+        // gating below waits for quiescence, so it does not count the refetches.
         auto phase = std::make_shared<int>(0);
-        auto sawSettle = std::make_shared<bool>(false);
-        // Each step of the sequence is judged only once the demand loop has
-        // gone quiet for this interval (several remote render round-trips), not
-        // on a fixed delay from the first settle. A slow runner's convergence
-        // jitter -- an extra late settle after a legitimate fetch -- then just
-        // re-arms the wait instead of failing the check, while the flicker this
-        // guards against never goes quiet at all and is caught by the watchdog.
-        auto* quiet = new QTimer(&application);
-        quiet->setSingleShot(true);
-        quiet->setInterval(2000);
+        // Judge each step once the demand loop has quiesced -- nothing on a
+        // worker and no settle since the last tick -- rather than after a fixed
+        // delay. A slow runner's extra convergence settle just costs a tick;
+        // a step that needs no refetch is quiet on the next tick instead of
+        // hanging; and the flicker regression (the demand endlessly re-issuing
+        // itself) never quiesces, so it trips the bounded-tick guard with its
+        // own exit code rather than being conflated with the watchdog. Same
+        // model as the fixed-scale-parity poll above.
+        auto* poll = new QTimer(&window);
+        poll->setInterval(100);
+        auto ticks = std::make_shared<int>(0);
+        auto settles = std::make_shared<int>(0);
+        auto settlesLastTick = std::make_shared<int>(-1);
+        QObject::connect(&window,
+            &amrvis::qt::MainWindow::interactiveSlicesSettled,
+            &application, [settles] { ++*settles; });
         QObject::connect(&window,
             &amrvis::qt::MainWindow::initialSliceFinished,
-            &application,
-            [&window, &application, phase, sawSettle, quiet](bool success) {
+            &application, [&window, &application, poll](bool success) {
                 if (!success) {
                     application.exit(2);
                     return;
                 }
-                // Every settle marks activity and (re)arms quiescence; the phase
-                // machine below advances only after the loop settles and stays
-                // quiet.
-                QObject::connect(&window,
-                    &amrvis::qt::MainWindow::interactiveSlicesSettled,
-                    &application, [sawSettle, quiet] {
-                        *sawSettle = true;
-                        quiet->start();
-                    });
-                QObject::connect(quiet, &QTimer::timeout, &application,
-                    [&window, &application, phase, sawSettle] {
-                        // A timeout before this step produced any settle (the gap
-                        // between issuing an input and its fetch arriving) is not
-                        // quiescence -- keep waiting.
-                        if (!*sawSettle) {
-                            return;
-                        }
-                        *sawSettle = false;
-                        if (*phase == 0) {
-                            // Fixed scale converged: the raster backs the whole
-                            // viewport and the demand loop stays quiet, rather
-                            // than re-issuing itself endlessly through the
-                            // as-needed scroll bars.
-                            *phase = 1;
-                            if (!window.fixedScaleStateMatchesForTest(32)
-                                || !window
-                        .allViewsFixedScaleRasterCoversViewportForTest()) {
-                                application.exit(1);
-                                return;
-                            }
-                            // Five cells' worth of pixels at 32x through the real
-                            // Shift+left mouse event path: the newly visible
-                            // cells are fetched, then the loop is quiet again.
-                            window.shiftDragActiveViewForTest(-160, 0);
-                            return;
-                        }
-                        if (*phase == 1) {
-                            // The scrolled fixed scale keeps the fetched raster
-                            // under the whole viewport, with the domain-spanning
-                            // scroll bars present.
-                            *phase = 2;
-                            if (!window.fixedScaleStateMatchesForTest(32)
-                                || !window
-                        .allViewsFixedScaleRasterCoversViewportForTest()
-                                || !window
-                                    .activeViewScrollBarsVisibleForTest()) {
-                                application.exit(1);
-                                return;
-                            }
-                            window.rubberBandZoomActiveViewForTest();
-                            return;
-                        }
-                        if (*phase == 2) {
-                            // The re-rendered selection stands alone, fitted to
-                            // the pane without scroll bars, as for local data.
-                            application.exit(
-                                window.activeViewIsZoomedForTest()
-                                    && !window
-                                        .activeViewScrollBarsVisibleForTest()
-                                    ? 0 : 1);
-                        }
-                    });
+                poll->start();
                 window.selectFixedScaleForTest(32);
             });
-        // Longer than three quiescence windows plus convergence, so only a demand
-        // loop that never settles (the flicker regression) reaches it.
+        QObject::connect(poll, &QTimer::timeout, &application,
+            [&window, &application, poll, phase, ticks, settles,
+                settlesLastTick] {
+                // Quiescence also requires no request queued behind the slice
+                // debounce: a pan/zoom schedules its refetch there, so between
+                // the input and the debounce firing nothing is on a worker yet
+                // and a bare in-flight check would read that gap as converged.
+                const auto quiet = !window.sliceRequestPendingForTest()
+                    && window.slicesInFlightForTest() == 0
+                    && *settles == *settlesLastTick;
+                *settlesLastTick = *settles;
+                if (!quiet) {
+                    // Non-quiescence for a whole budget in a row is the flicker
+                    // regression: the demand loop re-issuing itself endlessly.
+                    // Any legitimate quiescence resets the budget, so only a
+                    // loop that never settles reaches this.
+                    if (++*ticks >= 100) {
+                        poll->stop();
+                        std::cerr << "the fixed-scale demand loop never "
+                                     "quiesced (flicker regression)\n";
+                        application.exit(5);
+                    }
+                    return;
+                }
+                *ticks = 0;
+                if (*phase == 0) {
+                    // Fixed scale converged: the raster backs the whole viewport
+                    // and the demand loop stays quiet, rather than re-issuing
+                    // itself through the as-needed scroll bars.
+                    *phase = 1;
+                    if (!window.fixedScaleStateMatchesForTest(32)
+                        || !window
+                            .allViewsFixedScaleRasterCoversViewportForTest()) {
+                        poll->stop();
+                        application.exit(1);
+                        return;
+                    }
+                    // Five cells' worth of pixels at 32x through the real
+                    // Shift+left mouse event path; the newly visible cells are
+                    // fetched, then the loop is quiet again.
+                    window.shiftDragActiveViewForTest(-160, 0);
+                    return;
+                }
+                if (*phase == 1) {
+                    // The scrolled fixed scale keeps the fetched raster under the
+                    // whole viewport, with the domain-spanning scroll bars.
+                    *phase = 2;
+                    if (!window.fixedScaleStateMatchesForTest(32)
+                        || !window
+                            .allViewsFixedScaleRasterCoversViewportForTest()
+                        || !window.activeViewScrollBarsVisibleForTest()) {
+                        poll->stop();
+                        application.exit(1);
+                        return;
+                    }
+                    window.rubberBandZoomActiveViewForTest();
+                    return;
+                }
+                if (*phase == 2) {
+                    // The re-rendered selection stands alone, fitted to the pane
+                    // without scroll bars, as for local data.
+                    poll->stop();
+                    application.exit(
+                        window.activeViewIsZoomedForTest()
+                            && !window.activeViewScrollBarsVisibleForTest()
+                            ? 0 : 1);
+                }
+            });
+        // Backstop for a hang outside the poll (e.g. the initial load never
+        // finishing); the poll's own bounded-tick guard catches a flicker first.
         QTimer::singleShot(20000, &application,
             [&application] { application.exit(4); });
         QTimer::singleShot(0, &window,

--- a/src/qt/main.cpp
+++ b/src/qt/main.cpp
@@ -1116,9 +1116,14 @@ int main(int argc, char* argv[])
         // model as the fixed-scale-parity poll above.
         auto* poll = new QTimer(&window);
         poll->setInterval(100);
-        auto ticks = std::make_shared<int>(0);
         auto settles = std::make_shared<int>(0);
         auto settlesLastTick = std::make_shared<int>(-1);
+        // Settle count when the current step's action was issued. The flicker
+        // guard bounds settles-per-step (fetch *rounds*), not elapsed ticks: a
+        // legitimate convergence is a few rounds however slow the runner, while
+        // the flicker re-issues without bound. Counting ticks instead would
+        // misread a starved-but-finite fetch chain as a loop.
+        auto settlesAtStep = std::make_shared<int>(0);
         QObject::connect(&window,
             &amrvis::qt::MainWindow::interactiveSlicesSettled,
             &application, [settles] { ++*settles; });
@@ -1133,8 +1138,8 @@ int main(int argc, char* argv[])
                 window.selectFixedScaleForTest(32);
             });
         QObject::connect(poll, &QTimer::timeout, &application,
-            [&window, &application, poll, phase, ticks, settles,
-                settlesLastTick] {
+            [&window, &application, poll, phase, settles, settlesLastTick,
+                settlesAtStep] {
                 // Quiescence also requires no request queued behind the slice
                 // debounce: a pan/zoom schedules its refetch there, so between
                 // the input and the debounce firing nothing is on a worker yet
@@ -1144,11 +1149,11 @@ int main(int argc, char* argv[])
                     && *settles == *settlesLastTick;
                 *settlesLastTick = *settles;
                 if (!quiet) {
-                    // Non-quiescence for a whole budget in a row is the flicker
-                    // regression: the demand loop re-issuing itself endlessly.
-                    // Any legitimate quiescence resets the budget, so only a
-                    // loop that never settles reaches this.
-                    if (++*ticks >= 100) {
+                    // Too many fetch rounds for one step is the flicker
+                    // regression (the demand loop re-issuing itself endlessly);
+                    // a legitimate step converges in a handful. A pure hang with
+                    // no settles is left to the watchdog, not misreported here.
+                    if (*settles - *settlesAtStep > 20) {
                         poll->stop();
                         std::cerr << "the fixed-scale demand loop never "
                                      "quiesced (flicker regression)\n";
@@ -1156,7 +1161,6 @@ int main(int argc, char* argv[])
                     }
                     return;
                 }
-                *ticks = 0;
                 if (*phase == 0) {
                     // Fixed scale converged: the raster backs the whole viewport
                     // and the demand loop stays quiet, rather than re-issuing
@@ -1172,6 +1176,7 @@ int main(int argc, char* argv[])
                     // Five cells' worth of pixels at 32x through the real
                     // Shift+left mouse event path; the newly visible cells are
                     // fetched, then the loop is quiet again.
+                    *settlesAtStep = *settles;
                     window.shiftDragActiveViewForTest(-160, 0);
                     return;
                 }
@@ -1187,6 +1192,7 @@ int main(int argc, char* argv[])
                         application.exit(1);
                         return;
                     }
+                    *settlesAtStep = *settles;
                     window.rubberBandZoomActiveViewForTest();
                     return;
                 }
@@ -1201,9 +1207,13 @@ int main(int argc, char* argv[])
                 }
             });
         // Backstop for a hang outside the poll (e.g. the initial load never
-        // finishing); the poll's own bounded-tick guard catches a flicker first.
+        // finishing); the poll's own settle-count guard catches a flicker first.
+        // Stop the poll so a tick in the same pass can't overwrite exit(4).
         QTimer::singleShot(20000, &application,
-            [&application] { application.exit(4); });
+            [&application, poll] {
+                poll->stop();
+                application.exit(4);
+            });
         QTimer::singleShot(0, &window,
             [&window, path = std::string(argv[2]), server = smokeServer] {
                 window.resize(420, 301);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -476,7 +476,7 @@ if(TARGET amrexplorer_qt)
             -P "${CMAKE_CURRENT_SOURCE_DIR}/qt_smoke_driver.cmake"
     )
     set_tests_properties(qt_remote_fixed_scale_flicker_smoke PROPERTIES
-        TIMEOUT 30)
+        TIMEOUT 60)
 
     # Regression for virtual-canvas-survives-wheel-zoom: a wheel notch over a
     # remote fixed scale switches the transform mode to Custom while leaving the


### PR DESCRIPTION
The test armed a 2 s window after the first settle and failed if any further settle landed in it. On a slow runner a legitimate late convergence settle falls inside that window, so the test flaked on macOS. Judge each step once the demand loop has been quiet for the interval instead: a benign extra settle just re-arms the wait, while the flicker regression (endless re-issue) never goes quiet and is caught by the watchdog. Same checks, same coverage.