### PR TITLE
extract FabNavigator from MainWindow

### DIFF
--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -12,6 +12,8 @@ add_executable(amrexplorer_qt
     DatasetWindow.hpp
     DiagnosticsModel.cpp
     DiagnosticsModel.hpp
+    FabNavigator.cpp
+    FabNavigator.hpp
     FabSelectorDock.cpp
     FabSelectorDock.hpp
     ImageView.cpp

--- a/src/qt/FabNavigator.cpp
+++ b/src/qt/FabNavigator.cpp
@@ -1,0 +1,389 @@
+#include "FabNavigator.hpp"
+
+#include "QtErrorText.hpp"
+
+#include <amrexplorer/io/FabCatalog.hpp>
+#include <amrexplorer/io/StandaloneMetadataReader.hpp>
+#include <amrexplorer/io/detail/FabHeaderParsing.hpp>
+
+#include <QCoreApplication>
+#include <QFutureWatcher>
+#include <QMessageBox>
+#include <QtConcurrent>
+
+#include <exception>
+#include <stdexcept>
+#include <utility>
+
+namespace amrvis::qt {
+
+FabNavigator::FabNavigator(Hooks hooks, QObject* parent)
+    : QObject(parent)
+    , m_hooks(std::move(hooks))
+{
+}
+
+FabSelectorDock* FabNavigator::createDock(QWidget* parent)
+{
+    auto* dock = new FabSelectorDock(parent);
+    dock->setVisible(false);
+    connect(dock, &FabSelectorDock::viewRequested, this,
+        [this](std::size_t entry) { viewEntry(entry); });
+    connect(dock, &FabSelectorDock::backRequested, this,
+        [this] { backToMultiFab(); });
+    m_dock = dock;
+    return dock;
+}
+
+FabSelectorBuild FabNavigator::buildSelector(
+    const PlotfileMetadataResult& result, const std::filesystem::path& path)
+{
+    const auto precisionLabel = [](FabRealPrecision precision) {
+        return precision == FabRealPrecision::Single
+            ? QCoreApplication::translate("MainWindow", "IEEE-32")
+            : QCoreApplication::translate("MainWindow", "IEEE-64");
+    };
+
+    FabSelectorBuild build;
+    build.root = path.parent_path();
+    if (build.root.empty()) {
+        build.root = ".";
+    }
+
+    if (result.fileVersion == "FAB") {
+        const auto records = scanFabFile(path);
+        build.entries.reserve(records.size());
+        for (const auto& record : records) {
+            build.entries.push_back({
+                .ordinal = record.ordinal,
+                .level = 0,
+                .blockIndex = record.ordinal,
+                .filePath = path,
+                .fileOffset = record.headerOffset,
+                .validBox = record.storedBox,
+                .storedBox = record.storedBox,
+                .dimension = record.dimension,
+                .components = record.components,
+                .precision = precisionLabel(record.precision),
+                .rawRecord = true
+            });
+        }
+        build.matched = true;
+        build.fabMode = true;
+        build.hasSourceMetadata = false;
+    } else if (result.fileVersion.starts_with("VisMF-")
+        && result.metadata->levels.size() == 1) {
+        const auto& metadata = *result.metadata;
+        const auto& level = metadata.levels.front();
+        build.entries.reserve(level.blocks.size());
+        for (std::size_t index = 0; index < level.blocks.size(); ++index) {
+            const auto& block = level.blocks[index];
+            // Overflow-guarded shared grow (this copy previously used
+            // plain int).
+            auto storedBox = amrvis::detail::grownBox<MetadataReadError>(
+                block.box, level.ghostWidth, metadata.dimension);
+            auto precision = FabRealPrecision::Double;
+            if (level.visMfHeaderVersion == 1) {
+                const auto record = inspectFabRecord(
+                    build.root / block.filePath, block.fileOffset);
+                storedBox = record.storedBox;
+                precision = record.precision;
+            } else {
+                precision = fabPrecisionFromDescriptor(level.realDescriptor);
+            }
+            build.entries.push_back({
+                .ordinal = index,
+                .level = level.level,
+                .blockIndex = index,
+                .filePath = build.root / block.filePath,
+                .fileOffset = block.fileOffset,
+                .validBox = block.box,
+                .storedBox = storedBox,
+                .dimension = metadata.dimension,
+                .components = level.storedComponents,
+                .precision = precisionLabel(precision),
+                .rawRecord = false
+            });
+        }
+        build.matched = true;
+        build.fabMode = false;
+        build.hasSourceMetadata = true;
+    }
+    return build;
+}
+
+void FabNavigator::applySelectorBuild(FabSelectorBuild build,
+    const std::filesystem::path& path, const PlotfileMetadataResult& metadata)
+{
+    if (build.matched) {
+        m_fabMode = build.fabMode;
+        if (build.hasSourceMetadata) {
+            m_sourceMetadata = metadata;
+        } else {
+            m_sourceMetadata.reset();
+        }
+    }
+    if (build.entries.empty()) {
+        if (m_dock) {
+            m_dock->setVisible(false);
+        }
+        return;
+    }
+    m_sourcePath = path;
+    m_dataRoot = build.root;
+    if (m_dock) {
+        m_dock->setEntries(std::move(build.entries));
+        m_dock->setBackAvailable(false);
+        m_dock->setVisible(true);
+        m_dock->raise();
+    }
+    emit windowTitleChanged();
+}
+
+void FabNavigator::openStandaloneFab(const std::filesystem::path& path)
+{
+    auto root = path.parent_path();
+    if (root.empty()) {
+        root = ".";
+    }
+    openStandaloneFabAsync(path, std::nullopt, std::move(root), false,
+        std::nullopt, tr("Cannot open FAB"), std::nullopt);
+}
+
+void FabNavigator::applyRollback(const SelectorRollback& rollback)
+{
+    m_fabMode = rollback.fabMode;
+    if (!m_dock) {
+        return;
+    }
+    m_dock->setBackAvailable(rollback.backAvailable);
+    if (rollback.ordinal) {
+        m_dock->selectEntry(*rollback.ordinal);
+    } else {
+        m_dock->clearSelection();
+    }
+}
+
+std::optional<FrameSliceSpec> FabNavigator::selectedEntrySpec() const
+{
+    auto spec = m_hooks.currentSpec ? m_hooks.currentSpec() : std::nullopt;
+    if (spec) {
+        // The selected FAB shows its own whole level at the file range; the
+        // rest of the display state (field, palette, zoom, ...) carries over.
+        spec->levelSelection = -1;
+        spec->rangeMode = RangeMode::File;
+        spec->userRange.reset();
+    }
+    return spec;
+}
+
+QWidget* FabNavigator::dialogParent() const
+{
+    return m_dock ? m_dock->parentWidget() : nullptr;
+}
+
+void FabNavigator::openStandaloneFabAsync(std::filesystem::path path,
+    std::optional<std::uint64_t> fileOffset, std::filesystem::path dataRoot,
+    bool preserveSelector, std::optional<FrameSliceSpec> initialSpec,
+    QString failureTitle, std::optional<SelectorRollback> rollback)
+{
+    emit loadActivityChanged(1);
+    const auto generation
+        = m_hooks.datasetGeneration ? m_hooks.datasetGeneration() : 0;
+    // Two of these can be in flight at once -- clicking a second raw record
+    // while the first is still reading, which is reachable precisely because
+    // the read does not freeze the GUI. Without a per-request token both
+    // completions match the generation they captured and the *first* to
+    // arrive opens, while the selector already shows the second: oldest-wins,
+    // and the window disagrees with the dock.
+    //
+    // Inheritance is decided here rather than at the call sites, because
+    // every request supersedes whatever was live -- including the direct-open
+    // entry point, which brings no rollback of its own. The read it supersedes
+    // will retire without restoring anything, so if this one fails the state
+    // to return to is still the one that was last displayed. Checked before
+    // the token moves, since moving it is what retires the other request.
+    const bool supersedesLive = m_pendingOpen
+        && m_pendingOpen->generation == generation
+        && m_pendingOpen->requestId == m_openGeneration;
+    if (supersedesLive) {
+        rollback = m_pendingOpen->rollback;
+    }
+    const auto requestId = ++m_openGeneration;
+    if (rollback) {
+        m_pendingOpen = PendingOpen{generation, requestId, *rollback};
+    } else {
+        // Nothing live and nothing to fall back to: this request owns the slot
+        // and a failure of it has nowhere to return to.
+        m_pendingOpen.reset();
+    }
+    auto* watcher = new QFutureWatcher<PlotfileMetadataResult>(this);
+    connect(watcher, &QFutureWatcher<PlotfileMetadataResult>::finished, this,
+        [this, watcher, generation, requestId, path,
+            dataRoot = std::move(dataRoot), preserveSelector,
+            initialSpec = std::move(initialSpec),
+            failureTitle = std::move(failureTitle)]() mutable {
+            emit loadActivityChanged(-1);
+            if (m_hooks.isShuttingDown && m_hooks.isShuttingDown()) {
+                watcher->deleteLater();
+                return;
+            }
+            // A dataset opened while this read was in flight owns the window
+            // now, and so does a newer FAB read or a selector teardown;
+            // publishing over any of them would be a stale result.
+            const auto currentGeneration
+                = m_hooks.datasetGeneration ? m_hooks.datasetGeneration() : 0;
+            const bool current = generation == currentGeneration
+                && requestId == m_openGeneration;
+            // Only the completion that recorded the pending entry may consume
+            // it. Anything that revoked it -- a dataset open, a teardown, a
+            // newer click -- has already made `current` false. Taken out of
+            // the member up front, not read back later: this completion
+            // decides the entry's fate either way, and the open below can
+            // throw *after* the success path has given the entry up.
+            std::optional<SelectorRollback> owned;
+            if (current && m_pendingOpen
+                && m_pendingOpen->generation == generation
+                && m_pendingOpen->requestId == requestId) {
+                owned = m_pendingOpen->rollback;
+                m_pendingOpen.reset();
+            }
+            try {
+                auto metadata = watcher->future().takeResult();
+                if (current) {
+                    m_hooks.openPrepared(path, std::move(metadata),
+                        std::move(dataRoot), preserveSelector,
+                        std::move(initialSpec));
+                } else {
+                    emit staleResultDropped();
+                }
+            } catch (const std::exception& error) {
+                if (current) {
+                    // The caller may have moved the selector to this FAB
+                    // before the read returned; the open did not happen, so
+                    // put it back before saying so.
+                    if (owned) {
+                        applyRollback(*owned);
+                    }
+                    emit openFailed(failureTitle, exceptionMessage(error));
+                } else {
+                    emit staleResultDropped();
+                }
+            }
+            watcher->deleteLater();
+        });
+    watcher->setFuture(QtConcurrent::run([path, fileOffset] {
+        return fileOffset
+            ? StandaloneMetadataReader{}.readFab(path, *fileOffset)
+            : StandaloneMetadataReader{}.readFab(path);
+    }));
+}
+
+void FabNavigator::viewEntry(std::size_t index)
+{
+    if (!m_dock) {
+        return;
+    }
+    const auto& entries = m_dock->entries();
+    if (index >= entries.size()) {
+        return;
+    }
+    const auto entry = entries[index];
+    try {
+        auto selectedSpec = selectedEntrySpec();
+        if (entry.rawRecord) {
+            // The record's own header has to be read; do it off the GUI thread
+            // and let the completion open it. The selector state is moved to
+            // the pending record immediately so the dock reflects the choice
+            // without waiting for the read -- but only a read that succeeds
+            // actually changes what the window displays, so a failure has to
+            // put the previous state back rather than leave the dock claiming
+            // a FAB that is not on screen.
+            //
+            // Snapshot what is displayed now; openStandaloneFabAsync prefers a
+            // still-live pending rollback over it, because from a displayed
+            // FAB X, clicking A then B and having B fail must return to X, not
+            // to the A the dock is merely showing -- A lost the request token
+            // and will never open.
+            const SelectorRollback rollback{m_fabMode, m_dock->backAvailable(),
+                m_dock->selectedOrdinal()};
+            m_fabMode = true;
+            m_dock->setBackAvailable(m_multifabReturn.has_value());
+            m_dock->selectEntry(entry.ordinal);
+            openStandaloneFabAsync(m_sourcePath, entry.fileOffset, m_dataRoot,
+                true, std::move(selectedSpec), tr("Cannot view FAB"), rollback);
+            return;
+        }
+        if (!m_sourceMetadata) {
+            throw std::runtime_error(
+                "the source MultiFab is no longer available");
+        }
+        if (!m_multifabReturn) {
+            auto returnSpec
+                = m_hooks.currentSpec ? m_hooks.currentSpec() : std::nullopt;
+            m_multifabReturn = MultiFabReturnState{m_sourcePath, m_dataRoot,
+                *m_sourceMetadata, returnSpec.value_or(FrameSliceSpec{})};
+        }
+        auto selected = makeSelectedFabMetadata(*m_sourceMetadata->metadata,
+            entry.level, entry.blockIndex, m_dataRoot);
+        m_fabMode = true;
+        m_dock->setBackAvailable(m_multifabReturn.has_value());
+        m_dock->selectEntry(entry.ordinal);
+        m_hooks.openPrepared(m_sourcePath, std::move(selected), m_dataRoot,
+            true, std::move(selectedSpec));
+    } catch (const std::exception& error) {
+        QMessageBox::critical(
+            dialogParent(), tr("Cannot view FAB"), exceptionMessage(error));
+    }
+}
+
+void FabNavigator::backToMultiFab()
+{
+    if (!m_multifabReturn) {
+        return;
+    }
+    auto state = std::move(*m_multifabReturn);
+    m_multifabReturn.reset();
+    m_fabMode = false;
+    if (m_dock) {
+        m_dock->setBackAvailable(false);
+    }
+    m_hooks.openPrepared(state.path, std::move(state.metadata),
+        std::move(state.dataRoot), true, std::move(state.spec));
+}
+
+void FabNavigator::reset()
+{
+    // Belt-and-braces, not the guarantee. Tearing the selector down has to
+    // revoke any read still in flight against it, but the dataset generation
+    // already does that at both call sites: openDatasetImpl bumps it further
+    // down the same straight-line body, and prepareSequence's callers reach
+    // MainWindow's frameSwitchStarted handler -- a direct connection, so the
+    // same event-loop slot -- which bumps it too. No completion can be
+    // delivered in between, so the generation check is already false for
+    // every earlier read and this token bump has never been what retires one.
+    // It is kept because it is cheap and because relying on a bump that
+    // happens a frame up the stack, in a signal handler, is not a property
+    // this function can see.
+    ++m_openGeneration;
+    m_pendingOpen.reset();
+    m_fabMode = false;
+    m_multifabReturn.reset();
+    m_sourceMetadata.reset();
+    m_sourcePath.clear();
+    m_dataRoot.clear();
+    if (m_dock) {
+        m_dock->setEntries({});
+        m_dock->setBackAvailable(false);
+        m_dock->setVisible(false);
+    }
+}
+
+bool FabNavigator::cleared() const
+{
+    return !m_fabMode && !m_multifabReturn && !m_sourceMetadata
+        && m_sourcePath.empty() && m_dataRoot.empty()
+        && (!m_dock || (m_dock->entries().empty() && !m_dock->isVisible()));
+}
+
+} // namespace amrvis::qt

--- a/src/qt/FabNavigator.hpp
+++ b/src/qt/FabNavigator.hpp
@@ -50,8 +50,11 @@ public:
         std::function<std::uint64_t()> datasetGeneration;
         // True once application shutdown began; late reads are dropped.
         std::function<bool()> isShuttingDown;
-        // The current frame spec while a dataset is open (the host's
-        // buildFrameSpec), or nullopt.
+        // The frame spec the host's controls currently describe (its
+        // buildFrameSpec), or nullopt when the host cannot say. It is read
+        // both for a selected FAB's initial spec and for the MultiFab return
+        // record, so it must answer even while a reload has no dataset
+        // installed -- the controls still do.
         std::function<std::optional<FrameSliceSpec>()> currentSpec;
         // Opens prepared metadata as the displayed dataset: (path, metadata,
         // dataRoot, preserveSelector, initialSpec) -- the host's

--- a/src/qt/FabNavigator.hpp
+++ b/src/qt/FabNavigator.hpp
@@ -1,0 +1,172 @@
+#pragma once
+
+#include "FabSelectorDock.hpp"
+
+#include <amrexplorer/io/PlotfileMetadataReader.hpp>
+#include <amrexplorer/pipeline/SlicePipeline.hpp>
+
+#include <QObject>
+#include <QPointer>
+#include <QString>
+
+#include <cstddef>
+#include <cstdint>
+#include <filesystem>
+#include <functional>
+#include <optional>
+#include <vector>
+
+class QWidget;
+
+namespace amrvis::qt {
+
+// Everything the FAB selector dock needs for a source, computed off the GUI
+// thread (see FabNavigator::buildSelector) so its header scans / per-block
+// preads never block the event loop. `matched` distinguishes a recognized FAB
+// or single-level-VisMF source (whose mode/source state should be applied)
+// from anything else (leave that state untouched, just hide the dock).
+struct FabSelectorBuild {
+    bool matched = false;
+    bool fabMode = false;
+    bool hasSourceMetadata = false;
+    std::vector<FabSelectorEntry> entries;
+    std::filesystem::path root;
+};
+
+// Standalone-FAB / MultiFab navigation extracted from MainWindow: the FAB
+// mode flag, the source the selector lists (path, data root, metadata), the
+// MultiFab-return record, the selector dock, and the asynchronous
+// standalone-FAB header reads with their rollback and request token. The host
+// opens whatever the navigator resolves (through Hooks::openPrepared, its
+// openDatasetImpl), supplies the current frame spec and dataset generation,
+// and applies the selector build its own open worker produced.
+class FabNavigator final : public QObject {
+    Q_OBJECT
+
+public:
+    struct Hooks {
+        // The host's dataset generation: bumped by every dataset open, so a
+        // header read that resolves after one is stale.
+        std::function<std::uint64_t()> datasetGeneration;
+        // True once application shutdown began; late reads are dropped.
+        std::function<bool()> isShuttingDown;
+        // The current frame spec while a dataset is open (the host's
+        // buildFrameSpec), or nullopt.
+        std::function<std::optional<FrameSliceSpec>()> currentSpec;
+        // Opens prepared metadata as the displayed dataset: (path, metadata,
+        // dataRoot, preserveSelector, initialSpec) -- the host's
+        // openDatasetImpl. preserveSelector is false only for a direct
+        // "Open FAB..." (the selector is rebuilt for the new file) and true
+        // for every drill-down or return within the current source.
+        std::function<void(const std::filesystem::path&, PlotfileMetadataResult,
+            std::filesystem::path, bool, std::optional<FrameSliceSpec>)>
+            openPrepared;
+    };
+
+    FabNavigator(Hooks hooks, QObject* parent = nullptr);
+
+    // The selector dock (hidden until a source has entries), wired to
+    // viewEntry/backToMultiFab. Owned by `parent`; the host adds it to a
+    // dock area and its View menu.
+    FabSelectorDock* createDock(QWidget* parent);
+
+    // Reads FAB/MultiFab record headers and builds the selector entries. Runs
+    // on a worker thread; it touches no widgets or navigator state.
+    [[nodiscard]] static FabSelectorBuild buildSelector(
+        const PlotfileMetadataResult& result, const std::filesystem::path& path);
+    // Installs what buildSelector produced for the dataset just opened at
+    // `path` (on the GUI thread; only blits, never reads files).
+    void applySelectorBuild(FabSelectorBuild build,
+        const std::filesystem::path& path,
+        const PlotfileMetadataResult& metadata);
+
+    // "Open FAB...": reads the raw file's header off the GUI thread and opens
+    // it from the completion. Supplies no rollback: nothing is displayed to
+    // fall back to.
+    void openStandaloneFab(const std::filesystem::path& path);
+    // The dock's view request: a raw record is read asynchronously with the
+    // dock moved to it at once (and put back if the read fails); a MultiFab
+    // block is opened synchronously from the source metadata, recording the
+    // return state the first time.
+    void viewEntry(std::size_t index);
+    void backToMultiFab();
+
+    // Clears the FAB/MultiFab view state (mode flag, MultiFab-return record,
+    // source metadata/paths, pending read) and hides the selector. Any path
+    // that replaces the displayed dataset with a non-FAB one -- a plain
+    // dataset open, or a plotfile sequence -- must call this or stale FAB
+    // state leaks into the new view (see open-sequence-stale-fab-state).
+    void reset();
+
+    [[nodiscard]] bool fabMode() const noexcept { return m_fabMode; }
+    // For tests: no FAB state at all, dock empty and hidden.
+    [[nodiscard]] bool cleared() const;
+
+signals:
+    // Background-read bookkeeping for the host's diagnostics (+1 when a
+    // header read starts, -1 when its watcher fires) and its stale count.
+    void loadActivityChanged(int delta);
+    void staleResultDropped();
+    // A read failed while it was still the current request; the host reports
+    // it non-modally ("<title>: <message>").
+    void openFailed(const QString& title, const QString& message);
+    // The dock's contents or the mode changed in a way the window title
+    // reflects.
+    void windowTitleChanged();
+
+private:
+    // The selector state a failed standalone-FAB open falls back to: the last
+    // one actually committed to the window, not merely highlighted.
+    struct SelectorRollback {
+        bool fabMode = false;
+        bool backAvailable = false;
+        std::optional<std::size_t> ordinal;
+    };
+    // A launched standalone-FAB header read that has not resolved yet,
+    // carrying the state to restore if it fails. The pair (generation,
+    // requestId) is what makes this safe without any site reaching in to
+    // clear it: only the completion holding both may consume the entry, so
+    // opening a dataset (which bumps the dataset generation) or tearing the
+    // selector down (which bumps the request token) revokes it as a side
+    // effect of what it already does. A second click while a read is in
+    // flight inherits the pending rollback rather than snapshotting the dock,
+    // because what the dock shows then is that pending selection, which was
+    // never displayed.
+    struct PendingOpen {
+        std::uint64_t generation = 0;
+        std::uint64_t requestId = 0;
+        SelectorRollback rollback;
+    };
+    // The MultiFab a selected block was drilled into from, and how it was
+    // displayed, so Back restores it.
+    struct MultiFabReturnState {
+        std::filesystem::path path;
+        std::filesystem::path dataRoot;
+        PlotfileMetadataResult metadata;
+        FrameSliceSpec spec;
+    };
+
+    void openStandaloneFabAsync(std::filesystem::path path,
+        std::optional<std::uint64_t> fileOffset, std::filesystem::path dataRoot,
+        bool preserveSelector, std::optional<FrameSliceSpec> initialSpec,
+        QString failureTitle, std::optional<SelectorRollback> rollback);
+    void applyRollback(const SelectorRollback& rollback);
+    [[nodiscard]] std::optional<FrameSliceSpec> selectedEntrySpec() const;
+    [[nodiscard]] QWidget* dialogParent() const;
+
+    Hooks m_hooks;
+    QPointer<FabSelectorDock> m_dock;
+    bool m_fabMode = false;
+    std::optional<MultiFabReturnState> m_multifabReturn;
+    std::optional<PlotfileMetadataResult> m_sourceMetadata;
+    std::filesystem::path m_sourcePath;
+    std::filesystem::path m_dataRoot;
+    // Newest-wins among overlapping standalone-FAB header reads. The dataset
+    // generation alone cannot order them: it is bumped by the open, which only
+    // runs once a read has already completed, so two reads in flight together
+    // both still match the generation they captured.
+    std::uint64_t m_openGeneration = 0;
+    std::optional<PendingOpen> m_pendingOpen;
+};
+
+} // namespace amrvis::qt

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -331,10 +331,11 @@ MainWindow::MainWindow(QWidget* parent)
         FabNavigator::Hooks{
             [this] { return m_generation; },
             [this] { return m_closing; },
+            // Unguarded on purpose: buildFrameSpec reads the controls, not
+            // the dataset, and the MultiFab-return record must capture them
+            // even when a click lands mid-reload with no dataset installed;
+            // gating here degraded that record to defaults.
             [this]() -> std::optional<FrameSliceSpec> {
-                if (!m_dataset) {
-                    return std::nullopt;
-                }
                 return buildFrameSpec();
             },
             [this](const std::filesystem::path& path,

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -324,13 +324,45 @@ MainWindow::MainWindow(QWidget* parent)
     // until updateAnimationDockVisibility() decides otherwise.
     m_animationDock->setVisible(false);
 
-    m_fabSelectorDock = new FabSelectorDock(this);
+    // FAB/MultiFab navigation lives in its navigator; it opens what it
+    // resolves through this window's openDatasetImpl and folds its header
+    // reads into the diagnostics.
+    m_fabNavigator = new FabNavigator(
+        FabNavigator::Hooks{
+            [this] { return m_generation; },
+            [this] { return m_closing; },
+            [this]() -> std::optional<FrameSliceSpec> {
+                if (!m_dataset) {
+                    return std::nullopt;
+                }
+                return buildFrameSpec();
+            },
+            [this](const std::filesystem::path& path,
+                PlotfileMetadataResult metadata, std::filesystem::path dataRoot,
+                bool preserveSelector, std::optional<FrameSliceSpec> spec) {
+                openDatasetImpl(path, false, std::move(metadata),
+                    std::move(dataRoot), preserveSelector, std::move(spec));
+            },
+        },
+        this);
+    connect(m_fabNavigator, &FabNavigator::loadActivityChanged, this,
+        [this](int delta) {
+            m_diagnosticsModel->adjustActivity(delta);
+            updateDiagnostics();
+        });
+    connect(m_fabNavigator, &FabNavigator::staleResultDropped, this,
+        [this] {
+            m_diagnosticsModel->noteStaleResult();
+            updateDiagnostics();
+        });
+    connect(m_fabNavigator, &FabNavigator::openFailed, this,
+        [this](const QString& title, const QString& message) {
+            reportBackgroundError(tr("%1: %2").arg(title, message));
+        });
+    connect(m_fabNavigator, &FabNavigator::windowTitleChanged, this,
+        [this] { updateWindowTitle(); });
+    m_fabSelectorDock = m_fabNavigator->createDock(this);
     addDockWidget(Qt::LeftDockWidgetArea, m_fabSelectorDock);
-    m_fabSelectorDock->setVisible(false);
-    connect(m_fabSelectorDock, &FabSelectorDock::viewRequested,
-        this, [this](std::size_t entry) { viewFab(entry); });
-    connect(m_fabSelectorDock, &FabSelectorDock::backRequested,
-        this, &MainWindow::backToMultiFab);
 
     // One playback timer drives either animation mode; starting one mode
     // stops the other (see setPlaybackMode).

--- a/src/qt/MainWindow.hpp
+++ b/src/qt/MainWindow.hpp
@@ -77,6 +77,7 @@ class IsoWidget;
 class LinePlotWindow;
 class ScientificDoubleSpinBox;
 class DiagnosticsModel;
+class FabNavigator;
 class PaletteController;
 class ParticleController;
 class SequenceController;
@@ -512,15 +513,6 @@ private:
     [[nodiscard]] static QString remoteServerExecutableFor(
         const QString& destination);
 
-    // Clears standalone FAB/MultiFab view state (mode flag, MultiFab-return
-    // record, source metadata/paths) and hides the FAB selector dock. Any path
-    // that replaces the displayed dataset with a non-FAB one -- a plain dataset
-    // open, or a plotfile sequence -- must call this or stale FAB state leaks
-    // into the new view (see open-sequence-stale-fab-state).
-    void resetFabState();
-
-    void viewFab(std::size_t entry);
-    void backToMultiFab();
     // A fresh independent top-level window (WA_DeleteOnClose) for the
     // "Open New Window" menu action; it shares no view/cache state with this one.
     MainWindow* createNewWindow();
@@ -763,47 +755,6 @@ private:
     // demand-driven and never clamped. Zero when there is nothing to report.
     // See agent-notes/issues/fixed-scale-clamped-native-raster.md.
     [[nodiscard]] double effectiveFixedScale(int factor) const;
-    // Reads a standalone FAB header off the GUI thread and opens it from the
-    // completion. The read is one small pread, but it is a *blocking* one, and
-    // on the network filesystems these datasets usually live on it freezes the
-    // event loop for as long as the server takes. Every other header read in
-    // this window already runs on a worker (see buildFabSelector); these two
-    // entry points were the exceptions.
-    //
-    // The selector state a failed standalone-FAB open falls back to: the last
-    // one actually committed to the window, not merely highlighted.
-    struct FabSelectorRollback {
-        bool fabMode = false;
-        bool backAvailable = false;
-        std::optional<std::size_t> ordinal;
-    };
-    // A launched standalone-FAB header read that has not resolved yet, carrying
-    // the state to restore if it fails. The pair (generation, requestId) is what
-    // makes this safe without any site reaching in to clear it: only the
-    // completion holding both may consume the entry, so opening a dataset
-    // (which bumps m_generation) or tearing the selector down (which bumps
-    // m_fabOpenGeneration) revokes it as a side effect of what it already does.
-    // A second click while a read is in flight inherits the pending rollback
-    // rather than snapshotting the dock, because what the dock shows then is
-    // that pending selection, which was never displayed.
-    struct PendingFabOpen {
-        std::uint64_t generation = 0;
-        std::uint64_t requestId = 0;
-        FabSelectorRollback rollback;
-    };
-
-    // A caller that moves the selector to the pending record before the read
-    // returns passes the state to fall back to; a read that fails while it is
-    // still the current request puts it back. Failures are reported through
-    // reportBackgroundError: this one arrives from a worker, like every other
-    // background load failure, and a modal dialog here would open a nested
-    // event loop on the arrival path.
-    void openStandaloneFabAsync(std::filesystem::path path,
-        std::optional<std::uint64_t> fileOffset,
-        std::filesystem::path dataRoot, bool preserveFabSelector,
-        std::optional<FrameSliceSpec> initialSpec, QString failureTitle,
-        std::optional<FabSelectorRollback> rollback = std::nullopt);
-    void applyFabSelectorRollback(const FabSelectorRollback& rollback);
     void configureSliceControls();
     // Enable the dataset-dependent field/level/range/menu controls once a
     // dataset (single or sequence frame) is loaded. Shared by
@@ -923,6 +874,10 @@ private:
     bool m_animationDockThreeD = false;
     // Arrow-key pan requests that reached a view, for the routing regression.
     std::size_t m_panStepRequests = 0;
+    // Standalone-FAB / MultiFab navigation: mode, source, return record,
+    // the selector dock and the async header reads. Its dock is what the
+    // View menu toggles.
+    FabNavigator* m_fabNavigator = nullptr;
     FabSelectorDock* m_fabSelectorDock = nullptr;
     QToolBar* m_sliceToolbar = nullptr;
     QToolBar* m_rangeToolbar = nullptr;
@@ -988,29 +943,12 @@ private:
     std::unique_ptr<SshRemoteSession> m_sshRemoteSession;
     bool m_remoteSequence = false;
     std::uint64_t m_remoteSequenceConnectionGeneration = 0;
-    struct MultiFabReturnState {
-        std::filesystem::path path;
-        std::filesystem::path dataRoot;
-        PlotfileMetadataResult metadata;
-        FrameSliceSpec spec;
-    };
-    std::optional<MultiFabReturnState> m_multifabReturn;
-    std::optional<PlotfileMetadataResult> m_fabSourceMetadata;
-    std::filesystem::path m_fabSourcePath;
-    std::filesystem::path m_fabDataRoot;
-    bool m_fabMode = false;
     // Owns the palette selection, its widgets and persistence; palette() is
     // what the renderer, color bar and overlays use.
     PaletteController* m_paletteController = nullptr;
     QString m_numberFormat = defaultNumberFormat();
     bool m_controlsReady = false;
     std::uint64_t m_generation = 0;
-    // Newest-wins among overlapping standalone-FAB header reads. m_generation
-    // alone cannot order them: it is bumped by openDatasetImpl, which only runs
-    // once a read has already completed, so two reads in flight together both
-    // still match the generation they captured.
-    std::uint64_t m_fabOpenGeneration = 0;
-    std::optional<PendingFabOpen> m_pendingFabOpen;
     bool m_closing = false;
     // Owns the Diagnostics panel's counters (background requests, stale
     // results), the last read's metrics, the cache state, the probe history

--- a/src/qt/MainWindowDataset.cpp
+++ b/src/qt/MainWindowDataset.cpp
@@ -4,19 +4,6 @@ namespace amrvis::qt {
 
 namespace {
 
-// Everything the FAB selector dock needs for a source, computed off the GUI
-// thread (see buildFabSelector) so its header scans / per-block preads never
-// block the event loop. `matched` distinguishes a recognized FAB or
-// single-level-VisMF source (whose m_fabMode/source state should be applied)
-// from anything else (leave that state untouched, just hide the dock).
-struct FabSelectorBuild {
-    bool matched = false;
-    bool fabMode = false;
-    bool hasSourceMetadata = false;
-    std::vector<FabSelectorEntry> entries;
-    std::filesystem::path root;
-};
-
 // The result of a dataset open worker: the metadata plus, when the caller did
 // not ask to preserve the existing selector, the FAB selector contents built
 // alongside it (so the GUI-thread completion only blits, never reads files).
@@ -25,86 +12,6 @@ struct OpenedDataset {
     std::optional<FabSelectorBuild> fabSelector;
     std::shared_ptr<DatasetSession> session;
 };
-
-// Reads FAB/MultiFab record headers and builds the selector entries. Runs on a
-// worker thread; QCoreApplication::translate is thread-safe, and it touches no
-// widgets or member state.
-FabSelectorBuild buildFabSelector(
-    const PlotfileMetadataResult& result, const std::filesystem::path& path)
-{
-    const auto precisionLabel = [](FabRealPrecision precision) {
-        return precision == FabRealPrecision::Single
-            ? QCoreApplication::translate("MainWindow", "IEEE-32")
-            : QCoreApplication::translate("MainWindow", "IEEE-64");
-    };
-
-    FabSelectorBuild build;
-    build.root = path.parent_path();
-    if (build.root.empty()) {
-        build.root = ".";
-    }
-
-    if (result.fileVersion == "FAB") {
-        const auto records = scanFabFile(path);
-        build.entries.reserve(records.size());
-        for (const auto& record : records) {
-            build.entries.push_back({
-                .ordinal = record.ordinal,
-                .level = 0,
-                .blockIndex = record.ordinal,
-                .filePath = path,
-                .fileOffset = record.headerOffset,
-                .validBox = record.storedBox,
-                .storedBox = record.storedBox,
-                .dimension = record.dimension,
-                .components = record.components,
-                .precision = precisionLabel(record.precision),
-                .rawRecord = true
-            });
-        }
-        build.matched = true;
-        build.fabMode = true;
-        build.hasSourceMetadata = false;
-    } else if (result.fileVersion.starts_with("VisMF-")
-        && result.metadata->levels.size() == 1) {
-        const auto& metadata = *result.metadata;
-        const auto& level = metadata.levels.front();
-        build.entries.reserve(level.blocks.size());
-        for (std::size_t index = 0; index < level.blocks.size(); ++index) {
-            const auto& block = level.blocks[index];
-            // Overflow-guarded shared grow (this copy previously used
-            // plain int).
-            auto storedBox = amrvis::detail::grownBox<MetadataReadError>(
-                block.box, level.ghostWidth, metadata.dimension);
-            auto precision = FabRealPrecision::Double;
-            if (level.visMfHeaderVersion == 1) {
-                const auto record = inspectFabRecord(
-                    build.root / block.filePath, block.fileOffset);
-                storedBox = record.storedBox;
-                precision = record.precision;
-            } else {
-                precision = fabPrecisionFromDescriptor(level.realDescriptor);
-            }
-            build.entries.push_back({
-                .ordinal = index,
-                .level = level.level,
-                .blockIndex = index,
-                .filePath = build.root / block.filePath,
-                .fileOffset = block.fileOffset,
-                .validBox = block.box,
-                .storedBox = storedBox,
-                .dimension = metadata.dimension,
-                .components = level.storedComponents,
-                .precision = precisionLabel(precision),
-                .rawRecord = false
-            });
-        }
-        build.matched = true;
-        build.fabMode = false;
-        build.hasSourceMetadata = true;
-    }
-    return build;
-}
 
 } // namespace
 
@@ -250,7 +157,7 @@ void MainWindow::updateWindowTitle()
     }
     // Standalone FABs and MultiFabs carry neither a simulation time nor an
     // AMR hierarchy, so their titles show just the format name.
-    if (m_fabMode) {
+    if (m_fabNavigator->fabMode()) {
         setWindowTitle(tr("AMReXplorer — %1 — FAB").arg(name));
     } else if (!metadata.hasPhysicalGeometry) {
         setWindowTitle(tr("AMReXplorer — %1 — MultiFab").arg(name));
@@ -307,206 +214,12 @@ void MainWindow::chooseStandaloneDataset(const QString& caption, bool rawFab)
         tr("AMReX data (*)"));
     if (!filename.isEmpty()) {
         if (rawFab) {
-            const auto path = std::filesystem::path(filename.toStdString());
-            auto root = path.parent_path();
-            if (root.empty()) {
-                root = ".";
-            }
-            openStandaloneFabAsync(path, std::nullopt, std::move(root), false,
-                std::nullopt, tr("Cannot open FAB"));
+            m_fabNavigator->openStandaloneFab(
+                std::filesystem::path(filename.toStdString()));
         } else {
             openDataset(filename.toStdString());
         }
     }
-}
-
-void MainWindow::applyFabSelectorRollback(const FabSelectorRollback& rollback)
-{
-    m_fabMode = rollback.fabMode;
-    m_fabSelectorDock->setBackAvailable(rollback.backAvailable);
-    if (rollback.ordinal) {
-        m_fabSelectorDock->selectEntry(*rollback.ordinal);
-    } else {
-        m_fabSelectorDock->clearSelection();
-    }
-}
-
-void MainWindow::openStandaloneFabAsync(std::filesystem::path path,
-    std::optional<std::uint64_t> fileOffset, std::filesystem::path dataRoot,
-    bool preserveFabSelector, std::optional<FrameSliceSpec> initialSpec,
-    QString failureTitle, std::optional<FabSelectorRollback> rollback)
-{
-    m_diagnosticsModel->adjustActivity(1);
-    const auto generation = m_generation;
-    // Two of these can be in flight at once -- clicking a second raw record
-    // while the first is still reading, which is reachable precisely because
-    // the read no longer freezes the GUI. Without a per-request token both
-    // completions match the generation they captured and the *first* to arrive
-    // opens, while the selector already shows the second: oldest-wins, and the
-    // window disagrees with the dock.
-    //
-    // Inheritance is decided here rather than at the call sites, because every
-    // request supersedes whatever was live -- including the direct-open entry
-    // point, which brings no rollback of its own. The read it supersedes will
-    // retire without restoring anything, so if this one fails the state to
-    // return to is still the one that was last displayed. Checked before the
-    // token moves, since moving it is what retires the other request.
-    const bool supersedesLive = m_pendingFabOpen
-        && m_pendingFabOpen->generation == generation
-        && m_pendingFabOpen->requestId == m_fabOpenGeneration;
-    if (supersedesLive) {
-        rollback = m_pendingFabOpen->rollback;
-    }
-    const auto requestId = ++m_fabOpenGeneration;
-    if (rollback) {
-        m_pendingFabOpen = PendingFabOpen{generation, requestId, *rollback};
-    } else {
-        // Nothing live and nothing to fall back to: this request owns the slot
-        // and a failure of it has nowhere to return to.
-        m_pendingFabOpen.reset();
-    }
-    auto* watcher = new QFutureWatcher<PlotfileMetadataResult>(this);
-    connect(watcher, &QFutureWatcher<PlotfileMetadataResult>::finished, this,
-        [this, watcher, generation, requestId, path,
-            dataRoot = std::move(dataRoot), preserveFabSelector,
-            initialSpec = std::move(initialSpec),
-            failureTitle = std::move(failureTitle)]() mutable {
-            m_diagnosticsModel->adjustActivity(-1);
-            if (m_closing) {
-                watcher->deleteLater();
-                return;
-            }
-            // A dataset opened while this read was in flight owns the window
-            // now, and so does a newer FAB read or a selector teardown;
-            // publishing over any of them would be a stale result.
-            const bool current = generation == m_generation
-                && requestId == m_fabOpenGeneration;
-            // Only the completion that recorded the pending entry may consume
-            // it. Anything that revoked it -- a dataset open, a teardown, a
-            // newer click -- has already made `current` false.
-            // Taken out of the member up front, not read back later: this
-            // completion decides the entry's fate either way, and openDatasetImpl
-            // below can throw *after* the success path has given the entry up.
-            // Reading `m_pendingFabOpen->rollback` in the catch would then
-            // dereference a disengaged optional.
-            std::optional<FabSelectorRollback> owned;
-            if (current && m_pendingFabOpen
-                && m_pendingFabOpen->generation == generation
-                && m_pendingFabOpen->requestId == requestId) {
-                owned = m_pendingFabOpen->rollback;
-                m_pendingFabOpen.reset();
-            }
-            try {
-                auto metadata = watcher->future().takeResult();
-                if (current) {
-                    openDatasetImpl(path, false, std::move(metadata),
-                        std::move(dataRoot), preserveFabSelector,
-                        std::move(initialSpec));
-                } else {
-                    m_diagnosticsModel->noteStaleResult();
-                }
-            } catch (const std::exception& error) {
-                if (current) {
-                    // The caller may have moved the selector to this FAB
-                    // before the read returned; the open did not happen, so
-                    // put it back before saying so.
-                    if (owned) {
-                        applyFabSelectorRollback(*owned);
-                    }
-                    reportBackgroundError(
-                        tr("%1: %2").arg(failureTitle, exceptionMessage(error)));
-                } else {
-                    m_diagnosticsModel->noteStaleResult();
-                }
-            }
-            updateDiagnostics();
-            watcher->deleteLater();
-        });
-    watcher->setFuture(QtConcurrent::run([path, fileOffset] {
-        return fileOffset
-            ? StandaloneMetadataReader{}.readFab(path, *fileOffset)
-            : StandaloneMetadataReader{}.readFab(path);
-    }));
-    updateDiagnostics();
-}
-
-void MainWindow::viewFab(std::size_t entryIndex)
-{
-    const auto& entries = m_fabSelectorDock->entries();
-    if (entryIndex >= entries.size()) {
-        return;
-    }
-    const auto entry = entries[entryIndex];
-    try {
-        auto selectedSpec = m_dataset
-            ? std::optional<FrameSliceSpec>{buildFrameSpec()}
-            : std::nullopt;
-        if (selectedSpec) {
-            selectedSpec->levelSelection = -1;
-            selectedSpec->rangeMode = RangeMode::File;
-            selectedSpec->userRange.reset();
-        }
-        PlotfileMetadataResult selected;
-        if (entry.rawRecord) {
-            // The record's own header has to be read; do it off the GUI thread
-            // and let the completion open it. The selector state is moved to
-            // the pending record immediately so the dock reflects the choice
-            // without waiting for the read -- but only a read that succeeds
-            // actually changes what the window displays, so a failure has to
-            // put the previous state back rather than leave the dock claiming
-            // a FAB that is not on screen.
-            //
-            // Snapshot what is displayed now; openStandaloneFabAsync prefers a
-            // still-live pending rollback over it, because from a displayed FAB
-            // X, clicking A then B and having B fail must return to X, not to
-            // the A the dock is merely showing -- A lost the request token and
-            // will never open.
-            const FabSelectorRollback rollback{m_fabMode,
-                m_fabSelectorDock->backAvailable(),
-                m_fabSelectorDock->selectedOrdinal()};
-            m_fabMode = true;
-            m_fabSelectorDock->setBackAvailable(m_multifabReturn.has_value());
-            m_fabSelectorDock->selectEntry(entry.ordinal);
-            openStandaloneFabAsync(m_fabSourcePath, entry.fileOffset,
-                m_fabDataRoot, true, std::move(selectedSpec),
-                tr("Cannot view FAB"), rollback);
-            return;
-        }
-        {
-            if (!m_fabSourceMetadata) {
-                throw std::runtime_error(
-                    "the source MultiFab is no longer available");
-            }
-            if (!m_multifabReturn) {
-                m_multifabReturn = MultiFabReturnState{
-                    m_fabSourcePath, m_fabDataRoot,
-                    *m_fabSourceMetadata, buildFrameSpec()};
-            }
-            selected = makeSelectedFabMetadata(*m_fabSourceMetadata->metadata,
-                entry.level, entry.blockIndex, m_fabDataRoot);
-        }
-        m_fabMode = true;
-        m_fabSelectorDock->setBackAvailable(m_multifabReturn.has_value());
-        m_fabSelectorDock->selectEntry(entry.ordinal);
-        openDatasetImpl(m_fabSourcePath, false, std::move(selected),
-            m_fabDataRoot, true, std::move(selectedSpec));
-    } catch (const std::exception& error) {
-        QMessageBox::critical(this, tr("Cannot view FAB"),
-            exceptionMessage(error));
-    }
-}
-
-void MainWindow::backToMultiFab()
-{
-    if (!m_multifabReturn) {
-        return;
-    }
-    auto state = std::move(*m_multifabReturn);
-    m_multifabReturn.reset();
-    m_fabMode = false;
-    m_fabSelectorDock->setBackAvailable(false);
-    openDatasetImpl(state.path, false, std::move(state.metadata),
-        std::move(state.dataRoot), true, std::move(state.spec));
 }
 
 void MainWindow::exportImage()
@@ -894,33 +607,6 @@ void MainWindow::openDataset(
         path, metadataOnly, std::nullopt, {}, false, std::nullopt);
 }
 
-void MainWindow::resetFabState()
-{
-    // Belt-and-braces, not the guarantee. Tearing the selector down has to
-    // revoke any read still in flight against it, but the dataset generation
-    // already does that at both call sites: openDatasetImpl bumps it further
-    // down the same straight-line body, and prepareSequence's callers reach
-    // MainWindow's frameSwitchStarted handler -- a direct connection, so the
-    // same event-loop slot -- which bumps it too. No completion can be
-    // delivered in between, so `generation == m_generation` is already false
-    // for every earlier read and this token bump has never been what retires
-    // one. It is kept because it is cheap and because relying on a bump that
-    // happens a frame up the stack, in a signal handler, is not a property
-    // this function can see. Do not read it as load-bearing: it is not
-    // covered by a test, and it cannot be, because the state it would guard
-    // is unreachable.
-    ++m_fabOpenGeneration;
-    m_pendingFabOpen.reset();
-    m_fabMode = false;
-    m_multifabReturn.reset();
-    m_fabSourceMetadata.reset();
-    m_fabSourcePath.clear();
-    m_fabDataRoot.clear();
-    m_fabSelectorDock->setEntries({});
-    m_fabSelectorDock->setBackAvailable(false);
-    m_fabSelectorDock->setVisible(false);
-}
-
 void MainWindow::useRemoteConnection(
     std::shared_ptr<remote::Connection> connection, QString label)
 {
@@ -1093,7 +779,7 @@ void MainWindow::openDatasetImpl(const std::filesystem::path& path,
     std::optional<RemoteOpen> remoteOpen)
 {
     if (!preserveFabSelector) {
-        resetFabState();
+        m_fabNavigator->reset();
     }
     // Opening a single dataset ends any plotfile sequence and stops playback
     // of either animation mode.
@@ -1235,26 +921,9 @@ void MainWindow::openDatasetImpl(const std::filesystem::path& path,
                     // metadata (when not preserving the existing selector);
                     // here we only apply them, no file I/O on the GUI thread.
                     if (result.fabSelector) {
-                        auto& fab = *result.fabSelector;
-                        if (fab.matched) {
-                            m_fabMode = fab.fabMode;
-                            if (fab.hasSourceMetadata) {
-                                m_fabSourceMetadata = result.metadata;
-                            } else {
-                                m_fabSourceMetadata.reset();
-                            }
-                        }
-                        if (fab.entries.empty()) {
-                            m_fabSelectorDock->setVisible(false);
-                        } else {
-                            m_fabSourcePath = path;
-                            m_fabDataRoot = fab.root;
-                            m_fabSelectorDock->setEntries(std::move(fab.entries));
-                            m_fabSelectorDock->setBackAvailable(false);
-                            m_fabSelectorDock->setVisible(true);
-                            m_fabSelectorDock->raise();
-                            updateWindowTitle();
-                        }
+                        m_fabNavigator->applySelectorBuild(
+                            std::move(*result.fabSelector), path,
+                            result.metadata);
                     }
                     emit datasetOpenFinished(true);
                     if (!metadataOnly) {
@@ -1329,7 +998,8 @@ void MainWindow::openDatasetImpl(const std::filesystem::path& path,
         // header scans / per-block preads it needs never freeze the event
         // loop. Skipped when the caller preserves the existing selector.
         if (!preserveFabSelector && !remoteOpen) {
-            opened.fabSelector = buildFabSelector(opened.metadata, path);
+            opened.fabSelector
+                = FabNavigator::buildSelector(opened.metadata, path);
         }
         return opened;
     }));

--- a/src/qt/MainWindowInternal.hpp
+++ b/src/qt/MainWindowInternal.hpp
@@ -30,9 +30,7 @@
 #include "Theme.hpp"
 #include "UserGuideDialog.hpp"
 
-#include <amrexplorer/io/FabCatalog.hpp>
 #include <amrexplorer/io/FitsWriter.hpp>
-#include <amrexplorer/io/detail/FabHeaderParsing.hpp>
 #include <amrexplorer/io/StandaloneMetadataReader.hpp>
 #include <amrexplorer/data/DatasetSession.hpp>
 #include <amrexplorer/core/CoordinateSystem.hpp>

--- a/src/qt/MainWindowInternal.hpp
+++ b/src/qt/MainWindowInternal.hpp
@@ -9,6 +9,7 @@
 #include "QtErrorText.hpp"
 #include "AnimationExporter.hpp"
 #include "DiagnosticsModel.hpp"
+#include "FabNavigator.hpp"
 #include "PaletteController.hpp"
 #include "ParticleController.hpp"
 #include "SequenceController.hpp"

--- a/src/qt/MainWindowSlice.cpp
+++ b/src/qt/MainWindowSlice.cpp
@@ -1311,7 +1311,7 @@ void MainWindow::prepareSequence(std::size_t frameCount)
     setPlaybackMode(PlaybackMode::None);
     closeSequence();
     resetRangeState();
-    resetFabState();
+    m_fabNavigator->reset();
     m_particleController->cancel();
     m_particleController->clearSamples();
     // A sequence is a different dataset, so it starts from defaults exactly as

--- a/src/qt/MainWindowTestAccess.cpp
+++ b/src/qt/MainWindowTestAccess.cpp
@@ -302,10 +302,7 @@ bool MainWindow::activeViewHasPhysicalAspectForTest(
 
 bool MainWindow::fabStateClearedForTest() const
 {
-    return !m_fabMode && !m_multifabReturn && !m_fabSourceMetadata
-        && m_fabSourcePath.empty() && m_fabDataRoot.empty()
-        && m_fabSelectorDock->entries().empty()
-        && !m_fabSelectorDock->isVisible()
+    return m_fabNavigator->cleared()
         && !windowTitle().endsWith(QStringLiteral(" FAB"));
 }
 
@@ -702,7 +699,7 @@ bool MainWindow::activeViewShowsWholeImageForTest() const
 
 void MainWindow::viewFabForTest(std::size_t index)
 {
-    viewFab(index);
+    m_fabNavigator->viewEntry(index);
 }
 
 bool MainWindow::activeViewIsZoomedForTest() const
@@ -864,12 +861,7 @@ bool MainWindow::particleLoadingUiSettledForTest() const
 
 void MainWindow::openStandaloneFabForTest(const std::filesystem::path& path)
 {
-    auto root = path.parent_path();
-    if (root.empty()) {
-        root = ".";
-    }
-    openStandaloneFabAsync(path, std::nullopt, std::move(root), false,
-        std::nullopt, tr("Cannot open FAB"));
+    m_fabNavigator->openStandaloneFab(path);
 }
 
 void MainWindow::startAnimationExportForTest(const QString& path,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -535,6 +535,31 @@ if(TARGET amrexplorer_qt)
         COMMAND "${CMAKE_COMMAND}" -E env QT_QPA_PLATFORM=offscreen
             "$<TARGET_FILE:test_diagnostics_model>")
 
+    add_executable(test_fab_navigator
+        unit/test_fab_navigator.cpp
+        "${PROJECT_SOURCE_DIR}/src/qt/FabNavigator.cpp"
+        "${PROJECT_SOURCE_DIR}/src/qt/FabNavigator.hpp"
+        "${PROJECT_SOURCE_DIR}/src/qt/FabSelectorDock.cpp"
+        "${PROJECT_SOURCE_DIR}/src/qt/FabSelectorDock.hpp"
+    )
+    set_target_properties(test_fab_navigator PROPERTIES AUTOMOC ON)
+    target_include_directories(test_fab_navigator
+        PRIVATE "${PROJECT_SOURCE_DIR}/src/qt")
+    target_link_libraries(test_fab_navigator
+        PRIVATE
+            amrexplorer::io
+            amrexplorer::pipeline
+            amrexplorer::warnings
+            Qt6::Concurrent
+            Qt6::Core
+            Qt6::Gui
+            Qt6::Widgets
+    )
+    add_test(NAME fab_navigator
+        COMMAND "${CMAKE_COMMAND}" -E env QT_QPA_PLATFORM=offscreen
+            "$<TARGET_FILE:test_fab_navigator>")
+    set_tests_properties(fab_navigator PROPERTIES TIMEOUT 60)
+
     add_executable(test_remote_endpoint unit/test_remote_endpoint.cpp)
     target_include_directories(test_remote_endpoint
         PRIVATE "${PROJECT_SOURCE_DIR}/src/qt")

--- a/tests/unit/test_fab_navigator.cpp
+++ b/tests/unit/test_fab_navigator.cpp
@@ -1,0 +1,381 @@
+#include "FabNavigator.hpp"
+
+#include <amrexplorer/io/StandaloneMetadataReader.hpp>
+
+#include <QApplication>
+#include <QTimer>
+#include <QWidget>
+
+#include <chrono>
+#include <cstdint>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace {
+
+constexpr std::string_view realDescriptor =
+    "((8, (64 11 52 0 1 12 0 1023)),(8, (8 7 6 5 4 3 2 1)))";
+
+void require(bool condition, const std::string& message)
+{
+    if (!condition) {
+        std::cerr << "FAILED: " << message << '\n';
+        std::exit(1);
+    }
+}
+
+void writeText(const std::filesystem::path& path, const std::string& text)
+{
+    std::ofstream output(path, std::ios::binary);
+    require(static_cast<bool>(output), "could not create fixture text");
+    output << text;
+}
+
+void appendFab(std::ofstream& output, std::string_view box,
+    const std::vector<double>& values)
+{
+    output << "FAB " << realDescriptor << box << " 1\n";
+    output.write(reinterpret_cast<const char*>(values.data()),
+        static_cast<std::streamsize>(values.size() * sizeof(double)));
+}
+
+// A raw FAB file holding two 2-D records: (0,0)-(1,1) then (0,0)-(3,0).
+void writeRawFabFile(const std::filesystem::path& path)
+{
+    std::ofstream output(path, std::ios::binary);
+    require(static_cast<bool>(output), "could not create fixture FAB");
+    appendFab(output, "((0,0) (1,1) (0,0))", {1.0, 2.0, 3.0, 4.0});
+    appendFab(output, "((0,0) (3,0) (0,0))", {5.0, 6.0, 7.0, 8.0});
+}
+
+// A single-level MultiFab (VisMF header plus two FABs), the shape whose
+// selector lists blocks that open from the source metadata.
+void writeMultiFab(const std::filesystem::path& root)
+{
+    std::filesystem::create_directories(root);
+    writeText(root / "Cell_H",
+        "1\n1\n1\n0\n"
+        "(2 0\n"
+        "((0,0) (3,2) (0,0))\n"
+        "((0,3) (2,3) (0,0))\n"
+        ")\n"
+        "2\n"
+        "FabOnDisk: Cell_D_00000 0\n"
+        "FabOnDisk: Cell_D_00001 0\n"
+        "\n"
+        "2,1\n0.0,\n30.0,\n\n2,1\n23.0,\n32.0,\n");
+    std::vector<double> gridA;
+    for (int j = 0; j <= 2; ++j) {
+        for (int i = 0; i <= 3; ++i) {
+            gridA.push_back(10.0 * j + i);
+        }
+    }
+    std::vector<double> gridB{30.0, 31.0, 32.0};
+    {
+        std::ofstream output(root / "Cell_D_00000", std::ios::binary);
+        appendFab(output, "((0,0) (3,2) (0,0))", gridA);
+    }
+    {
+        std::ofstream output(root / "Cell_D_00001", std::ios::binary);
+        appendFab(output, "((0,3) (2,3) (0,0))", gridB);
+    }
+}
+
+// What the host would see: every openPrepared call and every signal.
+struct Opened {
+    std::filesystem::path path;
+    std::string fileVersion;
+    std::size_t levelBlocks = 0;
+    bool preserveSelector = false;
+    bool hadSpec = false;
+    int levelSelection = 0;
+};
+
+struct Host {
+    std::uint64_t generation = 1;
+    bool shuttingDown = false;
+    bool datasetOpen = false;
+    std::vector<Opened> opened;
+    int activity = 0;
+    int activityEvents = 0;
+    int stale = 0;
+    QStringList failures;
+    int titleChanges = 0;
+
+    amrvis::qt::FabNavigator::Hooks hooks()
+    {
+        return amrvis::qt::FabNavigator::Hooks{
+            [this] { return generation; },
+            [this] { return shuttingDown; },
+            [this]() -> std::optional<amrvis::FrameSliceSpec> {
+                if (!datasetOpen) {
+                    return std::nullopt;
+                }
+                amrvis::FrameSliceSpec spec;
+                spec.levelSelection = 2;
+                spec.rangeMode = amrvis::RangeMode::User;
+                spec.userRange = std::pair{0.0, 1.0};
+                return spec;
+            },
+            [this](const std::filesystem::path& path,
+                amrvis::PlotfileMetadataResult metadata,
+                std::filesystem::path, bool preserve,
+                std::optional<amrvis::FrameSliceSpec> spec) {
+                Opened entry;
+                entry.path = path;
+                entry.fileVersion = metadata.fileVersion;
+                entry.levelBlocks = metadata.metadata->levels.front().blocks.size();
+                entry.preserveSelector = preserve;
+                entry.hadSpec = spec.has_value();
+                entry.levelSelection = spec ? spec->levelSelection : 99;
+                opened.push_back(entry);
+                datasetOpen = true;
+            },
+        };
+    }
+
+    void observe(amrvis::qt::FabNavigator& navigator)
+    {
+        QObject::connect(&navigator,
+            &amrvis::qt::FabNavigator::loadActivityChanged, &navigator,
+            [this](int delta) {
+                activity += delta;
+                ++activityEvents;
+            });
+        QObject::connect(&navigator,
+            &amrvis::qt::FabNavigator::staleResultDropped, &navigator,
+            [this] { ++stale; });
+        QObject::connect(&navigator, &amrvis::qt::FabNavigator::openFailed,
+            &navigator, [this](const QString& title, const QString& message) {
+                failures << title + QStringLiteral(": ") + message;
+            });
+        QObject::connect(&navigator,
+            &amrvis::qt::FabNavigator::windowTitleChanged, &navigator,
+            [this] { ++titleChanges; });
+    }
+};
+
+template <typename Predicate>
+void waitFor(QCoreApplication& application, Predicate done, const char* what)
+{
+    QTimer poll;
+    QTimer timeout;
+    timeout.setSingleShot(true);
+    bool timedOut = false;
+    QObject::connect(&timeout, &QTimer::timeout, &application,
+        [&application, &timedOut] {
+            timedOut = true;
+            application.quit();
+        });
+    QObject::connect(&poll, &QTimer::timeout, &application,
+        [&application, &done] {
+            if (done()) {
+                application.quit();
+            }
+        });
+    poll.start(5);
+    timeout.start(5000);
+    application.exec();
+    require(!timedOut, what);
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    QApplication application(argc, argv);
+    using amrvis::qt::FabNavigator;
+
+    const auto unique
+        = std::chrono::steady_clock::now().time_since_epoch().count();
+    const auto root = std::filesystem::temp_directory_path()
+        / ("amrexplorer-fab-navigator-" + std::to_string(unique));
+    std::filesystem::create_directories(root);
+    const auto fabPath = root / "records.fab";
+    writeRawFabFile(fabPath);
+    const auto multifabRoot = root / "mf";
+    writeMultiFab(multifabRoot);
+    const auto multifabPath = multifabRoot / "Cell_H";
+
+    // A raw FAB source: the selector lists its records as raw records, the
+    // navigator is in FAB mode with no source metadata, and reset() clears it.
+    {
+        Host host;
+        FabNavigator navigator(host.hooks());
+        host.observe(navigator);
+        QWidget window;
+        auto* dock = navigator.createDock(&window);
+        window.show();
+        require(navigator.cleared() && !dock->isVisible(),
+            "a fresh navigator is not cleared");
+        const auto metadata = amrvis::readDatasetMetadata(fabPath);
+        auto build = FabNavigator::buildSelector(metadata, fabPath);
+        require(build.matched && build.fabMode && !build.hasSourceMetadata
+                && build.entries.size() == 2 && build.entries[0].rawRecord
+                && build.entries[1].fileOffset > 0,
+            "the raw FAB selector build is wrong");
+        navigator.applySelectorBuild(build, fabPath, metadata);
+        require(navigator.fabMode() && dock->isVisible()
+                && dock->entries().size() == 2 && !dock->backAvailable()
+                && host.titleChanges == 1 && !navigator.cleared(),
+            "applying the raw FAB build did not install it");
+        navigator.reset();
+        require(navigator.cleared() && !navigator.fabMode()
+                && dock->entries().empty() && !dock->isVisible(),
+            "reset left FAB state behind");
+    }
+
+    // A MultiFab source: blocks open synchronously from the source metadata
+    // (one block per opened level, the selector kept, the current spec with
+    // level/range reset), the first drill-down records the return state, and
+    // Back reopens the source with the spec it was displayed with.
+    {
+        Host host;
+        host.datasetOpen = true;
+        FabNavigator navigator(host.hooks());
+        host.observe(navigator);
+        QWidget window;
+        auto* dock = navigator.createDock(&window);
+        window.show();
+        const auto metadata = amrvis::readDatasetMetadata(multifabPath);
+        auto build = FabNavigator::buildSelector(metadata, multifabPath);
+        require(build.matched && !build.fabMode && build.hasSourceMetadata
+                && build.entries.size() == 2 && !build.entries[0].rawRecord,
+            "the MultiFab selector build is wrong");
+        navigator.applySelectorBuild(build, multifabPath, metadata);
+        require(!navigator.fabMode() && dock->entries().size() == 2,
+            "applying the MultiFab build did not install it");
+        navigator.viewEntry(1);
+        require(host.opened.size() == 1, "viewing a block did not open it");
+        const auto& block = host.opened.back();
+        require(block.path == multifabPath && block.preserveSelector
+                && block.levelBlocks == 1 && block.hadSpec
+                && block.levelSelection == -1,
+            "the drilled-into block was opened wrongly");
+        require(navigator.fabMode() && dock->backAvailable()
+                && dock->selectedOrdinal() == std::optional<std::size_t>{1},
+            "the selector does not reflect the drilled-into block");
+        navigator.viewEntry(5);
+        require(host.opened.size() == 1, "an out-of-range entry opened");
+        navigator.backToMultiFab();
+        require(host.opened.size() == 2, "Back did not reopen the source");
+        const auto& source = host.opened.back();
+        require(source.path == multifabPath && source.preserveSelector
+                && source.levelBlocks == 2 && source.hadSpec
+                && source.levelSelection == 2,
+            "Back did not restore the source with its display spec");
+        require(!navigator.fabMode() && !dock->backAvailable(),
+            "Back left FAB mode or the Back button on");
+        navigator.backToMultiFab();
+        require(host.opened.size() == 2, "a second Back reopened again");
+    }
+
+    // The direct "Open FAB...": an asynchronous header read that opens with
+    // the selector rebuilt (preserve = false), balancing the activity count;
+    // a missing file fails once and opens nothing.
+    {
+        Host host;
+        FabNavigator navigator(host.hooks());
+        host.observe(navigator);
+        navigator.openStandaloneFab(fabPath);
+        require(host.activity == 1, "the read did not announce itself");
+        waitFor(application, [&] { return host.activityEvents == 2; },
+            "the FAB read did not finish");
+        require(host.activity == 0 && host.opened.size() == 1
+                && host.opened.back().fileVersion == "FAB"
+                && !host.opened.back().preserveSelector
+                && !host.opened.back().hadSpec && host.failures.isEmpty(),
+            "the raw FAB was not opened as a fresh dataset");
+        navigator.openStandaloneFab(root / "missing.fab");
+        waitFor(application, [&] { return host.activityEvents == 4; },
+            "the failing FAB read did not finish");
+        require(host.activity == 0 && host.opened.size() == 1
+                && host.failures.size() == 1
+                && host.failures.front().startsWith(
+                    QStringLiteral("Cannot open FAB: ")),
+            "a missing FAB was not reported once");
+    }
+
+    // A read that resolves after the dataset generation moved is stale: it
+    // neither opens nor reports.
+    {
+        Host host;
+        FabNavigator navigator(host.hooks());
+        host.observe(navigator);
+        navigator.openStandaloneFab(fabPath);
+        ++host.generation;
+        waitFor(application, [&] { return host.activityEvents == 2; },
+            "the superseded FAB read did not finish");
+        require(host.opened.empty() && host.stale == 1
+                && host.failures.isEmpty(),
+            "a read from a previous dataset generation was not dropped");
+    }
+
+    // Raw-record drill-down and rollback: the dock moves to the clicked
+    // record at once; a read that fails puts it back and reports; two clicks
+    // in flight together return to what was displayed before either.
+    {
+        Host host;
+        host.datasetOpen = true;
+        FabNavigator navigator(host.hooks());
+        host.observe(navigator);
+        QWidget window;
+        auto* dock = navigator.createDock(&window);
+        window.show();
+        const auto metadata = amrvis::readDatasetMetadata(fabPath);
+        navigator.applySelectorBuild(
+            FabNavigator::buildSelector(metadata, fabPath), fabPath, metadata);
+        navigator.viewEntry(0);
+        require(dock->selectedOrdinal() == std::optional<std::size_t>{0}
+                && navigator.fabMode(),
+            "the dock did not move to the clicked record");
+        waitFor(application, [&] { return host.activityEvents == 2; },
+            "the record read did not finish");
+        require(host.opened.size() == 1 && host.opened.back().preserveSelector
+                && host.opened.back().hadSpec
+                && host.opened.back().levelSelection == -1,
+            "the raw record was not opened keeping the selector");
+        // Break the source, then click 1: it must fail and roll back to 0.
+        std::filesystem::remove(fabPath);
+        navigator.viewEntry(1);
+        require(dock->selectedOrdinal() == std::optional<std::size_t>{1},
+            "the dock did not move to the second record");
+        waitFor(application, [&] { return host.activityEvents == 4; },
+            "the failing record read did not finish");
+        require(host.failures.size() == 1
+                && host.failures.front().startsWith(
+                    QStringLiteral("Cannot view FAB: "))
+                && dock->selectedOrdinal() == std::optional<std::size_t>{0}
+                && host.opened.size() == 1,
+            "a failed record read did not roll the dock back");
+        // Two clicks in flight: the first is superseded (stale, restores
+        // nothing), the second fails and returns to what was displayed
+        // before either -- record 0 -- not to record 1.
+        navigator.viewEntry(1);
+        navigator.viewEntry(0);
+        navigator.viewEntry(1);
+        waitFor(application, [&] { return host.activityEvents == 10; },
+            "the overlapping record reads did not finish");
+        require(host.stale == 2 && host.failures.size() == 2
+                && dock->selectedOrdinal() == std::optional<std::size_t>{0},
+            "overlapping failed reads did not return to the displayed record");
+        // Shutdown: a late result touches nothing.
+        navigator.viewEntry(1);
+        host.shuttingDown = true;
+        waitFor(application, [&] { return host.activity == 0; },
+            "the shutdown-time read did not release its activity");
+        require(host.failures.size() == 2 && host.stale == 2,
+            "a shutdown-time result was reported");
+    }
+
+    std::error_code cleanup;
+    std::filesystem::remove_all(root, cleanup);
+    std::cout << "fab navigator tests passed\n";
+    return 0;
+}

--- a/tests/unit/test_fab_navigator.cpp
+++ b/tests/unit/test_fab_navigator.cpp
@@ -354,11 +354,13 @@ int main(int argc, char** argv)
                 && dock->selectedOrdinal() == std::optional<std::size_t>{0}
                 && host.opened.size() == 1,
             "a failed record read did not roll the dock back");
-        // Two clicks in flight: the first is superseded (stale, restores
-        // nothing), the second fails and returns to what was displayed
-        // before either -- record 0 -- not to record 1.
+        // Three clicks on record 1 in flight: the first two are superseded
+        // (stale, restore nothing), the last fails and returns to what was
+        // displayed before any of them -- record 0. Identical clicks matter:
+        // the later ones must inherit the pending rollback rather than
+        // snapshot the dock, which by then already highlights record 1.
         navigator.viewEntry(1);
-        navigator.viewEntry(0);
+        navigator.viewEntry(1);
         navigator.viewEntry(1);
         waitFor(application, [&] { return host.activityEvents == 10; },
             "the overlapping record reads did not finish");


### PR DESCRIPTION
Standalone-FAB / MultiFab navigation -- the FAB mode flag, the source the selector lists, the MultiFab-return record, the selector dock, the off-thread selector build, and the asynchronous standalone-FAB header reads with their rollback and request token -- moves into FabNavigator. MainWindow opens whatever it resolves through a hook onto openDatasetImpl, supplies the dataset generation and current frame spec, and folds its reads into the diagnostics. Unit-tested against real FAB and MultiFab fixtures: selector builds, block drill-down and Back, the direct open, stale-by-generation, failure rollback and overlapping reads. Eight members and five methods leave MainWindow.