### PR TITLE
share the block index between the slice and line queries

### DIFF
--- a/include/amrexplorer/query/detail/BlockLookup.hpp
+++ b/include/amrexplorer/query/detail/BlockLookup.hpp
@@ -152,31 +152,52 @@ public:
         : m_axis0(axes[0])
         , m_axis1(axes[1])
     {
-        if (blocks.empty()) {
-            return;
-        }
         m_blockCount = blocks.size();
         const bool singleAxis = m_axis0 == m_axis1;
         const auto a0 = static_cast<std::size_t>(m_axis0);
         const auto a1 = static_cast<std::size_t>(m_axis1);
+        // A box inverted on a binned axis contains no point (contains() can
+        // never match it), so it takes no part in the index: not in the
+        // bounds, the tile sizing, or either CSR pass -- the one predicate
+        // every pass shares, so the count and the fill cannot disagree. (The
+        // readers reject inverted boxes long before this, but the class is a
+        // public one, and a negative extent here would wrap the entry count
+        // and under-allocate the fill.)
+        const auto indexable = [a0, a1](const IntBox& box) {
+            return box.lower[a0] <= box.upper[a0]
+                && box.lower[a1] <= box.upper[a1];
+        };
         m_lo0 = std::numeric_limits<std::int64_t>::max();
         m_lo1 = std::numeric_limits<std::int64_t>::max();
         m_hi0 = std::numeric_limits<std::int64_t>::min();
         m_hi1 = std::numeric_limits<std::int64_t>::min();
+        std::vector<std::int64_t> extents0;
+        std::vector<std::int64_t> extents1;
+        extents0.reserve(blocks.size());
+        extents1.reserve(blocks.size());
         for (const auto& block : blocks) {
-            m_lo0 = std::min(m_lo0,
-                static_cast<std::int64_t>(block.validBox.lower[a0]));
-            m_lo1 = std::min(m_lo1,
-                static_cast<std::int64_t>(block.validBox.lower[a1]));
-            m_hi0 = std::max(m_hi0,
-                static_cast<std::int64_t>(block.validBox.upper[a0]));
-            m_hi1 = std::max(m_hi1,
-                static_cast<std::int64_t>(block.validBox.upper[a1]));
+            const auto& box = block.validBox;
+            if (!indexable(box)) {
+                continue;
+            }
+            m_lo0 = std::min(m_lo0, static_cast<std::int64_t>(box.lower[a0]));
+            m_lo1 = std::min(m_lo1, static_cast<std::int64_t>(box.lower[a1]));
+            m_hi0 = std::max(m_hi0, static_cast<std::int64_t>(box.upper[a0]));
+            m_hi1 = std::max(m_hi1, static_cast<std::int64_t>(box.upper[a1]));
+            extents0.push_back(
+                static_cast<std::int64_t>(box.upper[a0]) - box.lower[a0] + 1);
+            extents1.push_back(
+                static_cast<std::int64_t>(box.upper[a1]) - box.lower[a1] + 1);
+        }
+        if (extents0.empty()) {
+            return;  // nothing indexable: the inverted default bounds reject all
         }
         const auto span0 = m_hi0 - m_lo0 + 1;
         const auto span1 = m_hi1 - m_lo1 + 1;
-        m_tile0 = medianExtent(blocks, a0);
-        m_tile1 = singleAxis ? span1 : medianExtent(blocks, a1);
+        // Tiles of the median block extent per axis (at least 1): the size
+        // that puts a typical block in about one tile.
+        m_tile0 = medianOf(extents0);
+        m_tile1 = singleAxis ? span1 : medianOf(extents1);
         // Cap the tile count at a few per block: a sparse level (few blocks in
         // a large span) would otherwise get a bucket per block-sized cell of
         // empty space. Coarsen by doubling the tiles of the axes that still
@@ -206,12 +227,15 @@ public:
         // identical result) rather than build an enormous index.
         const auto maxEntries = 8 * (blocks.size() + tileCount);
         // CSR build: count per tile, prefix-sum into offsets, then fill.
-        // Box coordinates are within [m_lo, m_hi], so the tile indices never
-        // overflow the narrowing cast in tile0()/tile1().
+        // Indexable box coordinates are within [m_lo, m_hi], so the tile
+        // indices never overflow the narrowing cast in tile0()/tile1().
         std::vector<std::uint32_t> counts(tileCount, 0);
         std::size_t entries = 0;
         for (const auto& block : blocks) {
             const auto& box = block.validBox;
+            if (!indexable(box)) {
+                continue;
+            }
             const auto t0First = tile0(box.lower[a0]);
             const auto t0Last = tile0(box.upper[a0]);
             const auto t1First = tile1(box.lower[a1]);
@@ -238,6 +262,9 @@ public:
         std::fill(counts.begin(), counts.end(), 0U);
         for (std::size_t index = 0; index < blocks.size(); ++index) {
             const auto& box = blocks[index].validBox;
+            if (!indexable(box)) {
+                continue;
+            }
             const auto t0Last = tile0(box.upper[a0]);
             const auto t1Last = tile1(box.upper[a1]);
             for (int t1 = tile1(box.lower[a1]); t1 <= t1Last; ++t1) {
@@ -300,18 +327,9 @@ public:
     }
 
 private:
-    // The median block extent along `axis` (at least 1): the tile size that
-    // puts a typical block in about one tile.
-    [[nodiscard]] static std::int64_t medianExtent(
-        const std::vector<LoadedBlock>& blocks, std::size_t axis)
+    // The median of a non-empty list of positive extents (reordered in place).
+    [[nodiscard]] static std::int64_t medianOf(std::vector<std::int64_t>& extents)
     {
-        std::vector<std::int64_t> extents;
-        extents.reserve(blocks.size());
-        for (const auto& block : blocks) {
-            extents.push_back(
-                static_cast<std::int64_t>(block.validBox.upper[axis])
-                - block.validBox.lower[axis] + 1);
-        }
         const auto middle = extents.begin()
             + static_cast<std::ptrdiff_t>(extents.size() / 2);
         std::nth_element(extents.begin(), middle, extents.end());

--- a/include/amrexplorer/query/detail/BlockLookup.hpp
+++ b/include/amrexplorer/query/detail/BlockLookup.hpp
@@ -9,10 +9,15 @@
 #include <amrexplorer/core/Metadata.hpp>
 #include <amrexplorer/io/PlotfileDataset.hpp>
 
+#include <algorithm>
+#include <array>
+#include <cmath>
 #include <cstddef>
 #include <cstdint>
 #include <limits>
+#include <optional>
 #include <stdexcept>
+#include <vector>
 
 namespace amrvis::detail {
 
@@ -105,6 +110,179 @@ struct LoadedBlock {
         throw std::overflow_error("3-D FAB offset exceeds addressable memory");
     }
     return static_cast<std::size_t>(offset);
+}
+
+// A uniform bin grid over one level's loaded blocks, on two chosen axes, for
+// O(1)-average point->block lookup. The composited-value lookup runs once per
+// output pixel (five times per pixel for linear sampling) and once per line
+// sample, and a linear scan of every intersecting block per point was
+// O(points * blocks) -- seconds on a full-resolution view of a block-heavy fine
+// level. Blocks within an AMReX level are non-overlapping, so a point lands in
+// at most one; the grid narrows the scan to the one tile the point falls in.
+//
+// A block that spans several tiles is listed in each, so every block covering a
+// point shares that point's tile and the bucket scan sees all candidates. Scans
+// run in ascending block index (buckets are filled in block order), so a
+// malformed overlapping catalog resolves to the smallest index -- identical to
+// the first-match order of a plain linear scan.
+class BlockGrid {
+public:
+    BlockGrid() = default;
+
+    BlockGrid(const std::vector<LoadedBlock>& blocks,
+        const std::array<int, 2>& axes)
+        : m_axis0(axes[0])
+        , m_axis1(axes[1])
+    {
+        if (blocks.empty()) {
+            return;
+        }
+        const auto a0 = static_cast<std::size_t>(m_axis0);
+        const auto a1 = static_cast<std::size_t>(m_axis1);
+        m_lo0 = std::numeric_limits<std::int64_t>::max();
+        m_lo1 = std::numeric_limits<std::int64_t>::max();
+        m_hi0 = std::numeric_limits<std::int64_t>::min();
+        m_hi1 = std::numeric_limits<std::int64_t>::min();
+        for (const auto& block : blocks) {
+            m_lo0 = std::min(m_lo0,
+                static_cast<std::int64_t>(block.validBox.lower[a0]));
+            m_lo1 = std::min(m_lo1,
+                static_cast<std::int64_t>(block.validBox.lower[a1]));
+            m_hi0 = std::max(m_hi0,
+                static_cast<std::int64_t>(block.validBox.upper[a0]));
+            m_hi1 = std::max(m_hi1,
+                static_cast<std::int64_t>(block.validBox.upper[a1]));
+        }
+        const auto span0 = m_hi0 - m_lo0 + 1;
+        const auto span1 = m_hi1 - m_lo1 + 1;
+        // ~sqrt(blocks) tiles per axis, capped so the bucket array is bounded.
+        // llround(sqrt(n)) >= 1 for n >= 1 (the empty case returned above), so
+        // only the upper cap is needed.
+        constexpr std::int64_t maxTilesPerAxis = 256;
+        const auto target = std::min<std::int64_t>(maxTilesPerAxis,
+            std::llround(std::sqrt(static_cast<double>(blocks.size()))));
+        m_tile0 = std::max<std::int64_t>(1, (span0 + target - 1) / target);
+        m_tile1 = std::max<std::int64_t>(1, (span1 + target - 1) / target);
+        m_n0 = static_cast<int>((span0 + m_tile0 - 1) / m_tile0);
+        m_n1 = static_cast<int>((span1 + m_tile1 - 1) / m_tile1);
+        const auto tileCount
+            = static_cast<std::size_t>(m_n0) * static_cast<std::size_t>(m_n1);
+        // Non-overlapping blocks (the level invariant) put ~one block in each
+        // tile, so the fill is O(blocks + tiles). validateMetadata does not
+        // forbid overlap, though, and a degenerate catalog of many large
+        // overlapping boxes would push billions of (block, tile) entries -- an
+        // unbounded, GB-scale allocation off a small header. Cap the total and
+        // fall back to a plain linear scan (bounded memory, identical result)
+        // rather than build an enormous index.
+        const auto maxEntries = 8 * (blocks.size() + tileCount);
+        m_buckets.assign(tileCount, {});
+        std::size_t entries = 0;
+        for (std::size_t index = 0; index < blocks.size(); ++index) {
+            const auto& box = blocks[index].validBox;
+            // Box coordinates are within [m_lo, m_hi], so these tile indices
+            // never overflow the narrowing cast in tile0()/tile1(); the loop
+            // bounds are hoisted out of the inner condition.
+            const auto t0Last = tile0(box.upper[a0]);
+            const auto t1Last = tile1(box.upper[a1]);
+            for (int t1 = tile1(box.lower[a1]); t1 <= t1Last; ++t1) {
+                for (int t0 = tile0(box.lower[a0]); t0 <= t0Last; ++t0) {
+                    if (++entries > maxEntries) {
+                        m_buckets.clear();
+                        m_buckets.shrink_to_fit();
+                        m_linearScan = true;
+                        return;
+                    }
+                    m_buckets[bucket(t0, t1)].push_back(static_cast<int>(index));
+                }
+            }
+        }
+    }
+
+    // Index into `blocks` of the block containing `point`, or -1 if none does.
+    // `blocks` must be the same vector the grid was built from.
+    [[nodiscard]] int find(const std::vector<LoadedBlock>& blocks,
+        const Int3& point, int dimension) const
+    {
+        if (m_linearScan) {
+            for (std::size_t index = 0; index < blocks.size(); ++index) {
+                if (contains(blocks[index].validBox, point, dimension)) {
+                    return static_cast<int>(index);
+                }
+            }
+            return -1;
+        }
+        const auto p0 = static_cast<std::int64_t>(
+            point[static_cast<std::size_t>(m_axis0)]);
+        const auto p1 = static_cast<std::int64_t>(
+            point[static_cast<std::size_t>(m_axis1)]);
+        // Reject out-of-bounds points in int64 *before* tiling. A point far
+        // above the bounding box would otherwise overflow the narrowing cast
+        // in tile0()/tile1() to a negative int and slip past a bare upper-tile
+        // check, indexing m_buckets wildly out of range. The empty-level case
+        // (inverted default bounds, m_hi < m_lo) is rejected here too.
+        if (p0 < m_lo0 || p0 > m_hi0 || p1 < m_lo1 || p1 > m_hi1) {
+            return -1;
+        }
+        for (const auto index : m_buckets[bucket(tile0(p0), tile1(p1))]) {
+            if (contains(blocks[static_cast<std::size_t>(index)].validBox,
+                    point, dimension)) {
+                return index;
+            }
+        }
+        return -1;
+    }
+
+private:
+    // Precondition: coordinate is within [m_lo, m_hi] on its axis, so the
+    // quotient is in [0, m_n - 1] and the narrowing cast cannot overflow.
+    [[nodiscard]] int tile0(std::int64_t coordinate) const noexcept
+    {
+        return static_cast<int>((coordinate - m_lo0) / m_tile0);
+    }
+    [[nodiscard]] int tile1(std::int64_t coordinate) const noexcept
+    {
+        return static_cast<int>((coordinate - m_lo1) / m_tile1);
+    }
+    [[nodiscard]] std::size_t bucket(int t0, int t1) const noexcept
+    {
+        return static_cast<std::size_t>(t1) * static_cast<std::size_t>(m_n0)
+            + static_cast<std::size_t>(t0);
+    }
+
+    int m_axis0 = 0;
+    int m_axis1 = 1;
+    // Inverted default range so an empty grid rejects every point in find().
+    std::int64_t m_lo0 = 0;
+    std::int64_t m_lo1 = 0;
+    std::int64_t m_hi0 = -1;
+    std::int64_t m_hi1 = -1;
+    std::int64_t m_tile0 = 1;
+    std::int64_t m_tile1 = 1;
+    int m_n0 = 0;
+    int m_n1 = 0;
+    bool m_linearScan = false;
+    std::vector<std::vector<int>> m_buckets;
+};
+
+// The value at `point` in the finest-covering block located by `grid`, or
+// nullopt when no block covers it. Throws if the covering block's FAB index is
+// out of range (a corrupt block whose loaded payload is smaller than its box).
+// The shared composed-sample tail for the slice and line queries; callers keep
+// the point and covering level.
+[[nodiscard]] inline std::optional<double> lookupBlockValue(
+    const BlockGrid& grid, const std::vector<LoadedBlock>& blocks,
+    const Int3& point, int dimension)
+{
+    const auto blockIndex = grid.find(blocks, point, dimension);
+    if (blockIndex < 0) {
+        return std::nullopt;
+    }
+    const auto& block = blocks[static_cast<std::size_t>(blockIndex)];
+    const auto offset = valueOffset(block.data->box, point, dimension);
+    if (offset >= block.data->values.size()) {
+        throw std::runtime_error("composed FAB index exceeds loaded block");
+    }
+    return block.data->values[offset];
 }
 
 } // namespace amrvis::detail

--- a/include/amrexplorer/query/detail/BlockLookup.hpp
+++ b/include/amrexplorer/query/detail/BlockLookup.hpp
@@ -16,6 +16,7 @@
 #include <limits>
 #include <optional>
 #include <stdexcept>
+#include <utility>
 #include <vector>
 
 namespace amrvis::detail {
@@ -111,23 +112,41 @@ struct LoadedBlock {
     return static_cast<std::size_t>(offset);
 }
 
-// A uniform bin grid over one level's loaded blocks, on two chosen axes, for
-// O(1)-average point->block lookup. The composited-value lookup runs once per
-// output pixel (five times per pixel for linear sampling) and once per line
-// sample, and a linear scan of every intersecting block per point was
+// A uniform bin grid over one level's loaded blocks, on one or two chosen
+// axes, for O(1)-average point->block lookup. The composited-value lookup runs
+// once per output pixel (five times per pixel for linear sampling) and once per
+// line sample, and a linear scan of every intersecting block per point was
 // O(points * blocks) -- seconds on a full-resolution view of a block-heavy fine
 // level. Blocks within an AMReX level are non-overlapping, so a point lands in
 // at most one; the grid narrows the scan to the one tile the point falls in.
+//
+// Tiles are sized from the blocks themselves: each axis's tile is the median
+// block extent on that axis, so a block spans about one tile whatever its
+// aspect ratio -- a 1x1000 pencil decomposition gets 1x1000 tiles, not the
+// square tiles that would list every pencil in dozens of buckets. Only the
+// tile count is capped (a few per block), so sparse levels coarsen their tiles
+// instead of allocating a bucket per empty cell.
 //
 // A block that spans several tiles is listed in each, so every block covering a
 // point shares that point's tile and the bucket scan sees all candidates. Scans
 // run in ascending block index (buckets are filled in block order), so a
 // malformed overlapping catalog resolves to the smallest index -- identical to
 // the first-match order of a plain linear scan.
+//
+// Buckets are one flat CSR array (per-tile offsets into one index array): two
+// allocations per build, not one per tile, since a build runs on every query.
 class BlockGrid {
 public:
     BlockGrid() = default;
 
+    // Bin on the one axis a query varies. The other coordinates of a query
+    // point are then pinned, and binning one of them would only list every
+    // block in every tile of that axis (they all straddle the pinned cell).
+    BlockGrid(const std::vector<LoadedBlock>& blocks, int axis)
+        : BlockGrid(blocks, std::array<int, 2>{axis, axis})
+    {}
+
+    // Bin on two axes (a slice's plane axes). Equal axes bin on that one axis.
     BlockGrid(const std::vector<LoadedBlock>& blocks,
         const std::array<int, 2>& axes)
         : m_axis0(axes[0])
@@ -137,6 +156,7 @@ public:
             return;
         }
         m_blockCount = blocks.size();
+        const bool singleAxis = m_axis0 == m_axis1;
         const auto a0 = static_cast<std::size_t>(m_axis0);
         const auto a1 = static_cast<std::size_t>(m_axis1);
         m_lo0 = std::numeric_limits<std::int64_t>::max();
@@ -155,54 +175,91 @@ public:
         }
         const auto span0 = m_hi0 - m_lo0 + 1;
         const auto span1 = m_hi1 - m_lo1 + 1;
-        // ~sqrt(blocks) tiles per axis, capped so the bucket array is bounded.
-        // llround(sqrt(n)) >= 1 for n >= 1 (the empty case returned above), so
-        // only the upper cap is needed.
-        constexpr std::int64_t maxTilesPerAxis = 256;
-        const auto target = std::min<std::int64_t>(maxTilesPerAxis,
-            std::llround(std::sqrt(static_cast<double>(blocks.size()))));
-        m_tile0 = std::max<std::int64_t>(1, (span0 + target - 1) / target);
-        m_tile1 = std::max<std::int64_t>(1, (span1 + target - 1) / target);
-        m_n0 = static_cast<int>((span0 + m_tile0 - 1) / m_tile0);
-        m_n1 = static_cast<int>((span1 + m_tile1 - 1) / m_tile1);
+        m_tile0 = medianExtent(blocks, a0);
+        m_tile1 = singleAxis ? span1 : medianExtent(blocks, a1);
+        // Cap the tile count at a few per block: a sparse level (few blocks in
+        // a large span) would otherwise get a bucket per block-sized cell of
+        // empty space. Coarsen by doubling the tiles of the axes that still
+        // have more than one, so the aspect ratio holds and an axis already
+        // down to one tile is left alone; the product is compared by division
+        // because two 32-bit spans of 1-cell tiles would overflow it.
+        const auto maxTiles
+            = static_cast<std::int64_t>(4 * blocks.size() + 64);
+        auto n0 = (span0 + m_tile0 - 1) / m_tile0;
+        auto n1 = (span1 + m_tile1 - 1) / m_tile1;
+        while (n0 > maxTiles / n1) {
+            m_tile0 = std::min(span0, m_tile0 * 2);
+            m_tile1 = std::min(span1, m_tile1 * 2);
+            n0 = (span0 + m_tile0 - 1) / m_tile0;
+            n1 = (span1 + m_tile1 - 1) / m_tile1;
+        }
+        m_n0 = static_cast<int>(n0);
+        m_n1 = static_cast<int>(n1);
         const auto tileCount
             = static_cast<std::size_t>(m_n0) * static_cast<std::size_t>(m_n1);
-        // Non-overlapping blocks (the level invariant) put ~one block in each
-        // tile, so the fill is O(blocks + tiles). validateMetadata does not
-        // forbid overlap, though, and a degenerate catalog of many large
-        // overlapping boxes would push billions of (block, tile) entries -- an
-        // unbounded, GB-scale allocation off a small header. Cap the total and
-        // fall back to a plain linear scan (bounded memory, identical result)
-        // rather than build an enormous index.
+        // With tiles sized to the blocks, a non-overlapping level puts each
+        // block in a handful of buckets and the fill is O(blocks + tiles).
+        // validateMetadata does not forbid overlap, though, and a degenerate
+        // catalog of many large overlapping boxes would push millions of
+        // (block, tile) entries -- an unbounded allocation off a small header.
+        // Cap the total and fall back to a plain linear scan (bounded memory,
+        // identical result) rather than build an enormous index.
         const auto maxEntries = 8 * (blocks.size() + tileCount);
-        m_buckets.assign(tileCount, {});
+        // CSR build: count per tile, prefix-sum into offsets, then fill.
+        // Box coordinates are within [m_lo, m_hi], so the tile indices never
+        // overflow the narrowing cast in tile0()/tile1().
+        std::vector<std::uint32_t> counts(tileCount, 0);
         std::size_t entries = 0;
+        for (const auto& block : blocks) {
+            const auto& box = block.validBox;
+            const auto t0First = tile0(box.lower[a0]);
+            const auto t0Last = tile0(box.upper[a0]);
+            const auto t1First = tile1(box.lower[a1]);
+            const auto t1Last = tile1(box.upper[a1]);
+            entries += static_cast<std::size_t>(t0Last - t0First + 1)
+                * static_cast<std::size_t>(t1Last - t1First + 1);
+            if (entries > maxEntries) {
+                m_linearScan = true;
+                return;
+            }
+            for (int t1 = t1First; t1 <= t1Last; ++t1) {
+                for (int t0 = t0First; t0 <= t0Last; ++t0) {
+                    ++counts[bucket(t0, t1)];
+                }
+            }
+        }
+        m_offsets.assign(tileCount + 1, 0);
+        for (std::size_t tile = 0; tile < tileCount; ++tile) {
+            m_offsets[tile + 1] = m_offsets[tile] + counts[tile];
+        }
+        m_indices.resize(entries);
+        // Reuse `counts` as the per-tile fill cursor; ascending block index
+        // within a bucket falls out of visiting blocks in order.
+        std::fill(counts.begin(), counts.end(), 0U);
         for (std::size_t index = 0; index < blocks.size(); ++index) {
             const auto& box = blocks[index].validBox;
-            // Box coordinates are within [m_lo, m_hi], so these tile indices
-            // never overflow the narrowing cast in tile0()/tile1(); the loop
-            // bounds are hoisted out of the inner condition.
             const auto t0Last = tile0(box.upper[a0]);
             const auto t1Last = tile1(box.upper[a1]);
             for (int t1 = tile1(box.lower[a1]); t1 <= t1Last; ++t1) {
                 for (int t0 = tile0(box.lower[a0]); t0 <= t0Last; ++t0) {
-                    if (++entries > maxEntries) {
-                        m_buckets.clear();
-                        m_buckets.shrink_to_fit();
-                        m_linearScan = true;
-                        return;
-                    }
-                    m_buckets[bucket(t0, t1)].push_back(static_cast<int>(index));
+                    const auto tile = bucket(t0, t1);
+                    m_indices[m_offsets[tile] + counts[tile]++]
+                        = static_cast<int>(index);
                 }
             }
         }
     }
 
+    // Whether lookups go through the index (false after the overlap fallback,
+    // where find() is the linear scan the index replaces). For tests and
+    // diagnostics; the result is the same either way.
+    [[nodiscard]] bool usesIndex() const noexcept { return !m_linearScan; }
+
     // Index into `blocks` of the block containing `point`, or -1 if none does.
     // `blocks` must be the same vector the grid was built from: the grid holds
     // indices into it, so a different vector would be read through stale
-    // ones. The size check is the cheap part of that contract that can be
-    // enforced.
+    // ones (IndexedBlocks below keeps the two together). The size check is the
+    // cheap part of that contract that can be enforced.
     [[nodiscard]] int find(const std::vector<LoadedBlock>& blocks,
         const Int3& point, int dimension) const
     {
@@ -225,12 +282,15 @@ public:
         // Reject out-of-bounds points in int64 *before* tiling. A point far
         // above the bounding box would otherwise overflow the narrowing cast
         // in tile0()/tile1() to a negative int and slip past a bare upper-tile
-        // check, indexing m_buckets wildly out of range. The empty-level case
-        // (inverted default bounds, m_hi < m_lo) is rejected here too.
+        // check, indexing the buckets wildly out of range. The empty-level
+        // case (inverted default bounds, m_hi < m_lo) is rejected here too.
         if (p0 < m_lo0 || p0 > m_hi0 || p1 < m_lo1 || p1 > m_hi1) {
             return -1;
         }
-        for (const auto index : m_buckets[bucket(tile0(p0), tile1(p1))]) {
+        const auto tile = bucket(tile0(p0), tile1(p1));
+        for (auto entry = m_offsets[tile]; entry < m_offsets[tile + 1];
+             ++entry) {
+            const auto index = m_indices[entry];
             if (contains(blocks[static_cast<std::size_t>(index)].validBox,
                     point, dimension)) {
                 return index;
@@ -240,6 +300,24 @@ public:
     }
 
 private:
+    // The median block extent along `axis` (at least 1): the tile size that
+    // puts a typical block in about one tile.
+    [[nodiscard]] static std::int64_t medianExtent(
+        const std::vector<LoadedBlock>& blocks, std::size_t axis)
+    {
+        std::vector<std::int64_t> extents;
+        extents.reserve(blocks.size());
+        for (const auto& block : blocks) {
+            extents.push_back(
+                static_cast<std::int64_t>(block.validBox.upper[axis])
+                - block.validBox.lower[axis] + 1);
+        }
+        const auto middle = extents.begin()
+            + static_cast<std::ptrdiff_t>(extents.size() / 2);
+        std::nth_element(extents.begin(), middle, extents.end());
+        return std::max<std::int64_t>(1, *middle);
+    }
+
     // Precondition: coordinate is within [m_lo, m_hi] on its axis, so the
     // quotient is in [0, m_n - 1] and the narrowing cast cannot overflow.
     [[nodiscard]] int tile0(std::int64_t coordinate) const noexcept
@@ -269,24 +347,45 @@ private:
     int m_n1 = 0;
     bool m_linearScan = false;
     std::size_t m_blockCount = 0;
-    std::vector<std::vector<int>> m_buckets;
+    std::vector<std::size_t> m_offsets;  // per tile: first entry in m_indices
+    std::vector<int> m_indices;          // block indices, bucket by bucket
 };
 
-// The value at `point` in the block of one level's `blocks` that covers it,
-// located by that level's `grid`, or nullopt when none does. Throws if the
-// covering block's FAB index is out of range (a corrupt block whose loaded
-// payload is smaller than its box). The shared composed-sample tail for the
-// slice and line queries; the caller walks the levels finest first and keeps
-// the point and covering level.
+// One level's loaded blocks together with the point->block grid over them.
+// The grid stores indices into `blocks`, so the two travel as one value:
+// build it from the loaded vector and query it through lookupBlockValue.
+struct IndexedBlocks {
+    IndexedBlocks() = default;
+
+    IndexedBlocks(std::vector<LoadedBlock> loaded, int axis)
+        : blocks(std::move(loaded))
+        , grid(blocks, axis)
+    {}
+
+    IndexedBlocks(
+        std::vector<LoadedBlock> loaded, const std::array<int, 2>& axes)
+        : blocks(std::move(loaded))
+        , grid(blocks, axes)
+    {}
+
+    std::vector<LoadedBlock> blocks;
+    BlockGrid grid;
+};
+
+// The value at `point` in the block of one level's `indexed` blocks that
+// covers it, or nullopt when none does. Throws if the covering block's FAB
+// index is out of range (a corrupt block whose loaded payload is smaller than
+// its box). The shared composed-sample tail for the slice and line queries;
+// the caller walks the levels finest first and keeps the point and covering
+// level.
 [[nodiscard]] inline std::optional<double> lookupBlockValue(
-    const BlockGrid& grid, const std::vector<LoadedBlock>& blocks,
-    const Int3& point, int dimension)
+    const IndexedBlocks& indexed, const Int3& point, int dimension)
 {
-    const auto blockIndex = grid.find(blocks, point, dimension);
+    const auto blockIndex = indexed.grid.find(indexed.blocks, point, dimension);
     if (blockIndex < 0) {
         return std::nullopt;
     }
-    const auto& block = blocks[static_cast<std::size_t>(blockIndex)];
+    const auto& block = indexed.blocks[static_cast<std::size_t>(blockIndex)];
     const auto offset = valueOffset(block.data->box, point, dimension);
     if (offset >= block.data->values.size()) {
         throw std::runtime_error("composed FAB index exceeds loaded block");

--- a/include/amrexplorer/query/detail/BlockLookup.hpp
+++ b/include/amrexplorer/query/detail/BlockLookup.hpp
@@ -1,9 +1,8 @@
 #pragma once
 
-// Shared per-point block-lookup helpers for the query layer. These were
-// previously copied verbatim between SliceQuery.cpp and LineQuery.cpp, with a
-// third, unchecked valueOffset variant in the GUI's DatasetExtract — this is
-// the one overflow-checked definition.
+// Shared per-point block-lookup helpers for the query layer: the one
+// overflow-checked valueOffset, and the point->block grid the slice and line
+// queries both index their loaded blocks with.
 
 #include <amrexplorer/core/Geometry.hpp>
 #include <amrexplorer/core/Metadata.hpp>
@@ -137,6 +136,7 @@ public:
         if (blocks.empty()) {
             return;
         }
+        m_blockCount = blocks.size();
         const auto a0 = static_cast<std::size_t>(m_axis0);
         const auto a1 = static_cast<std::size_t>(m_axis1);
         m_lo0 = std::numeric_limits<std::int64_t>::max();
@@ -199,10 +199,17 @@ public:
     }
 
     // Index into `blocks` of the block containing `point`, or -1 if none does.
-    // `blocks` must be the same vector the grid was built from.
+    // `blocks` must be the same vector the grid was built from: the grid holds
+    // indices into it, so a different vector would be read through stale
+    // ones. The size check is the cheap part of that contract that can be
+    // enforced.
     [[nodiscard]] int find(const std::vector<LoadedBlock>& blocks,
         const Int3& point, int dimension) const
     {
+        if (blocks.size() != m_blockCount) {
+            throw std::logic_error(
+                "BlockGrid::find given a block set other than its own");
+        }
         if (m_linearScan) {
             for (std::size_t index = 0; index < blocks.size(); ++index) {
                 if (contains(blocks[index].validBox, point, dimension)) {
@@ -261,13 +268,15 @@ private:
     int m_n0 = 0;
     int m_n1 = 0;
     bool m_linearScan = false;
+    std::size_t m_blockCount = 0;
     std::vector<std::vector<int>> m_buckets;
 };
 
-// The value at `point` in the finest-covering block located by `grid`, or
-// nullopt when no block covers it. Throws if the covering block's FAB index is
-// out of range (a corrupt block whose loaded payload is smaller than its box).
-// The shared composed-sample tail for the slice and line queries; callers keep
+// The value at `point` in the block of one level's `blocks` that covers it,
+// located by that level's `grid`, or nullopt when none does. Throws if the
+// covering block's FAB index is out of range (a corrupt block whose loaded
+// payload is smaller than its box). The shared composed-sample tail for the
+// slice and line queries; the caller walks the levels finest first and keeps
 // the point and covering level.
 [[nodiscard]] inline std::optional<double> lookupBlockValue(
     const BlockGrid& grid, const std::vector<LoadedBlock>& blocks,

--- a/src/query/LineQuery.cpp
+++ b/src/query/LineQuery.cpp
@@ -14,11 +14,11 @@
 namespace amrvis {
 namespace {
 
+using detail::BlockGrid;
 using detail::LoadedBlock;
 using detail::intersects;
-using detail::contains;
+using detail::lookupBlockValue;
 using detail::physicalToIndex;
-using detail::valueOffset;
 
 // A covering cell hit during the line walk: which level won, the cell index,
 // and the cell-centered value there.
@@ -85,9 +85,17 @@ LineQueryResult LineQuery::execute(
     result.line.valid.reserve(maxSamples);
     result.line.sourceLevel.reserve(maxSamples);
 
-    // Pre-load every block the line crosses, per participating level.
+    // Pre-load every block the line crosses, per participating level, and index
+    // each level's blocks for O(1)-average point lookup during the walk. The
+    // grid bins on the line axis (the walk varies only that coordinate; the
+    // off-axes are pinned to the line's fixed cell) plus one other axis to give
+    // BlockGrid two distinct axes.
     std::vector<std::vector<LoadedBlock>> loadedByLevel(
         static_cast<std::size_t>(maximumLevel) + 1);
+    std::vector<BlockGrid> gridByLevel(
+        static_cast<std::size_t>(maximumLevel) + 1);
+    const std::array<int, 2> gridAxes{
+        request.axis, (request.axis + 1) % metadata.dimension};
     for (int levelIndex = minimumLevel; levelIndex <= maximumLevel; ++levelIndex) {
         if (cancellation.stop_requested()) {
             throw ReadCancelled();
@@ -144,6 +152,8 @@ LineQueryResult LineQuery::execute(
             }
             loaded.push_back({block.box, std::move(access.handle)});
         }
+        gridByLevel[static_cast<std::size_t>(levelIndex)]
+            = BlockGrid(loaded, gridAxes);
     }
 
     // Find the finest level covering position x (fine overrides coarse).
@@ -158,17 +168,13 @@ LineQueryResult LineQuery::execute(
                         : request.fixedCoordinates[static_cast<std::size_t>(axis)],
                     metadata, level, axis);
             }
-            for (const auto& block : loadedByLevel[static_cast<std::size_t>(levelIndex)]) {
-                if (!contains(block.validBox, point, metadata.dimension)) {
-                    continue;
-                }
-                const auto offset = valueOffset(block.data->box, point, metadata.dimension);
-                if (offset >= block.data->values.size()) {
-                    throw std::runtime_error("composed FAB index exceeds loaded block");
-                }
+            const auto entry = static_cast<std::size_t>(levelIndex);
+            if (const auto value = lookupBlockValue(
+                    gridByLevel[entry], loadedByLevel[entry], point,
+                    metadata.dimension)) {
                 cover.level = levelIndex;
                 cover.point = point;
-                cover.value = static_cast<float>(block.data->values[offset]);
+                cover.value = static_cast<float>(*value);
                 return true;
             }
         }

--- a/src/query/LineQuery.cpp
+++ b/src/query/LineQuery.cpp
@@ -88,8 +88,9 @@ LineQueryResult LineQuery::execute(
     // Pre-load every block the line crosses, per participating level, and index
     // each level's blocks for O(1)-average point lookup during the walk. The
     // grid bins on the line axis (the walk varies only that coordinate; the
-    // off-axes are pinned to the line's fixed cell) plus one other axis to give
-    // BlockGrid two distinct axes.
+    // off-axes are pinned to the line's fixed cell) plus the next axis. In 1-D
+    // that is the line axis again, which BlockGrid tolerates: it bins the same
+    // coordinate twice, no less correctly.
     std::vector<std::vector<LoadedBlock>> loadedByLevel(
         static_cast<std::size_t>(maximumLevel) + 1);
     std::vector<BlockGrid> gridByLevel(

--- a/src/query/LineQuery.cpp
+++ b/src/query/LineQuery.cpp
@@ -14,7 +14,7 @@
 namespace amrvis {
 namespace {
 
-using detail::BlockGrid;
+using detail::IndexedBlocks;
 using detail::LoadedBlock;
 using detail::intersects;
 using detail::lookupBlockValue;
@@ -87,16 +87,11 @@ LineQueryResult LineQuery::execute(
 
     // Pre-load every block the line crosses, per participating level, and index
     // each level's blocks for O(1)-average point lookup during the walk. The
-    // grid bins on the line axis (the walk varies only that coordinate; the
-    // off-axes are pinned to the line's fixed cell) plus the next axis. In 1-D
-    // that is the line axis again, which BlockGrid tolerates: it bins the same
-    // coordinate twice, no less correctly.
-    std::vector<std::vector<LoadedBlock>> loadedByLevel(
+    // grid bins on the line axis alone: the walk varies only that coordinate,
+    // and every loaded block straddles the line's pinned cell on the other
+    // axes, so binning one of those would list every block in every tile.
+    std::vector<IndexedBlocks> blocksByLevel(
         static_cast<std::size_t>(maximumLevel) + 1);
-    std::vector<BlockGrid> gridByLevel(
-        static_cast<std::size_t>(maximumLevel) + 1);
-    const std::array<int, 2> gridAxes{
-        request.axis, (request.axis + 1) % metadata.dimension};
     for (int levelIndex = minimumLevel; levelIndex <= maximumLevel; ++levelIndex) {
         if (cancellation.stop_requested()) {
             throw ReadCancelled();
@@ -132,7 +127,7 @@ LineQueryResult LineQuery::execute(
                 continue;  // the region misses this level entirely
             }
         }
-        auto& loaded = loadedByLevel[static_cast<std::size_t>(levelIndex)];
+        std::vector<LoadedBlock> loaded;
         for (std::size_t grid = 0; grid < level.blocks.size(); ++grid) {
             const auto& block = level.blocks[grid];
             if (!intersects(block.box, lineBox, metadata.dimension)) {
@@ -153,8 +148,8 @@ LineQueryResult LineQuery::execute(
             }
             loaded.push_back({block.box, std::move(access.handle)});
         }
-        gridByLevel[static_cast<std::size_t>(levelIndex)]
-            = BlockGrid(loaded, gridAxes);
+        blocksByLevel[static_cast<std::size_t>(levelIndex)]
+            = IndexedBlocks(std::move(loaded), request.axis);
     }
 
     // Find the finest level covering position x (fine overrides coarse).
@@ -169,9 +164,8 @@ LineQueryResult LineQuery::execute(
                         : request.fixedCoordinates[static_cast<std::size_t>(axis)],
                     metadata, level, axis);
             }
-            const auto entry = static_cast<std::size_t>(levelIndex);
             if (const auto value = lookupBlockValue(
-                    gridByLevel[entry], loadedByLevel[entry], point,
+                    blocksByLevel[static_cast<std::size_t>(levelIndex)], point,
                     metadata.dimension)) {
                 cover.level = levelIndex;
                 cover.point = point;

--- a/src/query/SliceQuery.cpp
+++ b/src/query/SliceQuery.cpp
@@ -15,170 +15,20 @@
 namespace amrvis {
 namespace {
 
+using detail::BlockGrid;
 using detail::LoadedBlock;
 using detail::intersects;
-using detail::contains;
+using detail::lookupBlockValue;
 using detail::physicalToIndex;
-using detail::valueOffset;
 
-// The blocks of one level that intersect the planning region. Levels are
-// processed finest first so the composed per-point lookup resolves fine
-// over coarse by construction.
+// The blocks of one level that intersect the planning region, plus a point->
+// block index over them. Levels are processed finest first so the composed
+// per-point lookup resolves fine over coarse by construction.
 struct LevelBlocks {
     int levelIndex = 0;
     std::vector<LoadedBlock> blocks;
+    BlockGrid grid;
 };
-
-// A uniform bin grid over one level's loaded blocks, on the two plane axes, for
-// O(1)-average point->block lookup. The composited-value lookup below runs once
-// per output pixel (five times per pixel for linear sampling), and a linear scan
-// of every intersecting block per pixel was O(pixels * blocks) -- seconds on a
-// full-resolution view of a block-heavy fine level. Blocks within an AMReX level
-// are non-overlapping, so a point lands in at most one; the grid narrows the scan
-// to the one tile the point falls in.
-//
-// A block that spans several tiles is listed in each, so every block covering a
-// point shares that point's tile and the bucket scan sees all candidates. Scans
-// run in ascending block index (buckets are filled in block order), so a
-// malformed overlapping catalog resolves to the smallest index -- identical to
-// the first-match order of the linear scan this replaces.
-class BlockGrid {
-public:
-    BlockGrid(const std::vector<LoadedBlock>& blocks,
-        const std::array<int, 2>& axes)
-        : m_axis0(axes[0])
-        , m_axis1(axes[1])
-    {
-        if (blocks.empty()) {
-            return;
-        }
-        const auto a0 = static_cast<std::size_t>(m_axis0);
-        const auto a1 = static_cast<std::size_t>(m_axis1);
-        m_lo0 = std::numeric_limits<std::int64_t>::max();
-        m_lo1 = std::numeric_limits<std::int64_t>::max();
-        m_hi0 = std::numeric_limits<std::int64_t>::min();
-        m_hi1 = std::numeric_limits<std::int64_t>::min();
-        for (const auto& block : blocks) {
-            m_lo0 = std::min(m_lo0,
-                static_cast<std::int64_t>(block.validBox.lower[a0]));
-            m_lo1 = std::min(m_lo1,
-                static_cast<std::int64_t>(block.validBox.lower[a1]));
-            m_hi0 = std::max(m_hi0,
-                static_cast<std::int64_t>(block.validBox.upper[a0]));
-            m_hi1 = std::max(m_hi1,
-                static_cast<std::int64_t>(block.validBox.upper[a1]));
-        }
-        const auto span0 = m_hi0 - m_lo0 + 1;
-        const auto span1 = m_hi1 - m_lo1 + 1;
-        // ~sqrt(blocks) tiles per axis, capped so the bucket array is bounded.
-        // llround(sqrt(n)) >= 1 for n >= 1 (the empty case returned above), so
-        // only the upper cap is needed.
-        constexpr std::int64_t maxTilesPerAxis = 256;
-        const auto target = std::min<std::int64_t>(maxTilesPerAxis,
-            std::llround(std::sqrt(static_cast<double>(blocks.size()))));
-        m_tile0 = std::max<std::int64_t>(1, (span0 + target - 1) / target);
-        m_tile1 = std::max<std::int64_t>(1, (span1 + target - 1) / target);
-        m_n0 = static_cast<int>((span0 + m_tile0 - 1) / m_tile0);
-        m_n1 = static_cast<int>((span1 + m_tile1 - 1) / m_tile1);
-        const auto tileCount
-            = static_cast<std::size_t>(m_n0) * static_cast<std::size_t>(m_n1);
-        // Non-overlapping blocks (the level invariant) put ~one block in each
-        // tile, so the fill is O(blocks + tiles). validateMetadata does not
-        // forbid overlap, though, and a degenerate catalog of many large
-        // overlapping boxes would push billions of (block, tile) entries -- an
-        // unbounded, GB-scale allocation off a small header. Cap the total and
-        // fall back to a plain linear scan (bounded memory, identical result)
-        // rather than build an enormous index.
-        const auto maxEntries = 8 * (blocks.size() + tileCount);
-        m_buckets.assign(tileCount, {});
-        std::size_t entries = 0;
-        for (std::size_t index = 0; index < blocks.size(); ++index) {
-            const auto& box = blocks[index].validBox;
-            // Box coordinates are within [m_lo, m_hi], so these tile indices
-            // never overflow the narrowing cast in tile0()/tile1(); the loop
-            // bounds are hoisted out of the inner condition.
-            const auto t0Last = tile0(box.upper[a0]);
-            const auto t1Last = tile1(box.upper[a1]);
-            for (int t1 = tile1(box.lower[a1]); t1 <= t1Last; ++t1) {
-                for (int t0 = tile0(box.lower[a0]); t0 <= t0Last; ++t0) {
-                    if (++entries > maxEntries) {
-                        m_buckets.clear();
-                        m_buckets.shrink_to_fit();
-                        m_linearScan = true;
-                        return;
-                    }
-                    m_buckets[bucket(t0, t1)].push_back(static_cast<int>(index));
-                }
-            }
-        }
-    }
-
-    // Index into `blocks` of the block containing `point`, or -1 if none does.
-    // `blocks` must be the same vector the grid was built from.
-    [[nodiscard]] int find(const std::vector<LoadedBlock>& blocks,
-        const Int3& point, int dimension) const
-    {
-        if (m_linearScan) {
-            for (std::size_t index = 0; index < blocks.size(); ++index) {
-                if (contains(blocks[index].validBox, point, dimension)) {
-                    return static_cast<int>(index);
-                }
-            }
-            return -1;
-        }
-        const auto p0 = static_cast<std::int64_t>(
-            point[static_cast<std::size_t>(m_axis0)]);
-        const auto p1 = static_cast<std::int64_t>(
-            point[static_cast<std::size_t>(m_axis1)]);
-        // Reject out-of-bounds points in int64 *before* tiling. A point far
-        // above the bounding box would otherwise overflow the narrowing cast
-        // in tile0()/tile1() to a negative int and slip past a bare upper-tile
-        // check, indexing m_buckets wildly out of range. The empty-level case
-        // (inverted default bounds, m_hi < m_lo) is rejected here too.
-        if (p0 < m_lo0 || p0 > m_hi0 || p1 < m_lo1 || p1 > m_hi1) {
-            return -1;
-        }
-        for (const auto index : m_buckets[bucket(tile0(p0), tile1(p1))]) {
-            if (contains(blocks[static_cast<std::size_t>(index)].validBox,
-                    point, dimension)) {
-                return index;
-            }
-        }
-        return -1;
-    }
-
-private:
-    // Precondition: coordinate is within [m_lo, m_hi] on its axis, so the
-    // quotient is in [0, m_n - 1] and the narrowing cast cannot overflow.
-    [[nodiscard]] int tile0(std::int64_t coordinate) const noexcept
-    {
-        return static_cast<int>((coordinate - m_lo0) / m_tile0);
-    }
-    [[nodiscard]] int tile1(std::int64_t coordinate) const noexcept
-    {
-        return static_cast<int>((coordinate - m_lo1) / m_tile1);
-    }
-    [[nodiscard]] std::size_t bucket(int t0, int t1) const noexcept
-    {
-        return static_cast<std::size_t>(t1) * static_cast<std::size_t>(m_n0)
-            + static_cast<std::size_t>(t0);
-    }
-
-    int m_axis0 = 0;
-    int m_axis1 = 1;
-    // Inverted default range so an empty grid rejects every point in find().
-    std::int64_t m_lo0 = 0;
-    std::int64_t m_lo1 = 0;
-    std::int64_t m_hi0 = -1;
-    std::int64_t m_hi1 = -1;
-    std::int64_t m_tile0 = 1;
-    std::int64_t m_tile1 = 1;
-    int m_n0 = 0;
-    int m_n1 = 0;
-    bool m_linearScan = false;
-    std::vector<std::vector<int>> m_buckets;
-};
-
 
 // The index box a physical region covers at one level. Piecewise sampling
 // passes the visible region; linear sampling passes a halo-expanded region
@@ -273,7 +123,7 @@ SliceQueryResult SliceQuery::execute(
         const auto& level = metadata.levels[static_cast<std::size_t>(levelIndex)];
         const auto queryBox = requestIndexBox(
             planningRegion, request, metadata, level, axes);
-        LevelBlocks levelBlocks{levelIndex, {}};
+        LevelBlocks levelBlocks{levelIndex, {}, {}};
         for (std::size_t grid = 0; grid < level.blocks.size(); ++grid) {
             const auto& block = level.blocks[grid];
             if (!intersects(block.box, queryBox, metadata.dimension)) {
@@ -331,24 +181,17 @@ SliceQueryResult SliceQuery::execute(
             }
             levelBlocks.blocks.push_back({block.box, std::move(access.handle)});
         }
+        levelBlocks.grid = BlockGrid(levelBlocks.blocks, axes);
         levels.push_back(std::move(levelBlocks));
-    }
-
-    // One point->block index per participating level, parallel to `levels`.
-    std::vector<BlockGrid> levelGrids;
-    levelGrids.reserve(levels.size());
-    for (const auto& levelBlocks : levels) {
-        levelGrids.emplace_back(levelBlocks.blocks, axes);
     }
 
     // The composed piecewise-constant field at a physical point: the finest
     // participating level with a block covering the point's cell wins.
     // Returns the value and the covering level, or nothing when the point
     // is outside every grid.
-    const auto valueAt = [&metadata, &levels, &levelGrids](const Real3& position)
+    const auto valueAt = [&metadata, &levels](const Real3& position)
         -> std::optional<std::pair<double, int>> {
-        for (std::size_t entry = 0; entry < levels.size(); ++entry) {
-            const auto& levelBlocks = levels[entry];
+        for (const auto& levelBlocks : levels) {
             const auto& level =
                 metadata.levels[static_cast<std::size_t>(levelBlocks.levelIndex)];
             Int3 point;
@@ -356,19 +199,11 @@ SliceQueryResult SliceQuery::execute(
                 point[static_cast<std::size_t>(axis)] = physicalToIndex(
                     position[static_cast<std::size_t>(axis)], metadata, level, axis);
             }
-            const auto blockIndex = levelGrids[entry].find(
-                levelBlocks.blocks, point, metadata.dimension);
-            if (blockIndex < 0) {
-                continue;
+            if (const auto value = lookupBlockValue(
+                    levelBlocks.grid, levelBlocks.blocks, point,
+                    metadata.dimension)) {
+                return std::pair{*value, levelBlocks.levelIndex};
             }
-            const auto& block =
-                levelBlocks.blocks[static_cast<std::size_t>(blockIndex)];
-            const auto offset =
-                valueOffset(block.data->box, point, metadata.dimension);
-            if (offset >= block.data->values.size()) {
-                throw std::runtime_error("composed FAB index exceeds loaded block");
-            }
-            return std::pair{block.data->values[offset], levelBlocks.levelIndex};
         }
         return std::nullopt;
     };

--- a/src/query/SliceQuery.cpp
+++ b/src/query/SliceQuery.cpp
@@ -15,19 +15,18 @@
 namespace amrvis {
 namespace {
 
-using detail::BlockGrid;
+using detail::IndexedBlocks;
 using detail::LoadedBlock;
 using detail::intersects;
 using detail::lookupBlockValue;
 using detail::physicalToIndex;
 
-// The blocks of one level that intersect the planning region, plus a point->
+// The blocks of one level that intersect the planning region, with the point->
 // block index over them. Levels are processed finest first so the composed
 // per-point lookup resolves fine over coarse by construction.
 struct LevelBlocks {
     int levelIndex = 0;
-    std::vector<LoadedBlock> blocks;
-    BlockGrid grid;
+    IndexedBlocks indexed;
 };
 
 // The index box a physical region covers at one level. Piecewise sampling
@@ -123,7 +122,7 @@ SliceQueryResult SliceQuery::execute(
         const auto& level = metadata.levels[static_cast<std::size_t>(levelIndex)];
         const auto queryBox = requestIndexBox(
             planningRegion, request, metadata, level, axes);
-        LevelBlocks levelBlocks{levelIndex, {}, {}};
+        std::vector<LoadedBlock> loaded;
         for (std::size_t grid = 0; grid < level.blocks.size(); ++grid) {
             const auto& block = level.blocks[grid];
             if (!intersects(block.box, queryBox, metadata.dimension)) {
@@ -179,10 +178,9 @@ SliceQueryResult SliceQuery::execute(
                 ++result.metrics.blocksRead;
                 result.metrics.payloadBytesRead += access.io.bytesRead;
             }
-            levelBlocks.blocks.push_back({block.box, std::move(access.handle)});
+            loaded.push_back({block.box, std::move(access.handle)});
         }
-        levelBlocks.grid = BlockGrid(levelBlocks.blocks, axes);
-        levels.push_back(std::move(levelBlocks));
+        levels.push_back({levelIndex, IndexedBlocks(std::move(loaded), axes)});
     }
 
     // The composed piecewise-constant field at a physical point: the finest
@@ -200,8 +198,7 @@ SliceQueryResult SliceQuery::execute(
                     position[static_cast<std::size_t>(axis)], metadata, level, axis);
             }
             if (const auto value = lookupBlockValue(
-                    levelBlocks.grid, levelBlocks.blocks, point,
-                    metadata.dimension)) {
+                    levelBlocks.indexed, point, metadata.dimension)) {
                 return std::pair{*value, levelBlocks.levelIndex};
             }
         }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -361,6 +361,10 @@ target_link_libraries(
 )
 add_test(NAME display_transitions COMMAND test_display_transitions)
 
+add_executable(test_block_lookup unit/test_block_lookup.cpp)
+target_link_libraries(test_block_lookup PRIVATE amrexplorer::query amrexplorer::warnings)
+add_test(NAME block_lookup COMMAND test_block_lookup)
+
 add_executable(test_slice_query integration/test_slice_query.cpp)
 target_link_libraries(test_slice_query PRIVATE amrexplorer::query amrexplorer::warnings)
 add_test(NAME slice_query COMMAND test_slice_query)

--- a/tests/unit/test_block_lookup.cpp
+++ b/tests/unit/test_block_lookup.cpp
@@ -1,0 +1,173 @@
+#include <amrexplorer/query/detail/BlockLookup.hpp>
+
+#include <array>
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
+#include <vector>
+
+namespace {
+
+using amrvis::IntBox;
+using amrvis::Int3;
+using amrvis::detail::BlockGrid;
+using amrvis::detail::LoadedBlock;
+
+void require(bool condition, const char* message)
+{
+    if (!condition) {
+        std::cerr << "FAILED: " << message << '\n';
+        std::exit(1);
+    }
+}
+
+// A 2-D block with only its valid box set; BlockGrid::find reads nothing else.
+LoadedBlock block(int lo0, int lo1, int hi0, int hi1)
+{
+    IntBox box;
+    box.lower = {{lo0, lo1, 0}};
+    box.upper = {{hi0, hi1, 0}};
+    box.centering = {{0, 0, 0}};
+    return LoadedBlock{box, {}};
+}
+
+Int3 point(int a, int b)
+{
+    return Int3{{a, b, 0}};
+}
+
+// The behavior the grid must reproduce exactly: the first (smallest-index)
+// block whose valid box contains the point, or -1.
+int linearFind(const std::vector<LoadedBlock>& blocks, const Int3& p)
+{
+    for (std::size_t i = 0; i < blocks.size(); ++i) {
+        if (amrvis::detail::contains(blocks[i].validBox, p, 2)) {
+            return static_cast<int>(i);
+        }
+    }
+    return -1;
+}
+
+std::uint64_t nextRandom(std::uint64_t& state)
+{
+    state += 0x9e3779b97f4a7c15ULL;
+    auto z = state;
+    z = (z ^ (z >> 30U)) * 0xbf58476d1ce4e5b9ULL;
+    z = (z ^ (z >> 27U)) * 0x94d049bb133111ebULL;
+    return z ^ (z >> 31U);
+}
+
+// Grid and linear scan must agree at every probed point, over the block set's
+// bounding box widened by a margin (so out-of-range points are exercised too).
+void requireAgrees(const std::vector<LoadedBlock>& blocks,
+    const std::array<int, 2>& axes, int lo, int hi, const char* context)
+{
+    const BlockGrid grid(blocks, axes);
+    std::uint64_t rng = 0xabcd1234ULL;
+    const auto span = static_cast<std::uint64_t>(hi - lo + 1);
+    for (int trial = 0; trial < 20000; ++trial) {
+        const auto p = point(
+            lo + static_cast<int>(nextRandom(rng) % span),
+            lo + static_cast<int>(nextRandom(rng) % span));
+        require(grid.find(blocks, p, 2) == linearFind(blocks, p), context);
+    }
+}
+
+} // namespace
+
+int main()
+{
+    const std::array<int, 2> axes{0, 1};
+
+    // A default-constructed grid and a grid over no blocks reject every point.
+    {
+        const BlockGrid empty;
+        require(empty.find({}, point(0, 0), 2) == -1,
+            "default-constructed grid returned a block");
+        const std::vector<LoadedBlock> none;
+        const BlockGrid overNone(none, axes);
+        require(overNone.find(none, point(3, 4), 2) == -1,
+            "grid over no blocks returned a block");
+    }
+
+    // A real multi-tile grid: a 4x4 arrangement of 4x4-cell blocks over a 16x16
+    // domain forces a multi-tile bin layout (not the 1x1 collapse of a handful
+    // of blocks). Every in-domain point must route to its block; out-of-domain
+    // points must miss.
+    {
+        std::vector<LoadedBlock> blocks;
+        for (int gj = 0; gj < 4; ++gj) {
+            for (int gi = 0; gi < 4; ++gi) {
+                blocks.push_back(block(
+                    gi * 4, gj * 4, gi * 4 + 3, gj * 4 + 3));
+            }
+        }
+        const BlockGrid grid(blocks, axes);
+        for (int y = 0; y < 16; ++y) {
+            for (int x = 0; x < 16; ++x) {
+                const auto expected = (x / 4) + 4 * (y / 4);
+                require(grid.find(blocks, point(x, y), 2) == expected,
+                    "multi-tile grid routed a point to the wrong block");
+            }
+        }
+        require(grid.find(blocks, point(16, 0), 2) == -1,
+            "multi-tile grid matched a point past the domain");
+        require(grid.find(blocks, point(-1, -1), 2) == -1,
+            "multi-tile grid matched a point below the domain");
+        requireAgrees(blocks, axes, -4, 19, "multi-tile differential");
+    }
+
+    // Regression for the tile-index overflow: blocks at a far-negative base
+    // with a tiny span (so the tile size is 1), then query points far to the
+    // positive side. The point sits >2^31 cells above the grid's lower bound,
+    // where the pre-fix narrowing cast wrapped negative and indexed the bucket
+    // array out of range. It must simply miss.
+    {
+        constexpr int base = -2000000000;
+        std::vector<LoadedBlock> blocks;
+        blocks.push_back(block(base, base, base + 1, base + 1));
+        blocks.push_back(block(base + 2, base, base + 3, base + 1));
+        const BlockGrid grid(blocks, axes);
+        require(grid.find(blocks, point(base, base), 2) == 0,
+            "negative-base grid missed its own first block");
+        require(grid.find(blocks, point(base + 2, base + 1), 2) == 1,
+            "negative-base grid missed its own second block");
+        // Far-out points: no crash / OOB (ASan would catch it), just a miss.
+        require(grid.find(blocks, point(1500000000, 1500000000), 2) == -1,
+            "far-positive point was not reported as uncovered");
+        require(grid.find(blocks, point(2000000000, base), 2) == -1,
+            "far-positive x was not reported as uncovered");
+        require(grid.find(blocks, point(base, 2000000000), 2) == -1,
+            "far-positive y was not reported as uncovered");
+    }
+
+    // Overlap fallback: many identical full-domain boxes exceed the grid's fill
+    // cap, so it falls back to a linear scan. The result must still match a
+    // linear scan exactly (smallest covering index), and out-of-range misses.
+    {
+        std::vector<LoadedBlock> blocks;
+        for (int i = 0; i < 400; ++i) {
+            blocks.push_back(block(0, 0, 63, 63));  // all identical, overlapping
+        }
+        const BlockGrid grid(blocks, axes);
+        require(grid.find(blocks, point(20, 40), 2) == 0,
+            "overlap fallback did not return the smallest covering block");
+        require(grid.find(blocks, point(64, 0), 2) == -1,
+            "overlap fallback matched a point past the domain");
+        requireAgrees(blocks, axes, -2, 66, "overlap-fallback differential");
+    }
+
+    // Irregular non-overlapping layout (varied block sizes) as a differential
+    // property check.
+    {
+        std::vector<LoadedBlock> blocks;
+        blocks.push_back(block(0, 0, 9, 3));
+        blocks.push_back(block(0, 4, 3, 9));
+        blocks.push_back(block(4, 4, 9, 9));
+        blocks.push_back(block(10, 0, 15, 15));
+        requireAgrees(blocks, axes, -3, 18, "irregular differential");
+    }
+
+    std::cout << "block lookup tests passed\n";
+    return 0;
+}

--- a/tests/unit/test_block_lookup.cpp
+++ b/tests/unit/test_block_lookup.cpp
@@ -4,7 +4,9 @@
 #include <cstdint>
 #include <cstdlib>
 #include <iostream>
+#include <memory>
 #include <stdexcept>
+#include <utility>
 #include <vector>
 
 namespace {
@@ -143,20 +145,99 @@ int main()
             "far-positive y was not reported as uncovered");
     }
 
-    // Overlap fallback: many identical full-domain boxes exceed the grid's fill
-    // cap, so it falls back to a linear scan. The result must still match a
-    // linear scan exactly (smallest covering index), and out-of-range misses.
+    // Overlap fallback: a degenerate catalog where 150 full-domain boxes sit
+    // over 250 single-cell ones. The single cells (the majority) set the
+    // median extent, so tiles are cells, every big box lands in every tile,
+    // and the fill cap trips; the grid must fall back to a linear scan whose
+    // result still matches a linear scan exactly (smallest covering index).
     {
         std::vector<LoadedBlock> blocks;
-        for (int i = 0; i < 400; ++i) {
-            blocks.push_back(block(0, 0, 63, 63));  // all identical, overlapping
+        for (int i = 0; i < 150; ++i) {
+            blocks.push_back(block(0, 0, 63, 63));  // identical, overlapping
+        }
+        for (int i = 0; i < 250; ++i) {
+            blocks.push_back(block(i % 64, i / 64, i % 64, i / 64));
         }
         const BlockGrid grid(blocks, axes);
+        require(!grid.usesIndex(),
+            "overlapping catalog did not trip the fill cap");
         require(grid.find(blocks, point(20, 40), 2) == 0,
             "overlap fallback did not return the smallest covering block");
         require(grid.find(blocks, point(64, 0), 2) == -1,
             "overlap fallback matched a point past the domain");
         requireAgrees(blocks, axes, -2, 66, "overlap-fallback differential");
+    }
+
+    // Identical boxes alone are not an overlap pathology for the index: with
+    // tiles sized to the blocks they all share one tile, so the index stays.
+    {
+        std::vector<LoadedBlock> blocks;
+        for (int i = 0; i < 400; ++i) {
+            blocks.push_back(block(0, 0, 63, 63));
+        }
+        const BlockGrid grid(blocks, axes);
+        require(grid.usesIndex(), "identical boxes tripped the fill cap");
+        require(grid.find(blocks, point(20, 40), 2) == 0,
+            "identical boxes did not resolve to the smallest index");
+    }
+
+    // A pencil decomposition -- 1000 non-overlapping 1x1000 columns -- is an
+    // ordinary layout, not overlap: the index must be kept (square tiles would
+    // list every column in dozens of buckets and trip the cap) and route each
+    // point to its column.
+    {
+        std::vector<LoadedBlock> blocks;
+        for (int i = 0; i < 1000; ++i) {
+            blocks.push_back(block(i, 0, i, 999));
+        }
+        const BlockGrid grid(blocks, axes);
+        require(grid.usesIndex(), "pencil layout tripped the fill cap");
+        for (int x = 0; x < 1000; x += 7) {
+            require(grid.find(blocks, point(x, 500), 2) == x,
+                "pencil layout routed a point to the wrong column");
+        }
+        requireAgrees(blocks, axes, -3, 1002, "pencil differential");
+    }
+
+    // A sparse level: a few small blocks scattered over a huge span. The tile
+    // count must be capped near the block count (not one tile per block-sized
+    // cell of empty space) while lookups stay exact.
+    {
+        std::vector<LoadedBlock> blocks;
+        std::uint64_t rng = 0x5ca7'7e12ULL;
+        for (int i = 0; i < 16; ++i) {
+            const auto x = static_cast<int>(nextRandom(rng) % 4088);
+            const auto y = static_cast<int>(nextRandom(rng) % 4088);
+            blocks.push_back(block(x, y, x + 7, y + 7));
+        }
+        const BlockGrid grid(blocks, axes);
+        require(grid.usesIndex(), "sparse layout tripped the fill cap");
+        requireAgrees(blocks, axes, -8, 4103, "sparse differential");
+    }
+
+    // The line query's single-axis grid: 4096 blocks along x that all straddle
+    // the pinned y/z cell. Binning y as well would list every block in every
+    // y tile and trip the cap; binning x alone must keep the index and route
+    // each sample to its block.
+    {
+        std::vector<LoadedBlock> blocks;
+        for (int i = 0; i < 4096; ++i) {
+            IntBox box;
+            box.lower = {{16 * i, 0, 0}};
+            box.upper = {{16 * i + 15, 15, 15}};
+            box.centering = {{0, 0, 0}};
+            blocks.push_back(LoadedBlock{box, {}});
+        }
+        const BlockGrid grid(blocks, 0);
+        require(grid.usesIndex(), "single-axis line grid tripped the fill cap");
+        for (int x = 0; x < 16 * 4096; x += 1001) {
+            require(grid.find(blocks, Int3{{x, 8, 8}}, 3) == x / 16,
+                "single-axis grid routed a sample to the wrong block");
+        }
+        require(grid.find(blocks, Int3{{40, 16, 8}}, 3) == -1,
+            "single-axis grid matched a point off the pinned cell");
+        require(grid.find(blocks, Int3{{-1, 8, 8}}, 3) == -1,
+            "single-axis grid matched a point before the first block");
     }
 
     // Irregular non-overlapping layout (varied block sizes) as a differential
@@ -212,6 +293,57 @@ int main()
             rejected = true;
         }
         require(rejected, "grid accepted a block set of the wrong size");
+    }
+
+    // lookupBlockValue over IndexedBlocks with real cache handles: the value
+    // is read at valueOffset within the covering block's FAB, a point outside
+    // every block is nullopt, and a block whose loaded payload is smaller than
+    // its box (corrupt) throws rather than reads past the end.
+    {
+        amrvis::PlotfileDataset::BlockCache cache(1 << 20);
+        const auto pin = [&cache](int grid, const IntBox& box,
+                             std::vector<double> values) {
+            auto fab = std::make_shared<amrvis::FabBlock>();
+            fab->box = box;
+            fab->values = amrvis::FabValues(std::move(values));
+            amrvis::BlockKey key;
+            key.grid = grid;
+            return cache.insertAndPin(key, std::move(fab), 64);
+        };
+        std::vector<LoadedBlock> loaded;
+        // Block 0: cells x 0..3, y 0..1 -> values 0..7 (x fastest).
+        IntBox first;
+        first.lower = {{0, 0, 0}};
+        first.upper = {{3, 1, 0}};
+        first.centering = {{0, 0, 0}};
+        loaded.push_back({first,
+            pin(0, first, {0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0})});
+        // Block 1: cells x 4..5, y 0..1, but only three values loaded.
+        IntBox corrupt;
+        corrupt.lower = {{4, 0, 0}};
+        corrupt.upper = {{5, 1, 0}};
+        corrupt.centering = {{0, 0, 0}};
+        loaded.push_back({corrupt, pin(1, corrupt, {10.0, 11.0, 12.0})});
+        const amrvis::detail::IndexedBlocks indexed(std::move(loaded), axes);
+
+        const auto at = [&indexed](int x, int y) {
+            return amrvis::detail::lookupBlockValue(indexed, point(x, y), 2);
+        };
+        require(at(0, 0) == 0.0 && at(3, 0) == 3.0 && at(0, 1) == 4.0
+                && at(2, 1) == 6.0,
+            "lookupBlockValue read the wrong FAB value");
+        require(!at(0, 2).has_value() && !at(-1, 0).has_value()
+                && !at(6, 0).has_value(),
+            "lookupBlockValue returned a value outside every block");
+        require(at(4, 0) == 10.0 && at(4, 1) == 12.0,
+            "lookupBlockValue misread the second block");
+        bool threw = false;
+        try {
+            static_cast<void>(at(5, 1));  // offset 3 into three values
+        } catch (const std::runtime_error&) {
+            threw = true;
+        }
+        require(threw, "lookupBlockValue read past a short FAB payload");
     }
 
     std::cout << "block lookup tests passed\n";

--- a/tests/unit/test_block_lookup.cpp
+++ b/tests/unit/test_block_lookup.cpp
@@ -295,6 +295,55 @@ int main()
         require(rejected, "grid accepted a block set of the wrong size");
     }
 
+    // Degenerate boxes (upper < lower on a binned axis) contain no point, and
+    // must neither be found nor break the build: an all-inverted set yields an
+    // empty grid, a mix leaves the inverted ones out (a negative extent would
+    // otherwise wrap the CSR entry count and under-allocate the fill), and a
+    // box inverted only on an unbinned axis is simply never matched. Each
+    // case must agree with the linear scan, which never matches them either.
+    {
+        std::vector<LoadedBlock> inverted;
+        inverted.push_back(block(5, 5, 4, 4));
+        const BlockGrid empty(inverted, axes);
+        require(empty.find(inverted, point(4, 4), 2) == -1
+                && empty.find(inverted, point(5, 5), 2) == -1,
+            "an inverted box was matched");
+        const BlockGrid emptySingle(inverted, 0);
+        require(emptySingle.find(inverted, point(4, 4), 2) == -1,
+            "an inverted box was matched by a single-axis grid");
+
+        std::vector<LoadedBlock> mixed;
+        mixed.push_back(block(0, 0, 3, 3));
+        mixed.push_back(block(4, 0, 7, 3));
+        mixed.push_back(block(8, 3, 11, 0));    // inverted on y
+        mixed.push_back(block(12, 0, 15, 3));
+        mixed.push_back(block(20, 0, 16, 3));   // inverted on x
+        for (const std::array<int, 2> gridAxes :
+            {std::array<int, 2>{0, 1}, std::array<int, 2>{1, 0},
+                std::array<int, 2>{0, 0}}) {
+            const BlockGrid grid(mixed, gridAxes);
+            require(grid.usesIndex(), "inverted boxes tripped the fill cap");
+            for (int y = -1; y <= 4; ++y) {
+                for (int x = -1; x <= 21; ++x) {
+                    require(grid.find(mixed, point(x, y), 2)
+                            == linearFind(mixed, point(x, y)),
+                        "grid with inverted boxes disagrees with a linear scan");
+                }
+            }
+        }
+
+        std::vector<LoadedBlock> zInverted;
+        IntBox box;
+        box.lower = {{0, 0, 3}};
+        box.upper = {{3, 3, 0}};  // inverted on z, the unbinned axis
+        box.centering = {{0, 0, 0}};
+        zInverted.push_back(LoadedBlock{box, {}});
+        const BlockGrid grid(zInverted, axes);
+        require(grid.find(zInverted, Int3{{1, 1, 0}}, 3) == -1
+                && grid.find(zInverted, Int3{{1, 1, 3}}, 3) == -1,
+            "a box inverted on the unbinned axis was matched");
+    }
+
     // lookupBlockValue over IndexedBlocks with real cache handles: the value
     // is read at valueOffset within the covering block's FAB, a point outside
     // every block is nullopt, and a block whose loaded payload is smaller than

--- a/tests/unit/test_block_lookup.cpp
+++ b/tests/unit/test_block_lookup.cpp
@@ -4,6 +4,7 @@
 #include <cstdint>
 #include <cstdlib>
 #include <iostream>
+#include <stdexcept>
 #include <vector>
 
 namespace {
@@ -38,10 +39,11 @@ Int3 point(int a, int b)
 
 // The behavior the grid must reproduce exactly: the first (smallest-index)
 // block whose valid box contains the point, or -1.
-int linearFind(const std::vector<LoadedBlock>& blocks, const Int3& p)
+int linearFind(
+    const std::vector<LoadedBlock>& blocks, const Int3& p, int dimension = 2)
 {
     for (std::size_t i = 0; i < blocks.size(); ++i) {
-        if (amrvis::detail::contains(blocks[i].validBox, p, 2)) {
+        if (amrvis::detail::contains(blocks[i].validBox, p, dimension)) {
             return static_cast<int>(i);
         }
     }
@@ -166,6 +168,50 @@ int main()
         blocks.push_back(block(4, 4, 9, 9));
         blocks.push_back(block(10, 0, 15, 15));
         requireAgrees(blocks, axes, -3, 18, "irregular differential");
+    }
+
+    // The axis selection: production grids bin on {plane axes} for a slice and
+    // {line axis, next axis} for a line -- {1, 0}, {2, 0}, and {0, 0} in 1-D --
+    // not only {0, 1}. 3-D blocks laid out along z, indexed on {2, 0} and
+    // {1, 2}, and the same-axis case {2, 2}, each against the linear scan.
+    {
+        std::vector<LoadedBlock> blocks;
+        for (int k = 0; k < 6; ++k) {
+            IntBox box;
+            box.lower = {{0, k % 2 == 0 ? 0 : 4, 8 * k}};
+            box.upper = {{7, k % 2 == 0 ? 3 : 7, 8 * k + 7}};
+            box.centering = {{0, 0, 0}};
+            blocks.push_back(LoadedBlock{box, {}});
+        }
+        for (const std::array<int, 2> gridAxes : {std::array<int, 2>{2, 0},
+                 std::array<int, 2>{1, 2}, std::array<int, 2>{2, 2}}) {
+            const BlockGrid grid(blocks, gridAxes);
+            std::uint64_t rng = 0x5eed'0000ULL;
+            for (int trial = 0; trial < 20000; ++trial) {
+                const Int3 p{{-2 + static_cast<int>(nextRandom(rng) % 12),
+                    -2 + static_cast<int>(nextRandom(rng) % 12),
+                    -4 + static_cast<int>(nextRandom(rng) % 56)}};
+                require(grid.find(blocks, p, 3) == linearFind(blocks, p, 3),
+                    "grid on non-default axes disagrees with a linear scan");
+            }
+        }
+    }
+
+    // A grid refuses a block set other than the one it indexes.
+    {
+        std::vector<LoadedBlock> two;
+        two.push_back(block(0, 0, 3, 3));
+        two.push_back(block(4, 0, 7, 3));
+        std::vector<LoadedBlock> one;
+        one.push_back(block(0, 0, 3, 3));
+        const BlockGrid grid(two, axes);
+        bool rejected = false;
+        try {
+            static_cast<void>(grid.find(one, point(1, 1), 2));
+        } catch (const std::logic_error&) {
+            rejected = true;
+        }
+        require(rejected, "grid accepted a block set of the wrong size");
     }
 
     std::cout << "block lookup tests passed\n";


### PR DESCRIPTION
Move BlockGrid into detail/BlockLookup.hpp (its shared home) and give LineQuery::findCovering the same O(1)-average lookup, replacing the per-sample linear block scan it still ran. A shared lookupBlockValue helper factors the find -> valueOffset -> bounds-throw tail both queries duplicated. The grid is now a member of SliceQuery's LevelBlocks (no parallel vector) and a per-level vector in LineQuery.

Header-exposing BlockGrid also makes it directly unit-testable: test_block_lookup checks multi-tile routing, the far-out/negative-base point that regressed as an out-of-bounds read, and the overlap fill-cap fallback -- against a linear-scan reference -- without a plotfile fixture.