### PR TITLE
harden the block grid's edges and measure it on clustered levels

### DIFF
--- a/include/amrexplorer/query/detail/BlockLookup.hpp
+++ b/include/amrexplorer/query/detail/BlockLookup.hpp
@@ -301,10 +301,14 @@ public:
         }
     }
 
-    // Whether lookups go through the index (false after the overlap fallback,
-    // where find() is the linear scan the index replaces). For tests and
-    // diagnostics; the result is the same either way.
-    [[nodiscard]] bool usesIndex() const noexcept { return !m_linearScan; }
+    // Whether lookups go through a built index: false for a grid over no
+    // blocks or one never built, and after the overlap fallback (where find()
+    // is the linear scan the index replaces). For tests and diagnostics; the
+    // result is the same either way.
+    [[nodiscard]] bool usesIndex() const noexcept
+    {
+        return !m_linearScan && !m_offsets.empty();
+    }
 
     // Index into `blocks` of the block containing `point`, or -1 if none does.
     // `blocks` must be the same vector the grid was built from: the grid holds
@@ -393,52 +397,93 @@ private:
     std::vector<int> m_indices;          // block indices, bucket by bucket
 };
 
+// The property every reader of a loaded block relies on, checked in one place:
+// the FAB's payload covers the catalog box the block was loaded for. Two
+// halves. The catalog box (the grid's valid box, what find()/intersects()
+// route by) must lie inside the FAB's own header box, which is what offsets
+// are computed in -- nothing upstream cross-checks the two (a v1 VisMF FAB
+// header can disagree with the Header's grid box), and a disagreement aliases
+// into the wrong cell without leaving the payload. And the payload must hold
+// every cell of that header box: PlotfileBlockReader sizes it so, but FabBlock
+// is an aggregate any producer can fill and FabValues::operator[] is
+// unchecked, so the reader's invariant is asserted here rather than assumed.
+// Both are per block, so a consumer checks once per block, not per cell.
+inline void requireBlockPayload(
+    const FabBlock& fab, const IntBox& catalogBox, int dimension)
+{
+    if (!contains(fab.box, catalogBox.lower, dimension)
+        || !contains(fab.box, catalogBox.upper, dimension)) {
+        throw std::runtime_error("FAB does not cover its catalog box");
+    }
+    // valueOffset of the header box's last cell is pointCount - 1, and it is
+    // overflow-checked (an inverted header box throws there).
+    if (fab.values.size() <= valueOffset(fab.box, fab.box.upper, dimension)) {
+        throw std::runtime_error("FAB payload is smaller than its box");
+    }
+}
+
 // One level's loaded blocks together with the point->block grid over them.
-// The grid stores indices into `blocks`, so the two travel as one value:
+// The grid stores indices into the blocks, so the two travel as one value:
 // build it from the loaded vector and query it through lookupBlockValue.
-struct IndexedBlocks {
+// Construction validates every block for the dataset's dimension (a payload
+// is present and requireBlockPayload holds against its valid box), which is
+// what lets the per-hit lookup below read the FAB with no checks of its own;
+// the members are read-only after that so the validated state cannot drift.
+class IndexedBlocks {
+public:
     IndexedBlocks() = default;
 
-    IndexedBlocks(std::vector<LoadedBlock> loaded, int axis)
-        : blocks(std::move(loaded))
-        , grid(blocks, axis)
-    {}
+    IndexedBlocks(int dimension, std::vector<LoadedBlock> loaded, int axis)
+        : m_blocks(std::move(loaded))
+        , m_grid(m_blocks, axis)
+    {
+        validate(dimension);
+    }
 
-    IndexedBlocks(
-        std::vector<LoadedBlock> loaded, const std::array<int, 2>& axes)
-        : blocks(std::move(loaded))
-        , grid(blocks, axes)
-    {}
+    IndexedBlocks(int dimension, std::vector<LoadedBlock> loaded,
+        const std::array<int, 2>& axes)
+        : m_blocks(std::move(loaded))
+        , m_grid(m_blocks, axes)
+    {
+        validate(dimension);
+    }
 
-    std::vector<LoadedBlock> blocks;
-    BlockGrid grid;
+    [[nodiscard]] const std::vector<LoadedBlock>& blocks() const noexcept
+    {
+        return m_blocks;
+    }
+    [[nodiscard]] const BlockGrid& grid() const noexcept { return m_grid; }
+
+private:
+    void validate(int dimension) const
+    {
+        for (const auto& block : m_blocks) {
+            if (!block.data) {
+                throw std::logic_error("indexed block has no loaded payload");
+            }
+            requireBlockPayload(*block.data, block.validBox, dimension);
+        }
+    }
+
+    std::vector<LoadedBlock> m_blocks;
+    BlockGrid m_grid;
 };
 
 // The value at `point` in the block of one level's `indexed` blocks that
-// covers it, or nullopt when none does. Throws if the covering block's FAB
-// index is out of range (a corrupt block whose loaded payload is smaller than
-// its box). The shared composed-sample tail for the slice and line queries;
-// the caller walks the levels finest first and keeps the point and covering
-// level.
+// covers it, or nullopt when none does. The shared composed-sample tail for
+// the slice and line queries; the caller walks the levels finest first and
+// keeps the point and covering level. No per-hit checks: a point find() places
+// in a block's valid box is inside that block's FAB box with a payload that
+// covers it, by IndexedBlocks' construction-time validation.
 [[nodiscard]] inline std::optional<double> lookupBlockValue(
     const IndexedBlocks& indexed, const Int3& point, int dimension)
 {
-    const auto blockIndex = indexed.grid.find(indexed.blocks, point, dimension);
+    const auto blockIndex
+        = indexed.grid().find(indexed.blocks(), point, dimension);
     if (blockIndex < 0) {
         return std::nullopt;
     }
-    const auto& block = indexed.blocks[static_cast<std::size_t>(blockIndex)];
-    if (!block.data) {
-        throw std::logic_error("covering block has no loaded payload");
-    }
-    // The point was found in the catalog's valid box; the offset is computed
-    // in the FAB's own header box. Nothing upstream cross-checks the two, and
-    // a disagreement aliases into the wrong cell without leaving the payload
-    // (which is sized to the FAB box exactly), so containment -- not payload
-    // size -- is the guard.
-    if (!contains(block.data->box, point, dimension)) {
-        throw std::runtime_error("composed FAB does not cover its catalog box");
-    }
+    const auto& block = indexed.blocks()[static_cast<std::size_t>(blockIndex)];
     return block.data->values[valueOffset(block.data->box, point, dimension)];
 }
 

--- a/include/amrexplorer/query/detail/BlockLookup.hpp
+++ b/include/amrexplorer/query/detail/BlockLookup.hpp
@@ -416,7 +416,8 @@ inline void requireBlockPayload(
         throw std::runtime_error("FAB does not cover its catalog box");
     }
     // valueOffset of the header box's last cell is pointCount - 1, and it is
-    // overflow-checked (an inverted header box throws there).
+    // overflow-checked. (An inverted header box never gets here: it contains
+    // no point, so the check above already threw.)
     if (fab.values.size() <= valueOffset(fab.box, fab.box.upper, dimension)) {
         throw std::runtime_error("FAB payload is smaller than its box");
     }

--- a/include/amrexplorer/query/detail/BlockLookup.hpp
+++ b/include/amrexplorer/query/detail/BlockLookup.hpp
@@ -22,8 +22,8 @@ namespace amrvis::detail {
 
 // One cached block pinned for a query: the grid's valid box plus the cache
 // handle that keeps its values resident. BlockGrid reads only the box, so a
-// grid can be built and searched over blocks with no payload; lookupBlockValue
-// needs the handle and rejects a null one.
+// grid can be built and searched over blocks with no payload; IndexedBlocks
+// (whose lookupBlockValue reads the payload) rejects a null one when built.
 struct LoadedBlock {
     IntBox validBox;
     PlotfileDataset::BlockCache::Handle data;
@@ -428,26 +428,30 @@ inline void requireBlockPayload(
 // Construction validates every block for the dataset's dimension (a payload
 // is present and requireBlockPayload holds against its valid box), which is
 // what lets the per-hit lookup below read the FAB with no checks of its own;
-// the members are read-only after that so the validated state cannot drift.
+// the members -- the dimension included, since it is what the validation was
+// for -- are read-only after that so the validated state cannot drift.
 class IndexedBlocks {
 public:
     IndexedBlocks() = default;
 
     IndexedBlocks(int dimension, std::vector<LoadedBlock> loaded, int axis)
-        : m_blocks(std::move(loaded))
+        : m_dimension(dimension)
+        , m_blocks(std::move(loaded))
         , m_grid(m_blocks, axis)
     {
-        validate(dimension);
+        validate();
     }
 
     IndexedBlocks(int dimension, std::vector<LoadedBlock> loaded,
         const std::array<int, 2>& axes)
-        : m_blocks(std::move(loaded))
+        : m_dimension(dimension)
+        , m_blocks(std::move(loaded))
         , m_grid(m_blocks, axes)
     {
-        validate(dimension);
+        validate();
     }
 
+    [[nodiscard]] int dimension() const noexcept { return m_dimension; }
     [[nodiscard]] const std::vector<LoadedBlock>& blocks() const noexcept
     {
         return m_blocks;
@@ -455,16 +459,18 @@ public:
     [[nodiscard]] const BlockGrid& grid() const noexcept { return m_grid; }
 
 private:
-    void validate(int dimension) const
+    void validate() const
     {
         for (const auto& block : m_blocks) {
             if (!block.data) {
                 throw std::logic_error("indexed block has no loaded payload");
             }
-            requireBlockPayload(*block.data, block.validBox, dimension);
+            requireBlockPayload(*block.data, block.validBox, m_dimension);
         }
     }
 
+    // Zero for a default-constructed (empty) set, whose grid finds nothing.
+    int m_dimension = 0;
     std::vector<LoadedBlock> m_blocks;
     BlockGrid m_grid;
 };
@@ -476,8 +482,9 @@ private:
 // in a block's valid box is inside that block's FAB box with a payload that
 // covers it, by IndexedBlocks' construction-time validation.
 [[nodiscard]] inline std::optional<double> lookupBlockValue(
-    const IndexedBlocks& indexed, const Int3& point, int dimension)
+    const IndexedBlocks& indexed, const Int3& point)
 {
+    const auto dimension = indexed.dimension();
     const auto blockIndex
         = indexed.grid().find(indexed.blocks(), point, dimension);
     if (blockIndex < 0) {

--- a/include/amrexplorer/query/detail/BlockLookup.hpp
+++ b/include/amrexplorer/query/detail/BlockLookup.hpp
@@ -10,7 +10,6 @@
 
 #include <algorithm>
 #include <array>
-#include <cmath>
 #include <cstddef>
 #include <cstdint>
 #include <limits>
@@ -22,7 +21,9 @@
 namespace amrvis::detail {
 
 // One cached block pinned for a query: the grid's valid box plus the cache
-// handle that keeps its values resident.
+// handle that keeps its values resident. BlockGrid reads only the box, so a
+// grid can be built and searched over blocks with no payload; lookupBlockValue
+// needs the handle and rejects a null one.
 struct LoadedBlock {
     IntBox validBox;
     PlotfileDataset::BlockCache::Handle data;
@@ -127,6 +128,17 @@ struct LoadedBlock {
 // tile count is capped (a few per block), so sparse levels coarsen their tiles
 // instead of allocating a bucket per empty cell.
 //
+// That cap is also what bounds the work per lookup on any layout, clustered
+// ones included: with about one (block, tile) entry per block and at least a
+// quarter as many tiles as blocks, the candidates scanned *averaged over
+// points spread across the bounding box* -- which is what a slice's pixels
+// and a line's samples are, since a query indexes only the blocks meeting its
+// visible region -- come to blocks/tiles, at most a few. A level of two
+// refined regions far apart does coarsen to dozens of blocks per occupied
+// bucket, but only the corresponding fraction of points lands in them; an
+// index that keeps block-sized tiles there (hashed sparse tiles behind a
+// coarse occupancy map) measured within noise of this one end to end.
+//
 // A block that spans several tiles is listed in each, so every block covering a
 // point shares that point's tile and the bucket scan sees all candidates. Scans
 // run in ascending block index (buckets are filled in block order), so a
@@ -208,7 +220,11 @@ public:
             = static_cast<std::int64_t>(4 * blocks.size() + 64);
         auto n0 = (span0 + m_tile0 - 1) / m_tile0;
         auto n1 = (span1 + m_tile1 - 1) / m_tile1;
-        while (n0 > maxTiles / n1) {
+        // Terminates when both tiles reach their spans (one tile each); that
+        // takes at most ~33 doublings for int32 spans, so the bound below is
+        // slack -- it turns a future edit that stops one axis from coarsening
+        // into a merely coarse index instead of a hang on the query thread.
+        for (int guard = 0; guard < 64 && n0 > maxTiles / n1; ++guard) {
             m_tile0 = std::min(span0, m_tile0 * 2);
             m_tile1 = std::min(span1, m_tile1 * 2);
             n0 = (span0 + m_tile0 - 1) / m_tile0;
@@ -404,6 +420,9 @@ struct IndexedBlocks {
         return std::nullopt;
     }
     const auto& block = indexed.blocks[static_cast<std::size_t>(blockIndex)];
+    if (!block.data) {
+        throw std::logic_error("covering block has no loaded payload");
+    }
     const auto offset = valueOffset(block.data->box, point, dimension);
     if (offset >= block.data->values.size()) {
         throw std::runtime_error("composed FAB index exceeds loaded block");

--- a/include/amrexplorer/query/detail/BlockLookup.hpp
+++ b/include/amrexplorer/query/detail/BlockLookup.hpp
@@ -128,16 +128,18 @@ struct LoadedBlock {
 // tile count is capped (a few per block), so sparse levels coarsen their tiles
 // instead of allocating a bucket per empty cell.
 //
-// That cap is also what bounds the work per lookup on any layout, clustered
-// ones included: with about one (block, tile) entry per block and at least a
-// quarter as many tiles as blocks, the candidates scanned *averaged over
-// points spread across the bounding box* -- which is what a slice's pixels
-// and a line's samples are, since a query indexes only the blocks meeting its
-// visible region -- come to blocks/tiles, at most a few. A level of two
-// refined regions far apart does coarsen to dozens of blocks per occupied
-// bucket, but only the corresponding fraction of points lands in them; an
-// index that keeps block-sized tiles there (hashed sparse tiles behind a
-// coarse occupancy map) measured within noise of this one end to end.
+// That cap is also what bounds the work per lookup on any *non-overlapping*
+// layout (the level invariant), clustered ones included: such blocks each
+// take about one (block, tile) entry, and with at least a quarter as many
+// tiles as blocks the candidates scanned *averaged over points spread across
+// the bounding box* -- which is what a slice's pixels and a line's samples
+// are, since a query indexes only the blocks meeting its visible region --
+// come to blocks/tiles, at most a few. A level of two refined regions far
+// apart does coarsen to dozens of blocks per occupied bucket, but only the
+// corresponding fraction of points lands in them; an index that keeps
+// block-sized tiles there (hashed sparse tiles behind a coarse occupancy map)
+// measured within noise of this one end to end. Overlapping catalogs get no
+// such bound -- identical boxes all share one tile -- only the memory cap.
 //
 // A block that spans several tiles is listed in each, so every block covering a
 // point shares that point's tile and the bucket scan sees all candidates. Scans
@@ -229,6 +231,12 @@ public:
             m_tile1 = std::min(span1, m_tile1 * 2);
             n0 = (span0 + m_tile0 - 1) / m_tile0;
             n1 = (span1 + m_tile1 - 1) / m_tile1;
+        }
+        if (n0 > maxTiles / n1) {
+            // Only reachable if the loop above stops coarsening an axis; the
+            // bucket array below relies on the cap, so scan instead.
+            m_linearScan = true;
+            return;
         }
         m_n0 = static_cast<int>(n0);
         m_n1 = static_cast<int>(n1);
@@ -423,11 +431,15 @@ struct IndexedBlocks {
     if (!block.data) {
         throw std::logic_error("covering block has no loaded payload");
     }
-    const auto offset = valueOffset(block.data->box, point, dimension);
-    if (offset >= block.data->values.size()) {
-        throw std::runtime_error("composed FAB index exceeds loaded block");
+    // The point was found in the catalog's valid box; the offset is computed
+    // in the FAB's own header box. Nothing upstream cross-checks the two, and
+    // a disagreement aliases into the wrong cell without leaving the payload
+    // (which is sized to the FAB box exactly), so containment -- not payload
+    // size -- is the guard.
+    if (!contains(block.data->box, point, dimension)) {
+        throw std::runtime_error("composed FAB does not cover its catalog box");
     }
-    return block.data->values[offset];
+    return block.data->values[valueOffset(block.data->box, point, dimension)];
 }
 
 } // namespace amrvis::detail

--- a/src/data/DatasetPage.cpp
+++ b/src/data/DatasetPage.cpp
@@ -150,32 +150,10 @@ DatasetPage extractDatasetPage(PlotfileDataset& dataset,
         const auto iUpper = std::min(validBox.upper[xAxis], page.upper[0]);
         const auto jLower = std::max(validBox.lower[yAxis], page.lower[1]);
         const auto jUpper = std::min(validBox.upper[yAxis], page.upper[1]);
-        // The cells read below come from the catalog's box; the offsets are
-        // computed in the FAB's own header box. Nothing upstream cross-checks
-        // the two (a v1 VisMF FAB header can disagree with the Header's grid
-        // box), and a disagreement aliases into the wrong cell without ever
-        // leaving the payload -- the payload is sized to the FAB box exactly.
-        // Require the whole cell range to lie in the FAB box, once per block.
-        {
-            Int3 first{};
-            Int3 last{};
-            first[xAxis] = iLower;
-            last[xAxis] = iUpper;
-            first[yAxis] = jLower;
-            last[yAxis] = jUpper;
-            if (metadata.dimension == 3) {
-                first[static_cast<std::size_t>(request.normalAxis)]
-                    = page.sliceIndex;
-                last[static_cast<std::size_t>(request.normalAxis)]
-                    = page.sliceIndex;
-            }
-            if (iLower <= iUpper && jLower <= jUpper
-                && (!detail::contains(fab.box, first, metadata.dimension)
-                    || !detail::contains(fab.box, last, metadata.dimension))) {
-                throw std::runtime_error(
-                    "dataset page block does not cover its catalog box");
-            }
-        }
+        // Once per block: the FAB covers the catalog box the cells below are
+        // taken from, and its payload covers the FAB box (see
+        // requireBlockPayload for why neither can be assumed).
+        detail::requireBlockPayload(fab, validBox, metadata.dimension);
         for (auto j = jLower; j <= jUpper; ++j) {
             if (cancellation.stop_requested()) {
                 throw ReadCancelled();

--- a/src/data/DatasetPage.cpp
+++ b/src/data/DatasetPage.cpp
@@ -150,6 +150,32 @@ DatasetPage extractDatasetPage(PlotfileDataset& dataset,
         const auto iUpper = std::min(validBox.upper[xAxis], page.upper[0]);
         const auto jLower = std::max(validBox.lower[yAxis], page.lower[1]);
         const auto jUpper = std::min(validBox.upper[yAxis], page.upper[1]);
+        // The cells read below come from the catalog's box; the offsets are
+        // computed in the FAB's own header box. Nothing upstream cross-checks
+        // the two (a v1 VisMF FAB header can disagree with the Header's grid
+        // box), and a disagreement aliases into the wrong cell without ever
+        // leaving the payload -- the payload is sized to the FAB box exactly.
+        // Require the whole cell range to lie in the FAB box, once per block.
+        {
+            Int3 first{};
+            Int3 last{};
+            first[xAxis] = iLower;
+            last[xAxis] = iUpper;
+            first[yAxis] = jLower;
+            last[yAxis] = jUpper;
+            if (metadata.dimension == 3) {
+                first[static_cast<std::size_t>(request.normalAxis)]
+                    = page.sliceIndex;
+                last[static_cast<std::size_t>(request.normalAxis)]
+                    = page.sliceIndex;
+            }
+            if (iLower <= iUpper && jLower <= jUpper
+                && (!detail::contains(fab.box, first, metadata.dimension)
+                    || !detail::contains(fab.box, last, metadata.dimension))) {
+                throw std::runtime_error(
+                    "dataset page block does not cover its catalog box");
+            }
+        }
         for (auto j = jLower; j <= jUpper; ++j) {
             if (cancellation.stop_requested()) {
                 throw ReadCancelled();
@@ -164,16 +190,8 @@ DatasetPage extractDatasetPage(PlotfileDataset& dataset,
                     cell[static_cast<std::size_t>(request.normalAxis)]
                         = page.sliceIndex;
                 }
-                // Same guard as lookupBlockValue: a corrupt block whose loaded
-                // payload is smaller than its box must throw, not be read
-                // past its end.
-                const auto fabOffset = detail::valueOffset(
-                    fab.box, cell, metadata.dimension);
-                if (fabOffset >= fab.values.size()) {
-                    throw std::runtime_error(
-                        "dataset page FAB index exceeds loaded block");
-                }
-                const auto value = fab.values[fabOffset];
+                const auto value = fab.values[detail::valueOffset(
+                    fab.box, cell, metadata.dimension)];
                 const auto valueX = static_cast<std::size_t>(
                     static_cast<std::int64_t>(i) - page.lower[0]);
                 const auto offset = valueX

--- a/src/data/DatasetPage.cpp
+++ b/src/data/DatasetPage.cpp
@@ -164,8 +164,16 @@ DatasetPage extractDatasetPage(PlotfileDataset& dataset,
                     cell[static_cast<std::size_t>(request.normalAxis)]
                         = page.sliceIndex;
                 }
-                const auto value = fab.values[detail::valueOffset(
-                    fab.box, cell, metadata.dimension)];
+                // Same guard as lookupBlockValue: a corrupt block whose loaded
+                // payload is smaller than its box must throw, not be read
+                // past its end.
+                const auto fabOffset = detail::valueOffset(
+                    fab.box, cell, metadata.dimension);
+                if (fabOffset >= fab.values.size()) {
+                    throw std::runtime_error(
+                        "dataset page FAB index exceeds loaded block");
+                }
+                const auto value = fab.values[fabOffset];
                 const auto valueX = static_cast<std::size_t>(
                     static_cast<std::int64_t>(i) - page.lower[0]);
                 const auto offset = valueX

--- a/src/query/LineQuery.cpp
+++ b/src/query/LineQuery.cpp
@@ -149,7 +149,7 @@ LineQueryResult LineQuery::execute(
             loaded.push_back({block.box, std::move(access.handle)});
         }
         blocksByLevel[static_cast<std::size_t>(levelIndex)]
-            = IndexedBlocks(std::move(loaded), request.axis);
+            = IndexedBlocks(metadata.dimension, std::move(loaded), request.axis);
     }
 
     // Find the finest level covering position x (fine overrides coarse).

--- a/src/query/LineQuery.cpp
+++ b/src/query/LineQuery.cpp
@@ -165,8 +165,8 @@ LineQueryResult LineQuery::execute(
                     metadata, level, axis);
             }
             if (const auto value = lookupBlockValue(
-                    blocksByLevel[static_cast<std::size_t>(levelIndex)], point,
-                    metadata.dimension)) {
+                    blocksByLevel[static_cast<std::size_t>(levelIndex)],
+                    point)) {
                 cover.level = levelIndex;
                 cover.point = point;
                 cover.value = static_cast<float>(*value);

--- a/src/query/SliceQuery.cpp
+++ b/src/query/SliceQuery.cpp
@@ -198,8 +198,8 @@ SliceQueryResult SliceQuery::execute(
                 point[static_cast<std::size_t>(axis)] = physicalToIndex(
                     position[static_cast<std::size_t>(axis)], metadata, level, axis);
             }
-            if (const auto value = lookupBlockValue(
-                    levelBlocks.indexed, point, metadata.dimension)) {
+            if (const auto value
+                = lookupBlockValue(levelBlocks.indexed, point)) {
                 return std::pair{*value, levelBlocks.levelIndex};
             }
         }

--- a/src/query/SliceQuery.cpp
+++ b/src/query/SliceQuery.cpp
@@ -180,7 +180,8 @@ SliceQueryResult SliceQuery::execute(
             }
             loaded.push_back({block.box, std::move(access.handle)});
         }
-        levels.push_back({levelIndex, IndexedBlocks(std::move(loaded), axes)});
+        levels.push_back({levelIndex,
+            IndexedBlocks(metadata.dimension, std::move(loaded), axes)});
     }
 
     // The composed piecewise-constant field at a physical point: the finest

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1403,8 +1403,10 @@ add_test(NAME slice_query_benchmark_resampled
 set_tests_properties(slice_query_benchmark_resampled PROPERTIES TIMEOUT 120)
 # Two clusters of blocks far apart (the ordinary AMR shape): exercises the
 # block index's sparse-tile path and the layout-aware coverage checks.
+# The trailing 1 requires the linear pass to have validated interpolated
+# values, so a change to these arguments cannot make the run vacuous.
 add_test(NAME slice_query_benchmark_clustered
-    COMMAND bench_slice_query 8 8 200 1 24)
+    COMMAND bench_slice_query 8 8 200 1 24 1)
 set_tests_properties(slice_query_benchmark_clustered PROPERTIES TIMEOUT 120)
 
 # Fuzz/property harness for the crafted-plotfile header parsers. No remote

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -302,6 +302,10 @@ add_executable(test_fits_writer unit/test_fits_writer.cpp)
 target_link_libraries(test_fits_writer PRIVATE amrexplorer::io amrexplorer::warnings)
 add_test(NAME fits_writer COMMAND test_fits_writer)
 
+add_executable(test_block_lookup unit/test_block_lookup.cpp)
+target_link_libraries(test_block_lookup PRIVATE amrexplorer::query amrexplorer::warnings)
+add_test(NAME block_lookup COMMAND test_block_lookup)
+
 add_executable(test_plotfile_metadata integration/test_plotfile_metadata.cpp)
 target_link_libraries(test_plotfile_metadata PRIVATE amrexplorer::io amrexplorer::warnings)
 add_test(
@@ -360,10 +364,6 @@ target_link_libraries(
     PRIVATE amrexplorer::pipeline amrexplorer::warnings
 )
 add_test(NAME display_transitions COMMAND test_display_transitions)
-
-add_executable(test_block_lookup unit/test_block_lookup.cpp)
-target_link_libraries(test_block_lookup PRIVATE amrexplorer::query amrexplorer::warnings)
-add_test(NAME block_lookup COMMAND test_block_lookup)
 
 add_executable(test_slice_query integration/test_slice_query.cpp)
 target_link_libraries(test_slice_query PRIVATE amrexplorer::query amrexplorer::warnings)
@@ -1401,6 +1401,11 @@ set_tests_properties(slice_query_benchmark PROPERTIES TIMEOUT 120)
 add_test(NAME slice_query_benchmark_resampled
     COMMAND bench_slice_query 16 8 200 1)
 set_tests_properties(slice_query_benchmark_resampled PROPERTIES TIMEOUT 120)
+# Two clusters of blocks far apart (the ordinary AMR shape): exercises the
+# block index's sparse-tile path and the layout-aware coverage checks.
+add_test(NAME slice_query_benchmark_clustered
+    COMMAND bench_slice_query 8 8 200 1 24)
+set_tests_properties(slice_query_benchmark_clustered PROPERTIES TIMEOUT 120)
 
 # Fuzz/property harness for the crafted-plotfile header parsers. No remote
 # dependency, so it builds and runs (including under the sanitizers preset)

--- a/tests/benchmark/bench_slice_query.cpp
+++ b/tests/benchmark/bench_slice_query.cpp
@@ -12,8 +12,14 @@
 // though the per-pixel lookup is O(1) -- that is the planning, not a regression.
 //
 //   bench_slice_query [blocksPerAxis] [cellsPerBlock] [outputDim] [iterations]
+//                     [clusterGap]
 //
-// The default workload is small so it stays fast in CI.
+// clusterGap = 0 (the default) tiles the whole domain uniformly. A positive
+// clusterGap instead places two blocksPerAxis^2 clusters at opposite corners
+// of a domain that many blocks wider and taller -- the ordinary AMR shape of
+// separate refined regions -- so the block index is measured on a level whose
+// blocks occupy a small fraction of their bounding box, not only on a dense
+// tiling. The default workload is small so it stays fast in CI.
 #include <amrexplorer/query/SliceQuery.hpp>
 
 #include <amrexplorer/io/PlotfileDataset.hpp>
@@ -98,19 +104,24 @@ int positiveArg(const char* text)
 
 int runBenchmark(int argc, char** argv)
 {
-    // A single level tiled into blocksPerAxis^2 blocks of cellsPerBlock^2 cells,
-    // unit cell size, field phi(i, j) = i + 3j (asymmetric so a transposed
-    // result is not bit-identical to the correct one).
+    // A single level of cellsPerBlock^2-cell blocks, unit cell size, field
+    // phi(i, j) = i + 3j (asymmetric so a transposed result is not
+    // bit-identical to the correct one). Uniform: blocksPerAxis^2 blocks tile
+    // the domain. Clustered (clusterGap > 0): two such clusters at opposite
+    // corners of a domain clusterGap blocks wider, the rest empty.
     const int blocksPerAxis = argc > 1 ? positiveArg(argv[1]) : 16;
     const int cellsPerBlock = argc > 2 ? positiveArg(argv[2]) : 8;
+    const int clusterGap = argc > 5 ? positiveArg(argv[5]) : 0;
+    const int blocksAcross
+        = clusterGap > 0 ? 2 * blocksPerAxis + clusterGap : blocksPerAxis;
     // Guard the derived sizes (long long) before narrowing to int, so a large
     // pair can't overflow the multiply.
     const long long domainLL
-        = static_cast<long long>(blocksPerAxis) * cellsPerBlock;
-    const long long blockCountLL
-        = static_cast<long long>(blocksPerAxis) * blocksPerAxis;
+        = static_cast<long long>(blocksAcross) * cellsPerBlock;
+    const long long blockCountLL = (clusterGap > 0 ? 2LL : 1LL)
+        * static_cast<long long>(blocksPerAxis) * blocksPerAxis;
     if (domainLL > 65536 || blockCountLL > 1000000) {
-        die("fixture too large: reduce blocksPerAxis / cellsPerBlock");
+        die("fixture too large: reduce blocksPerAxis / cellsPerBlock / gap");
     }
     const int domain = static_cast<int>(domainLL);
     const int outputDim = argc > 3 ? positiveArg(argv[3]) : domain;
@@ -121,6 +132,20 @@ int runBenchmark(int argc, char** argv)
     }
     const int iterations = argc > 4 ? positiveArg(argv[4]) : 5;
     const int blockCount = static_cast<int>(blockCountLL);
+    // Whether block coordinate (gi, gj) holds a block, and whether cell (i, j)
+    // lies in one; the value checks below key on this rather than assuming
+    // full coverage.
+    const auto blockAt = [&](int gi, int gj) {
+        if (clusterGap == 0) {
+            return true;
+        }
+        const int second = blocksPerAxis + clusterGap;
+        return (gi < blocksPerAxis && gj < blocksPerAxis)
+            || (gi >= second && gj >= second);
+    };
+    const auto cellCovered = [&](int i, int j) {
+        return blockAt(i / cellsPerBlock, j / cellsPerBlock);
+    };
 
     const auto unique
         = std::chrono::steady_clock::now().time_since_epoch().count();
@@ -140,8 +165,11 @@ int runBenchmark(int argc, char** argv)
     std::string minRows;
     std::string maxRows;
     int fabNumber = 0;
-    for (int gj = 0; gj < blocksPerAxis; ++gj) {
-        for (int gi = 0; gi < blocksPerAxis; ++gi) {
+    for (int gj = 0; gj < blocksAcross; ++gj) {
+        for (int gi = 0; gi < blocksAcross; ++gi) {
+            if (!blockAt(gi, gj)) {
+                continue;
+            }
             const int i0 = gi * cellsPerBlock;
             const int j0 = gj * cellsPerBlock;
             const int i1 = i0 + cellsPerBlock - 1;
@@ -246,7 +274,27 @@ int runBenchmark(int argc, char** argv)
                 const auto off = static_cast<std::size_t>(x)
                     + static_cast<std::size_t>(outputDim)
                         * static_cast<std::size_t>(y);
-                if (warm.plane.valid[off] == 0) {
+                // Coverage must follow the layout exactly: a pixel whose every
+                // candidate cell lies in a block is covered, one whose none
+                // does is not (a block-lookup regression that dropped blocks
+                // must fail here, not read as "faster"); on a block edge
+                // either bracketing cell decides.
+                int inBlock = 0;
+                int candidates = 0;
+                for (const int i : sampleCells(px)) {
+                    for (const int j : sampleCells(py)) {
+                        ++candidates;
+                        inBlock += cellCovered(i, j) ? 1 : 0;
+                    }
+                }
+                const bool isCovered = warm.plane.valid[off] != 0;
+                if (inBlock == candidates && !isCovered) {
+                    die("benchmark slice left a block pixel uncovered");
+                }
+                if (inBlock == 0 && isCovered) {
+                    die("benchmark slice covered a pixel outside every block");
+                }
+                if (!isCovered) {
                     continue;
                 }
                 ++covered;
@@ -257,7 +305,8 @@ int runBenchmark(int argc, char** argv)
                     bool matched = false;
                     for (const int i : sampleCells(px)) {
                         for (const int j : sampleCells(py)) {
-                            if (value == static_cast<double>(i + 3 * j)) {
+                            if (cellCovered(i, j)
+                                && value == static_cast<double>(i + 3 * j)) {
                                 matched = true;
                             }
                         }
@@ -265,21 +314,28 @@ int runBenchmark(int argc, char** argv)
                     if (!matched) {
                         die("benchmark piecewise slice value is wrong");
                     }
-                } else if (px >= 0.5 && px <= extent - 0.5
-                    && py >= 0.5 && py <= extent - 0.5) {
-                    // Linear over the linear field phi = i + 3j is exact away
-                    // from the clamped border: phi(px, py) = px + 3py - 2 (cell
-                    // centers sit at half-integers). Border pixels clamp, so
-                    // only require them to be covered.
-                    ++linearChecked;
-                    if (std::fabs(value - (px + 3.0 * py - 2.0)) > 1e-2) {
-                        die("benchmark linear slice value is wrong");
+                } else {
+                    // Linear over the linear field phi = i + 3j is exact where
+                    // all four bracketing cell centers exist (cell centers sit
+                    // at half-integers): phi(px, py) = px + 3py - 2. Pixels
+                    // whose bracket reaches the domain border or an empty
+                    // region clamp, so only require those to be covered.
+                    const int i0 = static_cast<int>(std::floor(px - 0.5));
+                    const int j0 = static_cast<int>(std::floor(py - 0.5));
+                    if (i0 >= 0 && j0 >= 0 && i0 + 1 <= domain - 1
+                        && j0 + 1 <= domain - 1 && cellCovered(i0, j0)
+                        && cellCovered(i0 + 1, j0) && cellCovered(i0, j0 + 1)
+                        && cellCovered(i0 + 1, j0 + 1)) {
+                        ++linearChecked;
+                        if (std::fabs(value - (px + 3.0 * py - 2.0)) > 1e-2) {
+                            die("benchmark linear slice value is wrong");
+                        }
                     }
                 }
             }
         }
-        if (covered != pixelCount) {
-            die("benchmark slice left output pixels uncovered");
+        if (covered == 0) {
+            die("benchmark slice covered no pixels");
         }
         // Require a validated linear pixel only where an interior pixel can
         // exist: at domain 1 the interior interval [0.5, 0.5] is a single point
@@ -314,8 +370,8 @@ int runBenchmark(int argc, char** argv)
             static_cast<double>(outputDim) * outputDim / (ms * 1000.0));
     };
 
-    std::printf("slice-query benchmark (cache-warm, median of %d):\n",
-        iterations);
+    std::printf("slice-query benchmark (cache-warm, median of %d%s):\n",
+        iterations, clusterGap > 0 ? ", two clusters" : "");
     run(amrvis::SamplingPolicy::PiecewiseConstant, "piecewise");
     run(amrvis::SamplingPolicy::Linear, "linear");
 

--- a/tests/benchmark/bench_slice_query.cpp
+++ b/tests/benchmark/bench_slice_query.cpp
@@ -101,8 +101,8 @@ int boundedArg(const char* text, long minimum)
     char* end = nullptr;
     const long value = std::strtol(text, &end, 10);
     if (end == text || *end != '\0' || value < minimum || value > 65536) {
-        die("arguments must be integers <= 65536 (clusterGap may be 0, the "
-            "rest at least 1)");
+        die("arguments must be integers <= 65536 (clusterGap and "
+            "requireLinear may be 0, the rest at least 1)");
     }
     return static_cast<int>(value);
 }
@@ -350,8 +350,10 @@ int runBenchmark(int argc, char** argv)
         }
         // The per-pixel checks above are exact for any layout; these two
         // refuse parameters under which they checked nothing. `covered` is
-        // exactly the pixels whose value was compared, so the first is exact
-        // for any layout. The second, for linear sampling, holds when the
+        // the pixels whose value was read -- every one of them compared under
+        // piecewise sampling, a subset under linear -- so covered == 0 means
+        // no value was compared in either mode and the first is exact for
+        // any layout. The second, for linear sampling, holds when the
         // layout guarantees a pixel with its whole bracket inside a block
         // (uniform, domain >= 2) or when the caller vouched for the
         // parameters with requireLinear; for other clustered runs the printed

--- a/tests/benchmark/bench_slice_query.cpp
+++ b/tests/benchmark/bench_slice_query.cpp
@@ -12,14 +12,20 @@
 // though the per-pixel lookup is O(1) -- that is the planning, not a regression.
 //
 //   bench_slice_query [blocksPerAxis] [cellsPerBlock] [outputDim] [iterations]
-//                     [clusterGap]
+//                     [clusterGap] [requireLinear]
 //
 // clusterGap = 0 (the default) tiles the whole domain uniformly. A positive
 // clusterGap instead places two blocksPerAxis^2 clusters at opposite corners
 // of a domain that many blocks wider and taller -- the ordinary AMR shape of
 // separate refined regions -- so the block index is measured on a level whose
 // blocks occupy a small fraction of their bounding box, not only on a dense
-// tiling. The default workload is small so it stays fast in CI.
+// tiling. requireLinear (0/1) says whether a linear run that validated no
+// interpolated value is a failure: on by default for the uniform tiling,
+// where a domain of at least two cells guarantees such a pixel exists, and
+// off by default for clustered layouts, where whether any pixel's whole
+// bracket falls inside a cluster is a property of the parameters -- a
+// registered clustered run passes 1 explicitly so it cannot silently become
+// vacuous. The default workload is small so it stays fast in CI.
 #include <amrexplorer/query/SliceQuery.hpp>
 
 #include <amrexplorer/io/PlotfileDataset.hpp>
@@ -118,6 +124,8 @@ int runBenchmark(int argc, char** argv)
     const int blocksPerAxis = argc > 1 ? positiveArg(argv[1]) : 16;
     const int cellsPerBlock = argc > 2 ? positiveArg(argv[2]) : 8;
     const int clusterGap = argc > 5 ? boundedArg(argv[5], 0) : 0;
+    const bool requireLinear
+        = argc > 6 ? boundedArg(argv[6], 0) != 0 : clusterGap == 0;
     const int blocksAcross
         = clusterGap > 0 ? 2 * blocksPerAxis + clusterGap : blocksPerAxis;
     // Guard the derived sizes (long long) before narrowing to int, so a large
@@ -270,7 +278,6 @@ int runBenchmark(int argc, char** argv)
             return {cell, cell};
         };
         std::size_t covered = 0;
-        std::size_t blockPixels = 0;     // every candidate cell in a block
         std::size_t linearChecked = 0;
         for (int y = 0; y < outputDim; ++y) {
             const double py = lower + (static_cast<double>(y) + 0.5) * extent
@@ -295,9 +302,6 @@ int runBenchmark(int argc, char** argv)
                     }
                 }
                 const bool isCovered = warm.plane.valid[off] != 0;
-                if (inBlock == candidates) {
-                    ++blockPixels;
-                }
                 if (inBlock == candidates && !isCovered) {
                     die("benchmark slice left a block pixel uncovered");
                 }
@@ -345,17 +349,19 @@ int runBenchmark(int argc, char** argv)
             }
         }
         // The per-pixel checks above are exact for any layout; these two
-        // refuse parameters under which they would have checked nothing, from
-        // the expectations the loop just computed: no pixel centre inside a
-        // block at all, or (for linear, past domain 1 where no interior
-        // interval exists) no pixel whose whole bracket lies in a block. A
-        // run that trips them measured something but validated nothing.
-        if (blockPixels == 0) {
+        // refuse parameters under which they checked nothing. `covered` is
+        // exactly the pixels whose value was compared, so the first is exact
+        // for any layout. The second, for linear sampling, holds when the
+        // layout guarantees a pixel with its whole bracket inside a block
+        // (uniform, domain >= 2) or when the caller vouched for the
+        // parameters with requireLinear; for other clustered runs the printed
+        // count is the record.
+        if (covered == 0) {
             die("no pixel centre lies inside a block: these parameters "
                 "validate nothing");
         }
-        if (sampling == amrvis::SamplingPolicy::Linear && domain >= 2
-            && linearChecked == 0) {
+        if (sampling == amrvis::SamplingPolicy::Linear && requireLinear
+            && domain >= 2 && linearChecked == 0) {
             die("no pixel has its whole linear bracket inside a block: these "
                 "parameters validate no interpolated value");
         }

--- a/tests/benchmark/bench_slice_query.cpp
+++ b/tests/benchmark/bench_slice_query.cpp
@@ -270,6 +270,7 @@ int runBenchmark(int argc, char** argv)
             return {cell, cell};
         };
         std::size_t covered = 0;
+        std::size_t blockPixels = 0;     // every candidate cell in a block
         std::size_t linearChecked = 0;
         for (int y = 0; y < outputDim; ++y) {
             const double py = lower + (static_cast<double>(y) + 0.5) * extent
@@ -294,6 +295,9 @@ int runBenchmark(int argc, char** argv)
                     }
                 }
                 const bool isCovered = warm.plane.valid[off] != 0;
+                if (inBlock == candidates) {
+                    ++blockPixels;
+                }
                 if (inBlock == candidates && !isCovered) {
                     die("benchmark slice left a block pixel uncovered");
                 }
@@ -340,18 +344,20 @@ int runBenchmark(int argc, char** argv)
                 }
             }
         }
-        // The per-pixel checks above are exact for any layout; these two only
-        // refuse parameters that would make them vacuous, and only for the
-        // uniform tiling, where every pixel is a block pixel and (at domain >=
-        // 2) an interior pixel exists. A clustered layout may legitimately put
-        // no pixel center in a block or no bracket fully inside one; there the
-        // printed counts show how much was validated.
-        if (clusterGap == 0 && covered == 0) {
-            die("benchmark slice covered no pixels");
+        // The per-pixel checks above are exact for any layout; these two
+        // refuse parameters under which they would have checked nothing, from
+        // the expectations the loop just computed: no pixel centre inside a
+        // block at all, or (for linear, past domain 1 where no interior
+        // interval exists) no pixel whose whole bracket lies in a block. A
+        // run that trips them measured something but validated nothing.
+        if (blockPixels == 0) {
+            die("no pixel centre lies inside a block: these parameters "
+                "validate nothing");
         }
-        if (clusterGap == 0 && sampling == amrvis::SamplingPolicy::Linear
-            && domain >= 2 && linearChecked == 0) {
-            die("benchmark linear run validated no pixels");
+        if (sampling == amrvis::SamplingPolicy::Linear && domain >= 2
+            && linearChecked == 0) {
+            die("no pixel has its whole linear bracket inside a block: these "
+                "parameters validate no interpolated value");
         }
         std::vector<double> samples;
         samples.reserve(static_cast<std::size_t>(iterations));

--- a/tests/benchmark/bench_slice_query.cpp
+++ b/tests/benchmark/bench_slice_query.cpp
@@ -87,17 +87,23 @@ double medianMillis(std::vector<double>& samples)
     return samples[samples.size() / 2];
 }
 
-// Strictly-positive, bounded integer argument. std::atoi returns 0 on garbage
-// (silently truncating to the "positive" guard); parse explicitly and bound so
+// Bounded integer argument, at least `minimum`. std::atoi returns 0 on
+// garbage (silently truncating to the guard); parse explicitly and bound so
 // the derived fixture sizes below cannot overflow int.
-int positiveArg(const char* text)
+int boundedArg(const char* text, long minimum)
 {
     char* end = nullptr;
     const long value = std::strtol(text, &end, 10);
-    if (end == text || *end != '\0' || value < 1 || value > 65536) {
-        die("arguments must be positive integers <= 65536");
+    if (end == text || *end != '\0' || value < minimum || value > 65536) {
+        die("arguments must be integers <= 65536 (clusterGap may be 0, the "
+            "rest at least 1)");
     }
     return static_cast<int>(value);
+}
+
+int positiveArg(const char* text)
+{
+    return boundedArg(text, 1);
 }
 
 } // namespace
@@ -111,7 +117,7 @@ int runBenchmark(int argc, char** argv)
     // corners of a domain clusterGap blocks wider, the rest empty.
     const int blocksPerAxis = argc > 1 ? positiveArg(argv[1]) : 16;
     const int cellsPerBlock = argc > 2 ? positiveArg(argv[2]) : 8;
-    const int clusterGap = argc > 5 ? positiveArg(argv[5]) : 0;
+    const int clusterGap = argc > 5 ? boundedArg(argv[5], 0) : 0;
     const int blocksAcross
         = clusterGap > 0 ? 2 * blocksPerAxis + clusterGap : blocksPerAxis;
     // Guard the derived sizes (long long) before narrowing to int, so a large
@@ -334,14 +340,17 @@ int runBenchmark(int argc, char** argv)
                 }
             }
         }
-        if (covered == 0) {
+        // The per-pixel checks above are exact for any layout; these two only
+        // refuse parameters that would make them vacuous, and only for the
+        // uniform tiling, where every pixel is a block pixel and (at domain >=
+        // 2) an interior pixel exists. A clustered layout may legitimately put
+        // no pixel center in a block or no bracket fully inside one; there the
+        // printed counts show how much was validated.
+        if (clusterGap == 0 && covered == 0) {
             die("benchmark slice covered no pixels");
         }
-        // Require a validated linear pixel only where an interior pixel can
-        // exist: at domain 1 the interior interval [0.5, 0.5] is a single point
-        // no pixel center lands on.
-        if (sampling == amrvis::SamplingPolicy::Linear && domain >= 2
-            && linearChecked == 0) {
+        if (clusterGap == 0 && sampling == amrvis::SamplingPolicy::Linear
+            && domain >= 2 && linearChecked == 0) {
             die("benchmark linear run validated no pixels");
         }
         std::vector<double> samples;
@@ -365,9 +374,16 @@ int runBenchmark(int argc, char** argv)
         }
         const auto ms = medianMillis(samples);
         std::printf("  %-10s %5d blocks  %d x %d px  median %8.3f ms  "
-            "(%6.1f Mpx/s)\n",
+            "(%6.1f Mpx/s)",
             label, blockCount, outputDim, outputDim, ms,
             static_cast<double>(outputDim) * outputDim / (ms * 1000.0));
+        if (clusterGap > 0 && sampling == amrvis::SamplingPolicy::Linear) {
+            std::printf("  [%zu px covered, %zu linear-validated]", covered,
+                linearChecked);
+        } else if (clusterGap > 0) {
+            std::printf("  [%zu px covered]", covered);
+        }
+        std::printf("\n");
     };
 
     std::printf("slice-query benchmark (cache-warm, median of %d%s):\n",

--- a/tests/integration/test_dataset_extract.cpp
+++ b/tests/integration/test_dataset_extract.cpp
@@ -12,6 +12,7 @@
 #include <fstream>
 #include <iostream>
 #include <span>
+#include <stdexcept>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -150,6 +151,45 @@ void writeSplitXPlotfile3d(const std::filesystem::path& root)
         "((2,0,0) (3,3,3) (0,0,0))", gridB);
 }
 
+// The 2-D split-coverage plotfile with grid B's FAB header box disagreeing
+// with the catalog: the Header/Cell_H say (0,3)-(2,3), the FAB on disk says
+// (0,3)-(1,3) and holds two values. A v1 VisMF layout permits this and nothing
+// upstream cross-checks the two boxes; reading it must fail, not alias.
+void writeMismatchedFabPlotfile(const std::filesystem::path& root)
+{
+    writeSplitCoveragePlotfile(root);
+    const std::vector<double> gridB{30.0, 31.0};
+    writeFab(root / "Level_0" / "Cell_D_00001", "((0,3) (1,3) (0,0))", gridB);
+}
+
+// The 3-D split-x plotfile with grid 1's FAB header box one z-plane short of
+// its catalog box: catalog (2,0,0)-(3,3,3), FAB (2,0,0)-(3,3,2), 48 values.
+void writeMismatchedFabPlotfile3d(const std::filesystem::path& root)
+{
+    writeSplitXPlotfile3d(root);
+    std::vector<double> gridB;
+    for (int z = 0; z <= 2; ++z) {
+        for (int y = 0; y <= 3; ++y) {
+            for (int x = 2; x <= 3; ++x) {
+                gridB.push_back(100.0 * x + 10.0 * y + z);
+            }
+        }
+    }
+    writeFab(root / "Level_0" / "Cell_D_00001",
+        "((2,0,0) (3,3,2) (0,0,0))", gridB);
+}
+
+template <typename Function>
+bool throwsRuntimeError(Function&& function)
+{
+    try {
+        function();
+    } catch (const std::runtime_error&) {
+        return true;
+    }
+    return false;
+}
+
 } // namespace
 
 int main()
@@ -284,6 +324,46 @@ int main()
 
         std::error_code cleanup3d;
         std::filesystem::remove_all(root3d, cleanup3d);
+    }
+
+    // --- a FAB that does not cover its catalog box is refused, not aliased ---
+    // 2-D: a whole-domain page touches grid B; 3-D: any z-slice reads grid 1,
+    // and its FAB is short on z. Both go through the page path's per-block
+    // requireBlockPayload, including the 3-D normal-axis handling.
+    {
+        const auto badRoot = std::filesystem::temp_directory_path()
+            / ("amrexplorer-dataset-extract-bad2d-" + std::to_string(unique));
+        writeMismatchedFabPlotfile(badRoot);
+        PlotfileDataset badDataset(badRoot, DatasetId{3}, 1ULL << 20);
+        require(throwsRuntimeError([&] {
+            static_cast<void>(extractDatasetLevel(badDataset, FieldId{0}, 0,
+                box2d(0.0, 4.0), 1, 0.0, datasetExtractMaxExtent));
+        }), "a 2-D FAB smaller than its catalog box was read");
+        std::error_code cleanupBad;
+        std::filesystem::remove_all(badRoot, cleanupBad);
+    }
+    {
+        const auto badRoot = std::filesystem::temp_directory_path()
+            / ("amrexplorer-dataset-extract-bad3d-" + std::to_string(unique));
+        writeMismatchedFabPlotfile3d(badRoot);
+        PlotfileDataset badDataset(badRoot, DatasetId{4}, 1ULL << 20);
+        RealBox full;
+        full.lower = {{0.0, 0.0, 0.0}};
+        full.upper = {{4.0, 4.0, 4.0}};
+        require(throwsRuntimeError([&] {
+            static_cast<void>(extractDatasetLevel(badDataset, FieldId{0}, 0,
+                full, /*normalAxis=*/2, /*slicePosition=*/0.5,
+                datasetExtractMaxExtent));
+        }), "a 3-D FAB short on the normal axis was read");
+        // Grid 0's FAB is intact, but a page over the whole plane reads
+        // grid 1 too, so it must fail even where grid 0 alone would do.
+        require(throwsRuntimeError([&] {
+            static_cast<void>(extractDatasetLevel(badDataset, FieldId{0}, 0,
+                full, /*normalAxis=*/0, /*slicePosition=*/3.5,
+                datasetExtractMaxExtent));
+        }), "a yz page over the short FAB was read");
+        std::error_code cleanupBad;
+        std::filesystem::remove_all(badRoot, cleanupBad);
     }
 
     std::error_code cleanupError;

--- a/tests/integration/test_dataset_extract.cpp
+++ b/tests/integration/test_dataset_extract.cpp
@@ -163,7 +163,7 @@ void writeMismatchedFabPlotfile(const std::filesystem::path& root)
 }
 
 // The 3-D split-x plotfile with grid 1's FAB header box one z-plane short of
-// its catalog box: catalog (2,0,0)-(3,3,3), FAB (2,0,0)-(3,3,2), 48 values.
+// its catalog box: catalog (2,0,0)-(3,3,3), FAB (2,0,0)-(3,3,2), 24 values.
 void writeMismatchedFabPlotfile3d(const std::filesystem::path& root)
 {
     writeSplitXPlotfile3d(root);
@@ -355,8 +355,8 @@ int main()
                 full, /*normalAxis=*/2, /*slicePosition=*/0.5,
                 datasetExtractMaxExtent));
         }), "a 3-D FAB short on the normal axis was read");
-        // Grid 0's FAB is intact, but a page over the whole plane reads
-        // grid 1 too, so it must fail even where grid 0 alone would do.
+        // A yz page at x = 3 reads grid 1 alone, and its cells at z = 3 lie
+        // past the short FAB: it must fail before reading them.
         require(throwsRuntimeError([&] {
             static_cast<void>(extractDatasetLevel(badDataset, FieldId{0}, 0,
                 full, /*normalAxis=*/0, /*slicePosition=*/3.5,

--- a/tests/unit/test_block_lookup.cpp
+++ b/tests/unit/test_block_lookup.cpp
@@ -94,15 +94,21 @@ int main()
 {
     const std::array<int, 2> axes{0, 1};
 
-    // A default-constructed grid and a grid over no blocks reject every point.
+    // A default-constructed grid and a grid over no blocks reject every point
+    // and report no index (so a usesIndex() assertion cannot pass on a grid
+    // that was never built).
     {
         const BlockGrid empty;
         require(empty.find({}, point(0, 0), 2) == -1,
             "default-constructed grid returned a block");
+        require(!empty.usesIndex(),
+            "a default-constructed grid claims to use an index");
         const std::vector<LoadedBlock> none;
         const BlockGrid overNone(none, axes);
         require(overNone.find(none, point(3, 4), 2) == -1,
             "grid over no blocks returned a block");
+        require(!overNone.usesIndex(),
+            "a grid over no blocks claims to use an index");
     }
 
     // A real multi-tile grid: a 4x4 arrangement of 4x4-cell blocks over a 16x16
@@ -461,7 +467,7 @@ int main()
         const amrvis::detail::IndexedBlocks indexed(2, std::move(loaded), axes);
 
         const auto at = [&indexed](int x, int y) {
-            return amrvis::detail::lookupBlockValue(indexed, point(x, y), 2);
+            return amrvis::detail::lookupBlockValue(indexed, point(x, y));
         };
         require(at(0, 0) == 0.0 && at(3, 0) == 3.0 && at(0, 1) == 4.0
                 && at(2, 1) == 6.0,
@@ -495,6 +501,14 @@ int main()
             {box2d(0, 0, 3, 3),
                 pin(2, box2d(0, 0, 1, 3),
                     {0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0})},
+            true);
+        // The other corner: a FAB header box that starts above the catalog
+        // box (its upper corner inside, its lower corner not).
+        rejects("a FAB header box starting past its catalog box was accepted",
+            {box2d(0, 0, 3, 3),
+                pin(5, box2d(1, 0, 3, 3),
+                    {0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0,
+                        11.0})},
             true);
         // Header box 2x2 but only three values: cell (5,1) would read past
         // the payload.

--- a/tests/unit/test_block_lookup.cpp
+++ b/tests/unit/test_block_lookup.cpp
@@ -63,18 +63,29 @@ std::uint64_t nextRandom(std::uint64_t& state)
 
 // Grid and linear scan must agree at every probed point, over the block set's
 // bounding box widened by a margin (so out-of-range points are exercised too).
-void requireAgrees(const std::vector<LoadedBlock>& blocks,
-    const std::array<int, 2>& axes, int lo, int hi, const char* context)
+// `lo`/`hi` bound the probe range on every axis of `dimension`.
+void requireAgreesWith(const BlockGrid& grid,
+    const std::vector<LoadedBlock>& blocks, int dimension, int lo, int hi,
+    const char* context)
 {
-    const BlockGrid grid(blocks, axes);
     std::uint64_t rng = 0xabcd1234ULL;
     const auto span = static_cast<std::uint64_t>(hi - lo + 1);
     for (int trial = 0; trial < 20000; ++trial) {
-        const auto p = point(
-            lo + static_cast<int>(nextRandom(rng) % span),
-            lo + static_cast<int>(nextRandom(rng) % span));
-        require(grid.find(blocks, p, 2) == linearFind(blocks, p), context);
+        Int3 p{};
+        for (int axis = 0; axis < dimension; ++axis) {
+            p[static_cast<std::size_t>(axis)]
+                = lo + static_cast<int>(nextRandom(rng) % span);
+        }
+        require(grid.find(blocks, p, dimension)
+                == linearFind(blocks, p, dimension),
+            context);
     }
+}
+
+void requireAgrees(const std::vector<LoadedBlock>& blocks,
+    const std::array<int, 2>& axes, int lo, int hi, const char* context)
+{
+    requireAgreesWith(BlockGrid(blocks, axes), blocks, 2, lo, hi, context);
 }
 
 } // namespace
@@ -168,8 +179,10 @@ int main()
         requireAgrees(blocks, axes, -2, 66, "overlap-fallback differential");
     }
 
-    // Identical boxes alone are not an overlap pathology for the index: with
-    // tiles sized to the blocks they all share one tile, so the index stays.
+    // Identical boxes alone must not trip the fill cap (memory-boundedness is
+    // what this pins): with tiles sized to the blocks they all share one tile,
+    // and find() there is the bucket scan over all of them -- the linear scan
+    // in all but name, which is the right answer for a fully overlapping set.
     {
         std::vector<LoadedBlock> blocks;
         for (int i = 0; i < 400; ++i) {
@@ -238,6 +251,64 @@ int main()
             "single-axis grid matched a point off the pinned cell");
         require(grid.find(blocks, Int3{{-1, 8, 8}}, 3) == -1,
             "single-axis grid matched a point before the first block");
+        // Differential over random y/z as well as x: the unbinned coordinates
+        // are checked by contains(), not by the tiles, and must still be.
+        {
+            std::vector<LoadedBlock> few;
+            for (int i = 0; i < 40; ++i) {
+                IntBox box;
+                box.lower = {{16 * i, i % 3, i % 5}};
+                box.upper = {{16 * i + 15, i % 3 + 12, i % 5 + 10}};
+                box.centering = {{0, 0, 0}};
+                few.push_back(LoadedBlock{box, {}});
+            }
+            requireAgreesWith(BlockGrid(few, 0), few, 3, -4, 660,
+                "single-axis differential");
+        }
+    }
+
+    // Single-axis overlap fallback: many blocks straddling one cell on the
+    // binned axis, with tiles set to one cell by a majority of single-cell
+    // blocks, trip the cap; the fallback must still be exact.
+    {
+        std::vector<LoadedBlock> blocks;
+        for (int i = 0; i < 100; ++i) {
+            blocks.push_back(block(0, 0, 63, 3));  // 64 cells on x, overlapping
+        }
+        for (int i = 0; i < 200; ++i) {
+            blocks.push_back(block(i % 64, 0, i % 64, 3));  // single cells
+        }
+        const BlockGrid grid(blocks, 0);
+        require(!grid.usesIndex(),
+            "single-axis overlapping catalog did not trip the fill cap");
+        requireAgreesWith(grid, blocks, 2, -2, 66,
+            "single-axis fallback differential");
+    }
+
+    // The ordinary AMR shape: two refined regions far apart. The tiles coarsen
+    // to fit the bounding box (dozens of blocks per occupied bucket), but the
+    // index must be kept and stay exact; averaged over points spread across
+    // the bounding box the candidates per lookup are still bounded by
+    // blocks/tiles (see the BlockGrid comment).
+    {
+        std::vector<LoadedBlock> blocks;
+        for (const int corner : {0, 4096 - 16 * 16}) {
+            for (int gj = 0; gj < 16; ++gj) {
+                for (int gi = 0; gi < 16; ++gi) {
+                    blocks.push_back(block(corner + 16 * gi, corner + 16 * gj,
+                        corner + 16 * gi + 15, corner + 16 * gj + 15));
+                }
+            }
+        }
+        const BlockGrid grid(blocks, axes);
+        require(grid.usesIndex(), "two-cluster layout tripped the fill cap");
+        for (std::size_t i = 0; i < blocks.size(); ++i) {
+            const auto& box = blocks[i].validBox;
+            require(grid.find(blocks, point(box.lower[0] + 3, box.upper[1] - 2), 2)
+                    == static_cast<int>(i),
+                "two-cluster layout routed a point to the wrong block");
+        }
+        requireAgrees(blocks, axes, -8, 4103, "two-cluster differential");
     }
 
     // Irregular non-overlapping layout (varied block sizes) as a differential
@@ -251,9 +322,9 @@ int main()
         requireAgrees(blocks, axes, -3, 18, "irregular differential");
     }
 
-    // The axis selection: production grids bin on {plane axes} for a slice and
-    // {line axis, next axis} for a line -- {1, 0}, {2, 0}, and {0, 0} in 1-D --
-    // not only {0, 1}. 3-D blocks laid out along z, indexed on {2, 0} and
+    // The axis selection: a slice bins on its plane axes -- {1, 2}, {0, 2},
+    // {0, 1} -- so the pairs are not only {0, 1}, and equal axes are the
+    // single-axis mode. 3-D blocks laid out along z, indexed on {2, 0} and
     // {1, 2}, and the same-axis case {2, 2}, each against the linear scan.
     {
         std::vector<LoadedBlock> blocks;

--- a/tests/unit/test_block_lookup.cpp
+++ b/tests/unit/test_block_lookup.cpp
@@ -418,11 +418,14 @@ int main()
     }
 
     // lookupBlockValue over IndexedBlocks with real cache handles: the value
-    // is read at valueOffset within the covering block's FAB, a point outside
-    // every block is nullopt, a FAB whose header box does not cover the
-    // catalog box it was loaded for throws rather than aliasing into the
-    // wrong cell (the payload is always sized to the header box, so payload
-    // size cannot catch that), and a block with no payload is refused.
+    // is read at valueOffset within the covering block's FAB and a point
+    // outside every block is nullopt. IndexedBlocks validates every block
+    // when built -- a FAB whose header box does not cover its catalog box
+    // (which would alias into the wrong cell without leaving the payload), a
+    // payload shorter than the FAB box (which would read past its end; the
+    // reader never produces one, but FabBlock is an aggregate any producer can
+    // fill), and a missing payload are each refused there, so the per-hit
+    // lookup carries no checks.
     {
         amrvis::PlotfileDataset::BlockCache cache(1 << 20);
         const auto pin = [&cache](int grid, const IntBox& box,
@@ -434,21 +437,28 @@ int main()
             key.grid = grid;
             return cache.insertAndPin(key, std::move(fab), 64);
         };
+        const auto box2d = [](int x0, int y0, int x1, int y1) {
+            IntBox box;
+            box.lower = {{x0, y0, 0}};
+            box.upper = {{x1, y1, 0}};
+            box.centering = {{0, 0, 0}};
+            return box;
+        };
         std::vector<LoadedBlock> loaded;
         // Block 0: cells x 0..3, y 0..1 -> values 0..7 (x fastest).
-        IntBox first;
-        first.lower = {{0, 0, 0}};
-        first.upper = {{3, 1, 0}};
-        first.centering = {{0, 0, 0}};
+        const auto first = box2d(0, 0, 3, 1);
         loaded.push_back({first,
             pin(0, first, {0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0})});
-        // Block 1: cells x 4..5, y 0..1 -> values 10..13.
-        IntBox second;
-        second.lower = {{4, 0, 0}};
-        second.upper = {{5, 1, 0}};
-        second.centering = {{0, 0, 0}};
-        loaded.push_back({second, pin(1, second, {10.0, 11.0, 12.0, 13.0})});
-        const amrvis::detail::IndexedBlocks indexed(std::move(loaded), axes);
+        // Block 1: cells x 4..5, y 0..1 -> values 10..13, in a FAB box grown
+        // by one cell on every side (ghost cells), as loaded FABs often are.
+        const auto second = box2d(4, 0, 5, 1);
+        std::vector<double> grown(16, -1.0);
+        grown[5] = 10.0;   // (4,0) in the 4x4 grown box (3..6, -1..2)
+        grown[6] = 11.0;   // (5,0)
+        grown[9] = 12.0;   // (4,1)
+        grown[10] = 13.0;  // (5,1)
+        loaded.push_back({second, pin(1, box2d(3, -1, 6, 2), grown)});
+        const amrvis::detail::IndexedBlocks indexed(2, std::move(loaded), axes);
 
         const auto at = [&indexed](int x, int y) {
             return amrvis::detail::lookupBlockValue(indexed, point(x, y), 2);
@@ -460,46 +470,40 @@ int main()
                 && !at(6, 0).has_value(),
             "lookupBlockValue returned a value outside every block");
         require(at(4, 0) == 10.0 && at(4, 1) == 12.0 && at(5, 1) == 13.0,
-            "lookupBlockValue misread the second block");
+            "lookupBlockValue misread the ghost-grown block");
 
-        // A block whose FAB header box does not cover its catalog box aliases
-        // into the wrong cell if only the payload size is checked; and a
-        // block with no payload at all must be refused, not dereferenced.
-        std::vector<LoadedBlock> mismatched;
-        IntBox catalog;
-        catalog.lower = {{0, 0, 0}};
-        catalog.upper = {{3, 3, 0}};  // 4x4 per the catalog ...
-        catalog.centering = {{0, 0, 0}};
-        IntBox header;
-        header.lower = {{0, 0, 0}};
-        header.upper = {{1, 3, 0}};   // ... but the FAB holds 2x4
-        header.centering = {{0, 0, 0}};
-        mismatched.push_back({catalog, pin(2, header,
-            {0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0})});
-        mismatched.push_back({second, {}});  // no payload
-        const amrvis::detail::IndexedBlocks mismatchedIndexed(
-            std::move(mismatched), axes);
-        const auto atMismatched = [&mismatchedIndexed](int x, int y) {
-            return amrvis::detail::lookupBlockValue(
-                mismatchedIndexed, point(x, y), 2);
+        // Each rejected shape, at construction, with the right exception:
+        // std::runtime_error for a corrupt payload, std::logic_error for the
+        // programming error of an unloaded block.
+        const auto rejects = [&](const char* what, LoadedBlock block,
+                                 bool corrupt) {
+            std::vector<LoadedBlock> blocks;
+            blocks.push_back(std::move(block));
+            bool threw = false;
+            try {
+                const amrvis::detail::IndexedBlocks bad(2, std::move(blocks), axes);
+            } catch (const std::runtime_error&) {
+                threw = corrupt;
+            } catch (const std::logic_error&) {
+                threw = !corrupt;
+            }
+            require(threw, what);
         };
-        require(atMismatched(1, 1) == 3.0,
-            "lookupBlockValue misread a cell inside both boxes");
-        bool boxThrew = false;
-        try {
-            static_cast<void>(atMismatched(3, 0));  // offset 3 < 8, cell (1,1)
-        } catch (const std::runtime_error&) {
-            boxThrew = true;
-        }
-        require(boxThrew,
-            "lookupBlockValue aliased a cell outside the FAB header box");
-        bool nullThrew = false;
-        try {
-            static_cast<void>(atMismatched(4, 0));  // the payload-less block
-        } catch (const std::logic_error&) {
-            nullThrew = true;
-        }
-        require(nullThrew, "lookupBlockValue dereferenced a null payload");
+        // Catalog 4x4, FAB header 2x4: cell (3,0) would be offset 3 < 8, i.e.
+        // cell (1,1)'s value, if only the payload size were checked.
+        rejects("a FAB header box smaller than its catalog box was accepted",
+            {box2d(0, 0, 3, 3),
+                pin(2, box2d(0, 0, 1, 3),
+                    {0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0})},
+            true);
+        // Header box 2x2 but only three values: cell (5,1) would read past
+        // the payload.
+        rejects("a payload shorter than its FAB box was accepted",
+            {second, pin(3, second, {10.0, 11.0, 12.0})}, true);
+        rejects("a block with no payload was accepted", {second, {}}, false);
+        // And an inverted FAB header box, which valueOffset refuses.
+        rejects("an inverted FAB header box was accepted",
+            {second, pin(4, box2d(5, 1, 4, 0), {0.0})}, true);
     }
 
     std::cout << "block lookup tests passed\n";

--- a/tests/unit/test_block_lookup.cpp
+++ b/tests/unit/test_block_lookup.cpp
@@ -269,8 +269,16 @@ int main()
                 box.centering = {{0, 0, 0}};
                 few.push_back(LoadedBlock{box, {}});
             }
-            requireAgreesWith(BlockGrid(few, 0), few, 3, -4, 660,
+            const BlockGrid fewGrid(few, 0);
+            require(fewGrid.usesIndex(),
+                "single-axis few-block grid tripped the fill cap");
+            requireAgreesWith(fewGrid, few, 3, -4, 660,
                 "single-axis differential");
+            // The same over a range that mostly straddles the y/z edges (the
+            // blocks lie in y, z <= 14): a grid that skipped contains() on
+            // the unbinned axes would pass few of these probes.
+            requireAgreesWith(fewGrid, few, 3, -4, 20,
+                "single-axis edge differential");
         }
     }
 
@@ -288,8 +296,14 @@ int main()
         const BlockGrid grid(blocks, 0);
         require(!grid.usesIndex(),
             "single-axis overlapping catalog did not trip the fill cap");
-        requireAgreesWith(grid, blocks, 2, -2, 66,
-            "single-axis fallback differential");
+        // Hand-computed answers rather than a differential: in fallback the
+        // grid *is* the linear scan, so comparing the two asserts nothing.
+        require(grid.find(blocks, point(20, 2), 2) == 0,
+            "single-axis fallback did not return the smallest covering block");
+        require(grid.find(blocks, point(64, 0), 2) == -1,
+            "single-axis fallback matched a point past the binned axis");
+        require(grid.find(blocks, point(20, 4), 2) == -1,
+            "single-axis fallback matched a point past the unbinned axis");
     }
 
     // The ordinary AMR shape: two refined regions far apart. The tiles coarsen
@@ -515,7 +529,7 @@ int main()
         rejects("a payload shorter than its FAB box was accepted",
             {second, pin(3, second, {10.0, 11.0, 12.0})}, true);
         rejects("a block with no payload was accepted", {second, {}}, false);
-        // And an inverted FAB header box, which valueOffset refuses.
+        // And an inverted FAB header box, which cannot contain the catalog box.
         rejects("an inverted FAB header box was accepted",
             {second, pin(4, box2d(5, 1, 4, 0), {0.0})}, true);
     }

--- a/tests/unit/test_block_lookup.cpp
+++ b/tests/unit/test_block_lookup.cpp
@@ -176,7 +176,8 @@ int main()
             "overlap fallback did not return the smallest covering block");
         require(grid.find(blocks, point(64, 0), 2) == -1,
             "overlap fallback matched a point past the domain");
-        requireAgrees(blocks, axes, -2, 66, "overlap-fallback differential");
+        requireAgreesWith(grid, blocks, 2, -2, 66,
+            "overlap-fallback differential");
     }
 
     // Identical boxes alone must not trip the fill cap (memory-boundedness is
@@ -308,7 +309,8 @@ int main()
                     == static_cast<int>(i),
                 "two-cluster layout routed a point to the wrong block");
         }
-        requireAgrees(blocks, axes, -8, 4103, "two-cluster differential");
+        requireAgreesWith(grid, blocks, 2, -8, 4103,
+            "two-cluster differential");
     }
 
     // Irregular non-overlapping layout (varied block sizes) as a differential
@@ -417,8 +419,10 @@ int main()
 
     // lookupBlockValue over IndexedBlocks with real cache handles: the value
     // is read at valueOffset within the covering block's FAB, a point outside
-    // every block is nullopt, and a block whose loaded payload is smaller than
-    // its box (corrupt) throws rather than reads past the end.
+    // every block is nullopt, a FAB whose header box does not cover the
+    // catalog box it was loaded for throws rather than aliasing into the
+    // wrong cell (the payload is always sized to the header box, so payload
+    // size cannot catch that), and a block with no payload is refused.
     {
         amrvis::PlotfileDataset::BlockCache cache(1 << 20);
         const auto pin = [&cache](int grid, const IntBox& box,
@@ -438,12 +442,12 @@ int main()
         first.centering = {{0, 0, 0}};
         loaded.push_back({first,
             pin(0, first, {0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0})});
-        // Block 1: cells x 4..5, y 0..1, but only three values loaded.
-        IntBox corrupt;
-        corrupt.lower = {{4, 0, 0}};
-        corrupt.upper = {{5, 1, 0}};
-        corrupt.centering = {{0, 0, 0}};
-        loaded.push_back({corrupt, pin(1, corrupt, {10.0, 11.0, 12.0})});
+        // Block 1: cells x 4..5, y 0..1 -> values 10..13.
+        IntBox second;
+        second.lower = {{4, 0, 0}};
+        second.upper = {{5, 1, 0}};
+        second.centering = {{0, 0, 0}};
+        loaded.push_back({second, pin(1, second, {10.0, 11.0, 12.0, 13.0})});
         const amrvis::detail::IndexedBlocks indexed(std::move(loaded), axes);
 
         const auto at = [&indexed](int x, int y) {
@@ -455,15 +459,47 @@ int main()
         require(!at(0, 2).has_value() && !at(-1, 0).has_value()
                 && !at(6, 0).has_value(),
             "lookupBlockValue returned a value outside every block");
-        require(at(4, 0) == 10.0 && at(4, 1) == 12.0,
+        require(at(4, 0) == 10.0 && at(4, 1) == 12.0 && at(5, 1) == 13.0,
             "lookupBlockValue misread the second block");
-        bool threw = false;
+
+        // A block whose FAB header box does not cover its catalog box aliases
+        // into the wrong cell if only the payload size is checked; and a
+        // block with no payload at all must be refused, not dereferenced.
+        std::vector<LoadedBlock> mismatched;
+        IntBox catalog;
+        catalog.lower = {{0, 0, 0}};
+        catalog.upper = {{3, 3, 0}};  // 4x4 per the catalog ...
+        catalog.centering = {{0, 0, 0}};
+        IntBox header;
+        header.lower = {{0, 0, 0}};
+        header.upper = {{1, 3, 0}};   // ... but the FAB holds 2x4
+        header.centering = {{0, 0, 0}};
+        mismatched.push_back({catalog, pin(2, header,
+            {0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0})});
+        mismatched.push_back({second, {}});  // no payload
+        const amrvis::detail::IndexedBlocks mismatchedIndexed(
+            std::move(mismatched), axes);
+        const auto atMismatched = [&mismatchedIndexed](int x, int y) {
+            return amrvis::detail::lookupBlockValue(
+                mismatchedIndexed, point(x, y), 2);
+        };
+        require(atMismatched(1, 1) == 3.0,
+            "lookupBlockValue misread a cell inside both boxes");
+        bool boxThrew = false;
         try {
-            static_cast<void>(at(5, 1));  // offset 3 into three values
+            static_cast<void>(atMismatched(3, 0));  // offset 3 < 8, cell (1,1)
         } catch (const std::runtime_error&) {
-            threw = true;
+            boxThrew = true;
         }
-        require(threw, "lookupBlockValue read past a short FAB payload");
+        require(boxThrew,
+            "lookupBlockValue aliased a cell outside the FAB header box");
+        bool nullThrew = false;
+        try {
+            static_cast<void>(atMismatched(4, 0));  // the payload-less block
+        } catch (const std::logic_error&) {
+            nullThrew = true;
+        }
+        require(nullThrew, "lookupBlockValue dereferenced a null payload");
     }
 
     std::cout << "block lookup tests passed\n";


### PR DESCRIPTION
Bound the tile-coarsening loop, reject a null payload in lookupBlockValue,
give the single-axis constructor differential and fallback coverage, and
correct the stale test comments. bench_slice_query gains a clusterGap
argument (two refined regions far apart, the ordinary AMR shape) with
layout-aware coverage checks, plus a clustered ctest. Measured there, an
index with block-sized sparse tiles is within noise of the coarsened
dense grid, because per-lookup work averaged over a query's points is
blocks/tiles for any layout; the header now says why.