### PR TITLE
extract PaletteController from MainWindow

### DIFF
--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -6,6 +6,7 @@ add_executable(amrexplorer_qt
     CacheConfig.hpp
     ColorBarWidget.cpp
     ColorBarWidget.hpp
+    CurrentRowBulletDelegate.hpp
     DatasetExtract.hpp
     DatasetWindow.cpp
     DatasetWindow.hpp
@@ -26,6 +27,8 @@ add_executable(amrexplorer_qt
     MainWindowSlice.cpp
     NumberFormat.cpp
     NumberFormat.hpp
+    PaletteController.cpp
+    PaletteController.hpp
     QtErrorText.hpp
     RemoteEndpoint.hpp
     RemoteFileDialog.cpp

--- a/src/qt/CurrentRowBulletDelegate.hpp
+++ b/src/qt/CurrentRowBulletDelegate.hpp
@@ -1,0 +1,109 @@
+#pragma once
+
+#include <QComboBox>
+#include <QModelIndex>
+#include <QPainter>
+#include <QPointer>
+#include <QStyle>
+#include <QStyleOptionViewItem>
+#include <QStyledItemDelegate>
+#include <QWidget>
+
+namespace amrvis::qt {
+
+// Marks the active row in a selector dropdown with a bullet. The bullet lives
+// in a reserved left column that every row's sizeHint accounts for, so names
+// align and the indented text is never clipped. Installed only on the combo's
+// popup view, so the closed combo still shows the clean palette name.
+class CurrentRowBulletDelegate : public QStyledItemDelegate {
+public:
+    explicit CurrentRowBulletDelegate(QComboBox* combo, QObject* parent)
+        : QStyledItemDelegate(parent), m_combo(combo) {}
+
+    void paint(QPainter* painter, const QStyleOptionViewItem& option,
+        const QModelIndex& index) const override
+    {
+        if (isSeparator(index)) {
+            // The default combo delegate draws separators as a thin rule; this
+            // custom delegate replaces it, so render the rule ourselves rather
+            // than leaving a tall blank row. Paint the same item-view panel the
+            // other rows use so the background matches, then draw the line.
+            QStyleOptionViewItem sepOpt = option;
+            initStyleOption(&sepOpt, index);
+            auto* const sepStyle =
+                sepOpt.widget != nullptr ? sepOpt.widget->style() : nullptr;
+            if (sepStyle != nullptr) {
+                sepStyle->drawPrimitive(
+                    QStyle::PE_PanelItemViewItem, &sepOpt, painter, sepOpt.widget);
+            }
+            painter->save();
+            painter->setPen(option.palette.color(QPalette::Mid));
+            const int y = option.rect.center().y();
+            painter->drawLine(option.rect.left() + kSeparatorMargin, y,
+                option.rect.right() - kSeparatorMargin, y);
+            painter->restore();
+            return;
+        }
+        QStyleOptionViewItem opt = option;
+        initStyleOption(&opt, index);
+        auto* const style = opt.widget != nullptr ? opt.widget->style() : nullptr;
+
+        // Full-width selection background, then the name indented past the
+        // marker column so all rows line up at the same x.
+        if (style != nullptr) {
+            style->drawPrimitive(
+                QStyle::PE_PanelItemViewItem, &opt, painter, opt.widget);
+        }
+        opt.rect.adjust(kMarkerColumn, 0, 0, 0);
+        if (style != nullptr) {
+            style->drawControl(
+                QStyle::CE_ItemViewItem, &opt, painter, opt.widget);
+        }
+
+        if (m_combo != nullptr && index.row() == m_combo->currentIndex()) {
+            const QPalette::ColorRole role =
+                (opt.state & QStyle::State_Selected) != 0
+                    ? QPalette::HighlightedText
+                    : QPalette::WindowText;
+            painter->save();
+            painter->setRenderHint(QPainter::Antialiasing, true);
+            painter->setPen(Qt::NoPen);
+            painter->setBrush(opt.palette.brush(role));
+            const QPointF center(option.rect.left() + kMarkerColumn / 2.0,
+                option.rect.center().y());
+            painter->drawEllipse(center, 2.5, 2.5);
+            painter->restore();
+        }
+    }
+
+    QSize sizeHint(const QStyleOptionViewItem& option,
+        const QModelIndex& index) const override
+    {
+        if (isSeparator(index)) {
+            // A short row for the rule; the default sizeHint would give it a
+            // full text-row height and read as a large gap.
+            return QSize(0, kSeparatorHeight);
+        }
+        QSize size = QStyledItemDelegate::sizeHint(option, index);
+        // Reserve the marker column horizontally and add vertical padding so
+        // the names have breathing room; keeps the closed combo unaffected.
+        size.setWidth(size.width() + kMarkerColumn);
+        size.setHeight(size.height() + kRowVerticalPadding);
+        return size;
+    }
+
+private:
+    static bool isSeparator(const QModelIndex& index)
+    {
+        return index.data(Qt::AccessibleDescriptionRole).toString()
+            == QLatin1String("separator");
+    }
+
+    static constexpr int kMarkerColumn = 16;
+    static constexpr int kRowVerticalPadding = 6;
+    static constexpr int kSeparatorHeight = 9;
+    static constexpr int kSeparatorMargin = 4;
+    QPointer<QComboBox> m_combo;
+};
+
+} // namespace amrvis::qt

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -2,7 +2,6 @@
 #include "SshRemoteSession.hpp"
 
 #include "CurrentRowBulletDelegate.hpp"
-#include "PaletteController.hpp"
 
 #include <QKeySequence>
 #include <QStyle>
@@ -25,13 +24,9 @@ MainWindow::MainWindow(QWidget* parent)
 
     // The palette selection lives in its controller. Consumers keep a pointer
     // to its palette(), the toolbar shows its selector, the View menu its
-    // menu, and paletteChanged drives the color bar and a re-render.
+    // menu, and paletteChanged (wired at the end of construction, once the
+    // widgets its handler touches exist) drives the color bar and a re-render.
     m_paletteController = new PaletteController(this);
-    connect(m_paletteController, &PaletteController::paletteChanged, this,
-        [this] {
-            saveSettings();
-            refreshPaletteDisplay();
-        });
     connect(m_paletteController, &PaletteController::loadFileRequested, this,
         [this] { loadPaletteFile(); });
 
@@ -527,6 +522,14 @@ MainWindow::MainWindow(QWidget* parent)
     statusBar()->showMessage(tr("No dataset open"));
     updateDiagnostics();
     restoreSettings();
+    // Only now: the handler persists settings and redraws through the color
+    // bar, views and iso widget, all of which exist by here, and restoreSettings
+    // above read the restored palette into the color bar itself.
+    connect(m_paletteController, &PaletteController::paletteChanged, this,
+        [this] {
+            saveSettings();
+            refreshPaletteDisplay();
+        });
     // Cancel in-flight async work on any quit path (last-window close, Cmd-Q,
     // menu Quit) so QThreadPool teardown does not block on an outstanding read
     // and the process can exit promptly. Only here -- where every window is

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -1,6 +1,9 @@
 #include "MainWindowInternal.hpp"
 #include "SshRemoteSession.hpp"
 
+#include "CurrentRowBulletDelegate.hpp"
+#include "PaletteController.hpp"
+
 #include <QKeySequence>
 #include <QStyle>
 
@@ -14,110 +17,23 @@ extern const char* const kVersion =
 #endif
     ;
 
-namespace {
-
-// Marks the active row in the palette dropdown with a bullet. The bullet lives
-// in a reserved left column that every row's sizeHint accounts for, so names
-// align and the indented text is never clipped. Installed only on the combo's
-// popup view, so the closed combo still shows the clean palette name.
-class CurrentRowBulletDelegate : public QStyledItemDelegate {
-public:
-    explicit CurrentRowBulletDelegate(QComboBox* combo, QObject* parent)
-        : QStyledItemDelegate(parent), m_combo(combo) {}
-
-    void paint(QPainter* painter, const QStyleOptionViewItem& option,
-        const QModelIndex& index) const override
-    {
-        if (isSeparator(index)) {
-            // The default combo delegate draws separators as a thin rule; this
-            // custom delegate replaces it, so render the rule ourselves rather
-            // than leaving a tall blank row. Paint the same item-view panel the
-            // other rows use so the background matches, then draw the line.
-            QStyleOptionViewItem sepOpt = option;
-            initStyleOption(&sepOpt, index);
-            auto* const sepStyle =
-                sepOpt.widget != nullptr ? sepOpt.widget->style() : nullptr;
-            if (sepStyle != nullptr) {
-                sepStyle->drawPrimitive(
-                    QStyle::PE_PanelItemViewItem, &sepOpt, painter, sepOpt.widget);
-            }
-            painter->save();
-            painter->setPen(option.palette.color(QPalette::Mid));
-            const int y = option.rect.center().y();
-            painter->drawLine(option.rect.left() + kSeparatorMargin, y,
-                option.rect.right() - kSeparatorMargin, y);
-            painter->restore();
-            return;
-        }
-        QStyleOptionViewItem opt = option;
-        initStyleOption(&opt, index);
-        auto* const style = opt.widget != nullptr ? opt.widget->style() : nullptr;
-
-        // Full-width selection background, then the name indented past the
-        // marker column so all rows line up at the same x.
-        if (style != nullptr) {
-            style->drawPrimitive(
-                QStyle::PE_PanelItemViewItem, &opt, painter, opt.widget);
-        }
-        opt.rect.adjust(kMarkerColumn, 0, 0, 0);
-        if (style != nullptr) {
-            style->drawControl(
-                QStyle::CE_ItemViewItem, &opt, painter, opt.widget);
-        }
-
-        if (m_combo != nullptr && index.row() == m_combo->currentIndex()) {
-            const QPalette::ColorRole role =
-                (opt.state & QStyle::State_Selected) != 0
-                    ? QPalette::HighlightedText
-                    : QPalette::WindowText;
-            painter->save();
-            painter->setRenderHint(QPainter::Antialiasing, true);
-            painter->setPen(Qt::NoPen);
-            painter->setBrush(opt.palette.brush(role));
-            const QPointF center(option.rect.left() + kMarkerColumn / 2.0,
-                option.rect.center().y());
-            painter->drawEllipse(center, 2.5, 2.5);
-            painter->restore();
-        }
-    }
-
-    QSize sizeHint(const QStyleOptionViewItem& option,
-        const QModelIndex& index) const override
-    {
-        if (isSeparator(index)) {
-            // A short row for the rule; the default sizeHint would give it a
-            // full text-row height and read as a large gap.
-            return QSize(0, kSeparatorHeight);
-        }
-        QSize size = QStyledItemDelegate::sizeHint(option, index);
-        // Reserve the marker column horizontally and add vertical padding so
-        // the names have breathing room; keeps the closed combo unaffected.
-        size.setWidth(size.width() + kMarkerColumn);
-        size.setHeight(size.height() + kRowVerticalPadding);
-        return size;
-    }
-
-private:
-    static bool isSeparator(const QModelIndex& index)
-    {
-        return index.data(Qt::AccessibleDescriptionRole).toString()
-            == QLatin1String("separator");
-    }
-
-    static constexpr int kMarkerColumn = 16;
-    static constexpr int kRowVerticalPadding = 6;
-    static constexpr int kSeparatorHeight = 9;
-    static constexpr int kSeparatorMargin = 4;
-    QPointer<QComboBox> m_combo;
-};
-
-} // namespace
-
 MainWindow::MainWindow(QWidget* parent)
     : QMainWindow(parent)
 {
     setWindowTitle(tr("AMReXplorer"));
     resize(960, 720);
+
+    // The palette selection lives in its controller. Consumers keep a pointer
+    // to its palette(), the toolbar shows its selector, the View menu its
+    // menu, and paletteChanged drives the color bar and a re-render.
+    m_paletteController = new PaletteController(this);
+    connect(m_paletteController, &PaletteController::paletteChanged, this,
+        [this] {
+            saveSettings();
+            refreshPaletteDisplay();
+        });
+    connect(m_paletteController, &PaletteController::loadFileRequested, this,
+        [this] { loadPaletteFile(); });
 
     // The plot area is a stacked widget: page 0 holds the single 2-D view,
     // page 1 the 3-D grid (XY top-left, XZ top-right, YZ bottom-left, iso
@@ -153,7 +69,7 @@ MainWindow::MainWindow(QWidget* parent)
             QString::fromLatin1(vAxis[idx]));
     }
     m_isoWidget = new IsoWidget(gridPage);
-    m_isoWidget->setColorPalette(&m_palette);
+    m_isoWidget->setColorPalette(&m_paletteController->palette());
     gridLayout->addWidget(m_planeViews[2].view, 0, 0);  // XY: plane normal to Z
     gridLayout->addWidget(m_planeViews[1].view, 0, 1);  // XZ: plane normal to Y
     gridLayout->addWidget(m_planeViews[0].view, 1, 0);  // YZ: plane normal to X
@@ -306,46 +222,7 @@ MainWindow::MainWindow(QWidget* parent)
     rangeToolbar->addWidget(m_logarithmic);
     rangeToolbar->addSeparator();
     rangeToolbar->addWidget(new QLabel(tr("Palette:"), rangeToolbar));
-    m_paletteSelector = new QComboBox(rangeToolbar);
-    const QFontMetrics paletteFm(m_paletteSelector->font());
-    int widestBuiltin = 0;
-    for (std::size_t index = 0; index < builtinPalettes.size(); ++index) {
-        const auto label = builtinPaletteLabel(index);
-        // Reserve room for the reversed form ("Plasma_r") so the closed
-        // selector never elides the "_r" suffix syncPaletteSelector appends.
-        widestBuiltin = std::max(widestBuiltin,
-            paletteFm.horizontalAdvance(label + QStringLiteral("_r")));
-        m_paletteSelector->addItem(label, static_cast<int>(index));
-    }
-    // A toggle that reverses the selected palette (data -3), kept at the end of
-    // the popup. Its label reflects the state (see syncPaletteSelector); it is
-    // never the closed selection, so it does not affect the fixed width below.
-    m_paletteSelector->insertSeparator(m_paletteSelector->count());
-    m_paletteSelector->addItem(tr("Reverse Colormap"), -3);
-    // Size the closed combo to exactly fit the longest builtin name (the popup
-    // expands independently, so the "Load Palette File..." / custom entries are
-    // never truncated there). Any custom entry shows elided when closed.
-    QStyleOptionComboBox comboBoxOption;
-    comboBoxOption.initFrom(m_paletteSelector);
-    const QSize content(widestBuiltin + 4, paletteFm.height());
-    m_paletteSelector->setFixedWidth(m_paletteSelector->style()->sizeFromContents(
-        QStyle::CT_ComboBox, &comboBoxOption, content, m_paletteSelector).width());
-    m_paletteSelector->view()->setItemDelegate(new CurrentRowBulletDelegate(
-        m_paletteSelector, m_paletteSelector->view()));
-    connect(m_paletteSelector, qOverload<int>(&QComboBox::currentIndexChanged),
-        this, [this](int) {
-            const auto selection = m_paletteSelector->currentData().toInt();
-            if (selection >= 0) {
-                selectBuiltinPalette(selection);
-            } else if (selection == -3) {
-                // The "Reverse Colormap" toggle: flip the state, then
-                // syncPaletteSelector restores the current index to the palette.
-                setReversePalette(!m_reversePalette);
-            }
-            // selection == -2 is the transient "Custom: <file>" entry added by
-            // syncPaletteSelector(); selecting it is a no-op.
-        });
-    rangeToolbar->addWidget(m_paletteSelector);
+    rangeToolbar->addWidget(m_paletteController->createSelector(rangeToolbar));
 
     m_sliceDebounce = new QTimer(this);
     m_sliceDebounce->setSingleShot(true);
@@ -1120,27 +997,7 @@ void MainWindow::createMenus()
             chooseStandaloneDataset(tr("Open AMReX MultiFab header"), false);
         });
 
-    m_paletteGroup = new QActionGroup(this);
-    auto* paletteMenu = new QMenu(tr("&Palette"), this);
-    for (std::size_t index = 0; index < builtinPalettes.size(); ++index) {
-        auto* action = new QAction(builtinPaletteLabel(index), paletteMenu);
-        action->setCheckable(true);
-        action->setActionGroup(m_paletteGroup);
-        connect(action, &QAction::triggered, this,
-            [this, index] { selectBuiltinPalette(static_cast<int>(index)); });
-        paletteMenu->addAction(action);
-    }
-    paletteMenu->addSeparator();
-    // Reverses the selected palette's color ramp (the "_r" variant, e.g.
-    // plasma_r), applied on top of whichever builtin or file palette is active.
-    m_reversePaletteAction = paletteMenu->addAction(tr("&Reverse Colormap"));
-    m_reversePaletteAction->setCheckable(true);
-    m_reversePaletteAction->setChecked(m_reversePalette);
-    connect(m_reversePaletteAction, &QAction::toggled, this,
-        [this](bool on) { setReversePalette(on); });
-    paletteMenu->addSeparator();
-    auto* loadPaletteAction = paletteMenu->addAction(tr("&Load Palette File..."));
-    connect(loadPaletteAction, &QAction::triggered, this, [this] { loadPaletteFile(); });
+    auto* paletteMenu = m_paletteController->createMenu(this);
 
     auto* exportAction = new QAction(tr("&Export Image..."), this);
     connect(exportAction, &QAction::triggered, this, [this] { exportImage(); });
@@ -1490,67 +1347,6 @@ void MainWindow::syncVariableMenu()
     }
 }
 
-void MainWindow::syncPaletteChecks()
-{
-    const auto actions = m_paletteGroup->actions();
-    for (int index = 0; index < actions.size(); ++index) {
-        actions[index]->setChecked(!m_paletteFromFile && index == m_builtinIndex);
-    }
-}
-
-void MainWindow::syncPaletteSelector()
-{
-    const QSignalBlocker blocker(m_paletteSelector);
-    // Drop any stale "custom palette file" entry before reconciling.
-    const int custom = m_paletteSelector->findData(-2);
-    if (custom >= 0) {
-        m_paletteSelector->removeItem(custom);
-    }
-
-    // Reversal is a global modifier, so every palette name carries the "_r"
-    // suffix (the plasma_r convention) while it is on -- including the closed
-    // selector, which shows the active one.
-    const QString suffix = m_reversePalette ? QStringLiteral("_r") : QString();
-    for (int item = 0; item < m_paletteSelector->count(); ++item) {
-        const auto entryData = m_paletteSelector->itemData(item);
-        if (!entryData.isValid()) {
-            continue;  // separator
-        }
-        const auto value = entryData.toInt();
-        if (value >= 0) {
-            m_paletteSelector->setItemText(item,
-                builtinPaletteLabel(static_cast<std::size_t>(value)) + suffix);
-        } else if (value == -3) {
-            // The toggle item shows a check mark while reversal is on.
-            m_paletteSelector->setItemText(item,
-                (m_reversePalette ? QStringLiteral("✓ ") : QString())
-                    + tr("Reverse Colormap"));
-        }
-    }
-
-    if (m_paletteFromFile) {
-        const auto label =
-            tr("Custom: %1").arg(QFileInfo(m_paletteFilePath).fileName()) + suffix;
-        // Insert just after the builtins (and before the separator) so the
-        // reverse toggle stays anchored at the bottom.
-        m_paletteSelector->insertItem(
-            static_cast<int>(builtinPalettes.size()), label, -2);
-        m_paletteSelector->setCurrentIndex(m_paletteSelector->findData(-2));
-    } else {
-        m_paletteSelector->setCurrentIndex(
-            m_paletteSelector->findData(m_builtinIndex));
-    }
-}
-
-void MainWindow::selectBuiltinPalette(int index)
-{
-    if (index < 0 || index >= static_cast<int>(builtinPalettes.size())) {
-        return;
-    }
-    applyPalette(builtinPalette(builtinPalettes[static_cast<std::size_t>(index)]),
-        index, QString());
-}
-
 void MainWindow::loadPaletteFile()
 {
     const auto settings = makeSettings();
@@ -1561,58 +1357,23 @@ void MainWindow::loadPaletteFile()
     if (filename.isEmpty()) {
         return;
     }
-    try {
-        applyPalette(Palette::load(filename.toStdString()), std::nullopt, filename);
-        auto writableSettings = makeSettings();
-        writableSettings.setValue(QStringLiteral("lastOpenDirectory"),
-            QFileInfo(filename).absolutePath());
-    } catch (const std::exception& error) {
-        QMessageBox::critical(this, tr("Cannot load palette"),
-            QString::fromUtf8(error.what()));
+    if (const auto error = m_paletteController->loadFile(filename)) {
+        QMessageBox::critical(this, tr("Cannot load palette"), *error);
+        return;
     }
-}
-
-void MainWindow::applyPalette(const Palette& palette, std::optional<int> builtinIndex,
-    const QString& filePath)
-{
-    m_basePalette = palette;
-    m_paletteFromFile = !builtinIndex.has_value();
-    if (builtinIndex.has_value()) {
-        m_builtinIndex = *builtinIndex;
-        m_paletteFilePath.clear();
-    } else {
-        m_paletteFilePath = filePath;
-    }
-    syncPaletteChecks();
-    syncPaletteSelector();
-    saveSettings();
-    refreshPaletteDisplay();
+    auto writableSettings = makeSettings();
+    writableSettings.setValue(QStringLiteral("lastOpenDirectory"),
+        QFileInfo(filename).absolutePath());
 }
 
 void MainWindow::refreshPaletteDisplay()
 {
-    m_palette = m_reversePalette ? m_basePalette.reversed() : m_basePalette;
-    m_colorBar->setPalette(&m_palette);
+    m_colorBar->setPalette(&m_paletteController->palette());
     scheduleSliceRequest();
     updateGridBoxes();
     updateOverlays();
     updateCrosshairs();
     m_isoWidget->update();
-}
-
-void MainWindow::setReversePalette(bool reversed)
-{
-    if (reversed == m_reversePalette) {
-        return;
-    }
-    m_reversePalette = reversed;
-    if (m_reversePaletteAction != nullptr) {
-        const QSignalBlocker blocker(m_reversePaletteAction);
-        m_reversePaletteAction->setChecked(reversed);
-    }
-    saveSettings();
-    refreshPaletteDisplay();
-    syncPaletteSelector();
 }
 
 void MainWindow::showContoursDialog()

--- a/src/qt/MainWindow.hpp
+++ b/src/qt/MainWindow.hpp
@@ -78,6 +78,7 @@ class ImageView;
 class IsoWidget;
 class LinePlotWindow;
 class ScientificDoubleSpinBox;
+class PaletteController;
 class SequenceController;
 class SshRemoteSession;
 struct PlaneMapping;
@@ -540,20 +541,13 @@ private:
     void rebuildVariableMenu();
     void syncMenuChecks();
     void syncVariableMenu();
-    void syncPaletteChecks();
-    void syncPaletteSelector();
-    void selectBuiltinPalette(int index);
+    // Runs the palette-file dialog for the controller's Load Palette File...
+    // and reports a load failure.
     void loadPaletteFile();
-    void applyPalette(const Palette& palette, std::optional<int> builtinIndex,
-        const QString& filePath);
-    // Derives m_palette from m_basePalette and the reverse toggle, then pushes
-    // it to the color bar, iso widget, and a re-render. Shared by applyPalette
-    // and the reverse-colormap toggle.
+    // The host's reaction to PaletteController::paletteChanged: pushes the
+    // effective palette to the color bar, iso widget, overlays and a
+    // re-render.
     void refreshPaletteDisplay();
-    // Sets the reverse-colormap state and keeps the menu action, toolbar
-    // selector, settings, and rendering in sync. The single entry point for
-    // both the menu toggle and the palette-selector toggle item.
-    void setReversePalette(bool reversed);
     // Per-field user range: each field remembers its own RangeMode and, when
     // User, its min/max. commitFieldRange snapshots the current widgets for a
     // field, applyFieldRange loads a field's snapshot (or the Visible default)
@@ -878,7 +872,6 @@ private:
     QComboBox* m_fieldSelector = nullptr;
     QComboBox* m_levelSelector = nullptr;
     QComboBox* m_rangeMode = nullptr;
-    QComboBox* m_paletteSelector = nullptr;
     QCheckBox* m_logarithmic = nullptr;
     ScientificDoubleSpinBox* m_rangeMinimum = nullptr;
     ScientificDoubleSpinBox* m_rangeMaximum = nullptr;
@@ -956,8 +949,6 @@ private:
     QActionGroup* m_scaleGroup = nullptr;
     QActionGroup* m_levelGroup = nullptr;
     QActionGroup* m_variableGroup = nullptr;
-    QActionGroup* m_paletteGroup = nullptr;
-    QAction* m_reversePaletteAction = nullptr;
     QAction* m_boxesAction = nullptr;
     QAction* m_slicePlanesAction = nullptr;
     QAction* m_resetZoomAction = nullptr;
@@ -1027,15 +1018,9 @@ private:
     std::filesystem::path m_fabSourcePath;
     std::filesystem::path m_fabDataRoot;
     bool m_fabMode = false;
-    // The selected palette before any reversal; m_palette is derived from it as
-    // m_reversePalette ? m_basePalette.reversed() : m_basePalette and is the
-    // value the renderer, color bar, and overlays actually use.
-    Palette m_basePalette = builtinPalette(BuiltinPalette::Rainbow);
-    Palette m_palette = builtinPalette(BuiltinPalette::Rainbow);
-    int m_builtinIndex = 0;
-    bool m_paletteFromFile = false;
-    bool m_reversePalette = false;
-    QString m_paletteFilePath;
+    // Owns the palette selection, its widgets and persistence; palette() is
+    // what the renderer, color bar and overlays use.
+    PaletteController* m_paletteController = nullptr;
     QString m_numberFormat = defaultNumberFormat();
     QStringList m_probeLines;
     QStringList m_backgroundErrors;

--- a/src/qt/MainWindowDataset.cpp
+++ b/src/qt/MainWindowDataset.cpp
@@ -149,45 +149,8 @@ void MainWindow::restoreSettings()
 {
     const auto settings = makeSettings();
 
-    auto paletteRestored = false;
-    if (settings.value(QStringLiteral("palette/fromFile"), false).toBool()) {
-        const auto path = settings.value(QStringLiteral("palette/filePath")).toString();
-        if (!path.isEmpty()) {
-            try {
-                m_basePalette = Palette::load(path.toStdString());
-                m_paletteFromFile = true;
-                m_paletteFilePath = path;
-                paletteRestored = true;
-            } catch (const std::exception&) {
-                paletteRestored = false;
-            }
-        }
-    }
-    if (!paletteRestored) {
-        const auto name = settings.value(QStringLiteral("palette/builtin"),
-            QStringLiteral("rainbow")).toString();
-        m_builtinIndex = 0;
-        for (std::size_t index = 0; index < builtinPalettes.size(); ++index) {
-            if (name == builtinPaletteKey(index)) {
-                m_builtinIndex = static_cast<int>(index);
-                break;
-            }
-        }
-        m_basePalette = builtinPalette(
-            builtinPalettes[static_cast<std::size_t>(m_builtinIndex)]);
-        m_paletteFromFile = false;
-        m_paletteFilePath.clear();
-    }
-    m_reversePalette = settings.value(QStringLiteral("palette/reversed"), false)
-        .toBool();
-    if (m_reversePaletteAction != nullptr) {
-        const QSignalBlocker blocker(m_reversePaletteAction);
-        m_reversePaletteAction->setChecked(m_reversePalette);
-    }
-    m_palette = m_reversePalette ? m_basePalette.reversed() : m_basePalette;
-    m_colorBar->setPalette(&m_palette);
-    syncPaletteChecks();
-    syncPaletteSelector();
+    m_paletteController->restore(settings);
+    m_colorBar->setPalette(&m_paletteController->palette());
 
     {
         const QSignalBlocker logarithmicBlocker(m_logarithmic);
@@ -257,11 +220,7 @@ void MainWindow::saveSettings()
     // depends on the dataset and restoring a different mode from a previous
     // session would produce unexpected color bars.
     settings.setValue(QStringLiteral("range/logarithmic"), m_logarithmic->isChecked());
-    settings.setValue(QStringLiteral("palette/fromFile"), m_paletteFromFile);
-    settings.setValue(QStringLiteral("palette/filePath"), m_paletteFilePath);
-    settings.setValue(QStringLiteral("palette/builtin"),
-        builtinPaletteKey(static_cast<std::size_t>(m_builtinIndex)));
-    settings.setValue(QStringLiteral("palette/reversed"), m_reversePalette);
+    m_paletteController->save(settings);
     settings.setValue(QStringLiteral("numberFormat"), m_numberFormat);
     settings.setValue(QStringLiteral("animation/speed"),
         m_animationPanel->speedValue());
@@ -1434,7 +1393,7 @@ void MainWindow::requestInitialSlice(
     // unavailable), linear scale, whole domain, midpoint positions.
     FrameSliceSpec spec = initialSpec.value_or(FrameSliceSpec{});
     if (!initialSpec) {
-        spec.palette = m_palette;
+        spec.palette = m_paletteController->palette();
         spec.displayMode = m_displayMode;
         spec.includeGridBoxes = m_boxesAction->isChecked();
         spec.vectorUField =

--- a/src/qt/MainWindowInteraction.cpp
+++ b/src/qt/MainWindowInteraction.cpp
@@ -189,7 +189,7 @@ QColor MainWindow::overlayColor() const
     }
     if (m_contourColor >= 0 && m_contourColor < Palette::slotCount) {
         return QColor::fromRgba(static_cast<QRgb>(
-            m_palette.slotArgb(m_contourColor)));
+            m_paletteController->palette().slotArgb(m_contourColor)));
     }
     return QColor(0, 0, 0);
 }
@@ -200,7 +200,7 @@ QColor MainWindow::sliceAxisColor(int axis) const
     // x -> slot 65, y -> slot 220, z -> slot 255.
     constexpr std::array<int, 3> paletteSlots{65, 220, 255};
     return QColor::fromRgba(static_cast<QRgb>(
-        m_palette.slotArgb(paletteSlots[static_cast<std::size_t>(axis)])));
+        m_paletteController->palette().slotArgb(paletteSlots[static_cast<std::size_t>(axis)])));
 }
 
 void MainWindow::updateOverlay(PlaneViewState& state)

--- a/src/qt/MainWindowInternal.hpp
+++ b/src/qt/MainWindowInternal.hpp
@@ -8,6 +8,7 @@
 #include "MainWindow.hpp"
 #include "QtErrorText.hpp"
 #include "AnimationExporter.hpp"
+#include "PaletteController.hpp"
 #include "SequenceController.hpp"
 #include "AnimationPanel.hpp"
 #include "CacheConfig.hpp"
@@ -141,50 +142,6 @@ namespace amrvis::qt {
 // is PRIVATE to amrexplorer_qt, so an inline variable would acquire a second,
 // conflicting definition in any other target that included this header.
 extern const char* const kVersion;
-
-inline constexpr std::array<BuiltinPalette, 7> builtinPalettes{
-    BuiltinPalette::Rainbow, BuiltinPalette::Turbo, BuiltinPalette::Viridis,
-    BuiltinPalette::Plasma, BuiltinPalette::Parula, BuiltinPalette::Coolwarm,
-    BuiltinPalette::Blackbody};
-
-// This array is what the Palette menu, the selector and restoreSettings all
-// enumerate, so a palette missing from it exists in render2d and nowhere a user
-// can reach. test_palette pins the seven names but cannot catch that: adding an
-// enumerator leaves this at seven and every name it does check still matches.
-static_assert(builtinPalettes.size()
-        == static_cast<std::size_t>(BuiltinPalette::Count),
-    "every BuiltinPalette must be listed in builtinPalettes");
-
-// The QSettings value for a builtin palette. This string is on disk in every
-// user's settings, and it comes from amrvis::builtinPaletteName(), which
-// render2d documents as the menu label *and* the settings key -- so renaming a
-// palette there is a settings-format change, not a presentation tweak.
-// test_palette pins the seven strings so that cannot happen silently.
-inline QString builtinPaletteKey(std::size_t index)
-{
-    if (index >= builtinPalettes.size()) {
-        return {};
-    }
-    const auto name = builtinPaletteName(builtinPalettes[index]);
-    return QString::fromLatin1(name.data(), static_cast<qsizetype>(name.size()));
-}
-
-// The palette's name for the menu and the selector, and the one definition of
-// its capitalization -- where the settings key above stays lowercase. Not the
-// only presentation rule: syncPaletteSelector still appends the "_r" reversal
-// suffix to the selector alone, so with reversal on the two surfaces differ by
-// that suffix. Folding it in here is the remaining half of the job. Kept apart from that key precisely so this rule can live here
-// without rewriting anyone's stored settings. It used to be a pass-through
-// with the capitalization spelled out at two of its three call sites, so the
-// Palette menu showed "rainbow" while the selector showed "Rainbow".
-inline QString builtinPaletteLabel(std::size_t index)
-{
-    auto label = builtinPaletteKey(index);
-    if (!label.isEmpty()) {
-        label[0] = label[0].toUpper();
-    }
-    return label;
-}
 
 // The single conversion from a rendered ImageBuffer to the QImage the views
 // display: ARGB32 over the buffer's rgba, mirrored vertically because plane

--- a/src/qt/MainWindowSlice.cpp
+++ b/src/qt/MainWindowSlice.cpp
@@ -268,7 +268,7 @@ void MainWindow::requestSlice(PlaneViewState& state, bool rasterDirty)
         userRange = std::pair{m_rangeMinimum->value(), m_rangeMaximum->value()};
     }
     const auto logarithmic = m_logarithmic->isChecked();
-    const auto palette = m_palette;
+    const auto palette = m_paletteController->palette();
     const auto displayMode = m_displayMode;
     // Each 3-D panel uses a different pair of vector components:
     //   XY (normal=2) → U,V   XZ (normal=1) → U,W   YZ (normal=0) → V,W
@@ -402,7 +402,7 @@ void MainWindow::requestSlice(PlaneViewState& state, bool rasterDirty)
                         // it skips) realigns the raster and contours here —
                         // that also avoids rendering each 3-D panel twice.
                         DisplayCoordinator::realignArrivalToRange(result,
-                            *cachedRange, m_palette, m_viewDimension != 3);
+                            *cachedRange, m_paletteController->palette(), m_viewDimension != 3);
                     }
                     // showSlice takes the arrival by value; the fallback levels
                     // are still needed below, so copy them out first rather
@@ -524,7 +524,7 @@ void MainWindow::updateGridBoxes(PlaneViewState& state)
         const auto color = levelIndex == firstLevel
             ? QColor(Qt::white)
             : QColor::fromRgb(static_cast<QRgb>(
-                m_palette.levelColor(levelIndex, lastLevel)));
+                m_paletteController->palette().levelColor(levelIndex, lastLevel)));
         if (spherical) {
             // xAxis is r, yAxis is theta. Branch on the state's mode (the
             // raster on screen), not m_sphericalDisplay (the menu
@@ -1212,7 +1212,7 @@ void MainWindow::syncVisibleRanges()
         watcher->setFuture(QtConcurrent::run([cachedRange, snapshots,
             logarithmic = m_logarithmic->isChecked(),
             contourMode = isContourMode(m_displayMode),
-            contourCount = m_contourCount, palette = m_palette] {
+            contourCount = m_contourCount, palette = m_paletteController->palette()] {
 #ifdef AMREXPLORER_QT_TEST_ACCESS
             // Held only when the staleness test has armed the gate.
             visible_sync_test::waitAtGate();
@@ -1708,7 +1708,7 @@ FrameSliceSpec MainWindow::buildFrameSpec()
 {
     FrameSliceSpec spec;
     spec.displayMode = m_displayMode;
-    spec.palette = m_palette;
+    spec.palette = m_paletteController->palette();
     spec.contourCount = m_contourCount;
     spec.sphericalSupersample = m_sphericalSupersample;
     spec.sphericalDisplay = m_sphericalDisplay;

--- a/src/qt/MainWindowTestAccess.cpp
+++ b/src/qt/MainWindowTestAccess.cpp
@@ -148,32 +148,12 @@ void MainWindow::setAnimationDockVisibleForTest(bool visible)
 
 QStringList MainWindow::paletteMenuLabelsForTest() const
 {
-    QStringList labels;
-    if (m_paletteGroup == nullptr) {
-        return labels;
-    }
-    for (const auto* action : m_paletteGroup->actions()) {
-        labels.append(action->text());
-    }
-    return labels;
+    return m_paletteController->menuLabels();
 }
 
 QStringList MainWindow::paletteSelectorLabelsForTest() const
 {
-    QStringList labels;
-    if (m_paletteSelector == nullptr) {
-        return labels;
-    }
-    for (int item = 0; item < m_paletteSelector->count(); ++item) {
-        const auto entryData = m_paletteSelector->itemData(item);
-        // Skip the separator, the custom-palette entry (-2) and the reverse
-        // toggle (-3): only the builtins have a non-negative index, and only
-        // they are built from the shared label helper.
-        if (entryData.isValid() && entryData.toInt() >= 0) {
-            labels.append(m_paletteSelector->itemText(item));
-        }
-    }
-    return labels;
+    return m_paletteController->selectorLabels();
 }
 
 QString MainWindow::viewPlaceholderForTest()
@@ -207,7 +187,7 @@ bool MainWindow::activeViewRasterMatchesDisplayRangeForTest()
         .minimum = state.displayMinimum,
         .maximum = state.displayMaximum,
         .logarithmic = state.displayLogarithmic,
-        .palette = &m_palette
+        .palette = &m_paletteController->palette()
     });
     if (!reference.valid()) {
         return false;

--- a/src/qt/PaletteController.cpp
+++ b/src/qt/PaletteController.cpp
@@ -38,6 +38,12 @@ QMenu* PaletteController::createMenu(QWidget* parent)
 {
     auto* menu = new QMenu(tr("&Palette"), parent);
     m_menuGroup = new QActionGroup(menu);
+    // A file palette leaves no builtin checked. ExclusiveOptional is the policy
+    // that documents an all-unchecked group (Exclusive only happens to allow
+    // it programmatically); a user click on the checked action still lands in
+    // selectBuiltin, which re-checks it.
+    m_menuGroup->setExclusionPolicy(
+        QActionGroup::ExclusionPolicy::ExclusiveOptional);
     for (std::size_t index = 0; index < builtinPalettes.size(); ++index) {
         auto* action = new QAction(builtinPaletteLabel(index), menu);
         action->setCheckable(true);
@@ -152,8 +158,13 @@ void PaletteController::setReversed(bool reversed)
 void PaletteController::apply(const State& requested)
 {
     State state = requested;
-    state.builtinIndex = std::clamp(state.builtinIndex, 0,
-        static_cast<int>(builtinPalettes.size()) - 1);
+    // An index the builtins do not have (an imported state from a build with
+    // more of them, say) falls back to the first, as restore() does for an
+    // unknown name -- one policy for one kind of bad input.
+    if (state.builtinIndex < 0
+        || state.builtinIndex >= static_cast<int>(builtinPalettes.size())) {
+        state.builtinIndex = 0;
+    }
     if (state.fromFile && !state.filePath.isEmpty()) {
         std::optional<Palette> loaded;
         try {

--- a/src/qt/PaletteController.cpp
+++ b/src/qt/PaletteController.cpp
@@ -1,0 +1,309 @@
+#include "PaletteController.hpp"
+
+#include "CurrentRowBulletDelegate.hpp"
+
+#include <QAbstractItemView>
+#include <QAction>
+#include <QActionGroup>
+#include <QComboBox>
+#include <QFileInfo>
+#include <QFontMetrics>
+#include <QMenu>
+#include <QSettings>
+#include <QSignalBlocker>
+#include <QStyle>
+#include <QStyleOptionComboBox>
+
+#include <algorithm>
+#include <exception>
+#include <utility>
+
+namespace amrvis::qt {
+
+namespace {
+
+// Selector item data: a builtin's index is >= 0; these two mark the entries
+// that are not palettes.
+constexpr int customEntry = -2;
+constexpr int reverseToggle = -3;
+
+} // namespace
+
+PaletteController::PaletteController(QObject* parent)
+    : QObject(parent)
+{
+}
+
+QMenu* PaletteController::createMenu(QWidget* parent)
+{
+    auto* menu = new QMenu(tr("&Palette"), parent);
+    m_menuGroup = new QActionGroup(menu);
+    for (std::size_t index = 0; index < builtinPalettes.size(); ++index) {
+        auto* action = new QAction(builtinPaletteLabel(index), menu);
+        action->setCheckable(true);
+        action->setActionGroup(m_menuGroup);
+        connect(action, &QAction::triggered, this,
+            [this, index] { selectBuiltin(static_cast<int>(index)); });
+        menu->addAction(action);
+    }
+    menu->addSeparator();
+    // Reverses the selected palette's color ramp (the "_r" variant, e.g.
+    // plasma_r), applied on top of whichever builtin or file palette is active.
+    m_reverseAction = menu->addAction(tr("&Reverse Colormap"));
+    m_reverseAction->setCheckable(true);
+    m_reverseAction->setChecked(m_state.reversed);
+    connect(m_reverseAction, &QAction::toggled, this,
+        [this](bool on) { setReversed(on); });
+    menu->addSeparator();
+    auto* loadAction = menu->addAction(tr("&Load Palette File..."));
+    connect(loadAction, &QAction::triggered, this,
+        [this] { emit loadFileRequested(); });
+    syncMenu();
+    return menu;
+}
+
+QComboBox* PaletteController::createSelector(QWidget* parent)
+{
+    auto* selector = new QComboBox(parent);
+    m_selector = selector;
+    const QFontMetrics metrics(selector->font());
+    int widestBuiltin = 0;
+    for (std::size_t index = 0; index < builtinPalettes.size(); ++index) {
+        const auto label = builtinPaletteLabel(index);
+        // Reserve room for the reversed form ("Plasma_r") so the closed
+        // selector never elides the "_r" suffix syncSelector appends.
+        widestBuiltin = std::max(widestBuiltin,
+            metrics.horizontalAdvance(label + QStringLiteral("_r")));
+        selector->addItem(label, static_cast<int>(index));
+    }
+    // A toggle that reverses the selected palette, kept at the end of the
+    // popup. Its label reflects the state (see syncSelector); it is never the
+    // closed selection, so it does not affect the fixed width below.
+    selector->insertSeparator(selector->count());
+    selector->addItem(tr("Reverse Colormap"), reverseToggle);
+    // Size the closed combo to exactly fit the longest builtin name (the popup
+    // expands independently, so the custom entry is never truncated there).
+    // Any custom entry shows elided when closed.
+    QStyleOptionComboBox option;
+    option.initFrom(selector);
+    const QSize content(widestBuiltin + 4, metrics.height());
+    selector->setFixedWidth(selector->style()
+            ->sizeFromContents(QStyle::CT_ComboBox, &option, content, selector)
+            .width());
+    selector->view()->setItemDelegate(
+        new CurrentRowBulletDelegate(selector, selector->view()));
+    connect(selector, qOverload<int>(&QComboBox::currentIndexChanged), this,
+        [this](int) {
+            if (!m_selector) {
+                return;
+            }
+            const auto selection = m_selector->currentData().toInt();
+            if (selection >= 0) {
+                selectBuiltin(selection);
+            } else if (selection == reverseToggle) {
+                // Flip the state; syncSelector then restores the current index
+                // to the palette.
+                setReversed(!m_state.reversed);
+            }
+            // The transient custom entry is already the selection: a no-op.
+        });
+    syncSelector();
+    return selector;
+}
+
+void PaletteController::selectBuiltin(int index)
+{
+    if (index < 0 || index >= static_cast<int>(builtinPalettes.size())) {
+        return;
+    }
+    State state = m_state;
+    state.builtinIndex = index;
+    state.fromFile = false;
+    state.filePath.clear();
+    install(builtinPalette(builtinPalettes[static_cast<std::size_t>(index)]),
+        std::move(state));
+}
+
+std::optional<QString> PaletteController::loadFile(const QString& path)
+{
+    Palette loaded;
+    try {
+        loaded = Palette::load(path.toStdString());
+    } catch (const std::exception& error) {
+        return QString::fromUtf8(error.what());
+    }
+    State state = m_state;
+    state.fromFile = true;
+    state.filePath = path;
+    install(std::move(loaded), std::move(state));
+    return std::nullopt;
+}
+
+void PaletteController::setReversed(bool reversed)
+{
+    if (reversed == m_state.reversed) {
+        return;
+    }
+    State state = m_state;
+    state.reversed = reversed;
+    install(m_basePalette, std::move(state));
+}
+
+void PaletteController::apply(const State& requested)
+{
+    State state = requested;
+    state.builtinIndex = std::clamp(state.builtinIndex, 0,
+        static_cast<int>(builtinPalettes.size()) - 1);
+    if (state.fromFile && !state.filePath.isEmpty()) {
+        std::optional<Palette> loaded;
+        try {
+            loaded = Palette::load(state.filePath.toStdString());
+        } catch (const std::exception&) {
+            // Fall through to the builtin the state carries.
+        }
+        if (loaded) {
+            install(std::move(*loaded), std::move(state));
+            return;
+        }
+    }
+    state.fromFile = false;
+    state.filePath.clear();
+    install(builtinPalette(
+                builtinPalettes[static_cast<std::size_t>(state.builtinIndex)]),
+        std::move(state));
+}
+
+void PaletteController::restore(const QSettings& settings)
+{
+    State state;
+    state.fromFile
+        = settings.value(QStringLiteral("palette/fromFile"), false).toBool();
+    state.filePath
+        = settings.value(QStringLiteral("palette/filePath")).toString();
+    const auto name = settings.value(QStringLiteral("palette/builtin"),
+        QStringLiteral("rainbow")).toString();
+    for (std::size_t index = 0; index < builtinPalettes.size(); ++index) {
+        if (name == builtinPaletteKey(index)) {
+            state.builtinIndex = static_cast<int>(index);
+            break;
+        }
+    }
+    state.reversed
+        = settings.value(QStringLiteral("palette/reversed"), false).toBool();
+    // Restore is not a change: block the signal the widgets and consumers are
+    // not yet wired for, and let the host read palette() when it is ready.
+    const QSignalBlocker blocker(this);
+    apply(state);
+}
+
+void PaletteController::save(QSettings& settings) const
+{
+    settings.setValue(QStringLiteral("palette/fromFile"), m_state.fromFile);
+    settings.setValue(QStringLiteral("palette/filePath"), m_state.filePath);
+    settings.setValue(QStringLiteral("palette/builtin"),
+        builtinPaletteKey(static_cast<std::size_t>(m_state.builtinIndex)));
+    settings.setValue(QStringLiteral("palette/reversed"), m_state.reversed);
+}
+
+QStringList PaletteController::menuLabels() const
+{
+    QStringList labels;
+    if (!m_menuGroup) {
+        return labels;
+    }
+    for (const auto* action : m_menuGroup->actions()) {
+        labels.append(action->text());
+    }
+    return labels;
+}
+
+QStringList PaletteController::selectorLabels() const
+{
+    QStringList labels;
+    if (!m_selector) {
+        return labels;
+    }
+    for (int item = 0; item < m_selector->count(); ++item) {
+        const auto entryData = m_selector->itemData(item);
+        // Only the builtins have a non-negative index; the separator, the
+        // custom entry and the reverse toggle are not palette names.
+        if (entryData.isValid() && entryData.toInt() >= 0) {
+            labels.append(m_selector->itemText(item));
+        }
+    }
+    return labels;
+}
+
+void PaletteController::install(Palette basePalette, State state)
+{
+    m_basePalette = std::move(basePalette);
+    m_state = std::move(state);
+    m_palette = m_state.reversed ? m_basePalette.reversed() : m_basePalette;
+    syncMenu();
+    syncSelector();
+    emit paletteChanged();
+}
+
+void PaletteController::syncMenu()
+{
+    if (m_menuGroup) {
+        const auto actions = m_menuGroup->actions();
+        for (int index = 0; index < actions.size(); ++index) {
+            actions[index]->setChecked(
+                !m_state.fromFile && index == m_state.builtinIndex);
+        }
+    }
+    if (m_reverseAction) {
+        const QSignalBlocker blocker(m_reverseAction);
+        m_reverseAction->setChecked(m_state.reversed);
+    }
+}
+
+void PaletteController::syncSelector()
+{
+    if (!m_selector) {
+        return;
+    }
+    const QSignalBlocker blocker(m_selector);
+    // Drop any stale custom-file entry before reconciling.
+    const int custom = m_selector->findData(customEntry);
+    if (custom >= 0) {
+        m_selector->removeItem(custom);
+    }
+    // Reversal is a global modifier, so every palette name carries the "_r"
+    // suffix (the plasma_r convention) while it is on -- including the closed
+    // selector, which shows the active one.
+    const QString suffix
+        = m_state.reversed ? QStringLiteral("_r") : QString();
+    for (int item = 0; item < m_selector->count(); ++item) {
+        const auto entryData = m_selector->itemData(item);
+        if (!entryData.isValid()) {
+            continue;  // separator
+        }
+        const auto value = entryData.toInt();
+        if (value >= 0) {
+            m_selector->setItemText(item,
+                builtinPaletteLabel(static_cast<std::size_t>(value)) + suffix);
+        } else if (value == reverseToggle) {
+            // The toggle item shows a check mark while reversal is on.
+            m_selector->setItemText(item,
+                (m_state.reversed ? QStringLiteral("✓ ") : QString())
+                    + tr("Reverse Colormap"));
+        }
+    }
+    if (m_state.fromFile) {
+        const auto label
+            = tr("Custom: %1").arg(QFileInfo(m_state.filePath).fileName())
+            + suffix;
+        // Insert just after the builtins (and before the separator) so the
+        // reverse toggle stays anchored at the bottom.
+        m_selector->insertItem(
+            static_cast<int>(builtinPalettes.size()), label, customEntry);
+        m_selector->setCurrentIndex(m_selector->findData(customEntry));
+    } else {
+        m_selector->setCurrentIndex(
+            m_selector->findData(m_state.builtinIndex));
+    }
+}
+
+} // namespace amrvis::qt

--- a/src/qt/PaletteController.hpp
+++ b/src/qt/PaletteController.hpp
@@ -51,8 +51,9 @@ inline QString builtinPaletteKey(std::size_t index)
 // its capitalization -- where the settings key above stays lowercase. Not the
 // only presentation rule: the selector still appends the "_r" reversal suffix
 // to its labels alone, so with reversal on the two surfaces differ by that
-// suffix. Kept apart from the key precisely so this rule can live here without
-// rewriting anyone's stored settings.
+// suffix. Folding it in here is the remaining half of the job. Kept apart from
+// the key precisely so this rule can live here without rewriting anyone's
+// stored settings.
 inline QString builtinPaletteLabel(std::size_t index)
 {
     auto label = builtinPaletteKey(index);
@@ -114,8 +115,10 @@ public:
     void apply(const State& state);
 
     // The palette keys of the application settings ("palette/…"). restore()
-    // does not emit paletteChanged: it runs before the host's consumers exist,
-    // and the host reads palette() itself once it has built them.
+    // does not emit paletteChanged: it reproduces a saved selection rather
+    // than changing one, so a host that has already wired the signal (persist,
+    // re-render) is not made to write the settings straight back and redraw
+    // nothing. The host reads palette() itself once restored.
     void restore(const QSettings& settings);
     void save(QSettings& settings) const;
 

--- a/src/qt/PaletteController.hpp
+++ b/src/qt/PaletteController.hpp
@@ -1,0 +1,154 @@
+#pragma once
+
+#include <amrexplorer/render2d/Palette.hpp>
+
+#include <QObject>
+#include <QPointer>
+#include <QString>
+#include <QStringList>
+
+#include <array>
+#include <cstddef>
+#include <optional>
+
+class QAction;
+class QActionGroup;
+class QComboBox;
+class QMenu;
+class QSettings;
+class QWidget;
+
+namespace amrvis::qt {
+
+inline constexpr std::array<BuiltinPalette, 7> builtinPalettes{
+    BuiltinPalette::Rainbow, BuiltinPalette::Turbo, BuiltinPalette::Viridis,
+    BuiltinPalette::Plasma, BuiltinPalette::Parula, BuiltinPalette::Coolwarm,
+    BuiltinPalette::Blackbody};
+
+// This array is what the Palette menu, the selector and settings restore all
+// enumerate, so a palette missing from it exists in render2d and nowhere a user
+// can reach. test_palette pins the seven names but cannot catch that: adding an
+// enumerator leaves this at seven and every name it does check still matches.
+static_assert(builtinPalettes.size()
+        == static_cast<std::size_t>(BuiltinPalette::Count),
+    "every BuiltinPalette must be listed in builtinPalettes");
+
+// The QSettings value for a builtin palette. This string is on disk in every
+// user's settings, and it comes from amrvis::builtinPaletteName(), which
+// render2d documents as the menu label *and* the settings key -- so renaming a
+// palette there is a settings-format change, not a presentation tweak.
+// test_palette pins the seven strings so that cannot happen silently.
+inline QString builtinPaletteKey(std::size_t index)
+{
+    if (index >= builtinPalettes.size()) {
+        return {};
+    }
+    const auto name = builtinPaletteName(builtinPalettes[index]);
+    return QString::fromLatin1(name.data(), static_cast<qsizetype>(name.size()));
+}
+
+// The palette's name for the menu and the selector, and the one definition of
+// its capitalization -- where the settings key above stays lowercase. Not the
+// only presentation rule: the selector still appends the "_r" reversal suffix
+// to its labels alone, so with reversal on the two surfaces differ by that
+// suffix. Kept apart from the key precisely so this rule can live here without
+// rewriting anyone's stored settings.
+inline QString builtinPaletteLabel(std::size_t index)
+{
+    auto label = builtinPaletteKey(index);
+    if (!label.isEmpty()) {
+        label[0] = label[0].toUpper();
+    }
+    return label;
+}
+
+// The palette selection extracted from MainWindow: which palette is chosen (a
+// builtin by index, or a legacy .pal file), whether it is reversed, the
+// effective Palette the renderer, color bar and overlays use, its QSettings
+// persistence, and the two widgets that present and drive it -- the Palette
+// menu and the toolbar selector. The host builds those widgets into its chrome
+// through createMenu/createSelector, pushes the palette to its consumers when
+// paletteChanged fires, and runs the file dialog when loadFileRequested fires.
+//
+// State is the explicit, serialisable selection; the Palette itself is derived
+// from it and never stored anywhere else, which is what lets a viewer-state
+// export/import restore a palette by round-tripping State alone.
+class PaletteController final : public QObject {
+    Q_OBJECT
+
+public:
+    struct State {
+        int builtinIndex = 0;
+        bool fromFile = false;
+        QString filePath;
+        bool reversed = false;
+    };
+
+    explicit PaletteController(QObject* parent = nullptr);
+
+    // The "&Palette" menu: one checkable action per builtin, the Reverse
+    // Colormap toggle, and Load Palette File... (which emits loadFileRequested).
+    // Owned by `parent`; the controller keeps its checks in step with the state.
+    QMenu* createMenu(QWidget* parent);
+    // The toolbar selector: the builtins (with the "_r" suffix while reversal
+    // is on), a transient "Custom: <file>" entry while a file palette is
+    // active, and a Reverse Colormap toggle item anchored at the bottom. Owned
+    // by `parent`; the controller keeps it in step with the state.
+    QComboBox* createSelector(QWidget* parent);
+
+    // The effective palette: the selection with reversal applied. The
+    // reference is stable for the controller's lifetime, so consumers that
+    // hold a pointer (the color bar) need not be re-pointed on every change.
+    [[nodiscard]] const Palette& palette() const noexcept { return m_palette; }
+    [[nodiscard]] const State& state() const noexcept { return m_state; }
+
+    void selectBuiltin(int index);
+    // Loads a legacy palette file and makes it the selection. On failure the
+    // selection is unchanged and the error text is returned for the host to
+    // show.
+    [[nodiscard]] std::optional<QString> loadFile(const QString& path);
+    void setReversed(bool reversed);
+    // Restores a whole selection (settings restore, viewer-state import). A
+    // file palette that no longer loads falls back to the builtin index the
+    // state carries, so the caller always ends up with a usable palette.
+    void apply(const State& state);
+
+    // The palette keys of the application settings ("palette/…"). restore()
+    // does not emit paletteChanged: it runs before the host's consumers exist,
+    // and the host reads palette() itself once it has built them.
+    void restore(const QSettings& settings);
+    void save(QSettings& settings) const;
+
+    // The builtin names as the menu actions and the selector items show them
+    // (the selector's with the reversal suffix, if on). Empty until the widget
+    // exists. For tests and diagnostics: the two must agree on every name.
+    [[nodiscard]] QStringList menuLabels() const;
+    [[nodiscard]] QStringList selectorLabels() const;
+
+signals:
+    // The effective palette changed (a new selection or the reversal toggle):
+    // the host pushes it to the color bar, overlays and a re-render, and
+    // persists settings.
+    void paletteChanged();
+    // The menu's Load Palette File... was chosen; the host runs its dialog and
+    // calls loadFile.
+    void loadFileRequested();
+
+private:
+    // Installs a selection and its base palette, syncs the widgets, derives
+    // the effective palette and emits paletteChanged.
+    void install(Palette basePalette, State state);
+    void syncMenu();
+    void syncSelector();
+
+    // The selected palette before any reversal; m_palette is derived from it as
+    // m_state.reversed ? m_basePalette.reversed() : m_basePalette.
+    Palette m_basePalette = builtinPalette(BuiltinPalette::Rainbow);
+    Palette m_palette = builtinPalette(BuiltinPalette::Rainbow);
+    State m_state;
+    QPointer<QActionGroup> m_menuGroup;
+    QPointer<QAction> m_reverseAction;
+    QPointer<QComboBox> m_selector;
+};
+
+} // namespace amrvis::qt

--- a/src/qt/main.cpp
+++ b/src/qt/main.cpp
@@ -1761,7 +1761,7 @@ int main(int argc, char* argv[])
         const auto menu = window.paletteMenuLabelsForTest();
         auto selector = window.paletteSelectorLabelsForTest();
         // The reversal suffix is a selector-only presentation rule: with
-        // "Reverse Colormap" on, syncPaletteSelector appends "_r" while the
+        // "Reverse Colormap" on, the selector appends "_r" while the
         // menu actions keep their original text. That divergence is real and
         // outside what this case is about, so it is normalized away rather
         // than asserted on -- the property here is that the two agree on the

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -469,6 +469,28 @@ if(TARGET amrexplorer_qt)
     )
     add_test(NAME sequence_controller COMMAND test_sequence_controller)
 
+    add_executable(test_palette_controller
+        unit/test_palette_controller.cpp
+        "${PROJECT_SOURCE_DIR}/src/qt/PaletteController.cpp"
+        "${PROJECT_SOURCE_DIR}/src/qt/PaletteController.hpp"
+    )
+    set_target_properties(test_palette_controller PROPERTIES AUTOMOC ON)
+    target_include_directories(test_palette_controller
+        PRIVATE "${PROJECT_SOURCE_DIR}/src/qt")
+    target_link_libraries(test_palette_controller
+        PRIVATE
+            amrexplorer::render2d
+            amrexplorer::warnings
+            Qt6::Core
+            Qt6::Gui
+            Qt6::Widgets
+    )
+    # The controller builds real widgets (menu, selector), so it needs a QPA
+    # platform; offscreen keeps it headless like the Qt smoke tests.
+    add_test(NAME palette_controller
+        COMMAND "${CMAKE_COMMAND}" -E env QT_QPA_PLATFORM=offscreen
+            "$<TARGET_FILE:test_palette_controller>")
+
     add_executable(test_remote_endpoint unit/test_remote_endpoint.cpp)
     target_include_directories(test_remote_endpoint
         PRIVATE "${PROJECT_SOURCE_DIR}/src/qt")

--- a/tests/unit/test_palette_controller.cpp
+++ b/tests/unit/test_palette_controller.cpp
@@ -80,7 +80,6 @@ int main(int argc, char** argv)
     QApplication application(argc, argv);
     using amrvis::qt::PaletteController;
     using amrvis::qt::builtinPalettes;
-    using amrvis::qt::builtinPaletteLabel;
 
     // Menu and selector present the same builtin names, in order, and the
     // first is "Rainbow" (pinned as a literal, not derived from the helper).
@@ -311,7 +310,9 @@ int main(int argc, char** argv)
     }
 
     // apply(State) is the viewer-state import path: it restores a selection
-    // wholesale and does emit, since consumers are wired by then.
+    // wholesale and does emit, since consumers are wired by then. A builtin
+    // index it does not have falls back to the first, as restore does for an
+    // unknown name.
     {
         PaletteController controller;
         int changes = 0;
@@ -326,6 +327,12 @@ int main(int argc, char** argv)
         require(changes == 2 && !controller.state().fromFile
                 && controller.state().builtinIndex == 2,
             "apply with an unloadable file did not fall back");
+        controller.apply(PaletteController::State{99, false, {}, false});
+        require(changes == 3 && controller.state().builtinIndex == 0,
+            "apply with an unknown builtin index did not fall back");
+        controller.apply(PaletteController::State{-1, false, {}, false});
+        require(changes == 4 && controller.state().builtinIndex == 0,
+            "apply with a negative builtin index did not fall back");
     }
 
     std::cout << "palette controller tests passed\n";

--- a/tests/unit/test_palette_controller.cpp
+++ b/tests/unit/test_palette_controller.cpp
@@ -1,0 +1,333 @@
+#include "PaletteController.hpp"
+
+#include <QAction>
+#include <QActionGroup>
+#include <QApplication>
+#include <QComboBox>
+#include <QDir>
+#include <QFile>
+#include <QMenu>
+#include <QSettings>
+#include <QTemporaryDir>
+
+#include <cstdlib>
+#include <iostream>
+
+namespace {
+
+void require(bool condition, const char* message)
+{
+    if (!condition) {
+        std::cerr << "FAILED: " << message << '\n';
+        std::exit(1);
+    }
+}
+
+bool samePalette(const amrvis::Palette& left, const amrvis::Palette& right)
+{
+    for (int slot = 0; slot < amrvis::Palette::slotCount; ++slot) {
+        if (left.slotArgb(slot) != right.slotArgb(slot)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+// The checked action of the menu group, or -1 (none checked: a file palette).
+int checkedMenuIndex(const QMenu& menu)
+{
+    const auto* group = menu.findChild<QActionGroup*>();
+    if (group == nullptr) {
+        return -2;
+    }
+    const auto actions = group->actions();
+    for (int index = 0; index < actions.size(); ++index) {
+        if (actions[index]->isChecked()) {
+            return index;
+        }
+    }
+    return -1;
+}
+
+const QAction* actionNamed(const QMenu& menu, const QString& text)
+{
+    for (const auto* action : menu.actions()) {
+        if (action->text() == text) {
+            return action;
+        }
+    }
+    return nullptr;
+}
+
+// A legacy sequential palette file: 768 bytes, red ramp only.
+QString writePaletteFile(const QTemporaryDir& dir, const char* name)
+{
+    const auto path = dir.filePath(QString::fromLatin1(name));
+    QFile file(path);
+    require(file.open(QIODevice::WriteOnly), "could not write palette fixture");
+    QByteArray bytes(768, '\0');
+    for (int slot = 0; slot < 256; ++slot) {
+        bytes[slot] = static_cast<char>(slot);
+    }
+    require(file.write(bytes) == bytes.size(), "short palette fixture write");
+    return path;
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    QApplication application(argc, argv);
+    using amrvis::qt::PaletteController;
+    using amrvis::qt::builtinPalettes;
+    using amrvis::qt::builtinPaletteLabel;
+
+    // Menu and selector present the same builtin names, in order, and the
+    // first is "Rainbow" (pinned as a literal, not derived from the helper).
+    {
+        PaletteController controller;
+        QWidget host;
+        auto* menu = controller.createMenu(&host);
+        auto* selector = controller.createSelector(&host);
+        const auto menuLabels = controller.menuLabels();
+        require(menuLabels.size() == static_cast<int>(builtinPalettes.size())
+                && menuLabels == controller.selectorLabels(),
+            "menu and selector disagree on the builtin names");
+        require(menuLabels.front() == QStringLiteral("Rainbow"),
+            "the first palette is not labelled Rainbow");
+        require(checkedMenuIndex(*menu) == 0
+                && selector->currentData().toInt() == 0,
+            "the initial selection is not the first builtin");
+        require(samePalette(controller.palette(),
+                    amrvis::builtinPalette(amrvis::BuiltinPalette::Rainbow)),
+            "the initial palette is not Rainbow");
+    }
+
+    // Selecting a builtin: state, palette, both widgets, one signal. The
+    // widgets drive it too: the selector's current-index change and the menu
+    // action both route to the same selection.
+    {
+        PaletteController controller;
+        QWidget host;
+        auto* menu = controller.createMenu(&host);
+        auto* selector = controller.createSelector(&host);
+        int changes = 0;
+        QObject::connect(&controller, &PaletteController::paletteChanged,
+            [&changes] { ++changes; });
+        controller.selectBuiltin(3);
+        require(changes == 1, "selectBuiltin did not emit paletteChanged once");
+        require(controller.state().builtinIndex == 3
+                && !controller.state().fromFile
+                && controller.state().filePath.isEmpty(),
+            "selectBuiltin left the wrong state");
+        require(samePalette(controller.palette(),
+                    amrvis::builtinPalette(builtinPalettes[3])),
+            "selectBuiltin did not install the palette");
+        require(checkedMenuIndex(*menu) == 3
+                && selector->currentData().toInt() == 3,
+            "selectBuiltin did not sync the widgets");
+        controller.selectBuiltin(99);
+        controller.selectBuiltin(-1);
+        require(changes == 1 && controller.state().builtinIndex == 3,
+            "an out-of-range builtin index was accepted");
+        selector->setCurrentIndex(selector->findData(5));
+        require(changes == 2 && controller.state().builtinIndex == 5
+                && checkedMenuIndex(*menu) == 5,
+            "the selector did not drive the selection");
+        menu->findChild<QActionGroup*>()->actions()[1]->trigger();
+        require(changes == 3 && controller.state().builtinIndex == 1
+                && selector->currentData().toInt() == 1,
+            "the menu action did not drive the selection");
+    }
+
+    // Reversal: the effective palette flips, the selector labels carry "_r"
+    // and its toggle item a check mark, the menu action follows, and the
+    // menu's names stay bare. Setting the same value again is a no-op.
+    {
+        PaletteController controller;
+        QWidget host;
+        auto* menu = controller.createMenu(&host);
+        auto* selector = controller.createSelector(&host);
+        int changes = 0;
+        QObject::connect(&controller, &PaletteController::paletteChanged,
+            [&changes] { ++changes; });
+        controller.setReversed(true);
+        require(changes == 1 && controller.state().reversed,
+            "setReversed did not take");
+        require(samePalette(controller.palette(),
+                    amrvis::builtinPalette(amrvis::BuiltinPalette::Rainbow)
+                        .reversed()),
+            "the reversed palette is not the base palette reversed");
+        for (const auto& label : controller.selectorLabels()) {
+            require(label.endsWith(QStringLiteral("_r")),
+                "a selector label lacks the reversal suffix");
+        }
+        require(controller.menuLabels().front() == QStringLiteral("Rainbow"),
+            "the menu label picked up the selector's suffix");
+        require(selector->itemText(selector->findData(-3))
+                    .startsWith(QStringLiteral("✓")),
+            "the reverse toggle item shows no check mark");
+        require(actionNamed(*menu, QStringLiteral("&Reverse Colormap"))
+                    ->isChecked(),
+            "the menu's reverse action is not checked");
+        require(selector->currentData().toInt() == 0,
+            "reversal moved the selector off the palette");
+        controller.setReversed(true);
+        require(changes == 1, "a no-op setReversed emitted paletteChanged");
+        // The selector's toggle item flips it back and restores the current
+        // index to the palette.
+        selector->setCurrentIndex(selector->findData(-3));
+        require(changes == 2 && !controller.state().reversed
+                && selector->currentData().toInt() == 0,
+            "the selector's reverse toggle did not flip and restore");
+        require(controller.selectorLabels().front() == QStringLiteral("Rainbow"),
+            "the reversal suffix was not removed");
+    }
+
+    // File palettes: a bad path is reported and changes nothing; a good one
+    // becomes a "Custom: <file>" entry with no builtin checked, and reversal
+    // applies on top of it. Selecting a builtin again drops the entry.
+    {
+        QTemporaryDir dir;
+        require(dir.isValid(), "no temporary directory");
+        PaletteController controller;
+        QWidget host;
+        auto* menu = controller.createMenu(&host);
+        auto* selector = controller.createSelector(&host);
+        int changes = 0;
+        QObject::connect(&controller, &PaletteController::paletteChanged,
+            [&changes] { ++changes; });
+        const auto error = controller.loadFile(dir.filePath("missing.pal"));
+        require(error.has_value() && changes == 0
+                && !controller.state().fromFile,
+            "a missing palette file was accepted");
+        const auto path = writePaletteFile(dir, "ramp.pal");
+        require(!controller.loadFile(path).has_value() && changes == 1,
+            "a valid palette file was rejected");
+        require(controller.state().fromFile
+                && controller.state().filePath == path,
+            "loadFile left the wrong state");
+        require(controller.palette().slotArgb(200) == 0xFFC80000U,
+            "the file palette's ramp was not installed");
+        require(checkedMenuIndex(*menu) == -1,
+            "a builtin stayed checked under a file palette");
+        require(selector->currentData().toInt() == -2
+                && selector->currentText()
+                    == QStringLiteral("Custom: ramp.pal"),
+            "the selector does not show the custom entry");
+        controller.setReversed(true);
+        require(controller.palette().slotArgb(200) != 0xFFC80000U
+                && selector->currentText()
+                    == QStringLiteral("Custom: ramp.pal_r"),
+            "reversal did not apply on top of the file palette");
+        controller.selectBuiltin(2);
+        require(selector->findData(-2) < 0 && checkedMenuIndex(*menu) == 2,
+            "selecting a builtin did not drop the custom entry");
+        // Load Palette File... asks the host; it does not load anything itself.
+        bool asked = false;
+        QObject::connect(&controller, &PaletteController::loadFileRequested,
+            [&asked] { asked = true; });
+        const_cast<QAction*>(
+            actionNamed(*menu, QStringLiteral("&Load Palette File...")))
+            ->trigger();
+        require(asked, "Load Palette File... did not ask the host");
+    }
+
+    // Settings round trip through the "palette/…" keys; restore is silent; a
+    // file that no longer loads falls back to the stored builtin; an unknown
+    // builtin name falls back to the first.
+    {
+        QTemporaryDir dir;
+        require(dir.isValid(), "no temporary directory");
+        const auto path = writePaletteFile(dir, "saved.pal");
+        const auto settingsPath = dir.filePath("settings.ini");
+        {
+            QSettings settings(settingsPath, QSettings::IniFormat);
+            PaletteController controller;
+            controller.selectBuiltin(4);
+            controller.setReversed(true);
+            controller.save(settings);
+            require(settings.value(QStringLiteral("palette/builtin")).toString()
+                        == QStringLiteral("parula")
+                    && settings.value(QStringLiteral("palette/reversed")).toBool()
+                    && !settings.value(QStringLiteral("palette/fromFile"))
+                            .toBool(),
+                "save wrote the wrong keys");
+        }
+        {
+            QSettings settings(settingsPath, QSettings::IniFormat);
+            PaletteController controller;
+            int changes = 0;
+            QObject::connect(&controller, &PaletteController::paletteChanged,
+                [&changes] { ++changes; });
+            controller.restore(settings);
+            require(changes == 0, "restore emitted paletteChanged");
+            require(controller.state().builtinIndex == 4
+                    && controller.state().reversed
+                    && !controller.state().fromFile,
+                "restore did not reproduce the saved builtin selection");
+            require(samePalette(controller.palette(),
+                        amrvis::builtinPalette(builtinPalettes[4]).reversed()),
+                "restore did not derive the reversed palette");
+        }
+        {
+            // A file palette on top of builtin 4: the state keeps carrying the
+            // builtin, which is what the fallback below returns to.
+            QSettings settings(settingsPath, QSettings::IniFormat);
+            PaletteController controller;
+            controller.selectBuiltin(4);
+            require(!controller.loadFile(path).has_value(), "fixture load");
+            controller.setReversed(false);
+            controller.save(settings);
+        }
+        {
+            QSettings settings(settingsPath, QSettings::IniFormat);
+            PaletteController controller;
+            controller.restore(settings);
+            require(controller.state().fromFile
+                    && controller.state().filePath == path
+                    && controller.palette().slotArgb(200) == 0xFFC80000U,
+                "restore did not reload the file palette");
+        }
+        require(QFile::remove(path), "could not remove the palette fixture");
+        {
+            QSettings settings(settingsPath, QSettings::IniFormat);
+            PaletteController controller;
+            controller.restore(settings);
+            require(!controller.state().fromFile
+                    && controller.state().builtinIndex == 4,
+                "a vanished file palette did not fall back to the builtin");
+        }
+        {
+            QSettings settings(settingsPath, QSettings::IniFormat);
+            settings.setValue(QStringLiteral("palette/fromFile"), false);
+            settings.setValue(QStringLiteral("palette/builtin"),
+                QStringLiteral("no-such-palette"));
+            PaletteController controller;
+            controller.restore(settings);
+            require(controller.state().builtinIndex == 0,
+                "an unknown builtin name did not fall back to the first");
+        }
+    }
+
+    // apply(State) is the viewer-state import path: it restores a selection
+    // wholesale and does emit, since consumers are wired by then.
+    {
+        PaletteController controller;
+        int changes = 0;
+        QObject::connect(&controller, &PaletteController::paletteChanged,
+            [&changes] { ++changes; });
+        controller.apply(PaletteController::State{6, false, {}, true});
+        require(changes == 1 && controller.state().builtinIndex == 6
+                && controller.state().reversed,
+            "apply did not install the state");
+        controller.apply(PaletteController::State{
+            2, true, QStringLiteral("/nonexistent/palette.pal"), false});
+        require(changes == 2 && !controller.state().fromFile
+                && controller.state().builtinIndex == 2,
+            "apply with an unloadable file did not fall back");
+    }
+
+    std::cout << "palette controller tests passed\n";
+    return 0;
+}


### PR DESCRIPTION
The palette selection -- builtin index or .pal file, reversal, the derived Palette, its QSettings keys, and the Palette menu and toolbar selector that present it -- moves into PaletteController, the first of the MainWindow collaborators. It exposes an explicit State with apply(State), so a viewer-state export/import can round-trip the selection, and it is unit-tested directly (offscreen widgets, real settings file, real .pal fixture). MainWindow keeps the file dialog and its reaction to paletteChanged; nine members and five methods leave it. The combo bullet delegate moves to its own header for the two selectors that still use it.