### PR TITLE
extract DiagnosticsModel from MainWindow

### DIFF
--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -8,6 +8,8 @@ add_executable(amrexplorer_qt
     ColorBarWidget.hpp
     CurrentRowBulletDelegate.hpp
     DatasetExtract.hpp
+    DiagnosticsModel.cpp
+    DiagnosticsModel.hpp
     DatasetWindow.cpp
     DatasetWindow.hpp
     FabSelectorDock.cpp

--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -8,10 +8,10 @@ add_executable(amrexplorer_qt
     ColorBarWidget.hpp
     CurrentRowBulletDelegate.hpp
     DatasetExtract.hpp
-    DiagnosticsModel.cpp
-    DiagnosticsModel.hpp
     DatasetWindow.cpp
     DatasetWindow.hpp
+    DiagnosticsModel.cpp
+    DiagnosticsModel.hpp
     FabSelectorDock.cpp
     FabSelectorDock.hpp
     ImageView.cpp

--- a/src/qt/DiagnosticsModel.cpp
+++ b/src/qt/DiagnosticsModel.cpp
@@ -1,0 +1,160 @@
+#include "DiagnosticsModel.hpp"
+
+#include <QDockWidget>
+#include <QPlainTextEdit>
+
+#include <utility>
+
+namespace amrvis::qt {
+
+namespace {
+
+constexpr int maximumProbeLines = 100;
+constexpr int maximumErrors = 50;
+
+} // namespace
+
+DiagnosticsModel::DiagnosticsModel(Hooks hooks, QObject* parent)
+    : QObject(parent)
+    , m_hooks(std::move(hooks))
+{
+}
+
+QDockWidget* DiagnosticsModel::createDock(QWidget* parent)
+{
+    auto* dock = new QDockWidget(tr("Diagnostics"), parent);
+    auto* view = new QPlainTextEdit(dock);
+    view->setReadOnly(true);
+    dock->setWidget(view);
+    dock->setVisible(false);
+    m_dock = dock;
+    m_view = view;
+    return dock;
+}
+
+void DiagnosticsModel::adjustActivity(int delta)
+{
+    if (delta >= 0) {
+        m_activeRequests += static_cast<std::uint64_t>(delta);
+        return;
+    }
+    const auto decrement = static_cast<std::uint64_t>(-delta);
+    if (decrement > m_activeRequests) {
+        // A decrement without its increment is a bookkeeping bug elsewhere;
+        // an unsigned wrap here would defeat every "nothing in flight" check
+        // that reads the count, so clamp and say so.
+        qWarning("diagnostics: active-request count would go negative "
+                 "(%llu - %llu); clamped to zero",
+            static_cast<unsigned long long>(m_activeRequests),
+            static_cast<unsigned long long>(decrement));
+        m_activeRequests = 0;
+        return;
+    }
+    m_activeRequests -= decrement;
+}
+
+void DiagnosticsModel::noteStaleResult()
+{
+    ++m_staleResults;
+}
+
+void DiagnosticsModel::setCacheMetrics(const CacheMetrics& metrics)
+{
+    m_cacheBudgetBytes = metrics.budgetBytes;
+    m_cacheResidentBytes = metrics.residentBytes;
+    m_cachePinnedBytes = metrics.pinnedBytes;
+    m_cacheEvictions = metrics.evictions;
+}
+
+void DiagnosticsModel::setMetadataMetrics(
+    std::uint64_t filesRead, std::uint64_t bytesRead)
+{
+    m_lastFilesRead = filesRead;
+    m_lastBytesRead = bytesRead;
+}
+
+void DiagnosticsModel::setSliceMetrics(std::uint64_t blocksRead,
+    std::uint64_t cacheHits, std::uint64_t payloadBytesRead)
+{
+    m_lastBlocksRead = blocksRead;
+    m_lastCacheHits = cacheHits;
+    m_lastPayloadBytesRead = payloadBytesRead;
+}
+
+void DiagnosticsModel::resetDatasetMetrics()
+{
+    m_lastBlocksRead = 0;
+    m_lastCacheHits = 0;
+    m_lastPayloadBytesRead = 0;
+    m_cacheBudgetBytes = 0;
+    m_cacheResidentBytes = 0;
+    m_cachePinnedBytes = 0;
+    m_cacheEvictions = 0;
+    m_probeLines.clear();
+}
+
+void DiagnosticsModel::appendProbeLine(const QString& line)
+{
+    m_probeLines.append(line);
+    while (m_probeLines.size() > maximumProbeLines) {
+        m_probeLines.removeFirst();
+    }
+}
+
+void DiagnosticsModel::reportBackgroundError(const QString& message)
+{
+    qWarning("%s", message.toUtf8().constData());
+    m_backgroundErrors.append(message);
+    while (m_backgroundErrors.size() > maximumErrors) {
+        m_backgroundErrors.removeFirst();
+    }
+    if (m_dock) {
+        m_dock->setVisible(true);
+    }
+    refresh();
+}
+
+QString DiagnosticsModel::text() const
+{
+    auto text = tr("generation: %1\nactive background requests: %2\n"
+                   "stale results discarded: %3\nmetadata files read: %4\n"
+                   "metadata bytes read: %5\nblocks read: %6\ncache hits: %7\n"
+                   "payload bytes read: %8\ncache budget bytes: %9\n"
+                   "cache resident bytes: %10\ncache pinned bytes: %11\n"
+                   "cache evictions: %12\nlast frame switch: %13 ms")
+                    .arg(m_hooks.generation ? m_hooks.generation() : 0)
+                    .arg(m_activeRequests)
+                    .arg(m_staleResults)
+                    .arg(m_lastFilesRead)
+                    .arg(m_lastBytesRead)
+                    .arg(m_lastBlocksRead)
+                    .arg(m_lastCacheHits)
+                    .arg(m_lastPayloadBytesRead)
+                    .arg(m_cacheBudgetBytes)
+                    .arg(m_cacheResidentBytes)
+                    .arg(m_cachePinnedBytes)
+                    .arg(m_cacheEvictions)
+                    .arg(m_hooks.lastFrameSwitchMs ? m_hooks.lastFrameSwitchMs()
+                                                   : 0);
+    if (m_hooks.remoteLines) {
+        text += m_hooks.remoteLines();
+    }
+    for (const auto& line : m_probeLines) {
+        text += QLatin1Char('\n');
+        text += line;
+    }
+    for (const auto& error : m_backgroundErrors) {
+        text += QLatin1Char('\n');
+        text += tr("background error: %1").arg(error);
+    }
+    return text;
+}
+
+void DiagnosticsModel::refresh()
+{
+    if (m_view) {
+        m_view->setPlainText(text());
+    }
+}
+
+} // namespace amrvis::qt

--- a/src/qt/DiagnosticsModel.hpp
+++ b/src/qt/DiagnosticsModel.hpp
@@ -1,0 +1,106 @@
+#pragma once
+
+#include <amrexplorer/cache/CacheMetrics.hpp>
+
+#include <QObject>
+#include <QPointer>
+#include <QString>
+#include <QStringList>
+
+#include <cstdint>
+#include <functional>
+
+class QDockWidget;
+class QPlainTextEdit;
+class QWidget;
+
+namespace amrvis::qt {
+
+// The Diagnostics panel's model extracted from MainWindow: the counters and
+// metrics the panel shows -- background request activity, superseded results
+// dropped, the last read's metadata and payload metrics, the cache state --
+// plus the probe readout history and the recent background errors, each with
+// its bounded-history rule. It owns the dock and its text widget and renders
+// itself on refresh(); the host supplies the lines only it knows (dataset
+// generation, last frame switch, remote endpoint) through Hooks, and keeps
+// its own reportBackgroundError as the place that also sets the status bar
+// and suppresses reports during shutdown.
+//
+// The active-request count is what "no background work in flight" decisions
+// read, so it must never underflow: an unbalanced decrement (a bug elsewhere)
+// is clamped and warned about rather than left to wrap to 2^64.
+class DiagnosticsModel final : public QObject {
+    Q_OBJECT
+
+public:
+    struct Hooks {
+        std::function<std::uint64_t()> generation;
+        std::function<qint64()> lastFrameSwitchMs;
+        // Extra lines for the remote endpoint, empty when there is none.
+        std::function<QString()> remoteLines;
+    };
+
+    DiagnosticsModel(Hooks hooks, QObject* parent = nullptr);
+
+    // The dock (hidden by default) holding the read-only text; the host adds
+    // it to its dock area and its View menu. Owned by `parent`.
+    QDockWidget* createDock(QWidget* parent);
+
+    // Background request bookkeeping: +1 when a worker starts, -1 when its
+    // watcher fires. Reads say whether any background work is in flight.
+    void adjustActivity(int delta);
+    [[nodiscard]] std::uint64_t activeRequests() const noexcept
+    {
+        return m_activeRequests;
+    }
+    [[nodiscard]] std::uint64_t staleResults() const noexcept
+    {
+        return m_staleResults;
+    }
+    // A load or query result arrived after being superseded and was dropped.
+    void noteStaleResult();
+
+    void setCacheMetrics(const CacheMetrics& metrics);
+    void setMetadataMetrics(std::uint64_t filesRead, std::uint64_t bytesRead);
+    void setSliceMetrics(std::uint64_t blocksRead, std::uint64_t cacheHits,
+        std::uint64_t payloadBytesRead);
+    // A dataset teardown: the per-dataset metrics and the probe history go;
+    // the request/stale counters and the error history stay.
+    void resetDatasetMetrics();
+
+    // The status-bar probe readouts the user clicked, newest last, capped.
+    void appendProbeLine(const QString& line);
+
+    // A background failure: logged, kept (newest 50), and the dock is shown
+    // so it is seen. The host sets its status bar and guards shutdown.
+    void reportBackgroundError(const QString& message);
+    [[nodiscard]] int backgroundErrorCount() const noexcept
+    {
+        return static_cast<int>(m_backgroundErrors.size());
+    }
+
+    // Re-renders the panel from the current state and the hooks.
+    void refresh();
+    // The rendered text (what refresh() shows); for tests.
+    [[nodiscard]] QString text() const;
+
+private:
+    Hooks m_hooks;
+    std::uint64_t m_activeRequests = 0;
+    std::uint64_t m_staleResults = 0;
+    std::uint64_t m_lastFilesRead = 0;
+    std::uint64_t m_lastBytesRead = 0;
+    std::uint64_t m_lastBlocksRead = 0;
+    std::uint64_t m_lastCacheHits = 0;
+    std::uint64_t m_lastPayloadBytesRead = 0;
+    std::uint64_t m_cacheBudgetBytes = 0;
+    std::uint64_t m_cacheResidentBytes = 0;
+    std::uint64_t m_cachePinnedBytes = 0;
+    std::uint64_t m_cacheEvictions = 0;
+    QStringList m_probeLines;
+    QStringList m_backgroundErrors;
+    QPointer<QDockWidget> m_dock;
+    QPointer<QPlainTextEdit> m_view;
+};
+
+} // namespace amrvis::qt

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -298,12 +298,18 @@ MainWindow::MainWindow(QWidget* parent)
     addDockWidget(Qt::LeftDockWidgetArea, m_metadataDock);
     m_metadataDock->setVisible(false);
 
-    m_diagnosticsDock = new QDockWidget(tr("Diagnostics"), this);
-    m_diagnostics = new QPlainTextEdit(m_diagnosticsDock);
-    m_diagnostics->setReadOnly(true);
-    m_diagnosticsDock->setWidget(m_diagnostics);
+    // The Diagnostics panel's counters, metrics and histories live in their
+    // model; it renders the dock, and this window supplies the lines only it
+    // knows.
+    m_diagnosticsModel = new DiagnosticsModel(
+        DiagnosticsModel::Hooks{
+            [this] { return m_generation; },
+            [this] { return m_sequenceController->lastFrameSwitchMs(); },
+            [this] { return remoteDiagnosticsLines(); },
+        },
+        this);
+    m_diagnosticsDock = m_diagnosticsModel->createDock(this);
     addDockWidget(Qt::BottomDockWidgetArea, m_diagnosticsDock);
-    m_diagnosticsDock->setVisible(false);
 
     m_colorBarDock = new QDockWidget(tr("Color Scale"), this);
     m_colorBar = new ColorBarWidget(m_colorBarDock);
@@ -373,16 +379,12 @@ MainWindow::MainWindow(QWidget* parent)
         });
     connect(m_sequenceController, &SequenceController::loadActivityChanged,
         this, [this](int delta) {
-            if (delta > 0) {
-                m_activeRequests += static_cast<std::uint64_t>(delta);
-            } else {
-                m_activeRequests -= static_cast<std::uint64_t>(-delta);
-            }
+            m_diagnosticsModel->adjustActivity(delta);
             updateDiagnostics();
         });
     connect(m_sequenceController, &SequenceController::staleResultDropped,
         this, [this] {
-            ++m_staleResults;
+            m_diagnosticsModel->noteStaleResult();
             updateDiagnostics();
         });
     connect(m_sequenceController, &SequenceController::statusMessage,
@@ -415,11 +417,7 @@ MainWindow::MainWindow(QWidget* parent)
         });
     connect(m_particleController, &ParticleController::loadActivityChanged,
         this, [this](int delta) {
-            if (delta > 0) {
-                m_activeRequests += static_cast<std::uint64_t>(delta);
-            } else {
-                m_activeRequests -= static_cast<std::uint64_t>(-delta);
-            }
+            m_diagnosticsModel->adjustActivity(delta);
             updateDiagnostics();
         });
     connect(m_particleController, &ParticleController::statusMessage, this,
@@ -429,7 +427,7 @@ MainWindow::MainWindow(QWidget* parent)
     connect(m_particleController, &ParticleController::loadFailed, this,
         [this](const QString& message) { reportBackgroundError(message); });
     connect(m_particleController, &ParticleController::staleResultDropped,
-        this, [this] { ++m_staleResults; });
+        this, [this] { m_diagnosticsModel->noteStaleResult(); });
     connect(m_particleController, &ParticleController::loadFinished, this,
         [this] { updateDiagnostics(); });
     connect(m_sequenceController, &SequenceController::frameDisplayed,

--- a/src/qt/MainWindow.hpp
+++ b/src/qt/MainWindow.hpp
@@ -77,6 +77,7 @@ class ImageView;
 class IsoWidget;
 class LinePlotWindow;
 class ScientificDoubleSpinBox;
+class DiagnosticsModel;
 class PaletteController;
 class ParticleController;
 class SequenceController;
@@ -248,10 +249,7 @@ public:
     // Saturates: reportBackgroundError keeps only the newest 50, so a test that
     // waits for this to exceed a baseline of 50 would wait forever. Both
     // current callers start from an empty list.
-    [[nodiscard]] int backgroundErrorCountForTest() const
-    {
-        return static_cast<int>(m_backgroundErrors.size());
-    }
+    [[nodiscard]] int backgroundErrorCountForTest() const;
     // Test-only: the direct "open a raw FAB file" entry point, reached in the
     // app through a file dialog. Supplies no rollback of its own, which is what
     // makes it the interesting case when it supersedes a selector click.
@@ -577,7 +575,12 @@ private:
     void showKeyboardMouseReference();
     void showAboutDialog();
     void showMetadata(const PlotfileMetadataResult& result, const std::filesystem::path& path);
+    // Re-renders the Diagnostics panel; the model owns the counters, this
+    // window only supplies the lines it alone knows (see the model's Hooks).
     void updateDiagnostics();
+    [[nodiscard]] QString remoteDiagnosticsLines() const;
+    // Non-modal failure report: status bar plus the model's error history
+    // (which shows the dock); suppressed while closing.
     void reportBackgroundError(const QString& message);
     void updateAnimationDockVisibility();
     void updateWindowTitle();
@@ -906,7 +909,6 @@ private:
     std::uint64_t m_visibleSyncStaleSkips = 0;
 #endif
     QTreeWidget* m_metadataTree = nullptr;
-    QPlainTextEdit* m_diagnostics = nullptr;
     QDockWidget* m_metadataDock = nullptr;
     QDockWidget* m_diagnosticsDock = nullptr;
     QDockWidget* m_colorBarDock = nullptr;
@@ -1001,8 +1003,6 @@ private:
     // what the renderer, color bar and overlays use.
     PaletteController* m_paletteController = nullptr;
     QString m_numberFormat = defaultNumberFormat();
-    QStringList m_probeLines;
-    QStringList m_backgroundErrors;
     bool m_controlsReady = false;
     std::uint64_t m_generation = 0;
     // Newest-wins among overlapping standalone-FAB header reads. m_generation
@@ -1011,18 +1011,11 @@ private:
     // still match the generation they captured.
     std::uint64_t m_fabOpenGeneration = 0;
     std::optional<PendingFabOpen> m_pendingFabOpen;
-    std::uint64_t m_activeRequests = 0;
     bool m_closing = false;
-    std::uint64_t m_staleResults = 0;
-    std::uint64_t m_lastFilesRead = 0;
-    std::uint64_t m_lastBytesRead = 0;
-    std::uint64_t m_lastBlocksRead = 0;
-    std::uint64_t m_lastCacheHits = 0;
-    std::uint64_t m_lastPayloadBytesRead = 0;
-    std::uint64_t m_cacheBudgetBytes = 0;
-    std::uint64_t m_cacheResidentBytes = 0;
-    std::uint64_t m_cachePinnedBytes = 0;
-    std::uint64_t m_cacheEvictions = 0;
+    // Owns the Diagnostics panel's counters (background requests, stale
+    // results), the last read's metrics, the cache state, the probe history
+    // and the background-error history, and renders the dock.
+    DiagnosticsModel* m_diagnosticsModel = nullptr;
 
     // Animation state. The sequence frames/index/in-flight/prefetch state
     // machine lives in the SequenceController; this window keeps only the

--- a/src/qt/MainWindow.hpp
+++ b/src/qt/MainWindow.hpp
@@ -723,7 +723,8 @@ private:
     void syncVisibleRanges();
     // Panel slices currently on a worker (summed PlaneViewState::pendingRequests);
     // the visible-range sync defers dispatch until this is zero. Panel work only
-    // -- excludes particle/line-plot/prefetch requests tracked by m_activeRequests.
+    // -- excludes particle/line-plot/prefetch requests, which the
+    // DiagnosticsModel's active count tracks.
     [[nodiscard]] int slicesInFlight() const;
 
     // Slice requests: the debounce timer coalesces into per-view requests.
@@ -904,8 +905,8 @@ private:
 #ifdef AMREXPLORER_QT_TEST_ACCESS
     // Test-only: superseded visible-range sync outcomes dropped by the
     // rerun guard. Sole writer is that drop, so the overlapping-sync test can
-    // assert an exact count. m_staleResults carries the same event for the
-    // user-facing diagnostics panel.
+    // assert an exact count. The DiagnosticsModel's stale count carries the
+    // same event for the user-facing diagnostics panel.
     std::uint64_t m_visibleSyncStaleSkips = 0;
 #endif
     QTreeWidget* m_metadataTree = nullptr;

--- a/src/qt/MainWindow.hpp
+++ b/src/qt/MainWindow.hpp
@@ -48,7 +48,6 @@ class QLabel;
 class QSpinBox;
 class QLineF;
 class QMenu;
-class QPlainTextEdit;
 class QProgressDialog;
 class QPushButton;
 class QStackedWidget;

--- a/src/qt/MainWindowDataset.cpp
+++ b/src/qt/MainWindowDataset.cpp
@@ -336,7 +336,7 @@ void MainWindow::openStandaloneFabAsync(std::filesystem::path path,
     bool preserveFabSelector, std::optional<FrameSliceSpec> initialSpec,
     QString failureTitle, std::optional<FabSelectorRollback> rollback)
 {
-    ++m_activeRequests;
+    m_diagnosticsModel->adjustActivity(1);
     const auto generation = m_generation;
     // Two of these can be in flight at once -- clicking a second raw record
     // while the first is still reading, which is reachable precisely because
@@ -371,7 +371,7 @@ void MainWindow::openStandaloneFabAsync(std::filesystem::path path,
             dataRoot = std::move(dataRoot), preserveFabSelector,
             initialSpec = std::move(initialSpec),
             failureTitle = std::move(failureTitle)]() mutable {
-            --m_activeRequests;
+            m_diagnosticsModel->adjustActivity(-1);
             if (m_closing) {
                 watcher->deleteLater();
                 return;
@@ -403,7 +403,7 @@ void MainWindow::openStandaloneFabAsync(std::filesystem::path path,
                         std::move(dataRoot), preserveFabSelector,
                         std::move(initialSpec));
                 } else {
-                    ++m_staleResults;
+                    m_diagnosticsModel->noteStaleResult();
                 }
             } catch (const std::exception& error) {
                 if (current) {
@@ -416,7 +416,7 @@ void MainWindow::openStandaloneFabAsync(std::filesystem::path path,
                     reportBackgroundError(
                         tr("%1: %2").arg(failureTitle, exceptionMessage(error)));
                 } else {
-                    ++m_staleResults;
+                    m_diagnosticsModel->noteStaleResult();
                 }
             }
             updateDiagnostics();
@@ -1172,13 +1172,7 @@ void MainWindow::openDatasetImpl(const std::filesystem::path& path,
     // so closing it on every open only discarded whatever the user had typed
     // but not yet applied.
     m_datasetPath = path;
-    m_lastBlocksRead = 0;
-    m_lastCacheHits = 0;
-    m_lastPayloadBytesRead = 0;
-    m_cacheBudgetBytes = 0;
-    m_cacheResidentBytes = 0;
-    m_cachePinnedBytes = 0;
-    m_cacheEvictions = 0;
+    m_diagnosticsModel->resetDatasetMetrics();
     m_fieldSelector->setEnabled(false);
     m_levelSelector->setEnabled(false);
     m_rangeMode->setEnabled(false);
@@ -1196,7 +1190,6 @@ void MainWindow::openDatasetImpl(const std::filesystem::path& path,
     m_exportAnimationAction->setEnabled(false);
     m_openMetadata.reset();
     m_fileVersion.clear();
-    m_probeLines.clear();
     m_vectorUField = -1;
     m_vectorVField = -1;
     m_vectorWField = -1;
@@ -1219,7 +1212,7 @@ void MainWindow::openDatasetImpl(const std::filesystem::path& path,
     m_metadataStopSource.request_stop();
     m_metadataStopSource = StopSource{};
     const auto metadataCancellation = m_metadataStopSource.get_token();
-    ++m_activeRequests;
+    m_diagnosticsModel->adjustActivity(1);
     statusBar()->showMessage(tr("Reading metadata for %1...").arg(
         QString::fromStdString(path.string())));
     updateDiagnostics();
@@ -1229,7 +1222,7 @@ void MainWindow::openDatasetImpl(const std::filesystem::path& path,
         [this, watcher, generation, path, metadataOnly,
             dataRoot = std::move(dataRoot),
             initialSpec = std::move(initialSpec)]() mutable {
-            --m_activeRequests;
+            m_diagnosticsModel->adjustActivity(-1);
             if (m_closing) {
                 watcher->deleteLater();
                 return;
@@ -1282,7 +1275,7 @@ void MainWindow::openDatasetImpl(const std::filesystem::path& path,
                             std::move(result.session));
                     }
                 } else {
-                    ++m_staleResults;
+                    m_diagnosticsModel->noteStaleResult();
                 }
             } catch (const std::exception& error) {
                 if (generation == m_generation) {
@@ -1305,7 +1298,7 @@ void MainWindow::openDatasetImpl(const std::filesystem::path& path,
                     updateAnimationDockVisibility();
                     emit datasetOpenFinished(false);
                 } else {
-                    ++m_staleResults;
+                    m_diagnosticsModel->noteStaleResult();
                 }
             }
             updateDiagnostics();
@@ -1425,7 +1418,7 @@ void MainWindow::requestInitialSlice(
     for (const auto* state : views) {
         viewGenerations.push_back(state->sliceGeneration);
     }
-    ++m_activeRequests;
+    m_diagnosticsModel->adjustActivity(1);
     statusBar()->showMessage(tr("Loading initial slice..."));
     updateDiagnostics();
 
@@ -1433,7 +1426,7 @@ void MainWindow::requestInitialSlice(
     connect(watcher, &QFutureWatcher<InitialSliceResult>::finished, this,
         [this, watcher, generation, cancellation, views, viewGenerations,
             restoredSpec, isRemote] {
-            --m_activeRequests;
+            m_diagnosticsModel->adjustActivity(-1);
             if (m_closing) {
                 watcher->deleteLater();
                 return;
@@ -1552,10 +1545,7 @@ void MainWindow::requestInitialSlice(
                         }
                     }
                     const auto cache = m_dataset->cacheMetrics();
-                    m_cacheBudgetBytes = cache.budgetBytes;
-                    m_cacheResidentBytes = cache.residentBytes;
-                    m_cachePinnedBytes = cache.pinnedBytes;
-                    m_cacheEvictions = cache.evictions;
+                    m_diagnosticsModel->setCacheMetrics(cache);
                     if (result.cacheFallbackToLevel >= 0) {
                         // Non-modal: an informational cache-fallback notice must
                         // not pop a modal dialog that would block the quit path.
@@ -1565,7 +1555,7 @@ void MainWindow::requestInitialSlice(
                     }
                     emit initialSliceFinished(true);
                 } else {
-                    ++m_staleResults;
+                    m_diagnosticsModel->noteStaleResult();
                 }
             } catch (const std::exception& error) {
                 if (generation == m_generation && !cancellation.stop_requested()) {
@@ -1580,7 +1570,7 @@ void MainWindow::requestInitialSlice(
                             .arg(QString::fromStdString(m_datasetPath.string())));
                     emit initialSliceFinished(false);
                 } else {
-                    ++m_staleResults;
+                    m_diagnosticsModel->noteStaleResult();
                 }
             }
             updateDiagnostics();

--- a/src/qt/MainWindowInteraction.cpp
+++ b/src/qt/MainWindowInteraction.cpp
@@ -812,11 +812,7 @@ void MainWindow::probeClicked(PlaneViewState& state, int x, int displayY)
     setActiveView(state);
     const auto line = probeReadout(state, x, displayY);
     m_probeLabel->setText(line);
-    constexpr int maximumProbeLines = 100;
-    m_probeLines.append(line);
-    while (m_probeLines.size() > maximumProbeLines) {
-        m_probeLines.removeFirst();
-    }
+    m_diagnosticsModel->appendProbeLine(line);
     updateDiagnostics();
 }
 
@@ -1379,7 +1375,7 @@ void MainWindow::linePlotRequested(PlaneViewState& state, int imageX, int imageY
         m_linePlotStopSource = StopSource{};
     }
     const auto cancellation = m_linePlotStopSource.get_token();
-    ++m_activeRequests;
+    m_diagnosticsModel->adjustActivity(1);
     statusBar()->showMessage(tr("Loading line plot for %1...").arg(
         QString::fromStdString(fieldName)));
     updateDiagnostics();
@@ -1389,7 +1385,7 @@ void MainWindow::linePlotRequested(PlaneViewState& state, int imageX, int imageY
     connect(watcher, &QFutureWatcher<LineQueryResult>::finished, this,
         [this, watcher, dataset, generation, cancellation, request, fieldName,
             dimension, primaryFixedAxis, maximumLevel, composition, view] {
-            --m_activeRequests;
+            m_diagnosticsModel->adjustActivity(-1);
             if (m_closing) {
                 watcher->deleteLater();
                 return;
@@ -1401,20 +1397,16 @@ void MainWindow::linePlotRequested(PlaneViewState& state, int imageX, int imageY
             try {
                 auto result = watcher->future().takeResult();
                 if (generation != m_generation || cancellation.stop_requested()) {
-                    ++m_staleResults;
+                    m_diagnosticsModel->noteStaleResult();
                 } else {
                     appendLinePlotCurve(result.line, fieldName, dimension,
                         primaryFixedAxis, request.axis,
                         request.fixedCoordinates,
                         maximumLevel, composition);
                     const auto cache = dataset->cacheMetrics();
-                    m_cacheBudgetBytes = cache.budgetBytes;
-                    m_cacheResidentBytes = cache.residentBytes;
-                    m_cachePinnedBytes = cache.pinnedBytes;
-                    m_cacheEvictions = cache.evictions;
-                    m_lastBlocksRead = result.metrics.blocksRead;
-                    m_lastCacheHits = result.metrics.cacheHits;
-                    m_lastPayloadBytesRead = result.metrics.payloadBytesRead;
+                    m_diagnosticsModel->setCacheMetrics(cache);
+                    m_diagnosticsModel->setSliceMetrics(result.metrics.blocksRead,
+                        result.metrics.cacheHits, result.metrics.payloadBytesRead);
                     statusBar()->showMessage(tr("Added line plot curve for %1")
                         .arg(QString::fromStdString(fieldName)));
                 }
@@ -1430,14 +1422,14 @@ void MainWindow::linePlotRequested(PlaneViewState& state, int imageX, int imageY
                         .arg(cacheBudgetText(
                             dataset->cacheMetrics().budgetBytes)));
                 } else {
-                    ++m_staleResults;
+                    m_diagnosticsModel->noteStaleResult();
                 }
             } catch (const std::exception& error) {
                 if (generation == m_generation && !cancellation.stop_requested()) {
                     reportBackgroundError(
                         tr("Cannot load line plot: %1").arg(exceptionMessage(error)));
                 } else {
-                    ++m_staleResults;
+                    m_diagnosticsModel->noteStaleResult();
                 }
             }
             updateDiagnostics();

--- a/src/qt/MainWindowInternal.hpp
+++ b/src/qt/MainWindowInternal.hpp
@@ -8,6 +8,7 @@
 #include "MainWindow.hpp"
 #include "QtErrorText.hpp"
 #include "AnimationExporter.hpp"
+#include "DiagnosticsModel.hpp"
 #include "PaletteController.hpp"
 #include "ParticleController.hpp"
 #include "SequenceController.hpp"

--- a/src/qt/MainWindowSlice.cpp
+++ b/src/qt/MainWindowSlice.cpp
@@ -309,7 +309,7 @@ void MainWindow::requestSlice(PlaneViewState& state, bool rasterDirty)
     const auto generation = m_generation;
     const auto sliceGeneration = ++state.sliceGeneration;
     ++state.pendingRequests;
-    ++m_activeRequests;
+    m_diagnosticsModel->adjustActivity(1);
     const auto tag = m_viewDimension == 3
         ? tr(" (%1)").arg(state.label) : QString();
     statusBar()->showMessage(tr("Loading %1%2...").arg(
@@ -359,7 +359,7 @@ void MainWindow::requestSlice(PlaneViewState& state, bool rasterDirty)
         [this, watcher, dataset, generation, sliceGeneration, cancellation,
          &state, rangeMode] {
             --state.pendingRequests;
-            --m_activeRequests;
+            m_diagnosticsModel->adjustActivity(-1);
             if (m_closing) {
                 watcher->deleteLater();
                 return;
@@ -424,10 +424,7 @@ void MainWindow::requestSlice(PlaneViewState& state, bool rasterDirty)
                         }
                     }
                     const auto cache = dataset->cacheMetrics();
-                    m_cacheBudgetBytes = cache.budgetBytes;
-                    m_cacheResidentBytes = cache.residentBytes;
-                    m_cachePinnedBytes = cache.pinnedBytes;
-                    m_cacheEvictions = cache.evictions;
+                    m_diagnosticsModel->setCacheMetrics(cache);
                     // A cache-pressure fallback lowered the composite level;
                     // reflect it in the level combo (no re-slice) and inform the
                     // user, matching the initial-load handling.
@@ -442,7 +439,7 @@ void MainWindow::requestSlice(PlaneViewState& state, bool rasterDirty)
                             *dataset, fallbackFromLevel, fallbackToLevel));
                     }
                 } else {
-                    ++m_staleResults;
+                    m_diagnosticsModel->noteStaleResult();
                 }
             } catch (const std::exception& error) {
                 if (generation == m_generation
@@ -451,7 +448,7 @@ void MainWindow::requestSlice(PlaneViewState& state, bool rasterDirty)
                     reportBackgroundError(
                         tr("Cannot load slice: %1").arg(exceptionMessage(error)));
                 } else {
-                    ++m_staleResults;
+                    m_diagnosticsModel->noteStaleResult();
                 }
             }
             // Dispatch the 3-D shared-range sync after the try/catch, not inside
@@ -477,7 +474,7 @@ void MainWindow::requestSlice(PlaneViewState& state, bool rasterDirty)
             watcher->deleteLater();
             // The interactive re-slice batch has drained once no view has work
             // in flight; the smoke test waits on this to read settled state.
-            if (m_activeRequests == 0) {
+            if (m_diagnosticsModel->activeRequests() == 0) {
                 emit interactiveSlicesSettled();
             }
         });
@@ -691,8 +688,8 @@ void MainWindow::showMetadata(
     m_fileVersion = result.fileVersion;
     updateWindowTitle();
 
-    m_lastFilesRead = result.metrics.filesRead;
-    m_lastBytesRead = result.metrics.bytesRead;
+    m_diagnosticsModel->setMetadataMetrics(
+        result.metrics.filesRead, result.metrics.bytesRead);
     statusBar()->showMessage(standalone
         ? tr("Metadata loaded: %1 field(s), %2 grid(s)")
               .arg(metadata.fields.size())
@@ -952,9 +949,8 @@ void MainWindow::showSlice(PlaneViewState& state, SliceDisplayResult display)
     // loop.
     refreshScaleReport();
 
-    m_lastBlocksRead = display.slice.metrics.blocksRead;
-    m_lastCacheHits = display.slice.metrics.cacheHits;
-    m_lastPayloadBytesRead = display.slice.metrics.payloadBytesRead;
+    m_diagnosticsModel->setSliceMetrics(display.slice.metrics.blocksRead,
+        display.slice.metrics.cacheHits, display.slice.metrics.payloadBytesRead);
     statusBar()->clearMessage();
 }
 
@@ -1047,7 +1043,7 @@ void MainWindow::syncVisibleRanges()
     connect(watcher, &QFutureWatcher<SyncOutcome>::finished, this,
         [this, watcher, generation, snapshotGenerations, views] {
             m_visibleSyncInFlight = false;
-            --m_activeRequests;
+            m_diagnosticsModel->adjustActivity(-1);
             if (m_closing) {
                 watcher->deleteLater();
                 return;
@@ -1196,7 +1192,7 @@ void MainWindow::syncVisibleRanges()
                         .arg(exceptionMessage(error)));
                 }
             }
-            if (m_activeRequests == 0) {
+            if (m_diagnosticsModel->activeRequests() == 0) {
                 emit interactiveSlicesSettled();
             }
         });
@@ -1207,7 +1203,7 @@ void MainWindow::syncVisibleRanges()
     // retry, drop the watcher, and swallow -- the failure must not escape this
     // slot or wedge the sync shut for the session.
     m_visibleSyncInFlight = true;
-    ++m_activeRequests;
+    m_diagnosticsModel->adjustActivity(1);
     try {
         watcher->setFuture(QtConcurrent::run([cachedRange, snapshots,
             logarithmic = m_logarithmic->isChecked(),
@@ -1239,7 +1235,7 @@ void MainWindow::syncVisibleRanges()
         }));
     } catch (const std::exception& error) {
         m_visibleSyncInFlight = false;
-        --m_activeRequests;
+        m_diagnosticsModel->adjustActivity(-1);
         watcher->deleteLater();
         reportBackgroundError(tr("Cannot synchronize views: %1")
             .arg(exceptionMessage(error)));
@@ -1506,10 +1502,7 @@ void MainWindow::displayFrameResult(InitialSliceResult& result,
         showSlice(*views[index], std::move(result.displays[index]));
     }
     const auto cache = m_dataset->cacheMetrics();
-    m_cacheBudgetBytes = cache.budgetBytes;
-    m_cacheResidentBytes = cache.residentBytes;
-    m_cachePinnedBytes = cache.pinnedBytes;
-    m_cacheEvictions = cache.evictions;
+    m_diagnosticsModel->setCacheMetrics(cache);
     validateVectorMode();
     // Frames need not share a domain, and the clamped scale report is computed
     // from one. A scale picked on an earlier frame otherwise kept that frame's
@@ -1844,38 +1837,13 @@ void MainWindow::reportBackgroundError(const QString& message)
     if (m_closing) {
         return;
     }
-    qWarning("%s", message.toUtf8().constData());
-    m_backgroundErrors.append(message);
-    constexpr int maximumErrors = 50;
-    while (m_backgroundErrors.size() > maximumErrors) {
-        m_backgroundErrors.removeFirst();
-    }
     statusBar()->showMessage(message.section(QLatin1Char('\n'), 0, 0));
-    m_diagnosticsDock->setVisible(true);
-    updateDiagnostics();
+    m_diagnosticsModel->reportBackgroundError(message);
 }
 
-void MainWindow::updateDiagnostics()
+QString MainWindow::remoteDiagnosticsLines() const
 {
-    auto text = tr("generation: %1\nactive background requests: %2\n"
-           "stale results discarded: %3\nmetadata files read: %4\n"
-           "metadata bytes read: %5\nblocks read: %6\ncache hits: %7\n"
-           "payload bytes read: %8\ncache budget bytes: %9\n"
-           "cache resident bytes: %10\ncache pinned bytes: %11\n"
-           "cache evictions: %12\nlast frame switch: %13 ms")
-            .arg(m_generation)
-            .arg(m_activeRequests)
-            .arg(m_staleResults)
-            .arg(m_lastFilesRead)
-            .arg(m_lastBytesRead)
-            .arg(m_lastBlocksRead)
-            .arg(m_lastCacheHits)
-            .arg(m_lastPayloadBytesRead)
-            .arg(m_cacheBudgetBytes)
-            .arg(m_cacheResidentBytes)
-            .arg(m_cachePinnedBytes)
-            .arg(m_cacheEvictions)
-            .arg(m_sequenceController->lastFrameSwitchMs());
+    QString text;
     if (m_remoteConnection) {
         text += tr("\nremote session: %1 (%2)")
                     .arg(m_remoteLabel,
@@ -1892,15 +1860,12 @@ void MainWindow::updateDiagnostics()
                     .arg(QString::fromStdString(
                         m_sshRemoteSession->destination()));
     }
-    for (const auto& line : m_probeLines) {
-        text += QLatin1Char('\n');
-        text += line;
-    }
-    for (const auto& error : m_backgroundErrors) {
-        text += QLatin1Char('\n');
-        text += tr("background error: %1").arg(error);
-    }
-    m_diagnostics->setPlainText(text);
+    return text;
+}
+
+void MainWindow::updateDiagnostics()
+{
+    m_diagnosticsModel->refresh();
 }
 
 } // namespace amrvis::qt

--- a/src/qt/MainWindowSlice.cpp
+++ b/src/qt/MainWindowSlice.cpp
@@ -985,9 +985,9 @@ void MainWindow::syncVisibleRanges()
     // against fully-current panels. Running against a settled batch is what lets
     // the completion apply all-or-nothing (a coherent shared range/log/color bar
     // across all three panels) instead of a stale subset. Gate on panel slice
-    // work only (slicesInFlight), never the global m_activeRequests -- particle
-    // loads, line plots, and sequence prefetch bump that, and would wedge the
-    // sync shut for the whole operation.
+    // work only (slicesInFlight), never the DiagnosticsModel's global active
+    // count -- particle loads, line plots, and sequence prefetch bump that,
+    // and would wedge the sync shut for the whole operation.
     if (slicesInFlight() != 0 || m_visibleSyncInFlight) {
         m_visibleSyncRerun = true;
         return;
@@ -1171,7 +1171,8 @@ void MainWindow::syncVisibleRanges()
                 // which recomputes the union over the current planes.
 #ifdef AMREXPLORER_QT_TEST_ACCESS
                 // Sole writer of this test-only tally; the staleness smoke test
-                // asserts its exact delta. m_staleResults is not touched.
+                // asserts its exact delta. The DiagnosticsModel's stale count
+                // is not touched.
                 ++m_visibleSyncStaleSkips;
 #endif
             } else if (generation != m_generation) {
@@ -1197,8 +1198,8 @@ void MainWindow::syncVisibleRanges()
             }
         });
     // Commit to "in flight" only now that the throwing allocations above
-    // succeeded; the sync joins the interactive batch (++m_activeRequests) so
-    // interactiveSlicesSettled waits for it. Guard the launch: if
+    // succeeded; the sync joins the interactive batch (adjustActivity(1) on
+    // the DiagnosticsModel) so interactiveSlicesSettled waits for it. Guard the launch: if
     // QtConcurrent::run throws (bad_alloc), un-latch so a later arrival can
     // retry, drop the watcher, and swallow -- the failure must not escape this
     // slot or wedge the sync shut for the session.

--- a/src/qt/MainWindowTestAccess.cpp
+++ b/src/qt/MainWindowTestAccess.cpp
@@ -881,4 +881,9 @@ void MainWindow::startAnimationExportForTest(const QString& path,
     beginAnimationExport(path, includeColorBar);
 }
 
+int MainWindow::backgroundErrorCountForTest() const
+{
+    return m_diagnosticsModel->backgroundErrorCount();
+}
+
 } // namespace amrvis::qt

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -515,6 +515,26 @@ if(TARGET amrexplorer_qt)
             "$<TARGET_FILE:test_particle_controller>")
     set_tests_properties(particle_controller PROPERTIES TIMEOUT 60)
 
+    add_executable(test_diagnostics_model
+        unit/test_diagnostics_model.cpp
+        "${PROJECT_SOURCE_DIR}/src/qt/DiagnosticsModel.cpp"
+        "${PROJECT_SOURCE_DIR}/src/qt/DiagnosticsModel.hpp"
+    )
+    set_target_properties(test_diagnostics_model PROPERTIES AUTOMOC ON)
+    target_include_directories(test_diagnostics_model
+        PRIVATE "${PROJECT_SOURCE_DIR}/src/qt")
+    target_link_libraries(test_diagnostics_model
+        PRIVATE
+            amrexplorer::cache
+            amrexplorer::warnings
+            Qt6::Core
+            Qt6::Gui
+            Qt6::Widgets
+    )
+    add_test(NAME diagnostics_model
+        COMMAND "${CMAKE_COMMAND}" -E env QT_QPA_PLATFORM=offscreen
+            "$<TARGET_FILE:test_diagnostics_model>")
+
     add_executable(test_remote_endpoint unit/test_remote_endpoint.cpp)
     target_include_directories(test_remote_endpoint
         PRIVATE "${PROJECT_SOURCE_DIR}/src/qt")

--- a/tests/unit/test_diagnostics_model.cpp
+++ b/tests/unit/test_diagnostics_model.cpp
@@ -1,0 +1,177 @@
+#include "DiagnosticsModel.hpp"
+
+#include <QApplication>
+#include <QDockWidget>
+#include <QPlainTextEdit>
+#include <QWidget>
+
+#include <cstdlib>
+#include <iostream>
+
+namespace {
+
+void require(bool condition, const char* message)
+{
+    if (!condition) {
+        std::cerr << "FAILED: " << message << '\n';
+        std::exit(1);
+    }
+}
+
+bool hasLine(const QString& text, const QString& line)
+{
+    return text.split(QLatin1Char('\n')).contains(line);
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    QApplication application(argc, argv);
+    using amrvis::qt::DiagnosticsModel;
+
+    std::uint64_t generation = 3;
+    qint64 frameSwitch = 42;
+    QString remote;
+    const auto hooks = [&] {
+        return DiagnosticsModel::Hooks{
+            [&generation] { return generation; },
+            [&frameSwitch] { return frameSwitch; },
+            [&remote] { return remote; },
+        };
+    };
+
+    // The rendered text: every counter on its own line, the host's lines
+    // through the hooks, and the remote block only when the host has one.
+    {
+        DiagnosticsModel model(hooks());
+        auto text = model.text();
+        require(hasLine(text, QStringLiteral("generation: 3"))
+                && hasLine(text, QStringLiteral("active background requests: 0"))
+                && hasLine(text, QStringLiteral("stale results discarded: 0"))
+                && hasLine(text, QStringLiteral("last frame switch: 42 ms")),
+            "the initial text lacks a counter or a hook value");
+        require(!text.contains(QStringLiteral("remote")),
+            "a remote block appeared with no remote endpoint");
+        remote = QStringLiteral("\nremote endpoint: host:7");
+        require(hasLine(model.text(), QStringLiteral("remote endpoint: host:7")),
+            "the remote hook's lines were not appended");
+        remote.clear();
+        generation = 4;
+        frameSwitch = 7;
+        require(hasLine(model.text(), QStringLiteral("generation: 4"))
+                && hasLine(model.text(), QStringLiteral("last frame switch: 7 ms")),
+            "hook values are not read live");
+    }
+
+    // Activity bookkeeping balances and never wraps: an unbalanced decrement
+    // clamps to zero (a wrap would defeat every "nothing in flight" check).
+    {
+        DiagnosticsModel model(hooks());
+        model.adjustActivity(1);
+        model.adjustActivity(1);
+        require(model.activeRequests() == 2, "increments were not counted");
+        model.adjustActivity(-1);
+        require(model.activeRequests() == 1, "a decrement was not counted");
+        model.adjustActivity(-2);
+        require(model.activeRequests() == 0,
+            "an unbalanced decrement did not clamp to zero");
+        model.adjustActivity(-1);
+        require(model.activeRequests() == 0, "the count wrapped");
+        model.adjustActivity(1);
+        require(model.activeRequests() == 1
+                && hasLine(model.text(),
+                    QStringLiteral("active background requests: 1")),
+            "activity after a clamp is not counted from zero");
+        model.noteStaleResult();
+        model.noteStaleResult();
+        require(model.staleResults() == 2
+                && hasLine(model.text(),
+                    QStringLiteral("stale results discarded: 2")),
+            "stale results were not counted");
+    }
+
+    // Metrics render, and a dataset reset clears the per-dataset ones (last
+    // read, cache, probe history) while the counters and errors survive.
+    {
+        DiagnosticsModel model(hooks());
+        amrvis::CacheMetrics cache;
+        cache.budgetBytes = 100;
+        cache.residentBytes = 60;
+        cache.pinnedBytes = 10;
+        cache.evictions = 2;
+        model.setCacheMetrics(cache);
+        model.setMetadataMetrics(5, 5000);
+        model.setSliceMetrics(8, 3, 800);
+        model.appendProbeLine(QStringLiteral("probe (1, 2) = 3"));
+        model.noteStaleResult();
+        model.reportBackgroundError(QStringLiteral("boom"));
+        auto text = model.text();
+        require(hasLine(text, QStringLiteral("cache budget bytes: 100"))
+                && hasLine(text, QStringLiteral("cache resident bytes: 60"))
+                && hasLine(text, QStringLiteral("cache pinned bytes: 10"))
+                && hasLine(text, QStringLiteral("cache evictions: 2"))
+                && hasLine(text, QStringLiteral("metadata files read: 5"))
+                && hasLine(text, QStringLiteral("metadata bytes read: 5000"))
+                && hasLine(text, QStringLiteral("blocks read: 8"))
+                && hasLine(text, QStringLiteral("cache hits: 3"))
+                && hasLine(text, QStringLiteral("payload bytes read: 800"))
+                && hasLine(text, QStringLiteral("probe (1, 2) = 3"))
+                && hasLine(text, QStringLiteral("background error: boom")),
+            "a metric, probe line or error is missing from the text");
+        model.resetDatasetMetrics();
+        text = model.text();
+        require(hasLine(text, QStringLiteral("cache budget bytes: 0"))
+                && hasLine(text, QStringLiteral("blocks read: 0"))
+                && !text.contains(QStringLiteral("probe (1, 2)")),
+            "the dataset reset left per-dataset state behind");
+        require(hasLine(text, QStringLiteral("stale results discarded: 1"))
+                && hasLine(text, QStringLiteral("background error: boom"))
+                && hasLine(text, QStringLiteral("metadata files read: 5")),
+            "the dataset reset took counters, errors or metadata metrics");
+    }
+
+    // Bounded histories: the newest 100 probe lines and the newest 50 errors.
+    {
+        DiagnosticsModel model(hooks());
+        for (int i = 0; i < 120; ++i) {
+            model.appendProbeLine(QStringLiteral("probe %1").arg(i));
+        }
+        for (int i = 0; i < 60; ++i) {
+            model.reportBackgroundError(QStringLiteral("error %1").arg(i));
+        }
+        const auto text = model.text();
+        require(!text.contains(QStringLiteral("probe 19\n"))
+                && hasLine(text, QStringLiteral("probe 20"))
+                && hasLine(text, QStringLiteral("probe 119")),
+            "the probe history is not the newest 100");
+        require(!text.contains(QStringLiteral("background error: error 9\n"))
+                && hasLine(text, QStringLiteral("background error: error 10"))
+                && hasLine(text, QStringLiteral("background error: error 59"))
+                && model.backgroundErrorCount() == 50,
+            "the error history is not the newest 50");
+    }
+
+    // The dock: hidden until an error is reported, then shown with the text.
+    {
+        DiagnosticsModel model(hooks());
+        QWidget host;
+        host.show();
+        auto* dock = model.createDock(&host);
+        require(dock != nullptr && dock->isHidden(),
+            "the dock did not start hidden");
+        model.refresh();
+        auto* view = dock->findChild<QPlainTextEdit*>();
+        require(view != nullptr && view->isReadOnly()
+                && view->toPlainText().contains(QStringLiteral("generation:")),
+            "refresh did not render into the dock's text");
+        model.reportBackgroundError(QStringLiteral("shown"));
+        require(!dock->isHidden()
+                && view->toPlainText().contains(
+                    QStringLiteral("background error: shown")),
+            "an error did not show the dock with the report");
+    }
+
+    std::cout << "diagnostics model tests passed\n";
+    return 0;
+}

--- a/tests/unit/test_diagnostics_model.cpp
+++ b/tests/unit/test_diagnostics_model.cpp
@@ -121,8 +121,14 @@ int main(int argc, char** argv)
             "a metric, probe line or error is missing from the text");
         model.resetDatasetMetrics();
         text = model.text();
-        require(hasLine(text, QStringLiteral("cache budget bytes: 0"))
-                && hasLine(text, QStringLiteral("blocks read: 0"))
+        // Every per-dataset field, so no single clear can go missing.
+        require(hasLine(text, QStringLiteral("blocks read: 0"))
+                && hasLine(text, QStringLiteral("cache hits: 0"))
+                && hasLine(text, QStringLiteral("payload bytes read: 0"))
+                && hasLine(text, QStringLiteral("cache budget bytes: 0"))
+                && hasLine(text, QStringLiteral("cache resident bytes: 0"))
+                && hasLine(text, QStringLiteral("cache pinned bytes: 0"))
+                && hasLine(text, QStringLiteral("cache evictions: 0"))
                 && !text.contains(QStringLiteral("probe (1, 2)")),
             "the dataset reset left per-dataset state behind");
         require(hasLine(text, QStringLiteral("stale results discarded: 1"))
@@ -158,8 +164,8 @@ int main(int argc, char** argv)
         QWidget host;
         host.show();
         auto* dock = model.createDock(&host);
-        require(dock != nullptr && dock->isHidden(),
-            "the dock did not start hidden");
+        require(dock != nullptr && dock->parent() == &host && dock->isHidden(),
+            "the dock did not start hidden, owned by the host");
         model.refresh();
         auto* view = dock->findChild<QPlainTextEdit*>();
         require(view != nullptr && view->isReadOnly()


### PR DESCRIPTION
The Diagnostics panel's counters (background requests, stale results), the last read's metadata/payload metrics, the cache state, the probe readout history and the background-error history -- each with its bounded-history rule -- move into DiagnosticsModel, which owns the dock and renders it; MainWindow supplies the lines only it knows (dataset generation, last frame switch, remote endpoint) through hooks and keeps reportBackgroundError as the status-bar/shutdown wrapper. The active-request count now clamps and warns instead of wrapping when a decrement has no increment. Unit-tested directly: rendering, balance and clamp, per-dataset reset, the two history caps, the dock. Fourteen members leave MainWindow.