### PR TITLE
add fuzz/property harnesses for the untrusted-input parsers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,8 @@ option(AMREXPLORER_BUILD_MACOS_APP_BUNDLE
 option(AMREXPLORER_WARNINGS_AS_ERRORS "Treat compiler warnings as errors" OFF)
 option(AMREXPLORER_ENABLE_SANITIZERS "Enable AddressSanitizer and UndefinedBehaviorSanitizer" OFF)
 option(AMREXPLORER_ENABLE_TSAN "Enable ThreadSanitizer (mutually exclusive with AMREXPLORER_ENABLE_SANITIZERS)" OFF)
+option(AMREXPLORER_LIBFUZZER
+    "Build the fuzz harnesses as coverage-guided libFuzzer drivers (Clang)" OFF)
 option(AMREXPLORER_FORCE_FETCH_FLATBUFFERS
     "Skip installed FlatBuffers discovery and use the pinned fallback" OFF)
 # Off under the sanitizers, where it is both pointless and a hazard: every
@@ -168,6 +170,11 @@ endif()
 if(AMREXPLORER_ENABLE_TSAN)
     include(amrexplorer_sanitizers)
     amrexplorer_enable_tsan()
+endif()
+
+if(AMREXPLORER_LIBFUZZER)
+    include(amrexplorer_sanitizers)
+    amrexplorer_enable_libfuzzer_instrumentation()
 endif()
 
 add_subdirectory(src/core)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,6 +202,7 @@ if(AMREXPLORER_ENABLE_REMOTE)
             GIT_REPOSITORY https://github.com/google/flatbuffers.git
             GIT_TAG v25.12.19
             GIT_SHALLOW TRUE
+            SYSTEM
         )
         FetchContent_MakeAvailable(flatbuffers)
         # GCC reports a bogus -Wstringop-overflow inside the std::vector insert

--- a/cmake/amrexplorer_sanitizers.cmake
+++ b/cmake/amrexplorer_sanitizers.cmake
@@ -41,3 +41,19 @@ function(amrexplorer_enable_tsan)
         -fno-sanitize-recover=all
     )
 endfunction()
+
+# libFuzzer coverage instrumentation, project-wide. The harness alone being
+# instrumented would leave the fuzzer blind to the branches that matter -- the
+# ones inside the parsers and validators it drives -- so every target is
+# compiled with the coverage hooks. fuzzer-no-link at link time supplies the
+# hooks' runtime without libFuzzer's main, so ordinary executables still link
+# and run as usual; only the fuzz drivers add -fsanitize=fuzzer for the driver
+# main (see amrexplorer_add_fuzz_target in tests/CMakeLists.txt).
+function(amrexplorer_enable_libfuzzer_instrumentation)
+    if(NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+        message(FATAL_ERROR
+            "AMREXPLORER_LIBFUZZER requires Clang (libFuzzer runtime).")
+    endif()
+    add_compile_options(-fsanitize=fuzzer-no-link)
+    add_link_options(-fsanitize=fuzzer-no-link)
+endfunction()

--- a/src/remote/CMakeLists.txt
+++ b/src/remote/CMakeLists.txt
@@ -4,15 +4,20 @@ set(amrexplorer_wire_generated_dir
     "${CMAKE_CURRENT_BINARY_DIR}/generated")
 set(amrexplorer_wire_generated
     "${amrexplorer_wire_generated_dir}/amrexplorer_wire_generated.h")
+# The embedded binary schema drives the reflection walk in Codec.cpp that
+# rejects vectors flatbuffers' Verifier leaves misaligned.
+set(amrexplorer_wire_bfbs_generated
+    "${amrexplorer_wire_generated_dir}/amrexplorer_wire_bfbs_generated.h")
 
 add_custom_command(
-    OUTPUT "${amrexplorer_wire_generated}"
+    OUTPUT "${amrexplorer_wire_generated}" "${amrexplorer_wire_bfbs_generated}"
     COMMAND "${CMAKE_COMMAND}" -E make_directory
         "${amrexplorer_wire_generated_dir}"
     COMMAND "$<TARGET_FILE:${AMREXPLORER_FLATC_TARGET}>"
         --cpp
         --gen-object-api
         --scoped-enums
+        --bfbs-gen-embed
         --warnings-as-errors
         -o "${amrexplorer_wire_generated_dir}"
         "${amrexplorer_wire_schema}"
@@ -29,6 +34,7 @@ add_library(amrexplorer_remote
     RemoteDatasetSession.cpp
     Server.cpp
     "${amrexplorer_wire_generated}"
+    "${amrexplorer_wire_bfbs_generated}"
 )
 if(AMREXPLORER_ENABLE_SERVER_TEST_HOOKS)
     target_sources(amrexplorer_remote PRIVATE ServerTestHooks.cpp)

--- a/src/remote/Codec.cpp
+++ b/src/remote/Codec.cpp
@@ -1,5 +1,8 @@
 #include "Codec.hpp"
 
+#include "amrexplorer_wire_bfbs_generated.h"
+
+#include <flatbuffers/reflection.h>
 #include <flatbuffers/verifier.h>
 
 #include <algorithm>
@@ -224,6 +227,137 @@ void validateResultVectors(
     }
 }
 
+// flatbuffers' Verifier checks the alignment of table scalars and of a
+// vector's 4-byte length prefix, but not of the vector's elements, so a
+// hostile buffer can place a [double] or [ulong] vector at a 4-byte offset
+// and still verify; UnPack then reads misaligned 8-byte scalars, which is UB
+// (and a fault on strict-alignment targets). A conforming builder aligns
+// every vector's elements naturally relative to the buffer start, so anything
+// else is malformed. This walks a verified buffer with the schema's own
+// reflection data and rejects it -- generic over the schema, so new vector
+// fields are covered without a hand-kept list. Everything dereferenced here
+// was bounds-checked by the Verifier against the same schema.
+class VectorAlignmentWalk
+{
+public:
+    VectorAlignmentWalk(
+        const reflection::Schema& schema, const std::uint8_t* base)
+        : schema_(schema), base_(base)
+    {}
+
+    bool aligned(
+        const reflection::Object& object,
+        const flatbuffers::Table& table) const
+    {
+        for (const auto* field : *object.fields()) {
+            const auto& type = *field->type();
+            switch (type.base_type()) {
+            case reflection::Obj: {
+                // Structs are stored inline and alignment-checked by the
+                // Verifier; only tables have contents to walk.
+                const auto& child = objectAt(type.index());
+                const auto* sub = child.is_struct()
+                    ? nullptr : flatbuffers::GetFieldT(table, *field);
+                if (sub && !aligned(child, *sub)) {
+                    return false;
+                }
+                break;
+            }
+            case reflection::Union: {
+                const auto* sub = flatbuffers::GetFieldT(table, *field);
+                if (sub && !alignedUnion(object, *field, table, *sub)) {
+                    return false;
+                }
+                break;
+            }
+            case reflection::Vector:
+                if (!alignedVector(*field, table)) {
+                    return false;
+                }
+                break;
+            default:
+                // Scalars and strings: the Verifier already checks them.
+                break;
+            }
+        }
+        return true;
+    }
+
+private:
+    bool alignedUnion(
+        const reflection::Object& parent, const reflection::Field& field,
+        const flatbuffers::Table& table, const flatbuffers::Table& sub) const
+    {
+        const auto* typeField = parent.fields()->LookupByKey(
+            (field.name()->str() + flatbuffers::UnionTypeFieldSuffix())
+                .c_str());
+        if (!typeField) {
+            return false;
+        }
+        const auto* member = schema_.enums()
+            ->Get(static_cast<flatbuffers::uoffset_t>(field.type()->index()))
+            ->values()->LookupByKey(
+                flatbuffers::GetFieldI<std::uint8_t>(table, *typeField));
+        // NONE and members this build does not know have no table to walk;
+        // decode rejects both before UnPack. Struct members are stored
+        // inline and alignment-checked by the Verifier.
+        if (!member || !member->union_type()
+            || member->union_type()->base_type() != reflection::Obj
+            || objectAt(member->union_type()->index()).is_struct()) {
+            return true;
+        }
+        return aligned(objectAt(member->union_type()->index()), sub);
+    }
+
+    bool alignedVector(
+        const reflection::Field& field, const flatbuffers::Table& table) const
+    {
+        const auto* vec = flatbuffers::GetFieldAnyV(table, field);
+        if (!vec || vec->size() == 0) {
+            return true;
+        }
+        const auto& type = *field.type();
+        const reflection::Object* element = type.element() == reflection::Obj
+            ? &objectAt(type.index()) : nullptr;
+        const std::size_t align = element
+            ? (element->is_struct()
+                ? static_cast<std::size_t>(element->minalign())
+                : sizeof(flatbuffers::uoffset_t))
+            : flatbuffers::GetTypeSize(type.element());
+        if (align > 1
+            && static_cast<std::size_t>(vec->Data() - base_) % align != 0) {
+            return false;
+        }
+        if (element && !element->is_struct()) {
+            const auto* tables = flatbuffers::GetFieldV<
+                flatbuffers::Offset<flatbuffers::Table>>(table, field);
+            for (const auto* sub : *tables) {
+                if (!aligned(*element, *sub)) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    const reflection::Object& objectAt(std::int32_t index) const
+    {
+        return *schema_.objects()->Get(
+            static_cast<flatbuffers::uoffset_t>(index));
+    }
+
+    const reflection::Schema& schema_;
+    const std::uint8_t* base_;
+};
+
+bool vectorsAligned(std::span<const std::uint8_t> bytes)
+{
+    static const reflection::Schema& schema
+        = *reflection::GetSchema(fb::EnvelopeBinarySchema::data());
+    return VectorAlignmentWalk(schema, bytes.data())
+        .aligned(*schema.root_table(), *flatbuffers::GetAnyRoot(bytes.data()));
+}
+
 } // namespace
 
 std::unique_ptr<NativeEnvelope> decode(
@@ -237,6 +371,9 @@ std::unique_ptr<NativeEnvelope> decode(
     flatbuffers::Verifier verifier(bytes.data(), bytes.size());
     if (!fb::VerifyEnvelopeBuffer(verifier)) {
         throw std::invalid_argument("wire payload failed verification");
+    }
+    if (!vectorsAligned(bytes)) {
+        throw std::invalid_argument("wire payload has misaligned vector data");
     }
     const auto* wireEnvelope = fb::GetEnvelope(bytes.data());
     if (wireEnvelope->request_id() == 0

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,23 +1,15 @@
-# The fuzz harnesses build two ways. Default (OFF): a deterministic, bounded
-# ctest that runs fixed seeds + a fixed-PRNG stream, so CI and the sanitizers
-# preset exercise the untrusted-input parsers on every run. ON (Clang only):
-# each harness is compiled as a coverage-guided libFuzzer driver
-# (LLVMFuzzerTestOneInput, its own main from the fuzzer runtime) to run by hand.
-# The flags are per target, not global, so they don't break the compiler check
-# with the fuzzer runtime's conflicting main.
-option(AMREXPLORER_LIBFUZZER
-    "Build the fuzz harnesses as coverage-guided libFuzzer drivers (Clang)" OFF)
-if(AMREXPLORER_LIBFUZZER AND NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    message(FATAL_ERROR
-        "AMREXPLORER_LIBFUZZER requires Clang (libFuzzer runtime).")
-endif()
-
-# Wire a fuzz-harness target for the mode selected above: a libFuzzer driver, or
-# a plain bounded ctest.
+# The fuzz harnesses build two ways. Default (AMREXPLORER_LIBFUZZER OFF): a
+# deterministic, bounded ctest that runs fixed seeds + a fixed-PRNG stream, so
+# CI and the sanitizers preset exercise the untrusted-input parsers on every
+# run. ON (Clang only): each harness is compiled as a coverage-guided libFuzzer
+# driver (LLVMFuzzerTestOneInput, its own main from the fuzzer runtime) to run
+# by hand; the coverage instrumentation itself is project-wide (see
+# amrexplorer_enable_libfuzzer_instrumentation), so the fuzzer sees the
+# parsers' own branches. Only the driver main is linked per target: it is
+# what would conflict with the compiler check and every other executable.
 function(amrexplorer_add_fuzz_target target)
     if(AMREXPLORER_LIBFUZZER)
         target_compile_definitions(${target} PRIVATE AMREXPLORER_LIBFUZZER)
-        target_compile_options(${target} PRIVATE -fsanitize=fuzzer-no-link)
         target_link_options(${target} PRIVATE -fsanitize=fuzzer)
     else()
         add_test(NAME ${target} COMMAND ${target})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,3 +1,30 @@
+# The fuzz harnesses build two ways. Default (OFF): a deterministic, bounded
+# ctest that runs fixed seeds + a fixed-PRNG stream, so CI and the sanitizers
+# preset exercise the untrusted-input parsers on every run. ON (Clang only):
+# each harness is compiled as a coverage-guided libFuzzer driver
+# (LLVMFuzzerTestOneInput, its own main from the fuzzer runtime) to run by hand.
+# The flags are per target, not global, so they don't break the compiler check
+# with the fuzzer runtime's conflicting main.
+option(AMREXPLORER_LIBFUZZER
+    "Build the fuzz harnesses as coverage-guided libFuzzer drivers (Clang)" OFF)
+if(AMREXPLORER_LIBFUZZER AND NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    message(FATAL_ERROR
+        "AMREXPLORER_LIBFUZZER requires Clang (libFuzzer runtime).")
+endif()
+
+# Wire a fuzz-harness target for the mode selected above: a libFuzzer driver, or
+# a plain bounded ctest.
+function(amrexplorer_add_fuzz_target target)
+    if(AMREXPLORER_LIBFUZZER)
+        target_compile_definitions(${target} PRIVATE AMREXPLORER_LIBFUZZER)
+        target_compile_options(${target} PRIVATE -fsanitize=fuzzer-no-link)
+        target_link_options(${target} PRIVATE -fsanitize=fuzzer)
+    else()
+        add_test(NAME ${target} COMMAND ${target})
+        set_tests_properties(${target} PROPERTIES TIMEOUT 120)
+    endif()
+endfunction()
+
 add_executable(test_core_metadata unit/test_core_metadata.cpp)
 target_link_libraries(test_core_metadata PRIVATE amrexplorer::core amrexplorer::warnings)
 add_test(NAME core_metadata COMMAND test_core_metadata)
@@ -128,7 +155,9 @@ if(TARGET amrexplorer_remote)
 
     # Fuzz/property harness for the remote wire decoder (malicious-peer trust
     # boundary). Deterministic + bounded so it runs as a normal ctest; run under
-    # the sanitizers preset for UB/OOB. See the file header for libFuzzer use.
+    # the qt-sanitizers preset for UB/OOB -- the plain sanitizers preset builds
+    # with remote OFF, so this target does not exist there. See the file header
+    # for libFuzzer use.
     add_executable(fuzz_wire_codec fuzz/fuzz_wire_codec.cpp)
     target_include_directories(fuzz_wire_codec PRIVATE
         "${CMAKE_CURRENT_SOURCE_DIR}/fuzz"
@@ -140,8 +169,7 @@ if(TARGET amrexplorer_remote)
             ${AMREXPLORER_FLATBUFFERS_LIBRARY_TARGET}
             amrexplorer::warnings
     )
-    add_test(NAME fuzz_wire_codec COMMAND fuzz_wire_codec)
-    set_tests_properties(fuzz_wire_codec PROPERTIES TIMEOUT 120)
+    amrexplorer_add_fuzz_target(fuzz_wire_codec)
 
     add_executable(test_remote_server
         integration/test_remote_server.cpp)
@@ -1384,7 +1412,8 @@ set_tests_properties(slice_query_benchmark_resampled PROPERTIES TIMEOUT 120)
 add_executable(fuzz_header_parsing fuzz/fuzz_header_parsing.cpp)
 target_include_directories(fuzz_header_parsing PRIVATE
     "${CMAKE_CURRENT_SOURCE_DIR}/fuzz")
+# amrexplorer::io, matching the sibling tests of amrvis::detail: the helpers
+# are header-only today, but the io target is their home.
 target_link_libraries(
-    fuzz_header_parsing PRIVATE amrexplorer::core amrexplorer::warnings)
-add_test(NAME fuzz_header_parsing COMMAND fuzz_header_parsing)
-set_tests_properties(fuzz_header_parsing PROPERTIES TIMEOUT 120)
+    fuzz_header_parsing PRIVATE amrexplorer::io amrexplorer::warnings)
+amrexplorer_add_fuzz_target(fuzz_header_parsing)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -126,6 +126,23 @@ if(TARGET amrexplorer_remote)
     )
     add_test(NAME remote_codec COMMAND test_remote_codec)
 
+    # Fuzz/property harness for the remote wire decoder (malicious-peer trust
+    # boundary). Deterministic + bounded so it runs as a normal ctest; run under
+    # the sanitizers preset for UB/OOB. See the file header for libFuzzer use.
+    add_executable(fuzz_wire_codec fuzz/fuzz_wire_codec.cpp)
+    target_include_directories(fuzz_wire_codec PRIVATE
+        "${CMAKE_CURRENT_SOURCE_DIR}/fuzz"
+        "${PROJECT_SOURCE_DIR}/src/remote"
+        "${PROJECT_BINARY_DIR}/src/remote/generated")
+    target_link_libraries(fuzz_wire_codec
+        PRIVATE
+            amrexplorer::remote
+            ${AMREXPLORER_FLATBUFFERS_LIBRARY_TARGET}
+            amrexplorer::warnings
+    )
+    add_test(NAME fuzz_wire_codec COMMAND fuzz_wire_codec)
+    set_tests_properties(fuzz_wire_codec PROPERTIES TIMEOUT 120)
+
     add_executable(test_remote_server
         integration/test_remote_server.cpp)
     target_include_directories(test_remote_server PRIVATE
@@ -1359,3 +1376,15 @@ set_tests_properties(slice_query_benchmark PROPERTIES TIMEOUT 120)
 add_test(NAME slice_query_benchmark_resampled
     COMMAND bench_slice_query 16 8 200 1)
 set_tests_properties(slice_query_benchmark_resampled PROPERTIES TIMEOUT 120)
+
+# Fuzz/property harness for the crafted-plotfile header parsers. No remote
+# dependency, so it builds and runs (including under the sanitizers preset)
+# regardless of remote support. Deterministic + bounded; see the file header
+# for libFuzzer use.
+add_executable(fuzz_header_parsing fuzz/fuzz_header_parsing.cpp)
+target_include_directories(fuzz_header_parsing PRIVATE
+    "${CMAKE_CURRENT_SOURCE_DIR}/fuzz")
+target_link_libraries(
+    fuzz_header_parsing PRIVATE amrexplorer::core amrexplorer::warnings)
+add_test(NAME fuzz_header_parsing COMMAND fuzz_header_parsing)
+set_tests_properties(fuzz_header_parsing PROPERTIES TIMEOUT 120)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,7 +3,8 @@
 # CI and the sanitizers preset exercise the untrusted-input parsers on every
 # run. ON (Clang only): each harness is compiled as a coverage-guided libFuzzer
 # driver (LLVMFuzzerTestOneInput, its own main from the fuzzer runtime) to run
-# by hand; the coverage instrumentation itself is project-wide (see
+# by hand -- pair it with AMREXPLORER_ENABLE_SANITIZERS=ON, or the fuzzer
+# only sees hard crashes; the coverage instrumentation itself is project-wide (see
 # amrexplorer_enable_libfuzzer_instrumentation), so the fuzzer sees the
 # parsers' own branches. Only the driver main is linked per target: it is
 # what would conflict with the compiler check and every other executable.

--- a/tests/fuzz/fuzz_header_parsing.cpp
+++ b/tests/fuzz/fuzz_header_parsing.cpp
@@ -1,0 +1,134 @@
+// Property/fuzz harness for the crafted-plotfile parsing helpers: the FAB/VisMF
+// header primitives that treat every byte of a header as hostile. Contract:
+// malformed input yields a std::exception and never crashes, reads out of
+// bounds, hangs, or lets a non-std::exception escape. Run under the sanitizers
+// preset to catch UB/OOB. Deterministic and bounded so it runs as a normal
+// ctest; build with -DAMREXPLORER_LIBFUZZER for coverage-guided fuzzing.
+#include "fuzz_util.hpp"
+
+#include <amrexplorer/io/detail/FabHeaderParsing.hpp>
+
+#include <cstdint>
+#include <cstdio>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace {
+
+// Any type constructible from std::string satisfies the helper's Error param.
+struct FuzzError : std::runtime_error {
+    using std::runtime_error::runtime_error;
+};
+
+void exerciseHeaderText(std::string_view text)
+{
+    namespace detail = amrvis::detail;
+    const std::string owned(text);
+    try {
+        static_cast<void>(detail::parseIntegers(owned));  // never throws
+        for (int dimension = 1; dimension <= 3; ++dimension) {
+            try {
+                static_cast<void>(
+                    detail::parseAmrexBox<FuzzError>(owned, dimension));
+            } catch (const std::exception&) {
+            }
+        }
+        try {
+            int inferred = 0;
+            static_cast<void>(detail::parseAmrexBoxInferDimension<FuzzError>(
+                owned, inferred));
+        } catch (const std::exception&) {
+        }
+        try {
+            static_cast<void>(
+                detail::balancedExpressionEnd<FuzzError>(owned, 0));
+        } catch (const std::exception&) {
+        }
+        try {
+            static_cast<void>(detail::parseRealDescriptor<FuzzError>(owned));
+        } catch (const std::exception&) {
+        }
+        {
+            std::istringstream input(owned);
+            std::string line;
+            try {
+                while (detail::readBoundedLine<FuzzError>(input, line)) {
+                }
+            } catch (const std::exception&) {
+            }
+        }
+        {
+            std::istringstream input(owned);
+            try {
+                static_cast<void>(detail::readBoundedToken<FuzzError>(
+                    input, "fuzz", "token"));
+            } catch (const std::exception&) {
+            }
+        }
+        {
+            std::istringstream input(owned);
+            try {
+                static_cast<void>(detail::readBoundedInteger<FuzzError, int>(
+                    input, "fuzz", "int"));
+            } catch (const std::exception&) {
+            }
+        }
+        {
+            std::istringstream input(owned);
+            try {
+                static_cast<void>(
+                    detail::readBoundedInteger<FuzzError, std::uint64_t>(
+                        input, "fuzz", "u64"));
+            } catch (const std::exception&) {
+            }
+        }
+    } catch (...) {
+        amrvis::fuzz::fail("a header helper let a non-std::exception escape");
+    }
+}
+
+const std::vector<std::string>& headerSeeds()
+{
+    static const std::vector<std::string> seeds{
+        "((8, (64 11 52 0 1 12 0 1023)),(8, (8 7 6 5 4 3 2 1)))",
+        "((8, (32 8 23 0 1 9 0 127)),(8, (1 2 3 4 5 6 7 8)))",
+        "((0,0) (7,7) (0,0))",
+        "((0,0,0) (3,3,3) (1,0,1))",
+        "FAB ((8, (64 11 52 0 1 12 0 1023)),(8, (1 2 3 4 5 6 7 8)))"
+        "((0,0) (7,7) (0,0)) 1",
+        "1\n1\n1\n0\n(1 0\n((0,0) (3,3) (0,0))\n)\n",
+        "2,1\n1.0,\n2.0,\n",
+        "-2147483648 2147483647 0 nan inf -inf",
+    };
+    return seeds;
+}
+
+} // namespace
+
+#if defined(AMREXPLORER_LIBFUZZER)
+extern "C" int LLVMFuzzerTestOneInput(const std::uint8_t* data, std::size_t size)
+{
+    exerciseHeaderText(
+        std::string_view(reinterpret_cast<const char*>(data), size));
+    return 0;
+}
+#else
+int main()
+{
+    constexpr int iterations = 60000;
+    std::uint64_t rng = 0x0f1e'2d3c'4b5a'6987ULL;
+    const auto& seeds = headerSeeds();
+    for (int i = 0; i < iterations; ++i) {
+        const auto bytes = amrvis::fuzz::randomBytes(rng, 256);
+        exerciseHeaderText(std::string_view(
+            reinterpret_cast<const char*>(bytes.data()), bytes.size()));
+        exerciseHeaderText(amrvis::fuzz::mutateText(
+            rng, seeds[amrvis::fuzz::nextRandom(rng) % seeds.size()]));
+    }
+    std::printf("fuzz_header_parsing: %d iterations, no crash\n", iterations);
+    return 0;
+}
+#endif

--- a/tests/fuzz/fuzz_header_parsing.cpp
+++ b/tests/fuzz/fuzz_header_parsing.cpp
@@ -2,18 +2,22 @@
 // header primitives that treat every byte of a header as hostile. Contract:
 // malformed input is rejected with exactly the caller-supplied Error type --
 // never any other exception, a crash, an out-of-bounds read, or a hang -- and
-// accepted input satisfies the helper's postconditions (a parsed box is valid,
-// an inferred dimension is 1..3). Run under the sanitizers preset to catch
-// UB/OOB. Deterministic and bounded so it runs as a normal ctest; configure
-// with -DAMREXPLORER_LIBFUZZER=ON (Clang) to build it instead as a
-// coverage-guided libFuzzer driver.
+// accepted input satisfies the helper's postconditions (a parsed box holds
+// exactly the integers in the text, an inferred dimension is 1..3, a bounded
+// reader stops exactly where its grammar ends). Run under the sanitizers
+// preset to catch UB/OOB. Deterministic and bounded so it runs as a normal
+// ctest; configure with -DAMREXPLORER_LIBFUZZER=ON (Clang), together with
+// AMREXPLORER_ENABLE_SANITIZERS=ON so the fuzzer sees UB/OOB and not only
+// hard crashes, to build it instead as a coverage-guided libFuzzer driver.
 #include "fuzz_util.hpp"
 
 #include <amrexplorer/io/detail/FabHeaderParsing.hpp>
 
 #include <cstddef>
 #include <cstdint>
+#include <cctype>
 #include <cstdio>
+#include <istream>
 #include <sstream>
 #include <stdexcept>
 #include <string>
@@ -32,6 +36,69 @@ namespace {
 struct FuzzError : std::runtime_error {
     using std::runtime_error::runtime_error;
 };
+
+// After a complete extraction the stream is at whitespace or end of file.
+bool nextIsSpaceOrEnd(std::istream& input)
+{
+    const auto next = input.peek();
+    return next == std::char_traits<char>::eof()
+        || std::isspace(static_cast<unsigned char>(next)) != 0;
+}
+
+// Postconditions of readBoundedInteger: on success the field ended exactly
+// where the digits do (the next character cannot extend it), and the value is
+// the digits it consumed -- re-serialising it reproduces the run modulo a
+// leading '+' and leading zeros, so a saturating or wrapped conversion (the
+// operator>> behaviour it replaces) is caught, not just a crash.
+template <typename Integer>
+void exerciseBoundedInteger(const std::string& owned, const char* description)
+{
+    namespace detail = amrvis::detail;
+    std::istringstream input(owned);
+    try {
+        const auto value = detail::readBoundedInteger<FuzzError, Integer>(
+            input, "fuzz", description);
+        const auto next = input.peek();
+        if (next != std::char_traits<char>::eof()
+            && next >= '0' && next <= '9') {
+            amrvis::fuzz::fail("readBoundedInteger stopped inside a number");
+        }
+        // The run it consumed: skip leading whitespace, take [+-]?digits.
+        std::size_t begin = 0;
+        while (begin < owned.size()
+            && std::isspace(static_cast<unsigned char>(owned[begin])) != 0) {
+            ++begin;
+        }
+        std::string run;
+        if (begin < owned.size() && owned[begin] == '-') {
+            run.push_back('-');
+            ++begin;
+        } else if (begin < owned.size() && owned[begin] == '+') {
+            ++begin;
+        }
+        const bool negative = !run.empty();
+        while (begin < owned.size() && owned[begin] == '0') {
+            ++begin;  // leading zeros
+        }
+        std::size_t digits = 0;
+        while (begin < owned.size() && owned[begin] >= '0'
+            && owned[begin] <= '9') {
+            run.push_back(owned[begin++]);
+            ++digits;
+        }
+        if (digits == 0) {
+            run = negative ? "-0" : "0";  // an all-zero run
+        }
+        if (run == "-0") {
+            run = "0";  // to_string(0) has no sign
+        }
+        if (std::to_string(value) != run) {
+            amrvis::fuzz::fail(
+                "readBoundedInteger returned a value other than its digits");
+        }
+    } catch (const FuzzError&) {
+    }
+}
 
 void exerciseHeaderText(std::string_view text)
 {
@@ -92,15 +159,49 @@ void exerciseHeaderText(std::string_view text)
         try {
             const auto end
                 = detail::balancedExpressionEnd<FuzzError>(owned, 0);
-            // Postcondition: one past the matching ')', so in (0, size()].
-            if (end == 0 || end > owned.size()) {
+            // Postcondition: one past the ')' that closes the '(' at 0, so
+            // the depth over [0, end) first returns to zero exactly at end --
+            // which is what an off-by-one (i for i + 1) or a miscounted
+            // nesting would break.
+            if (end < 2 || end > owned.size() || owned[end - 1] != ')') {
                 amrvis::fuzz::fail(
                     "balancedExpressionEnd returned an out-of-range index");
+            }
+            int depth = 0;
+            for (std::size_t i = 0; i < end; ++i) {
+                depth += owned[i] == '(' ? 1 : owned[i] == ')' ? -1 : 0;
+                if (depth == 0 && i + 1 != end) {
+                    amrvis::fuzz::fail(
+                        "balancedExpressionEnd overshot the matching ')'");
+                }
+            }
+            if (depth != 0) {
+                amrvis::fuzz::fail(
+                    "balancedExpressionEnd stopped before the matching ')'");
             }
         } catch (const FuzzError&) {
         }
         try {
-            static_cast<void>(detail::parseRealDescriptor<FuzzError>(owned));
+            const auto descriptor
+                = detail::parseRealDescriptor<FuzzError>(owned);
+            // Postcondition: an accepted descriptor is IEEE-32 or IEEE-64,
+            // and its byte order is the ascending or descending run the text
+            // spells out at index 10 (after "8, (<8 format ints>), <count>").
+            const auto bytes = descriptor.bytes;
+            if ((bytes != 4 && bytes != 8) || integers.size() < 10 + bytes
+                || integers[9] != static_cast<int>(bytes)) {
+                amrvis::fuzz::fail(
+                    "parseRealDescriptor accepted an unsupported format");
+            }
+            for (std::size_t byte = 0; byte < bytes; ++byte) {
+                const auto expected = descriptor.littleEndian
+                    ? static_cast<int>(bytes - byte)
+                    : static_cast<int>(byte + 1);
+                if (integers[10 + byte] != expected) {
+                    amrvis::fuzz::fail(
+                        "parseRealDescriptor misread the byte order");
+                }
+            }
         } catch (const FuzzError&) {
         }
         {
@@ -122,30 +223,20 @@ void exerciseHeaderText(std::string_view text)
             try {
                 const auto token = detail::readBoundedToken<FuzzError>(
                     input, "fuzz", "token");
-                if (token.size() > detail::maximumHeaderTokenBytes) {
+                // Postcondition: a delivered token is complete -- what
+                // follows it on the stream is whitespace or end of file. (Its
+                // length is capped by setw by construction; a truncated token
+                // shows up as a non-space next character, which is exactly
+                // the silent misparse the helper exists to refuse.)
+                if (token.empty() || !nextIsSpaceOrEnd(input)) {
                     amrvis::fuzz::fail(
-                        "readBoundedToken delivered an over-limit token");
+                        "readBoundedToken delivered a truncated token");
                 }
             } catch (const FuzzError&) {
             }
         }
-        {
-            std::istringstream input(owned);
-            try {
-                static_cast<void>(detail::readBoundedInteger<FuzzError, int>(
-                    input, "fuzz", "int"));
-            } catch (const FuzzError&) {
-            }
-        }
-        {
-            std::istringstream input(owned);
-            try {
-                static_cast<void>(
-                    detail::readBoundedInteger<FuzzError, std::uint64_t>(
-                        input, "fuzz", "u64"));
-            } catch (const FuzzError&) {
-            }
-        }
+        exerciseBoundedInteger<int>(owned, "int");
+        exerciseBoundedInteger<std::uint64_t>(owned, "u64");
     } catch (const std::exception& error) {
         std::fprintf(stderr, "fuzz: escaping exception: %s\n", error.what());
         amrvis::fuzz::fail(
@@ -192,8 +283,9 @@ int main()
     const auto& seeds = headerSeeds();
     // Boundary inputs the 256-byte random cases never reach: a single
     // token/line at and just past the reader ceilings (maximumHeaderTokenBytes,
-    // maximumHeaderLineBytes), so the most hostile length limits are exercised
-    // deterministically and keep tracking the constants.
+    // maximumHeaderLineBytes), and a digit run at and just past
+    // maximumHeaderNumberBytes, so the most hostile length limits are
+    // exercised deterministically and keep tracking the constants.
     namespace detail = amrvis::detail;
     long iteration = 0;
     for (const std::size_t n : {detail::maximumHeaderTokenBytes - 1,
@@ -203,6 +295,28 @@ int main()
         const std::string text(n, 'x');
         amrvis::fuzz::setCurrentInput(iteration++, text.data(), text.size());
         exerciseHeaderText(text);
+    }
+    for (const std::size_t n : {detail::maximumHeaderNumberBytes - 1,
+             detail::maximumHeaderNumberBytes,
+             detail::maximumHeaderNumberBytes + 1}) {
+        // Zeros: up to the ceiling the value is 0 and must be accepted (a
+        // ceiling that fires early or a conversion that chokes on the length
+        // both show); one past it must be refused as over-long.
+        const std::string text(n, '0');
+        amrvis::fuzz::setCurrentInput(iteration++, text.data(), text.size());
+        exerciseHeaderText(text);
+        std::istringstream input(text);
+        bool accepted = true;
+        try {
+            static_cast<void>(detail::readBoundedInteger<FuzzError, int>(
+                input, "fuzz", "int"));
+        } catch (const FuzzError&) {
+            accepted = false;
+        }
+        if (accepted != (n <= detail::maximumHeaderNumberBytes)) {
+            amrvis::fuzz::fail(
+                "readBoundedInteger's length ceiling is off its constant");
+        }
     }
     for (int i = 0; i < iterations; ++i) {
         const auto bytes = amrvis::fuzz::randomBytes(rng, 256);

--- a/tests/fuzz/fuzz_header_parsing.cpp
+++ b/tests/fuzz/fuzz_header_parsing.cpp
@@ -1,13 +1,17 @@
 // Property/fuzz harness for the crafted-plotfile parsing helpers: the FAB/VisMF
 // header primitives that treat every byte of a header as hostile. Contract:
-// malformed input yields a std::exception and never crashes, reads out of
-// bounds, hangs, or lets a non-std::exception escape. Run under the sanitizers
-// preset to catch UB/OOB. Deterministic and bounded so it runs as a normal
-// ctest; build with -DAMREXPLORER_LIBFUZZER for coverage-guided fuzzing.
+// malformed input is rejected with exactly the caller-supplied Error type --
+// never any other exception, a crash, an out-of-bounds read, or a hang -- and
+// accepted input satisfies the helper's postconditions (a parsed box is valid,
+// an inferred dimension is 1..3). Run under the sanitizers preset to catch
+// UB/OOB. Deterministic and bounded so it runs as a normal ctest; configure
+// with -DAMREXPLORER_LIBFUZZER=ON (Clang) to build it instead as a
+// coverage-guided libFuzzer driver.
 #include "fuzz_util.hpp"
 
 #include <amrexplorer/io/detail/FabHeaderParsing.hpp>
 
+#include <cstddef>
 #include <cstdint>
 #include <cstdio>
 #include <sstream>
@@ -19,6 +23,12 @@
 namespace {
 
 // Any type constructible from std::string satisfies the helper's Error param.
+// Deliberately NOT derived from the std:: hierarchy's common leaf types the
+// helpers might throw by accident: catching FuzzError (and only FuzzError) as
+// the expected path is what pins the "failures arrive as the caller's Error
+// type" contract -- real call sites catch narrowly, so a leaked
+// std::out_of_range would crash the reader while a loose harness catch
+// (const std::exception&) would record it as a clean rejection.
 struct FuzzError : std::runtime_error {
     using std::runtime_error::runtime_error;
 };
@@ -28,44 +38,95 @@ void exerciseHeaderText(std::string_view text)
     namespace detail = amrvis::detail;
     const std::string owned(text);
     try {
-        static_cast<void>(detail::parseIntegers(owned));  // never throws
+        const auto integers = detail::parseIntegers(owned);  // never throws
         for (int dimension = 1; dimension <= 3; ++dimension) {
             try {
-                static_cast<void>(
-                    detail::parseAmrexBox<FuzzError>(owned, dimension));
-            } catch (const std::exception&) {
+                const auto box
+                    = detail::parseAmrexBox<FuzzError>(owned, dimension);
+                // Postcondition: parse is extraction, not validation (an
+                // inverted box is rejected downstream by pointCount) -- but it
+                // must extract faithfully: the box holds exactly the integers
+                // parseIntegers saw, in lower/upper/centering order.
+                for (int axis = 0; axis < dimension; ++axis) {
+                    const auto i = static_cast<std::size_t>(axis);
+                    const auto d = static_cast<std::size_t>(dimension);
+                    if (box.lower[i] != integers[i]
+                        || box.upper[i] != integers[d + i]
+                        || box.centering[i] != integers[2 * d + i]) {
+                        amrvis::fuzz::fail(
+                            "parseAmrexBox transposed the parsed integers");
+                    }
+                }
+                // A grown box either throws the Error type or stays exact.
+                try {
+                    const auto grown = detail::grownBox<FuzzError>(
+                        box, {1, 1, 1}, dimension);
+                    for (int axis = 0; axis < dimension; ++axis) {
+                        const auto i = static_cast<std::size_t>(axis);
+                        // int64 arithmetic: the harness must not overflow in
+                        // the very comparison that checks for a wrap.
+                        if (static_cast<std::int64_t>(grown.lower[i])
+                                != static_cast<std::int64_t>(box.lower[i]) - 1
+                            || static_cast<std::int64_t>(grown.upper[i])
+                                != static_cast<std::int64_t>(box.upper[i]) + 1) {
+                            amrvis::fuzz::fail(
+                                "grownBox produced a wrong or wrapped box");
+                        }
+                    }
+                } catch (const FuzzError&) {
+                }
+            } catch (const FuzzError&) {
             }
         }
         try {
             int inferred = 0;
             static_cast<void>(detail::parseAmrexBoxInferDimension<FuzzError>(
                 owned, inferred));
-        } catch (const std::exception&) {
+            // Postcondition: the inferred dimension is a real one.
+            if (inferred < 1 || inferred > 3) {
+                amrvis::fuzz::fail(
+                    "parseAmrexBoxInferDimension accepted a bad dimension");
+            }
+        } catch (const FuzzError&) {
         }
         try {
-            static_cast<void>(
-                detail::balancedExpressionEnd<FuzzError>(owned, 0));
-        } catch (const std::exception&) {
+            const auto end
+                = detail::balancedExpressionEnd<FuzzError>(owned, 0);
+            // Postcondition: one past the matching ')', so in (0, size()].
+            if (end == 0 || end > owned.size()) {
+                amrvis::fuzz::fail(
+                    "balancedExpressionEnd returned an out-of-range index");
+            }
+        } catch (const FuzzError&) {
         }
         try {
             static_cast<void>(detail::parseRealDescriptor<FuzzError>(owned));
-        } catch (const std::exception&) {
+        } catch (const FuzzError&) {
         }
         {
             std::istringstream input(owned);
             std::string line;
             try {
                 while (detail::readBoundedLine<FuzzError>(input, line)) {
+                    // Postcondition: a delivered line respects the ceiling.
+                    if (line.size() > detail::maximumHeaderLineBytes) {
+                        amrvis::fuzz::fail(
+                            "readBoundedLine delivered an over-limit line");
+                    }
                 }
-            } catch (const std::exception&) {
+            } catch (const FuzzError&) {
             }
         }
         {
             std::istringstream input(owned);
             try {
-                static_cast<void>(detail::readBoundedToken<FuzzError>(
-                    input, "fuzz", "token"));
-            } catch (const std::exception&) {
+                const auto token = detail::readBoundedToken<FuzzError>(
+                    input, "fuzz", "token");
+                if (token.size() > detail::maximumHeaderTokenBytes) {
+                    amrvis::fuzz::fail(
+                        "readBoundedToken delivered an over-limit token");
+                }
+            } catch (const FuzzError&) {
             }
         }
         {
@@ -73,7 +134,7 @@ void exerciseHeaderText(std::string_view text)
             try {
                 static_cast<void>(detail::readBoundedInteger<FuzzError, int>(
                     input, "fuzz", "int"));
-            } catch (const std::exception&) {
+            } catch (const FuzzError&) {
             }
         }
         {
@@ -82,14 +143,19 @@ void exerciseHeaderText(std::string_view text)
                 static_cast<void>(
                     detail::readBoundedInteger<FuzzError, std::uint64_t>(
                         input, "fuzz", "u64"));
-            } catch (const std::exception&) {
+            } catch (const FuzzError&) {
             }
         }
+    } catch (const std::exception& error) {
+        std::fprintf(stderr, "fuzz: escaping exception: %s\n", error.what());
+        amrvis::fuzz::fail(
+            "a header helper threw something other than the Error type");
     } catch (...) {
         amrvis::fuzz::fail("a header helper let a non-std::exception escape");
     }
 }
 
+#if !defined(AMREXPLORER_LIBFUZZER)
 const std::vector<std::string>& headerSeeds()
 {
     static const std::vector<std::string> seeds{
@@ -105,14 +171,17 @@ const std::vector<std::string>& headerSeeds()
     };
     return seeds;
 }
+#endif
 
 } // namespace
 
 #if defined(AMREXPLORER_LIBFUZZER)
 extern "C" int LLVMFuzzerTestOneInput(const std::uint8_t* data, std::size_t size)
 {
-    exerciseHeaderText(
-        std::string_view(reinterpret_cast<const char*>(data), size));
+    amrvis::fuzz::setCurrentInput(0, data, size);
+    exerciseHeaderText(size == 0
+        ? std::string_view{}
+        : std::string_view(reinterpret_cast<const char*>(data), size));
     return 0;
 }
 #else
@@ -121,12 +190,29 @@ int main()
     constexpr int iterations = 60000;
     std::uint64_t rng = 0x0f1e'2d3c'4b5a'6987ULL;
     const auto& seeds = headerSeeds();
+    // Boundary inputs the 256-byte random cases never reach: a single
+    // token/line at and just past the reader ceilings (maximumHeaderTokenBytes,
+    // maximumHeaderLineBytes), so the most hostile length limits are exercised
+    // deterministically and keep tracking the constants.
+    namespace detail = amrvis::detail;
+    long iteration = 0;
+    for (const std::size_t n : {detail::maximumHeaderTokenBytes - 1,
+             detail::maximumHeaderTokenBytes, detail::maximumHeaderTokenBytes + 1,
+             detail::maximumHeaderLineBytes - 1, detail::maximumHeaderLineBytes,
+             detail::maximumHeaderLineBytes + 1}) {
+        const std::string text(n, 'x');
+        amrvis::fuzz::setCurrentInput(iteration++, text.data(), text.size());
+        exerciseHeaderText(text);
+    }
     for (int i = 0; i < iterations; ++i) {
         const auto bytes = amrvis::fuzz::randomBytes(rng, 256);
-        exerciseHeaderText(std::string_view(
-            reinterpret_cast<const char*>(bytes.data()), bytes.size()));
-        exerciseHeaderText(amrvis::fuzz::mutateText(
-            rng, seeds[amrvis::fuzz::nextRandom(rng) % seeds.size()]));
+        amrvis::fuzz::setCurrentInput(iteration++, bytes.data(), bytes.size());
+        exerciseHeaderText(amrvis::fuzz::viewOf(bytes));
+        const auto mutated = amrvis::fuzz::mutateText(
+            rng, seeds[amrvis::fuzz::nextRandom(rng) % seeds.size()]);
+        amrvis::fuzz::setCurrentInput(
+            iteration++, mutated.data(), mutated.size());
+        exerciseHeaderText(mutated);
     }
     std::printf("fuzz_header_parsing: %d iterations, no crash\n", iterations);
     return 0;

--- a/tests/fuzz/fuzz_util.hpp
+++ b/tests/fuzz/fuzz_util.hpp
@@ -1,22 +1,56 @@
 #pragma once
 
 // Shared plumbing for the deterministic fuzz/property harnesses: a fixed-seed
-// PRNG, random and near-valid (mutated) input generators, and a failure abort.
-// The harnesses are ordinary bounded ctests; run them under the sanitizers
-// preset to turn UB/OOB into a failure.
+// PRNG, random and near-valid (mutated) input generators, and a failure abort
+// that prints a reproducer (current input as hex + the iteration context set
+// by the harness loop). The harnesses are ordinary bounded ctests; run them
+// under the sanitizers preset to turn UB/OOB into a failure.
 
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace amrvis::fuzz {
 
+// Reproducer context: the harness loop stores the iteration and the exact
+// bytes it is about to feed, so fail() can print how to reproduce a failure
+// instead of a bare message. Plain globals: the harnesses are single-threaded.
+inline long currentIteration = -1;
+inline std::vector<std::uint8_t> currentInput;
+
+inline void setCurrentInput(long iteration, const void* data, std::size_t size)
+{
+    currentIteration = iteration;
+    const auto* bytes = static_cast<const std::uint8_t*>(data);
+    currentInput.assign(bytes, bytes + size);
+}
+
 [[noreturn]] inline void fail(const char* what)
 {
     std::fprintf(stderr, "fuzz: %s\n", what);
+    if (currentIteration >= 0) {
+        std::fprintf(stderr, "fuzz: iteration %ld, input %zu bytes:\n",
+            currentIteration, currentInput.size());
+        for (std::size_t i = 0; i < currentInput.size(); ++i) {
+            std::fprintf(stderr, "%02x%s", currentInput[i],
+                (i + 1) % 32 == 0 ? "\n" : " ");
+        }
+        std::fputc('\n', stderr);
+    }
     std::abort();
+}
+
+// A string_view over a byte buffer that is safe for empty input:
+// string_view(nullptr, 0) violates the constructor's precondition.
+inline std::string_view viewOf(const std::vector<std::uint8_t>& bytes)
+{
+    return bytes.empty()
+        ? std::string_view{}
+        : std::string_view(
+              reinterpret_cast<const char*>(bytes.data()), bytes.size());
 }
 
 inline std::uint64_t nextRandom(std::uint64_t& state)
@@ -82,8 +116,10 @@ inline std::string mutateText(std::uint64_t& rng, const std::string& seed)
     for (unsigned r = 0; r < rounds && !out.empty(); ++r) {
         switch (nextRandom(rng) % 4U) {
         case 0:
+            // Full byte range, not % 128: high bytes are where locale/isspace
+            // style footguns live, and near-valid inputs must reach them.
             out[nextRandom(rng) % out.size()]
-                = static_cast<char>(nextRandom(rng) % 128U);
+                = static_cast<char>(nextRandom(rng) % 256U);
             break;
         case 1:
             out.resize(static_cast<std::size_t>(nextRandom(rng) % out.size()));
@@ -93,7 +129,7 @@ inline std::string mutateText(std::uint64_t& rng, const std::string& seed)
                 out.begin()
                     + static_cast<std::ptrdiff_t>(
                         nextRandom(rng) % (out.size() + 1)),
-                static_cast<char>(nextRandom(rng) % 128U));
+                static_cast<char>(nextRandom(rng) % 256U));
             break;
         default:
             out[nextRandom(rng) % out.size()]

--- a/tests/fuzz/fuzz_util.hpp
+++ b/tests/fuzz/fuzz_util.hpp
@@ -6,6 +6,7 @@
 // by the harness loop). The harnesses are ordinary bounded ctests; run them
 // under the sanitizers preset to turn UB/OOB into a failure.
 
+#include <array>
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
@@ -74,8 +75,26 @@ inline std::vector<std::uint8_t> randomBytes(
     return bytes;
 }
 
+// Overwrite an aligned `size`-byte slot of `out` with `value`, little-endian
+// (the FlatBuffers wire order), if the buffer has room for one.
+inline void writeAligned(std::vector<std::uint8_t>& out, std::uint64_t& rng,
+    std::uint64_t value, std::size_t size)
+{
+    if (out.size() < size) {
+        return;
+    }
+    const auto slot = (nextRandom(rng) % (out.size() / size)) * size;
+    for (std::size_t i = 0; i < size; ++i) {
+        out[slot + i] = static_cast<std::uint8_t>(value >> (8 * i));
+    }
+}
+
 // Copy `seed` and apply one random mutation, so the input stays near a valid
-// structure -- the region where boundary bugs hide.
+// structure -- the region where boundary bugs hide. Besides byte-level edits
+// this plants "interesting" scalars (NaN, infinities, zero, all-ones, the
+// sign bit) at aligned offsets, the way libFuzzer does: they are what a
+// decoder's finite/range checks exist for, and a single byte or bit change to
+// a valid double or count practically never produces one.
 inline std::vector<std::uint8_t> mutate(
     std::uint64_t& rng, const std::vector<std::uint8_t>& seed)
 {
@@ -83,7 +102,25 @@ inline std::vector<std::uint8_t> mutate(
     if (out.empty()) {
         return randomBytes(rng, 64);
     }
-    switch (nextRandom(rng) % 4U) {
+    static constexpr std::array<std::uint64_t, 6> interesting64{
+        0x7FF8'0000'0000'0000ULL,  // NaN
+        0x7FF0'0000'0000'0000ULL,  // +inf
+        0xFFF0'0000'0000'0000ULL,  // -inf
+        0ULL, ~0ULL, 0x8000'0000'0000'0000ULL};
+    static constexpr std::array<std::uint32_t, 6> interesting32{
+        0x7FC0'0000U,  // NaN
+        0x7F80'0000U,  // +inf
+        0xFF80'0000U,  // -inf
+        0U, ~0U, 0x8000'0000U};
+    switch (nextRandom(rng) % 6U) {
+    case 4:
+        writeAligned(out, rng,
+            interesting64[nextRandom(rng) % interesting64.size()], 8);
+        break;
+    case 5:
+        writeAligned(out, rng,
+            interesting32[nextRandom(rng) % interesting32.size()], 4);
+        break;
     case 0:
         out[nextRandom(rng) % out.size()]
             ^= static_cast<std::uint8_t>(1U << (nextRandom(rng) % 8U));

--- a/tests/fuzz/fuzz_util.hpp
+++ b/tests/fuzz/fuzz_util.hpp
@@ -1,0 +1,107 @@
+#pragma once
+
+// Shared plumbing for the deterministic fuzz/property harnesses: a fixed-seed
+// PRNG, random and near-valid (mutated) input generators, and a failure abort.
+// The harnesses are ordinary bounded ctests; run them under the sanitizers
+// preset to turn UB/OOB into a failure.
+
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+#include <vector>
+
+namespace amrvis::fuzz {
+
+[[noreturn]] inline void fail(const char* what)
+{
+    std::fprintf(stderr, "fuzz: %s\n", what);
+    std::abort();
+}
+
+inline std::uint64_t nextRandom(std::uint64_t& state)
+{
+    state += 0x9e3779b97f4a7c15ULL;
+    auto z = state;
+    z = (z ^ (z >> 30U)) * 0xbf58476d1ce4e5b9ULL;
+    z = (z ^ (z >> 27U)) * 0x94d049bb133111ebULL;
+    return z ^ (z >> 31U);
+}
+
+inline std::vector<std::uint8_t> randomBytes(
+    std::uint64_t& rng, std::size_t maxLen)
+{
+    const auto length
+        = static_cast<std::size_t>(nextRandom(rng) % (maxLen + 1));
+    std::vector<std::uint8_t> bytes(length);
+    for (auto& byte : bytes) {
+        byte = static_cast<std::uint8_t>(nextRandom(rng));
+    }
+    return bytes;
+}
+
+// Copy `seed` and apply one random mutation, so the input stays near a valid
+// structure -- the region where boundary bugs hide.
+inline std::vector<std::uint8_t> mutate(
+    std::uint64_t& rng, const std::vector<std::uint8_t>& seed)
+{
+    auto out = seed;
+    if (out.empty()) {
+        return randomBytes(rng, 64);
+    }
+    switch (nextRandom(rng) % 4U) {
+    case 0:
+        out[nextRandom(rng) % out.size()]
+            ^= static_cast<std::uint8_t>(1U << (nextRandom(rng) % 8U));
+        break;
+    case 1:
+        out.resize(static_cast<std::size_t>(nextRandom(rng) % out.size()));
+        break;
+    case 2:
+        out[nextRandom(rng) % out.size()]
+            = static_cast<std::uint8_t>(nextRandom(rng));
+        break;
+    default:
+        out.insert(
+            out.begin()
+                + static_cast<std::ptrdiff_t>(
+                    nextRandom(rng) % (out.size() + 1)),
+            static_cast<std::uint8_t>(nextRandom(rng)));
+        break;
+    }
+    return out;
+}
+
+inline std::string mutateText(std::uint64_t& rng, const std::string& seed)
+{
+    std::string out = seed;
+    if (out.empty()) {
+        return out;
+    }
+    const auto rounds = 1U + static_cast<unsigned>(nextRandom(rng) % 4U);
+    for (unsigned r = 0; r < rounds && !out.empty(); ++r) {
+        switch (nextRandom(rng) % 4U) {
+        case 0:
+            out[nextRandom(rng) % out.size()]
+                = static_cast<char>(nextRandom(rng) % 128U);
+            break;
+        case 1:
+            out.resize(static_cast<std::size_t>(nextRandom(rng) % out.size()));
+            break;
+        case 2:
+            out.insert(
+                out.begin()
+                    + static_cast<std::ptrdiff_t>(
+                        nextRandom(rng) % (out.size() + 1)),
+                static_cast<char>(nextRandom(rng) % 128U));
+            break;
+        default:
+            out[nextRandom(rng) % out.size()]
+                = "()[]{}, \n\t0123456789-"[nextRandom(rng) % 21U];
+            break;
+        }
+    }
+    return out;
+}
+
+} // namespace amrvis::fuzz

--- a/tests/fuzz/fuzz_wire_codec.cpp
+++ b/tests/fuzz/fuzz_wire_codec.cpp
@@ -1,9 +1,15 @@
-// Property/fuzz harness for the remote wire decoder -- the malicious-peer trust
-// boundary. Contract: codec::decode of arbitrary or near-valid bytes yields a
-// std::exception and never crashes, reads out of bounds, or lets a
-// non-std::exception escape. Run under the sanitizers preset to catch UB/OOB.
-// Deterministic and bounded so it runs as a normal ctest; build with
-// -DAMREXPLORER_LIBFUZZER for coverage-guided fuzzing.
+// Property/fuzz harness for the remote wire trust boundary. Contract:
+// codec::decode of arbitrary or near-valid bytes, inspect of the decoded
+// envelope, and every payload-matching fromWire converter (where the hostile
+// payload *contents* are validated -- vector length agreement, finite values,
+// enum ranges) yield a std::exception on rejection and never crash, read out
+// of bounds, or let a non-std::exception escape; an accepted envelope's
+// inspect() must agree with the envelope it summarizes. Run under the
+// qt-sanitizers preset to catch UB/OOB (the plain sanitizers preset builds
+// without remote support, so this target does not exist there). Deterministic
+// and bounded so it runs as a normal ctest; configure with
+// -DAMREXPLORER_LIBFUZZER=ON (Clang) to build it instead as a coverage-guided
+// libFuzzer driver.
 #include "fuzz_util.hpp"
 
 #include "Codec.hpp"
@@ -11,54 +17,169 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstdio>
+#include <cstring>
 #include <span>
 #include <stdexcept>
 #include <vector>
 
 namespace {
 
-void exerciseWire(std::span<const std::uint8_t> bytes)
+namespace codec = amrvis::remote::codec;
+namespace fb = codec::fb;
+
+// fromWire on a payload pointer, mirroring the server: a null pointer (the
+// union tag disagreeing with the stored table on a crafted buffer) is the
+// server's "payload is missing" rejection, not a dereference.
+template <typename Payload>
+void convert(const Payload* payload)
 {
-    try {
-        auto envelope = amrvis::remote::codec::decode(bytes);
-        // A decode that succeeds must be inspectable without surprises.
-        static_cast<void>(amrvis::remote::codec::inspect(*envelope));
-    } catch (const std::exception&) {
-        // Expected rejection path.
-    } catch (...) {
-        amrvis::fuzz::fail("codec::decode let a non-std::exception escape");
+    if (payload != nullptr) {
+        static_cast<void>(codec::fromWire(*payload));
     }
 }
 
+// Route a decoded envelope's payload through the matching fromWire converter
+// -- the layer where the server/client actually validate hostile payload
+// contents (validateResultVectors, finite-value and enum checks). Only arms
+// with a nontrivial converter are dispatched; a converter throwing
+// std::exception is the expected rejection.
+void exerciseFromWire(const codec::NativeEnvelope& envelope)
+{
+    switch (envelope.payload.type) {
+    case fb::Payload::HelloRequest:
+        convert(envelope.payload.AsHelloRequest());
+        break;
+    case fb::Payload::HelloResponse:
+        convert(envelope.payload.AsHelloResponse());
+        break;
+    case fb::Payload::OpenDatasetRequest:
+        convert(envelope.payload.AsOpenDatasetRequest());
+        break;
+    case fb::Payload::DatasetOpened:
+        convert(envelope.payload.AsDatasetOpened());
+        break;
+    case fb::Payload::SliceViewRequest:
+        convert(envelope.payload.AsSliceViewRequest());
+        break;
+    case fb::Payload::SliceViewResponse:
+        convert(envelope.payload.AsSliceViewResponse());
+        break;
+    case fb::Payload::LineViewRequest:
+        convert(envelope.payload.AsLineViewRequest());
+        break;
+    case fb::Payload::LineViewResponse:
+        convert(envelope.payload.AsLineViewResponse());
+        break;
+    case fb::Payload::DatasetPageRequest:
+        convert(envelope.payload.AsDatasetPageRequest());
+        break;
+    case fb::Payload::DatasetPageResponse:
+        convert(envelope.payload.AsDatasetPageResponse());
+        break;
+    case fb::Payload::ParticleSampleRequest:
+        convert(envelope.payload.AsParticleSampleRequest());
+        break;
+    case fb::Payload::ParticleSampleResponse:
+        convert(envelope.payload.AsParticleSampleResponse());
+        break;
+    case fb::Payload::RangeRequest:
+        convert(envelope.payload.AsRangeRequest());
+        break;
+    case fb::Payload::RangeResponse:
+        convert(envelope.payload.AsRangeResponse());
+        break;
+    default:
+        break;  // trivial payloads (ping/pong/cancel/...) have no converter
+    }
+}
+
+void exerciseWire(std::span<const std::uint8_t> bytes)
+{
+    try {
+        auto envelope = codec::decode(bytes);
+        // Postcondition: a decode that succeeds must be inspectable, and the
+        // summary must agree with the envelope it summarizes.
+        const auto info = codec::inspect(*envelope);
+        if (info.requestId != envelope->request_id
+            || info.protocolMajor != envelope->protocol_major
+            || info.protocolMinorVersion != envelope->protocol_minor_version) {
+            amrvis::fuzz::fail("codec::inspect disagrees with its envelope");
+        }
+        exerciseFromWire(*envelope);
+    } catch (const std::exception&) {
+        // Expected rejection path (the codec's documented contract).
+    } catch (...) {
+        amrvis::fuzz::fail("the wire codec let a non-std::exception escape");
+    }
+}
+
+#if !defined(AMREXPLORER_LIBFUZZER)
+// Seeds across the payload arms, including the vector-bearing responses whose
+// fromWire converters hold the length/content validation -- mutations of these
+// are what actually reach validateResultVectors with near-valid data.
 std::vector<std::vector<std::uint8_t>> wireSeeds()
 {
-    namespace codec = amrvis::remote::codec;
     std::vector<std::vector<std::uint8_t>> seeds;
     {
-        codec::fb::PingRequestT ping;
+        fb::PingRequestT ping;
         ping.nonce = 7;
         seeds.push_back(codec::encode(1, std::move(ping)));
     }
     {
-        codec::fb::HelloRequestT hello;
+        fb::HelloRequestT hello;
         hello.client_name = "fuzz";
         hello.maximum_frame_bytes = 1 << 20;
         hello.maximum_minor_version = 1;
         seeds.push_back(codec::encode(2, std::move(hello)));
     }
     {
-        codec::fb::ErrorResponseT error;
+        fb::ErrorResponseT error;
         error.message = "boom";
         seeds.push_back(codec::encode(3, std::move(error)));
     }
+    {
+        fb::SliceViewResponseT slice;
+        slice.width = 2;
+        slice.height = 2;
+        slice.physical_region = std::make_unique<fb::RealBoxT>();
+        slice.values = {1.0F, 2.0F, 3.0F, 4.0F};
+        slice.valid = {1, 1, 1, 1};
+        slice.source_level = {0, 0, 0, 0};
+        seeds.push_back(codec::encode(4, std::move(slice)));
+    }
+    {
+        fb::LineViewResponseT line;
+        line.positions = {0.5, 1.5};
+        line.values = {1.0, 2.0};
+        line.valid = {1, 1};
+        line.source_level = {0, 0};
+        seeds.push_back(codec::encode(5, std::move(line)));
+    }
+    {
+        fb::ParticleSampleResponseT particles;
+        particles.ids = {11, 12};
+        particles.positions = {0.0, 0.0, 0.0, 1.0, 1.0, 1.0};
+        seeds.push_back(codec::encode(6, std::move(particles)));
+    }
+    {
+        fb::SliceViewRequestT request;
+        request.dataset_id = 1;
+        request.field = 0;
+        request.visible_region = std::make_unique<fb::RealBoxT>();
+        request.width = 4;
+        request.height = 4;
+        seeds.push_back(codec::encode(7, std::move(request)));
+    }
     return seeds;
 }
+#endif
 
 } // namespace
 
 #if defined(AMREXPLORER_LIBFUZZER)
 extern "C" int LLVMFuzzerTestOneInput(const std::uint8_t* data, std::size_t size)
 {
+    amrvis::fuzz::setCurrentInput(0, data, size);
     exerciseWire({data, size});
     return 0;
 }
@@ -68,10 +189,24 @@ int main()
     constexpr int iterations = 60000;
     std::uint64_t rng = 0x1234'5678'9abc'def0ULL;
     const auto seeds = wireSeeds();
+    long iteration = 0;
     for (int i = 0; i < iterations; ++i) {
-        exerciseWire(amrvis::fuzz::randomBytes(rng, 512));
-        exerciseWire(amrvis::fuzz::mutate(
-            rng, seeds[amrvis::fuzz::nextRandom(rng) % seeds.size()]));
+        // Purely random bytes can never carry the AVR2 file identifier, so
+        // decode would reject every one at its first check and the verifier
+        // would sit idle. Stamp the identifier at its flatbuffer offset
+        // (bytes 4..8) on half the buffers so random inputs reach the
+        // verifier and the envelope checks too.
+        auto bytes = amrvis::fuzz::randomBytes(rng, 512);
+        if (bytes.size() >= 8 && (i % 2) == 0) {
+            std::memcpy(bytes.data() + 4, "AVR2", 4);
+        }
+        amrvis::fuzz::setCurrentInput(iteration++, bytes.data(), bytes.size());
+        exerciseWire(bytes);
+        const auto mutated = amrvis::fuzz::mutate(
+            rng, seeds[amrvis::fuzz::nextRandom(rng) % seeds.size()]);
+        amrvis::fuzz::setCurrentInput(
+            iteration++, mutated.data(), mutated.size());
+        exerciseWire(mutated);
     }
     std::printf("fuzz_wire_codec: %d iterations, no crash\n", iterations);
     return 0;

--- a/tests/fuzz/fuzz_wire_codec.cpp
+++ b/tests/fuzz/fuzz_wire_codec.cpp
@@ -18,8 +18,10 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
+#include <memory>
 #include <span>
 #include <stdexcept>
+#include <utility>
 #include <vector>
 
 namespace {
@@ -88,6 +90,9 @@ void exerciseFromWire(const codec::NativeEnvelope& envelope)
     case fb::Payload::RangeResponse:
         convert(envelope.payload.AsRangeResponse());
         break;
+    case fb::Payload::ErrorResponse:
+        convert(envelope.payload.AsErrorResponse());
+        break;
     default:
         break;  // trivial payloads (ping/pong/cancel/...) have no converter
     }
@@ -114,38 +119,137 @@ void exerciseWire(std::span<const std::uint8_t> bytes)
 }
 
 #if !defined(AMREXPLORER_LIBFUZZER)
-// Seeds across the payload arms, including the vector-bearing responses whose
-// fromWire converters hold the length/content validation -- mutations of these
-// are what actually reach validateResultVectors with near-valid data.
+std::unique_ptr<fb::Real3T> real3(double x, double y, double z)
+{
+    auto value = std::make_unique<fb::Real3T>();
+    value->values = {x, y, z};
+    return value;
+}
+
+std::unique_ptr<fb::Int3T> int3(int x, int y, int z)
+{
+    auto value = std::make_unique<fb::Int3T>();
+    value->values = {x, y, z};
+    return value;
+}
+
+std::unique_ptr<fb::RealBoxT> unitBox()
+{
+    auto box = std::make_unique<fb::RealBoxT>();
+    box->lower = real3(0.0, 0.0, 0.0);
+    box->upper = real3(1.0, 1.0, 1.0);
+    return box;
+}
+
+// One seed per fromWire converter arm (plus a trivial ping), each valid enough
+// to pass its converter unmutated -- main() checks that -- so mutations reach
+// the deep validators (validateResultVectors, finite-value and enum checks)
+// with near-valid data instead of dying at a converter's first check.
 std::vector<std::vector<std::uint8_t>> wireSeeds()
 {
     std::vector<std::vector<std::uint8_t>> seeds;
+    std::uint64_t requestId = 0;
+    const auto add = [&](auto payload) {
+        seeds.push_back(codec::encode(++requestId, std::move(payload)));
+    };
     {
         fb::PingRequestT ping;
         ping.nonce = 7;
-        seeds.push_back(codec::encode(1, std::move(ping)));
+        add(std::move(ping));
     }
     {
         fb::HelloRequestT hello;
         hello.client_name = "fuzz";
         hello.maximum_frame_bytes = 1 << 20;
         hello.maximum_minor_version = 1;
-        seeds.push_back(codec::encode(2, std::move(hello)));
+        add(std::move(hello));
     }
     {
-        fb::ErrorResponseT error;
-        error.message = "boom";
-        seeds.push_back(codec::encode(3, std::move(error)));
+        fb::HelloResponseT hello;
+        hello.server_name = "fuzz";
+        hello.maximum_frame_bytes = 1 << 20;
+        hello.maximum_datasets = 2;
+        hello.capabilities = {1, 2};
+        add(std::move(hello));
+    }
+    {
+        fb::OpenDatasetRequestT open;
+        open.path = "/plt00000";
+        open.cache_budget_bytes = 1 << 20;
+        add(std::move(open));
+    }
+    {
+        // Two fields on a one-level, two-box catalog: the smallest shape that
+        // exercises every count check in fromWire(DatasetOpenedT).
+        fb::DatasetOpenedT opened;
+        opened.dataset_id = 1;
+        opened.dimension = 3;
+        opened.finest_level = 0;
+        opened.time = 0.5;
+        opened.physical_domain = unitBox();
+        for (const char* name : {"density", "pressure"}) {
+            auto field = std::make_unique<fb::FieldCatalogT>();
+            field->name = name;
+            opened.fields.push_back(std::move(field));
+        }
+        auto level = std::make_unique<fb::LevelCatalogT>();
+        auto domain = std::make_unique<fb::IntBoxT>();
+        domain->lower = int3(0, 0, 0);
+        domain->upper = int3(3, 3, 3);
+        domain->centering = int3(0, 0, 0);
+        level->domain = std::move(domain);
+        level->cell_size = real3(0.25, 0.25, 0.25);
+        level->index_origin = real3(0.0, 0.0, 0.0);
+        for (int lo : {0, 2}) {
+            auto box = std::make_unique<fb::IntBoxT>();
+            box->lower = int3(lo, 0, 0);
+            box->upper = int3(lo + 1, 3, 3);
+            box->centering = int3(0, 0, 0);
+            level->boxes.push_back(std::move(box));
+        }
+        opened.levels.push_back(std::move(level));
+        auto species = std::make_unique<fb::ParticleSpeciesCatalogT>();
+        species->name = "electrons";
+        species->dimension = 3;
+        opened.particle_species.push_back(std::move(species));
+        opened.file_range_available = {1, 1};
+        opened.level_range_available = {1, 0};
+        opened.metadata_metrics = std::make_unique<fb::MetadataReadMetricsT>();
+        opened.cache = std::make_unique<fb::CacheStateT>();
+        add(std::move(opened));
+    }
+    {
+        fb::SliceViewRequestT request;
+        request.dataset_id = 1;
+        request.field = 0;
+        request.visible_region = unitBox();
+        request.width = 4;
+        request.height = 4;
+        add(std::move(request));
     }
     {
         fb::SliceViewResponseT slice;
         slice.width = 2;
         slice.height = 2;
-        slice.physical_region = std::make_unique<fb::RealBoxT>();
+        slice.physical_region = unitBox();
         slice.values = {1.0F, 2.0F, 3.0F, 4.0F};
         slice.valid = {1, 1, 1, 1};
         slice.source_level = {0, 0, 0, 0};
-        seeds.push_back(codec::encode(4, std::move(slice)));
+        auto gridBox = std::make_unique<fb::SliceGridBoxT>();
+        gridBox->physical_region = unitBox();
+        slice.grid_boxes.push_back(std::move(gridBox));
+        slice.cache = std::make_unique<fb::CacheStateT>();
+        add(std::move(slice));
+    }
+    {
+        fb::LineViewRequestT request;
+        request.dataset_id = 1;
+        request.axis = 0;
+        request.fixed_coordinates = real3(0.5, 0.5, 0.5);
+        request.region = unitBox();
+        request.has_region = true;
+        request.output_width = 8;
+        add(std::move(request));
     }
     {
         fb::LineViewResponseT line;
@@ -153,22 +257,69 @@ std::vector<std::vector<std::uint8_t>> wireSeeds()
         line.values = {1.0, 2.0};
         line.valid = {1, 1};
         line.source_level = {0, 0};
-        seeds.push_back(codec::encode(5, std::move(line)));
+        line.cache = std::make_unique<fb::CacheStateT>();
+        add(std::move(line));
+    }
+    {
+        fb::DatasetPageRequestT request;
+        request.dataset_id = 1;
+        request.region = unitBox();
+        request.slice_position = 0.5;
+        request.maximum_extent = 8;
+        add(std::move(request));
+    }
+    {
+        fb::DatasetPageResponseT page;
+        page.lower = {0, 0};
+        page.upper = {1, 1};
+        page.nx = 2;
+        page.ny = 2;
+        page.values = {1.0F, 2.0F, 3.0F, 4.0F};
+        page.covered = {1, 1, 1, 1};
+        page.minimum = 1.0;
+        page.maximum = 4.0;
+        page.has_finite_values = true;
+        page.cache = std::make_unique<fb::CacheStateT>();
+        add(std::move(page));
+    }
+    {
+        fb::ParticleSampleRequestT request;
+        request.dataset_id = 1;
+        request.species = "electrons";
+        request.fraction = 0.5;
+        request.seed = 3;
+        add(std::move(request));
     }
     {
         fb::ParticleSampleResponseT particles;
+        particles.species = std::make_unique<fb::ParticleSpeciesCatalogT>();
+        particles.species->name = "electrons";
+        particles.species->dimension = 3;
         particles.ids = {11, 12};
         particles.positions = {0.0, 0.0, 0.0, 1.0, 1.0, 1.0};
-        seeds.push_back(codec::encode(6, std::move(particles)));
+        particles.cache = std::make_unique<fb::CacheStateT>();
+        add(std::move(particles));
     }
     {
-        fb::SliceViewRequestT request;
+        fb::RangeRequestT request;
         request.dataset_id = 1;
         request.field = 0;
-        request.visible_region = std::make_unique<fb::RealBoxT>();
-        request.width = 4;
-        request.height = 4;
-        seeds.push_back(codec::encode(7, std::move(request)));
+        request.scope = fb::RangeScope::Level;
+        add(std::move(request));
+    }
+    {
+        fb::RangeResponseT range;
+        range.has_range = true;
+        range.minimum = -1.0;
+        range.maximum = 1.0;
+        range.cache = std::make_unique<fb::CacheStateT>();
+        add(std::move(range));
+    }
+    {
+        fb::ErrorResponseT error;
+        error.code = fb::ErrorCode::InvalidRequest;
+        error.message = "boom";
+        add(std::move(error));
     }
     return seeds;
 }
@@ -190,6 +341,16 @@ int main()
     std::uint64_t rng = 0x1234'5678'9abc'def0ULL;
     const auto seeds = wireSeeds();
     long iteration = 0;
+    // A seed its own converter rejects would only ever exercise that first
+    // check, so require every seed to decode and convert unmutated.
+    for (const auto& seed : seeds) {
+        amrvis::fuzz::setCurrentInput(iteration++, seed.data(), seed.size());
+        try {
+            exerciseFromWire(*codec::decode(seed));
+        } catch (const std::exception&) {
+            amrvis::fuzz::fail("a wire seed is rejected before mutation");
+        }
+    }
     for (int i = 0; i < iterations; ++i) {
         // Purely random bytes can never carry the AVR2 file identifier, so
         // decode would reject every one at its first check and the verifier

--- a/tests/fuzz/fuzz_wire_codec.cpp
+++ b/tests/fuzz/fuzz_wire_codec.cpp
@@ -1,0 +1,79 @@
+// Property/fuzz harness for the remote wire decoder -- the malicious-peer trust
+// boundary. Contract: codec::decode of arbitrary or near-valid bytes yields a
+// std::exception and never crashes, reads out of bounds, or lets a
+// non-std::exception escape. Run under the sanitizers preset to catch UB/OOB.
+// Deterministic and bounded so it runs as a normal ctest; build with
+// -DAMREXPLORER_LIBFUZZER for coverage-guided fuzzing.
+#include "fuzz_util.hpp"
+
+#include "Codec.hpp"
+
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <span>
+#include <stdexcept>
+#include <vector>
+
+namespace {
+
+void exerciseWire(std::span<const std::uint8_t> bytes)
+{
+    try {
+        auto envelope = amrvis::remote::codec::decode(bytes);
+        // A decode that succeeds must be inspectable without surprises.
+        static_cast<void>(amrvis::remote::codec::inspect(*envelope));
+    } catch (const std::exception&) {
+        // Expected rejection path.
+    } catch (...) {
+        amrvis::fuzz::fail("codec::decode let a non-std::exception escape");
+    }
+}
+
+std::vector<std::vector<std::uint8_t>> wireSeeds()
+{
+    namespace codec = amrvis::remote::codec;
+    std::vector<std::vector<std::uint8_t>> seeds;
+    {
+        codec::fb::PingRequestT ping;
+        ping.nonce = 7;
+        seeds.push_back(codec::encode(1, std::move(ping)));
+    }
+    {
+        codec::fb::HelloRequestT hello;
+        hello.client_name = "fuzz";
+        hello.maximum_frame_bytes = 1 << 20;
+        hello.maximum_minor_version = 1;
+        seeds.push_back(codec::encode(2, std::move(hello)));
+    }
+    {
+        codec::fb::ErrorResponseT error;
+        error.message = "boom";
+        seeds.push_back(codec::encode(3, std::move(error)));
+    }
+    return seeds;
+}
+
+} // namespace
+
+#if defined(AMREXPLORER_LIBFUZZER)
+extern "C" int LLVMFuzzerTestOneInput(const std::uint8_t* data, std::size_t size)
+{
+    exerciseWire({data, size});
+    return 0;
+}
+#else
+int main()
+{
+    constexpr int iterations = 60000;
+    std::uint64_t rng = 0x1234'5678'9abc'def0ULL;
+    const auto seeds = wireSeeds();
+    for (int i = 0; i < iterations; ++i) {
+        exerciseWire(amrvis::fuzz::randomBytes(rng, 512));
+        exerciseWire(amrvis::fuzz::mutate(
+            rng, seeds[amrvis::fuzz::nextRandom(rng) % seeds.size()]));
+    }
+    std::printf("fuzz_wire_codec: %d iterations, no crash\n", iterations);
+    return 0;
+}
+#endif

--- a/tests/fuzz/fuzz_wire_codec.cpp
+++ b/tests/fuzz/fuzz_wire_codec.cpp
@@ -2,18 +2,24 @@
 // codec::decode of arbitrary or near-valid bytes, inspect of the decoded
 // envelope, and every payload-matching fromWire converter (where the hostile
 // payload *contents* are validated -- vector length agreement, finite values,
-// enum ranges) yield a std::exception on rejection and never crash, read out
-// of bounds, or let a non-std::exception escape; an accepted envelope's
-// inspect() must agree with the envelope it summarizes. Run under the
-// qt-sanitizers preset to catch UB/OOB (the plain sanitizers preset builds
-// without remote support, so this target does not exist there). Deterministic
-// and bounded so it runs as a normal ctest; configure with
-// -DAMREXPLORER_LIBFUZZER=ON (Clang) to build it instead as a coverage-guided
-// libFuzzer driver.
+// enum ranges) yield a std::exception on rejection (the type production
+// catches, see Server.cpp/Connection.cpp) and never crash, read out of
+// bounds, or let a non-std::exception escape; a decoded envelope is
+// inspectable and its summary agrees with it; an accepted payload satisfies
+// what its converter claims to have validated (checkConverted below). Run
+// under the qt-sanitizers preset to catch UB/OOB (the plain sanitizers preset
+// builds without remote support, so this target does not exist there).
+// Deterministic and bounded so it runs as a normal ctest; configure with
+// -DAMREXPLORER_LIBFUZZER=ON (Clang), together with
+// AMREXPLORER_ENABLE_SANITIZERS=ON so the fuzzer sees UB/OOB and not only
+// hard crashes, to build it instead as a coverage-guided libFuzzer driver.
 #include "fuzz_util.hpp"
 
 #include "Codec.hpp"
 
+#include <algorithm>
+#include <array>
+#include <cmath>
 #include <cstddef>
 #include <cstdint>
 #include <cstdio>
@@ -29,22 +35,264 @@ namespace {
 namespace codec = amrvis::remote::codec;
 namespace fb = codec::fb;
 
+using amrvis::fuzz::fail;
+
+bool finite(double value)
+{
+    return std::isfinite(value);
+}
+
+bool finite(const amrvis::Real3& value)
+{
+    return std::all_of(value.values.begin(), value.values.end(),
+        [](double component) { return std::isfinite(component); });
+}
+
+bool finite(const amrvis::RealBox& box)
+{
+    return finite(box.lower) && finite(box.upper);
+}
+
+// Bitwise equality: sample values may legitimately be NaN, which == denies.
+bool sameBits(const std::vector<float>& a, const std::vector<float>& b)
+{
+    return a.size() == b.size()
+        && (a.empty()
+            || std::memcmp(a.data(), b.data(), a.size() * sizeof(float)) == 0);
+}
+
+// Postconditions of an accepted payload: what its fromWire converter claims
+// to have validated (vector-length agreement, finite values, enum ranges,
+// well-formed ranges) and that what it copies is the wire's own data -- so a
+// converter that stops validating, or transposes, fails here instead of
+// passing as "no crash".
+void checkConverted(
+    const fb::HelloRequestT& wire, const amrvis::remote::HelloRequestData& result)
+{
+    if (result.clientName != wire.client_name
+        || result.sessionToken != wire.session_token
+        || result.maximumFrameBytes != wire.maximum_frame_bytes
+        || result.capabilities != wire.capabilities) {
+        fail("HelloRequest did not convert faithfully");
+    }
+}
+
+void checkConverted(const fb::HelloResponseT& wire,
+    const amrvis::remote::HelloResponseData& result)
+{
+    if (result.serverName != wire.server_name
+        || result.maximumFrameBytes != wire.maximum_frame_bytes
+        || result.capabilities != wire.capabilities) {
+        fail("HelloResponse did not convert faithfully");
+    }
+}
+
+void checkConverted(const fb::OpenDatasetRequestT& wire,
+    const amrvis::remote::OpenDatasetData& result)
+{
+    if (result.path != wire.path
+        || result.cacheBudgetBytes != wire.cache_budget_bytes) {
+        fail("OpenDatasetRequest did not convert faithfully");
+    }
+}
+
+void checkConverted(
+    const fb::DatasetOpenedT& wire, const amrvis::remote::OpenedDataset& result)
+{
+    const auto& catalog = result.catalog;
+    const auto levels = catalog.levels.size();
+    if (catalog.dimension < 1 || catalog.dimension > 3
+        || catalog.finestLevel < 0
+        || levels != static_cast<std::size_t>(catalog.finestLevel) + 1
+        || levels != wire.levels.size()
+        || catalog.fields.size() != wire.fields.size()
+        || result.particleSpecies.size() != wire.particle_species.size()
+        || result.fileRangeAvailable.size() != catalog.fields.size()
+        || result.levelRangeAvailable.size() != catalog.fields.size() * levels
+        || !finite(catalog.time) || !finite(catalog.physicalDomain)) {
+        fail("DatasetOpened converter accepted an inconsistent catalog");
+    }
+    for (std::size_t i = 0; i < levels; ++i) {
+        const auto& level = catalog.levels[i];
+        if (level.boxes.size() != wire.levels[i]->boxes.size()
+            || !finite(level.cellSize) || !finite(level.indexOrigin)) {
+            fail("DatasetOpened converter accepted an inconsistent level");
+        }
+    }
+}
+
+void checkConverted(
+    const fb::SliceViewRequestT& wire, const amrvis::SliceRequest& result)
+{
+    if (!finite(result.visibleRegion) || !finite(result.physicalPosition)
+        || result.outputSize != std::array{wire.width, wire.height}
+        || result.dataset.value != wire.dataset_id) {
+        fail("SliceViewRequest converter accepted a bad request");
+    }
+}
+
+void checkConverted(
+    const fb::SliceViewResponseT& wire, const amrvis::SliceQueryResult& result)
+{
+    const auto& plane = result.plane;
+    if (plane.width < 1 || plane.height < 1) {
+        fail("SliceViewResponse converter accepted bad dimensions");
+    }
+    const auto expected = static_cast<std::size_t>(plane.width)
+        * static_cast<std::size_t>(plane.height);
+    if (plane.values.size() != expected || plane.valid.size() != expected
+        || plane.sourceLevel.size() != expected
+        || !sameBits(plane.values, wire.values)
+        || !finite(plane.physicalRegion)
+        || result.gridBoxes.size() != wire.grid_boxes.size()) {
+        fail("SliceViewResponse converter accepted inconsistent vectors");
+    }
+    for (const auto& box : result.gridBoxes) {
+        if (!finite(box.physicalRegion)) {
+            fail("SliceViewResponse converter accepted a non-finite grid box");
+        }
+    }
+}
+
+void checkConverted(
+    const fb::LineViewRequestT& wire, const amrvis::LineViewRequest& result)
+{
+    if (!finite(amrvis::Real3{result.query.fixedCoordinates})
+        || result.query.region.has_value() != wire.has_region
+        || (result.query.region && !finite(*result.query.region))) {
+        fail("LineViewRequest converter accepted a bad request");
+    }
+}
+
+void checkConverted(
+    const fb::LineViewResponseT& wire, const amrvis::LineQueryResult& result)
+{
+    const auto& line = result.line;
+    const auto expected = line.positions.size();
+    if (line.values.size() != expected || line.valid.size() != expected
+        || line.sourceLevel.size() != expected
+        || line.positions != wire.positions
+        || !std::all_of(line.positions.begin(), line.positions.end(),
+            [](double position) { return std::isfinite(position); })) {
+        fail("LineViewResponse converter accepted inconsistent vectors");
+    }
+}
+
+void checkConverted(
+    const fb::DatasetPageRequestT& wire, const amrvis::DatasetPageRequest& result)
+{
+    if (!finite(result.region) || !finite(result.slicePosition)
+        || result.slicePosition != wire.slice_position) {
+        fail("DatasetPageRequest converter accepted a bad request");
+    }
+}
+
+void checkConverted(
+    const fb::DatasetPageResponseT& wire, const amrvis::DatasetPage& result)
+{
+    if (result.nx < 0 || result.ny < 0
+        || result.nx > amrvis::datasetPageMaxExtent
+        || result.ny > amrvis::datasetPageMaxExtent) {
+        fail("DatasetPageResponse converter accepted a bad extent");
+    }
+    const auto expected = static_cast<std::size_t>(result.nx)
+        * static_cast<std::size_t>(result.ny);
+    if (result.values.size() != expected || result.covered.size() != expected
+        || !sameBits(result.values, wire.values) || wire.lower.size() != 2
+        || wire.upper.size() != 2
+        || !std::equal(result.lower.begin(), result.lower.end(),
+            wire.lower.begin())) {
+        fail("DatasetPageResponse converter accepted inconsistent vectors");
+    }
+    if (result.hasFiniteValues
+        && (!finite(result.minimum) || !finite(result.maximum)
+            || result.minimum > result.maximum)) {
+        fail("DatasetPageResponse converter accepted a bad value range");
+    }
+}
+
+void checkConverted(const fb::ParticleSampleRequestT& wire,
+    const codec::ParticleSampleRequestData& result)
+{
+    if (result.species.empty() || result.species != wire.species
+        || !(result.fraction > 0.0) || result.fraction > 1.0) {
+        fail("ParticleSampleRequest converter accepted a bad request");
+    }
+}
+
+void checkConverted(
+    const fb::ParticleSampleResponseT& wire, const amrvis::ParticleSample& result)
+{
+    if (result.points.size() != wire.ids.size()
+        || wire.positions.size() != 3 * result.points.size()) {
+        fail("ParticleSampleResponse converter accepted inconsistent vectors");
+    }
+    for (std::size_t i = 0; i < result.points.size(); ++i) {
+        const auto& point = result.points[i];
+        if (point.id != wire.ids[i] || !finite(point.position)
+            || !std::equal(point.position.values.begin(),
+                point.position.values.end(),
+                wire.positions.begin() + static_cast<std::ptrdiff_t>(3 * i))) {
+            fail("ParticleSampleResponse converter misread a particle");
+        }
+    }
+}
+
+void checkConverted(const fb::RangeRequestT& wire,
+    const std::pair<amrvis::DatasetId, amrvis::RangeRequest>& result)
+{
+    // The enums went through fromWire; sending them back must reproduce the
+    // wire values, or the mapping is not the bijection the server relies on.
+    const auto roundTrip = codec::toWire(result.first, result.second);
+    if (result.first.value != wire.dataset_id
+        || result.second.field.value != wire.field
+        || roundTrip.composition != wire.composition
+        || roundTrip.scope != wire.scope) {
+        fail("RangeRequest did not convert faithfully");
+    }
+}
+
+void checkConverted(const fb::RangeResponseT& wire,
+    const std::optional<amrvis::ValueRange>& result)
+{
+    if (result.has_value() != wire.has_range) {
+        fail("RangeResponse converter lost the has_range flag");
+    }
+    if (result
+        && (!finite(result->minimum) || !finite(result->maximum)
+            || result->minimum > result->maximum
+            || result->minimum != wire.minimum
+            || result->maximum != wire.maximum)) {
+        fail("RangeResponse converter accepted a bad range");
+    }
+}
+
+void checkConverted(
+    const fb::ErrorResponseT& wire, const amrvis::remote::ErrorData& result)
+{
+    if (result.message != wire.message || codec::toWire(result).code != wire.code) {
+        fail("ErrorResponse did not convert faithfully");
+    }
+}
+
 // fromWire on a payload pointer, mirroring the server: a null pointer (the
 // union tag disagreeing with the stored table on a crafted buffer) is the
-// server's "payload is missing" rejection, not a dereference.
+// server's "payload is missing" rejection, not a dereference. An accepted
+// payload must satisfy its checkConverted postconditions.
 template <typename Payload>
 void convert(const Payload* payload)
 {
     if (payload != nullptr) {
-        static_cast<void>(codec::fromWire(*payload));
+        checkConverted(*payload, codec::fromWire(*payload));
     }
 }
 
 // Route a decoded envelope's payload through the matching fromWire converter
 // -- the layer where the server/client actually validate hostile payload
-// contents (validateResultVectors, finite-value and enum checks). Only arms
-// with a nontrivial converter are dispatched; a converter throwing
-// std::exception is the expected rejection.
+// contents (validateResultVectors, finite-value and enum checks). Every arm
+// is named (no default) so a new payload type fails to compile here under
+// -Wswitch until it is either converted or listed as trivial; a converter
+// throwing std::exception is the expected rejection.
 void exerciseFromWire(const codec::NativeEnvelope& envelope)
 {
     switch (envelope.payload.type) {
@@ -93,28 +341,52 @@ void exerciseFromWire(const codec::NativeEnvelope& envelope)
     case fb::Payload::ErrorResponse:
         convert(envelope.payload.AsErrorResponse());
         break;
-    default:
-        break;  // trivial payloads (ping/pong/cancel/...) have no converter
+    case fb::Payload::NONE:
+    case fb::Payload::CloseDatasetRequest:
+    case fb::Payload::DatasetClosed:
+    case fb::Payload::ClearCacheRequest:
+    case fb::Payload::SetCacheBudgetRequest:
+    case fb::Payload::CacheResponse:
+    case fb::Payload::CancelRequest:
+    case fb::Payload::CancelAcknowledged:
+    case fb::Payload::PingRequest:
+    case fb::Payload::PongResponse:
+        break;  // trivial payloads: no converter, nothing to validate
     }
 }
 
 void exerciseWire(std::span<const std::uint8_t> bytes)
 {
+    std::unique_ptr<codec::NativeEnvelope> envelope;
     try {
-        auto envelope = codec::decode(bytes);
-        // Postcondition: a decode that succeeds must be inspectable, and the
-        // summary must agree with the envelope it summarizes.
+        envelope = codec::decode(bytes);
+    } catch (const std::exception&) {
+        return;  // the documented rejection, and what production catches
+    } catch (...) {
+        fail("codec::decode let a non-std::exception escape");
+    }
+    // Postcondition: a decoded envelope is inspectable -- outside the
+    // rejection catch, so an inspect that throws is a failure, not a clean
+    // rejection -- and the summary agrees with it, payload kind included: the
+    // one field that is a translation, and the one the server dispatches on.
+    try {
         const auto info = codec::inspect(*envelope);
         if (info.requestId != envelope->request_id
             || info.protocolMajor != envelope->protocol_major
-            || info.protocolMinorVersion != envelope->protocol_minor_version) {
-            amrvis::fuzz::fail("codec::inspect disagrees with its envelope");
+            || info.protocolMinorVersion != envelope->protocol_minor_version
+            || static_cast<std::uint8_t>(info.payload)
+                != static_cast<std::uint8_t>(envelope->payload.type)) {
+            fail("codec::inspect disagrees with its envelope");
         }
+    } catch (const std::exception&) {
+        fail("codec::inspect rejected an envelope decode accepted");
+    }
+    try {
         exerciseFromWire(*envelope);
     } catch (const std::exception&) {
         // Expected rejection path (the codec's documented contract).
     } catch (...) {
-        amrvis::fuzz::fail("the wire codec let a non-std::exception escape");
+        fail("a fromWire converter let a non-std::exception escape");
     }
 }
 
@@ -179,12 +451,15 @@ std::vector<std::vector<std::uint8_t>> wireSeeds()
         add(std::move(open));
     }
     {
-        // Two fields on a one-level, two-box catalog: the smallest shape that
-        // exercises every count check in fromWire(DatasetOpenedT).
+        // Two fields on a two-level, two-box catalog: the smallest shape that
+        // exercises every count check in fromWire(DatasetOpenedT). Two levels
+        // rather than one so finest_level is non-default and therefore
+        // present in the buffer for the mutator to reach (FlatBuffers omits
+        // default-valued scalars).
         fb::DatasetOpenedT opened;
         opened.dataset_id = 1;
         opened.dimension = 3;
-        opened.finest_level = 0;
+        opened.finest_level = 1;
         opened.time = 0.5;
         opened.physical_domain = unitBox();
         for (const char* name : {"density", "pressure"}) {
@@ -192,28 +467,34 @@ std::vector<std::vector<std::uint8_t>> wireSeeds()
             field->name = name;
             opened.fields.push_back(std::move(field));
         }
-        auto level = std::make_unique<fb::LevelCatalogT>();
-        auto domain = std::make_unique<fb::IntBoxT>();
-        domain->lower = int3(0, 0, 0);
-        domain->upper = int3(3, 3, 3);
-        domain->centering = int3(0, 0, 0);
-        level->domain = std::move(domain);
-        level->cell_size = real3(0.25, 0.25, 0.25);
-        level->index_origin = real3(0.0, 0.0, 0.0);
-        for (int lo : {0, 2}) {
-            auto box = std::make_unique<fb::IntBoxT>();
-            box->lower = int3(lo, 0, 0);
-            box->upper = int3(lo + 1, 3, 3);
-            box->centering = int3(0, 0, 0);
-            level->boxes.push_back(std::move(box));
+        for (int refinement : {1, 2}) {
+            auto level = std::make_unique<fb::LevelCatalogT>();
+            level->level = refinement - 1;
+            auto domain = std::make_unique<fb::IntBoxT>();
+            domain->lower = int3(0, 0, 0);
+            domain->upper = int3(4 * refinement - 1, 4 * refinement - 1,
+                4 * refinement - 1);
+            domain->centering = int3(0, 0, 0);
+            level->domain = std::move(domain);
+            level->cell_size = real3(
+                0.25 / refinement, 0.25 / refinement, 0.25 / refinement);
+            level->index_origin = real3(0.0, 0.0, 0.0);
+            for (int lo : {0, 2}) {
+                auto box = std::make_unique<fb::IntBoxT>();
+                box->lower = int3(lo * refinement, 0, 0);
+                box->upper = int3(
+                    lo * refinement + 1, 4 * refinement - 1, 4 * refinement - 1);
+                box->centering = int3(0, 0, 0);
+                level->boxes.push_back(std::move(box));
+            }
+            opened.levels.push_back(std::move(level));
         }
-        opened.levels.push_back(std::move(level));
         auto species = std::make_unique<fb::ParticleSpeciesCatalogT>();
         species->name = "electrons";
         species->dimension = 3;
         opened.particle_species.push_back(std::move(species));
         opened.file_range_available = {1, 1};
-        opened.level_range_available = {1, 0};
+        opened.level_range_available = {1, 0, 1, 1};
         opened.metadata_metrics = std::make_unique<fb::MetadataReadMetricsT>();
         opened.cache = std::make_unique<fb::CacheStateT>();
         add(std::move(opened));
@@ -348,7 +629,25 @@ int main()
         try {
             exerciseFromWire(*codec::decode(seed));
         } catch (const std::exception&) {
-            amrvis::fuzz::fail("a wire seed is rejected before mutation");
+            fail("a wire seed is rejected before mutation");
+        }
+    }
+    // Systematic single-byte corruption of every seed: each byte set to each
+    // of a few extreme values, so every field of every payload -- counts,
+    // enum tags, offsets, the top byte of every double -- is perturbed
+    // deterministically rather than when the random stream happens to land
+    // on it (a ~800-byte seed sees a given byte only a few times in 60000
+    // random edits).
+    for (const auto& seed : seeds) {
+        for (std::size_t offset = 0; offset < seed.size(); ++offset) {
+            for (const std::uint8_t value : std::array<std::uint8_t, 5>{
+                     0x00, 0x01, 0x7F, 0x80, 0xFF}) {
+                auto corrupted = seed;
+                corrupted[offset] = value;
+                amrvis::fuzz::setCurrentInput(
+                    iteration++, corrupted.data(), corrupted.size());
+                exerciseWire(corrupted);
+            }
         }
     }
     for (int i = 0; i < iterations; ++i) {
@@ -356,7 +655,9 @@ int main()
         // decode would reject every one at its first check and the verifier
         // would sit idle. Stamp the identifier at its flatbuffer offset
         // (bytes 4..8) on half the buffers so random inputs reach the
-        // verifier and the envelope checks too.
+        // Verifier -- its rejection paths on garbage are the target here; a
+        // random root offset and vtable never pass it, so the mutated seeds
+        // below are what reach the envelope checks and the converters.
         auto bytes = amrvis::fuzz::randomBytes(rng, 512);
         if (bytes.size() >= 8 && (i % 2) == 0) {
             std::memcpy(bytes.data() + 4, "AVR2", 4);

--- a/tests/unit/test_remote_codec.cpp
+++ b/tests/unit/test_remote_codec.cpp
@@ -2,6 +2,7 @@
 
 #include <array>
 #include <cstdlib>
+#include <cstring>
 #include <iostream>
 #include <limits>
 #include <memory>
@@ -45,6 +46,36 @@ amrvis::remote::codec::Bytes preCapabilitiesHelloFixture()
         amrvis::remote::protocolMajor,
         amrvis::remote::protocolMinorVersion, 41,
         codec::fb::Payload::HelloRequest, hello.Union());
+    codec::fb::FinishEnvelopeBuffer(builder, envelope);
+    return {builder.GetBufferPointer(),
+        builder.GetBufferPointer() + builder.GetSize()};
+}
+
+// A LineViewResponse whose [double] positions vector is only 4-byte aligned,
+// which flatbuffers' own Verifier permits (it checks the vector's length
+// prefix, not its elements). `pad` shifts the vector by four bytes relative to
+// the buffer start, so exactly one of the two layouts leaves the doubles
+// misaligned and the other is the control that must still decode.
+amrvis::remote::codec::Bytes fourByteAlignedPositionsFixture(bool pad)
+{
+    namespace codec = amrvis::remote::codec;
+    flatbuffers::FlatBufferBuilder builder;
+    if (pad) {
+        // An orphan empty vector: four bytes nothing references, which shifts
+        // everything built after it (hence before it in memory) by four.
+        static_cast<void>(builder.CreateVector(std::vector<std::uint8_t>{}));
+    }
+    std::uint8_t* raw = nullptr;
+    const flatbuffers::Offset<flatbuffers::Vector<double>> positions(
+        builder.CreateUninitializedVector(2, sizeof(double), 4, &raw));
+    const std::array<double, 2> values{0.5, 1.5};
+    std::memcpy(raw, values.data(), sizeof(values));
+    const auto response
+        = codec::fb::CreateLineViewResponse(builder, 0, false, positions);
+    const auto envelope = codec::fb::CreateEnvelope(builder,
+        amrvis::remote::protocolMajor,
+        amrvis::remote::protocolMinorVersion, 43,
+        codec::fb::Payload::LineViewResponse, response.Union());
     codec::fb::FinishEnvelopeBuffer(builder, envelope);
     return {builder.GetBufferPointer(),
         builder.GetBufferPointer() + builder.GetSize()};
@@ -212,6 +243,33 @@ int main()
         zeroIdBuilder.GetBufferPointer(), zeroIdBuilder.GetSize());
     requireRejected([&] { static_cast<void>(codec::decode(zeroIdBytes)); },
         "zero request ID was accepted while decoding");
+
+    // flatbuffers' Verifier does not check vector element alignment, so
+    // decode must reject a misaligned [double] vector itself rather than let
+    // UnPack read it.
+    int misalignedLayouts = 0;
+    for (const bool pad : {false, true}) {
+        const auto layout = fourByteAlignedPositionsFixture(pad);
+        flatbuffers::Verifier verifier(layout.data(), layout.size());
+        require(codec::fb::VerifyEnvelopeBuffer(verifier),
+            "four-byte-aligned positions layout failed the verifier");
+        const auto* positions = codec::fb::GetEnvelope(layout.data())
+            ->payload_as_LineViewResponse()->positions();
+        const bool aligned = static_cast<std::size_t>(
+            positions->Data() - layout.data()) % alignof(double) == 0;
+        if (aligned) {
+            const auto decodedLayout = codec::decode(layout);
+            require(decodedLayout->payload.AsLineViewResponse()->positions
+                    == std::vector<double>{0.5, 1.5},
+                "aligned positions layout did not decode");
+        } else {
+            ++misalignedLayouts;
+            requireRejected([&] { static_cast<void>(codec::decode(layout)); },
+                "misaligned [double] vector was accepted while decoding");
+        }
+    }
+    require(misalignedLayouts == 1,
+        "the fixture did not produce a misaligned [double] layout");
 
     codec::fb::SliceViewResponseT inconsistent;
     inconsistent.width = 2;


### PR DESCRIPTION
Two deterministic, bounded harnesses that feed random and near-valid (mutated) input to the two trust boundaries and assert the contract that malformed input throws a std::exception and never crashes, reads out of bounds, or lets a non-std::exception escape:

- fuzz_wire_codec: codec::decode (the malicious-peer wire boundary).
- fuzz_header_parsing: the FAB/VisMF header parsing helpers (crafted plotfiles); no remote dependency, so it also runs under the sanitizers preset regardless of remote support.

Registered as ordinary ctests (fixed seed, generous timeout) so they run without flaking; run under the sanitizers preset to catch UB/OOB, or build with -DAMREXPLORER_LIBFUZZER for coverage-guided fuzzing. Both are clean at 60k iterations under ASan+UBSan today.