### PR TITLE
drop the redundant contour fine plane

### DIFF
--- a/include/amrexplorer/pipeline/DisplayCoordinator.hpp
+++ b/include/amrexplorer/pipeline/DisplayCoordinator.hpp
@@ -95,9 +95,8 @@ public:
 
     // One panel's inputs to / outputs of the shared-range sync below.
     struct PanelSyncInput {
-        const ScalarPlane* plane = nullptr;            // display plane
-        const ScalarPlane* contourFinePlane = nullptr; // contour modes only
-        int contourFineFactor = 1;
+        const ScalarPlane* plane = nullptr;        // display plane
+        const ScalarPlane* contourPlane = nullptr; // contour modes only
         std::array<int, 2> outputSize{0, 0};  // display size for contours
     };
     struct PanelSyncUpdate {

--- a/include/amrexplorer/pipeline/SlicePipeline.hpp
+++ b/include/amrexplorer/pipeline/SlicePipeline.hpp
@@ -67,7 +67,7 @@ struct SliceDisplayResult {
     RealBox displayRegion;
     std::vector<VectorSegment> vectors;
     // Contour modes only: the plane the contours were traced on (at contour
-    // resolution, which since #8 removed supersampling is the plane the
+    // resolution, which since #56 removed supersampling is the plane the
     // contours are extracted from directly), and the polylines extracted from
     // it, already mapped to display-plane pixel space (empty otherwise).
     ScalarPlane contourPlane;
@@ -258,7 +258,7 @@ void appendVectorGlyphs(const std::shared_ptr<DatasetSession>& dataset,
     StopToken cancellation);
 
 // Extracts contour polylines for the request at data resolution and maps
-// them to display-plane pixel space; caches the fine plane on the result so
+// them to display-plane pixel space; caches the contour plane on the result so
 // range and contour-count changes can re-extract without a new SliceQuery.
 void appendContours(const std::shared_ptr<DatasetSession>& dataset,
     const SliceRequest& request, int contourCount, double minimum,
@@ -283,10 +283,10 @@ void appendContours(const std::shared_ptr<DatasetSession>& dataset,
     std::uint32_t vectorUField, std::uint32_t vectorVField,
     int contourCount, bool rasterDirty, StopToken cancellation = {});
 
-// Re-extract contour polylines from an already-populated fine plane after the
-// display range is replaced downstream of appendContours/refreshCachedSlice —
-// full-domain-range reuse, the 3-D shared Visible range, or syncVisibleRanges.
-// Cheap: the fine plane is cached, so no SliceQuery runs. Returns empty when
+// Re-extract contour polylines from an already-populated contour plane after
+// the display range is replaced downstream of appendContours/refreshCachedSlice
+// — full-domain-range reuse, the 3-D shared Visible range, or syncVisibleRanges.
+// Cheap: the contour plane is cached, so no SliceQuery runs. Returns empty when
 // the range is unusable (non-positive log range, zero extent), so a bad range
 // clears the overlay rather than throwing. See the
 // contours-stale-after-visible-range-sync issue.

--- a/include/amrexplorer/pipeline/SlicePipeline.hpp
+++ b/include/amrexplorer/pipeline/SlicePipeline.hpp
@@ -48,11 +48,11 @@ struct SliceDisplayResult {
     // for "changed", so identity-keyed staleness guards must gate on something
     // else (see PlaneViewState::plane in MainWindow.hpp).
     //
-    // NOT covered by this fast path: the contour-mode companion planes
-    // (contourPlane / contourFinePlane below) are still deep-copied by value,
-    // ~14 MB each per view (~42 MB per interactive tweak in 3-D). They retire
-    // with the wider "stop round-tripping planes through SliceDisplayResult"
-    // cleanup, which also removes this dual reusedPlane/slice.plane slot.
+    // NOT covered by this fast path: the contour-mode companion plane
+    // (contourPlane below) is still deep-copied by value, ~14 MB per view. It
+    // retires with the wider "stop round-tripping planes through
+    // SliceDisplayResult" cleanup, which also removes this dual
+    // reusedPlane/slice.plane slot.
     std::shared_ptr<const ScalarPlane> reusedPlane;
     // Coordinate system of the dataset (AMReX Header code). 2 (spherical) warps
     // `image` into physical (R, Z); all others leave it in logical space.
@@ -66,17 +66,11 @@ struct SliceDisplayResult {
     // Overlays and the probe map through this.
     RealBox displayRegion;
     std::vector<VectorSegment> vectors;
-    // Contour modes only: the piecewise plane at data resolution the
-    // contours were extracted from (the display plane itself when the data
-    // is finer than the display), the plane the contours were traced on, and
-    // the polylines extracted from it, already mapped to display-plane pixel
-    // space (empty otherwise).
+    // Contour modes only: the plane the contours were traced on (at contour
+    // resolution, which since #8 removed supersampling is the plane the
+    // contours are extracted from directly), and the polylines extracted from
+    // it, already mapped to display-plane pixel space (empty otherwise).
     ScalarPlane contourPlane;
-    ScalarPlane contourFinePlane;
-    // Always 1: #8 removed contour supersampling, so contourFinePlane above is
-    // just a copy of contourPlane. Both retire together when the "stop
-    // round-tripping planes through SliceDisplayResult" cleanup lands.
-    int contourFineFactor = 1;
     std::vector<ContourPolyline> contourPolylines;
     std::string fieldName;
     double minimum = 0.0;
@@ -282,8 +276,7 @@ void appendContours(const std::shared_ptr<DatasetSession>& dataset,
     const std::shared_ptr<DatasetSession>& dataset,
     const SliceRequest& request,
     std::shared_ptr<const ScalarPlane> displayPlanePtr,
-    ScalarPlane contourPlane, ScalarPlane contourFinePlane,
-    int contourFineFactor, std::vector<VectorSegment> vectors,
+    ScalarPlane contourPlane, std::vector<VectorSegment> vectors,
     RangeMode rangeMode,
     const std::optional<std::pair<double, double>>& userRange,
     bool logarithmic, const Palette& palette, DisplayMode displayMode,
@@ -298,7 +291,7 @@ void appendContours(const std::shared_ptr<DatasetSession>& dataset,
 // clears the overlay rather than throwing. See the
 // contours-stale-after-visible-range-sync issue.
 [[nodiscard]] std::vector<ContourPolyline> recomputeContourPolylines(
-    const ScalarPlane& finePlane, int fineFactor, double minimum,
+    const ScalarPlane& plane, double minimum,
     double maximum, bool logarithmic, int contourCount,
     int displayWidth, int displayHeight);
 

--- a/include/amrexplorer/render2d/Contours.hpp
+++ b/include/amrexplorer/render2d/Contours.hpp
@@ -64,15 +64,12 @@ struct ContourPolyline {
 
 // Marching squares + chaining + one Chaikin corner-cutting pass on a contour
 // plane, with the output mapped from contour-plane pixel space into
-// display-plane pixel space. fineFactor is the refinement factor the plane
-// was produced with (1 when the plane is already at contour resolution, which
-// is what the slice pipeline produces): fine coordinate f corresponds to
-// original sample coordinate f / fineFactor, and original sample center j
-// maps to display pixel ((j + 0.5) * display / original) - 0.5 (cell-center
-// to cell-center; display-plane sample i sits at scene coordinate i).
-// Throws std::invalid_argument when fineFactor < 1.
+// display-plane pixel space. The plane is at contour resolution (one sample per
+// contour cell), so sample center j maps to display pixel
+// ((j + 0.5) * display / plane) - 0.5 (cell-center to cell-center; display-plane
+// sample i sits at scene coordinate i).
 [[nodiscard]] std::vector<ContourPolyline> contourPolylinesForDisplay(
-    const ScalarPlane& finePlane, int fineFactor,
+    const ScalarPlane& plane,
     const std::vector<double>& values, int displayWidth, int displayHeight);
 
 } // namespace amrvis

--- a/include/amrexplorer/render2d/Contours.hpp
+++ b/include/amrexplorer/render2d/Contours.hpp
@@ -64,10 +64,10 @@ struct ContourPolyline {
 
 // Marching squares + chaining + one Chaikin corner-cutting pass on a contour
 // plane, with the output mapped from contour-plane pixel space into
-// display-plane pixel space. The plane is at contour resolution (one sample per
-// contour cell), so sample center j maps to display pixel
-// ((j + 0.5) * display / plane) - 0.5 (cell-center to cell-center; display-plane
-// sample i sits at scene coordinate i).
+// display-plane pixel space. The plane is at contour resolution (its samples
+// are the marching-squares grid; #56 removed supersampling), so sample center j
+// maps to display pixel ((j + 0.5) * display / plane) - 0.5 (cell-center to
+// cell-center; display-plane sample i sits at scene coordinate i).
 [[nodiscard]] std::vector<ContourPolyline> contourPolylinesForDisplay(
     const ScalarPlane& plane,
     const std::vector<double>& values, int displayWidth, int displayHeight);

--- a/src/pipeline/DisplayCoordinator.cpp
+++ b/src/pipeline/DisplayCoordinator.cpp
@@ -145,10 +145,10 @@ DisplayCoordinator::renderPanelsToSharedRange(
         }
         update.applies = true;
         // Contours before the raster, mirroring the original inline order.
-        if (contourMode && panel.contourFinePlane != nullptr
-            && panel.contourFinePlane->width > 0) {
+        if (contourMode && panel.contourPlane != nullptr
+            && panel.contourPlane->width > 0) {
             update.contourPolylines = recomputeContourPolylines(
-                *panel.contourFinePlane, panel.contourFineFactor,
+                *panel.contourPlane,
                 sync.range.first, sync.range.second, sync.logarithmic,
                 contourCount, panel.outputSize[0], panel.outputSize[1]);
             update.contoursRecomputed = true;

--- a/src/pipeline/DisplayCoordinator.cpp
+++ b/src/pipeline/DisplayCoordinator.cpp
@@ -146,7 +146,8 @@ DisplayCoordinator::renderPanelsToSharedRange(
         update.applies = true;
         // Contours before the raster, mirroring the original inline order.
         if (contourMode && panel.contourPlane != nullptr
-            && panel.contourPlane->width > 0) {
+            && panel.contourPlane->width > 0
+            && panel.contourPlane->height > 0) {
             update.contourPolylines = recomputeContourPolylines(
                 *panel.contourPlane,
                 sync.range.first, sync.range.second, sync.logarithmic,

--- a/src/pipeline/SlicePipeline.cpp
+++ b/src/pipeline/SlicePipeline.cpp
@@ -449,7 +449,7 @@ void appendContours(const std::shared_ptr<DatasetSession>& dataset,
     result.slice.metrics.cacheHits += contour.metrics.cacheHits;
     result.slice.metrics.payloadBytesRead += contour.metrics.payloadBytesRead;
 
-    // No supersampling (#8 removed it): the linear plane is already at contour
+    // No supersampling (#56 removed it): the linear plane is already at contour
     // resolution, so contours are extracted from contourPlane directly.
     const auto values = contourValues(
         minimum, maximum, contourCount, logarithmic);

--- a/src/pipeline/SlicePipeline.cpp
+++ b/src/pipeline/SlicePipeline.cpp
@@ -449,24 +449,19 @@ void appendContours(const std::shared_ptr<DatasetSession>& dataset,
     result.slice.metrics.cacheHits += contour.metrics.cacheHits;
     result.slice.metrics.payloadBytesRead += contour.metrics.payloadBytesRead;
 
-    // No supersampling (#8 removed it): the linear plane is already smooth, so
-    // store it as the fine plane too (factor 1) for refreshCachedSlice to
-    // reuse. The copy and the factor retire together when the "stop
-    // round-tripping planes through SliceDisplayResult" cleanup lands.
-    result.contourFinePlane = result.contourPlane;
-    result.contourFineFactor = 1;
+    // No supersampling (#8 removed it): the linear plane is already at contour
+    // resolution, so contours are extracted from contourPlane directly.
     const auto values = contourValues(
         minimum, maximum, contourCount, logarithmic);
     result.contourPolylines = contourPolylinesForDisplay(
-        result.contourFinePlane, 1, values, displayWidth, displayHeight);
+        result.contourPlane, values, displayWidth, displayHeight);
 }
 
 SliceDisplayResult refreshCachedSlice(
     const std::shared_ptr<DatasetSession>& dataset,
     const SliceRequest& request,
     std::shared_ptr<const ScalarPlane> displayPlanePtr,
-    ScalarPlane contourPlane, ScalarPlane contourFinePlane, int contourFineFactor,
-    std::vector<VectorSegment> vectors,
+    ScalarPlane contourPlane, std::vector<VectorSegment> vectors,
     RangeMode rangeMode,
     const std::optional<std::pair<double, double>>& userRange,
     bool logarithmic, const Palette& palette, DisplayMode displayMode,
@@ -511,12 +506,10 @@ SliceDisplayResult refreshCachedSlice(
     }
     if (isContourMode(displayMode)) {
         result.contourPlane = std::move(contourPlane);
-        result.contourFinePlane = std::move(contourFinePlane);
-        result.contourFineFactor = contourFineFactor;
         const auto values = contourValues(
             range.minimum, range.maximum, contourCount, range.logarithmic);
         result.contourPolylines = contourPolylinesForDisplay(
-            result.contourFinePlane, contourFineFactor, values,
+            result.contourPlane, values,
             request.outputSize[0], request.outputSize[1]);
     }
     if (displayMode == DisplayMode::VelocityVectors) {
@@ -527,11 +520,11 @@ SliceDisplayResult refreshCachedSlice(
 }
 
 std::vector<ContourPolyline> recomputeContourPolylines(
-    const ScalarPlane& finePlane, int fineFactor, double minimum,
+    const ScalarPlane& plane, double minimum,
     double maximum, bool logarithmic, int contourCount,
     int displayWidth, int displayHeight)
 {
-    if (finePlane.width <= 0 || finePlane.height <= 0 || contourCount < 1
+    if (plane.width <= 0 || plane.height <= 0 || contourCount < 1
         || !(minimum < maximum) || (logarithmic && !(minimum > 0.0))) {
         return {};
     }
@@ -539,7 +532,7 @@ std::vector<ContourPolyline> recomputeContourPolylines(
         const auto values = contourValues(
             minimum, maximum, contourCount, logarithmic);
         return contourPolylinesForDisplay(
-            finePlane, fineFactor, values, displayWidth, displayHeight);
+            plane, values, displayWidth, displayHeight);
     } catch (const std::exception&) {
         return {};
     }
@@ -551,7 +544,7 @@ void recomputeContourPolylines(SliceDisplayResult& result)
         return;
     }
     result.contourPolylines = recomputeContourPolylines(
-        result.contourFinePlane, result.contourFineFactor, result.minimum,
+        result.contourPlane, result.minimum,
         result.maximum, result.logarithmic, result.contourCount,
         result.request.outputSize[0], result.request.outputSize[1]);
 }

--- a/src/qt/MainWindow.hpp
+++ b/src/qt/MainWindow.hpp
@@ -430,9 +430,6 @@ private:
         // and contour-count changes refresh without a new SliceQuery.
         std::shared_ptr<const ScalarPlane> contourPlane
             = std::make_shared<const ScalarPlane>();
-        std::shared_ptr<const ScalarPlane> contourFinePlane
-            = std::make_shared<const ScalarPlane>();
-        int contourFineFactor = 1;
         std::vector<ContourPolyline> contourPolylines;
         QString fieldName;
         std::optional<RealBox> visibleRegion;

--- a/src/qt/MainWindowDataset.cpp
+++ b/src/qt/MainWindowDataset.cpp
@@ -1113,8 +1113,6 @@ void MainWindow::openDatasetImpl(const std::filesystem::path& path,
         // PlaneViewState).
         state->plane = std::make_shared<const ScalarPlane>();
         state->contourPlane = std::make_shared<const ScalarPlane>();
-        state->contourFinePlane = std::make_shared<const ScalarPlane>();
-        state->contourFineFactor = 1;
         // Plane rewrite: drop any in-flight sync's outcome for this view
         // (see PlaneViewState::renderGeneration).
         ++state->renderGeneration;

--- a/src/qt/MainWindowSlice.cpp
+++ b/src/qt/MainWindowSlice.cpp
@@ -287,7 +287,7 @@ void MainWindow::requestSlice(PlaneViewState& state, bool rasterDirty)
         && state.cachedVectorVField == vectorVField
         && state.cachedVectorUField == vectorUField
         && displayMode == state.cachedMode
-        && (!isContourMode(displayMode) || state.contourFinePlane->width > 0)
+        && (!isContourMode(displayMode) || state.contourPlane->width > 0)
         && (displayMode != DisplayMode::VelocityVectors
             || (!state.vectorSegments.empty()
                 && contourCount == state.cachedContourCount
@@ -325,21 +325,18 @@ void MainWindow::requestSlice(PlaneViewState& state, bool rasterDirty)
         // showSlice, so the former ~110 MB copy per range/log/palette tweak is
         // gone. A newer arrival can safely replace the view's pointers
         // meanwhile; this worker keeps reading its own snapshots. (The
-        // contour-resolution planes are still deref'd into by-value copies at
-        // the call below -- ~14 MB each; see SliceDisplayResult::reusedPlane for
-        // why they are not yet reused.)
+        // contour-resolution plane is still deref'd into a by-value copy at
+        // the call below -- ~14 MB; see SliceDisplayResult::reusedPlane for
+        // why it is not yet reused.)
         future = QtConcurrent::run([dataset, request,
             displayPlane = state.plane,
             contourPlane = state.contourPlane,
-            contourFinePlane = state.contourFinePlane,
-            contourFineFactor = state.contourFineFactor,
             vectors = state.vectorSegments,
             rangeMode, userRange, logarithmic, palette, displayMode,
             vectorUField, vectorVField, contourCount, rasterDirty,
             cancellation]() mutable {
             return refreshCachedSlice(dataset, request, std::move(displayPlane),
-                *contourPlane, *contourFinePlane,
-                contourFineFactor, std::move(vectors), rangeMode, userRange,
+                *contourPlane, std::move(vectors), rangeMode, userRange,
                 logarithmic, palette, displayMode, vectorUField, vectorVField,
                 contourCount, rasterDirty, cancellation);
         });
@@ -905,9 +902,6 @@ void MainWindow::showSlice(PlaneViewState& state, SliceDisplayResult display)
     state.displayRegion = display.displayRegion;
     state.contourPlane
         = std::make_shared<const ScalarPlane>(std::move(display.contourPlane));
-    state.contourFinePlane = std::make_shared<const ScalarPlane>(
-        std::move(display.contourFinePlane));
-    state.contourFineFactor = display.contourFineFactor;
     state.contourPolylines = std::move(display.contourPolylines);
     const auto fieldName = QString::fromStdString(display.fieldName);
     state.fieldName = fieldName;
@@ -1020,8 +1014,7 @@ void MainWindow::syncVisibleRanges()
 
     struct PanelSnapshot {
         std::shared_ptr<const ScalarPlane> plane;
-        std::shared_ptr<const ScalarPlane> contourFinePlane;
-        int contourFineFactor = 1;
+        std::shared_ptr<const ScalarPlane> contourPlane;
         std::array<int, 2> outputSize{0, 0};
     };
     std::array<PlaneViewState*, 3> views{
@@ -1033,8 +1026,8 @@ void MainWindow::syncVisibleRanges()
     std::array<std::uint64_t, 3> snapshotGenerations{};
     for (std::size_t index = 0; index < views.size(); ++index) {
         const auto* state = views[index];
-        snapshots[index] = {state->plane, state->contourFinePlane,
-            state->contourFineFactor, state->cachedRequest.outputSize};
+        snapshots[index] = {state->plane, state->contourPlane,
+            state->cachedRequest.outputSize};
         snapshotGenerations[index] = state->renderGeneration;
     }
 
@@ -1228,8 +1221,7 @@ void MainWindow::syncVisibleRanges()
             for (std::size_t index = 0; index < snapshots.size(); ++index) {
                 const auto& snapshot = snapshots[index];
                 inputs[index] = {snapshot.plane.get(),
-                    snapshot.contourFinePlane.get(), snapshot.contourFineFactor,
-                    snapshot.outputSize};
+                    snapshot.contourPlane.get(), snapshot.outputSize};
             }
             SyncOutcome outcome;
             outcome.sync = DisplayCoordinator::renderPanelsToSharedRange(

--- a/src/render2d/Contours.cpp
+++ b/src/render2d/Contours.cpp
@@ -389,33 +389,24 @@ std::vector<ContourPolyline> generateContourPolylines(
 }
 
 std::vector<ContourPolyline> contourPolylinesForDisplay(
-    const ScalarPlane& finePlane, int fineFactor,
+    const ScalarPlane& plane,
     const std::vector<double>& values, int displayWidth, int displayHeight)
 {
-    if (fineFactor < 1) {
-        throw std::invalid_argument("fine factor must be at least 1");
-    }
     // The contour plane is already at contour resolution; one Chaikin pass
     // softens the cell-scale corners.
-    auto polylines = generateContourPolylines(finePlane, values, 1);
-    if (finePlane.width < 1 || finePlane.height < 1) {
+    auto polylines = generateContourPolylines(plane, values, 1);
+    if (plane.width < 1 || plane.height < 1) {
         return polylines;
     }
-    // Recover the original (pre-refinement) dimensions the fine plane was
-    // produced from, then map fine coordinates into display pixel space: fine
-    // coordinate f is original sample coordinate f / fineFactor, and original
-    // sample center j maps to display pixel
-    // ((j + 0.5) * display / original) - 0.5, cell-center to cell-center.
-    const auto originalWidth = (finePlane.width - 1) / fineFactor + 1;
-    const auto originalHeight = (finePlane.height - 1) / fineFactor + 1;
+    // Map contour-plane coordinates into display pixel space: sample center j
+    // maps to display pixel ((j + 0.5) * display / plane) - 0.5, cell-center to
+    // cell-center.
     const auto scaleX = static_cast<double>(displayWidth)
-        / (static_cast<double>(fineFactor) * static_cast<double>(originalWidth));
+        / static_cast<double>(plane.width);
     const auto scaleY = static_cast<double>(displayHeight)
-        / (static_cast<double>(fineFactor) * static_cast<double>(originalHeight));
-    const auto offsetX = 0.5 * (static_cast<double>(displayWidth)
-        / static_cast<double>(originalWidth) - 1.0);
-    const auto offsetY = 0.5 * (static_cast<double>(displayHeight)
-        / static_cast<double>(originalHeight) - 1.0);
+        / static_cast<double>(plane.height);
+    const auto offsetX = 0.5 * (scaleX - 1.0);
+    const auto offsetY = 0.5 * (scaleY - 1.0);
     for (auto& polyline : polylines) {
         for (auto& point : polyline.points) {
             point[0] = static_cast<float>(

--- a/tests/integration/test_display_transitions.cpp
+++ b/tests/integration/test_display_transitions.cpp
@@ -686,8 +686,7 @@ int main()
             static_cast<void>(amrvis::refreshCachedSlice(recording,
                 d0.request,
                 std::make_shared<const amrvis::ScalarPlane>(d0.slice.plane),
-                d0.contourPlane,
-                d0.contourFinePlane, d0.contourFineFactor, {},
+                d0.contourPlane, {},
                 amrvis::RangeMode::File, std::nullopt, true, palette,
                 amrvis::DisplayMode::RasterContours, 0, 0, 4, true,
                 stoppedRange.get_token()));
@@ -707,9 +706,8 @@ int main()
         const auto reusedInput
             = std::make_shared<const amrvis::ScalarPlane>(d0.slice.plane);
         const auto log = amrvis::refreshCachedSlice(baseLoad.dataset,
-            d0.request, reusedInput,
-            d0.contourPlane, d0.contourFinePlane,
-            d0.contourFineFactor, {}, amrvis::RangeMode::File, std::nullopt,
+            d0.request, reusedInput, d0.contourPlane, {},
+            amrvis::RangeMode::File, std::nullopt,
             true, palette, amrvis::DisplayMode::RasterContours, 0, 0, 4, true);
         require(log.logarithmic, "cached-plane log toggle fell back");
         require(log.reusedPlane.get() == reusedInput.get()
@@ -724,8 +722,8 @@ int main()
         bool nullPlaneRejected = false;
         try {
             static_cast<void>(amrvis::refreshCachedSlice(baseLoad.dataset,
-                d0.request, nullptr, d0.contourPlane, d0.contourFinePlane,
-                d0.contourFineFactor, {}, amrvis::RangeMode::File, std::nullopt,
+                d0.request, nullptr, d0.contourPlane, {},
+                amrvis::RangeMode::File, std::nullopt,
                 false, palette, amrvis::DisplayMode::Raster, 0, 0, 0, true));
         } catch (const std::invalid_argument&) {
             nullPlaneRejected = true;
@@ -737,8 +735,7 @@ int main()
         const auto recount = amrvis::refreshCachedSlice(baseLoad.dataset,
             d0.request,
             std::make_shared<const amrvis::ScalarPlane>(d0.slice.plane),
-            d0.contourPlane, d0.contourFinePlane,
-            d0.contourFineFactor, {}, amrvis::RangeMode::File, std::nullopt,
+            d0.contourPlane, {}, amrvis::RangeMode::File, std::nullopt,
             false, palette, amrvis::DisplayMode::RasterContours, 0, 0, 2,
             false);
         require(recount.rasterUnchanged && recount.image.width == 0,
@@ -751,8 +748,7 @@ int main()
         const auto user = amrvis::refreshCachedSlice(baseLoad.dataset,
             d0.request,
             std::make_shared<const amrvis::ScalarPlane>(d0.slice.plane),
-            d0.contourPlane, d0.contourFinePlane,
-            d0.contourFineFactor, {}, amrvis::RangeMode::User,
+            d0.contourPlane, {}, amrvis::RangeMode::User,
             std::pair{2.0, 3.0}, false, palette,
             amrvis::DisplayMode::RasterContours, 0, 0, 4, true);
         require(nearlyEqual(user.minimum, 2.0)

--- a/tests/unit/test_contours.cpp
+++ b/tests/unit/test_contours.cpp
@@ -355,44 +355,47 @@ int main()
             && hasSegment(saddleMean, 0.5, 1.0, 1.0, 0.5),
         "saddle at the mean did not follow the center rule");
 
-    // (m) contourPolylinesForDisplay on the 4x4 data plane v = (i + j) / 2:
-    // the 2.3 iso-line (i + j = 4.6 in sample coordinates) stays straight,
-    // and the known edge crossings at sample coordinates (3, 1.6) and
-    // (1.6, 3) land at display pixels (559.5, 335.5) and (335.5, 559.5)
-    // under the cell-center mapping d = ((c + 0.5) * 160) - 0.5.
+    // (m) contourPolylinesForDisplay on a NON-square 4x8 plane against a
+    // non-square 640x320 display, so scaleX (160) != scaleY (40): swapping the
+    // two axes' scales would move every contour point off the raster, which a
+    // square plane/display cannot catch. The field v = i is constant in j, so
+    // the 1.5 iso-line is the vertical line i = 1.5 spanning all j; under the
+    // cell-center mapping d = ((c + 0.5) * scale) - 0.5 that is display x = 319.5
+    // with y running from 19.5 (j = 0) to 299.5 (j = 7).
     amrvis::ScalarPlane data;
     data.width = 4;
-    data.height = 4;
-    data.values.resize(16);
-    data.valid.assign(16, 1);
-    for (int j = 0; j < 4; ++j) {
+    data.height = 8;
+    data.values.resize(32);
+    data.valid.assign(32, 1);
+    for (int j = 0; j < 8; ++j) {
         for (int i = 0; i < 4; ++i) {
             data.values[static_cast<std::size_t>(i + 4 * j)]
-                = 0.5F * static_cast<float>(i + j);
+                = static_cast<float>(i);
         }
     }
     // The slice pipeline supplies a contour plane already at contour
     // resolution, so exercise that mapping directly.
     const auto displayLines = amrvis::contourPolylinesForDisplay(
-        data, {2.3}, 640, 640);
+        data, {1.5}, 640, 320);
     require(displayLines.size() == 1, "display contour split into pieces");
     require(!displayLines.front().closed, "display contour should stay open");
     for (const auto& point : displayLines.front().points) {
-        const auto ci = (static_cast<double>(point[0]) + 0.5) / 160.0 - 0.5;
-        const auto cj = (static_cast<double>(point[1]) + 0.5) / 160.0 - 0.5;
-        require(std::fabs(ci + cj - 4.6) / std::sqrt(2.0) < 0.05,
-            "display contour deviates from the analytic iso-line");
+        require(std::fabs(static_cast<double>(point[0]) - 319.5) < 0.5,
+            "display contour x off the vertical iso-line (scaleX misapplied)");
+        require(static_cast<double>(point[1]) >= 19.0
+                && static_cast<double>(point[1]) <= 300.0,
+            "display contour y outside the mapped span (scaleY misapplied)");
     }
-    // Chaikin keeps an open polyline's endpoints fixed, so the two ends are
-    // the mapped edge crossings, in either chaining direction.
+    // Chaikin keeps an open polyline's endpoints fixed, so the two ends are the
+    // mapped edge crossings at j = 0 and j = 7, in either chaining direction.
     const auto& firstPoint = displayLines.front().points.front();
     const auto& lastPoint = displayLines.front().points.back();
     const auto nearPoint = [](const std::array<float, 2>& point, double x, double y) {
         return std::fabs(static_cast<double>(point[0]) - x) <= 1.0
             && std::fabs(static_cast<double>(point[1]) - y) <= 1.0;
     };
-    require((nearPoint(firstPoint, 559.5, 335.5) && nearPoint(lastPoint, 335.5, 559.5))
-            || (nearPoint(firstPoint, 335.5, 559.5) && nearPoint(lastPoint, 559.5, 335.5)),
+    require((nearPoint(firstPoint, 319.5, 19.5) && nearPoint(lastPoint, 319.5, 299.5))
+            || (nearPoint(firstPoint, 319.5, 299.5) && nearPoint(lastPoint, 319.5, 19.5)),
         "display contour endpoints miss the expected display pixels");
 
     // (n) One-pixel-thick planes have no complete 2x2 marching-squares cell

--- a/tests/unit/test_contours.cpp
+++ b/tests/unit/test_contours.cpp
@@ -371,10 +371,10 @@ int main()
                 = 0.5F * static_cast<float>(i + j);
         }
     }
-    // The slice pipeline always supplies a contour plane already at contour
-    // resolution (fineFactor 1), so exercise that mapping directly.
+    // The slice pipeline supplies a contour plane already at contour
+    // resolution, so exercise that mapping directly.
     const auto displayLines = amrvis::contourPolylinesForDisplay(
-        data, 1, {2.3}, 640, 640);
+        data, {2.3}, 640, 640);
     require(displayLines.size() == 1, "display contour split into pieces");
     require(!displayLines.front().closed, "display contour should stay open");
     for (const auto& point : displayLines.front().points) {

--- a/tests/unit/test_display_coordinator.cpp
+++ b/tests/unit/test_display_coordinator.cpp
@@ -153,7 +153,7 @@ int main()
         result.maximum = 3.0;
         result.mode = amrvis::DisplayMode::RasterContours;
         result.contourCount = 2;
-        result.contourFinePlane = makePlane({1.0F, 3.0F});
+        result.contourPlane = makePlane({1.0F, 3.0F});
         result.request.outputSize = {2, 1};
         const amrvis::Palette palette;
 
@@ -201,9 +201,9 @@ int main()
         const auto fine = makePlane({2.0F, 6.0F});
         const amrvis::ScalarPlane empty;
         const std::array<DisplayCoordinator::PanelSyncInput, 3> inputs{{
-            {&a, &fine, 1, {2, 1}},
-            {&b, nullptr, 1, {2, 1}},
-            {&empty, nullptr, 1, {0, 0}},
+            {&a, &fine, {2, 1}},
+            {&b, nullptr, {2, 1}},
+            {&empty, nullptr, {0, 0}},
         }};
 
         // No cached range: the union across panels drives every update.
@@ -234,7 +234,7 @@ int main()
         // Neither cache nor finite samples: nothing to synchronize to.
         coordinator.invalidateRangeCache();
         const std::array<DisplayCoordinator::PanelSyncInput, 1> emptyOnly{{
-            {&empty, nullptr, 1, {0, 0}}}};
+            {&empty, nullptr, {0, 0}}}};
         require(!coordinator.syncPanelsToSharedRange(
                 key, emptyOnly, false, false, 3, palette).has_value(),
             "an empty panel set produced a sync");
@@ -251,8 +251,8 @@ int main()
         const auto crossing = makePlane({-4.0F, 1.0F});  // crosses zero
         const auto fine = makePlane({2.0F, 6.0F});
         const std::array<DisplayCoordinator::PanelSyncInput, 2> mixed{{
-            {&positive, &fine, 1, {2, 1}},
-            {&crossing, nullptr, 1, {2, 1}},
+            {&positive, &fine, {2, 1}},
+            {&crossing, nullptr, {2, 1}},
         }};
         const auto sync = DisplayCoordinator::renderPanelsToSharedRange(
             std::nullopt, mixed, true, true, 3, palette);
@@ -269,8 +269,8 @@ int main()
         // An all-positive union keeps the requested log mapping.
         const auto other = makePlane({3.0F, 5.0F});
         const std::array<DisplayCoordinator::PanelSyncInput, 2> allPositive{{
-            {&positive, nullptr, 1, {2, 1}},
-            {&other, nullptr, 1, {2, 1}},
+            {&positive, nullptr, {2, 1}},
+            {&other, nullptr, {2, 1}},
         }};
         const auto positiveSync = DisplayCoordinator::renderPanelsToSharedRange(
             std::nullopt, allPositive, true, false, 3, palette);


### PR DESCRIPTION
Contour supersampling was removed in #8, so contourFinePlane was always an exact copy of contourPlane and contourFineFactor was always 1 -- a full extra plane copied and carried through the result, the view state, and the 3-D sync path for every contour slice. Extract contours from contourPlane directly and drop the fineFactor plumbing from contourPolylinesForDisplay and recomputeContourPolylines.