### PR TITLE
browse the remote server's directories from the Open Remote dialogs

### DIFF
--- a/docs/remote-client-server-plan.md
+++ b/docs/remote-client-server-plan.md
@@ -104,7 +104,8 @@ rasterize the current view.
   let other local users on the server host connect through the owning user's
   account. It is not user authentication or transport encryption; SSH still
   provides those.)
-- Remote filesystem browsing.
+- Remote filesystem browsing. (Added in protocol 1.1, 2026-08: a bounded,
+  directories-only listing -- see §5.4 and §9.2.)
 - Server-side rendering, palettes, contours, glyph generation, or image
   export for protocol 1.0.
 - Shared datasets or cache state between separate client connections.
@@ -332,6 +333,7 @@ The production schema will cover:
 | `ClearCacheRequest` | `CacheState` | Clear unpinned blocks |
 | `CancelRequest` | `CancelAcknowledged` | Request cancellation by request ID |
 | `PingRequest` | `PongResponse` | Explicit health check |
+| `ListDirectoryRequest` (1.1) | `DirectoryListing` | List a server directory's subdirectories, marking plotfiles |
 | any request | `ErrorResponse` | Typed terminal failure |
 
 Every ordinary request has exactly one terminal response with the same
@@ -628,9 +630,13 @@ integration tests, the Qt smoke harness, and `amrexplorer-render-equivalence`.
 
 - **File > Open Remote Plotfile...** / **File > Open Remote Plotfile
   Sequence...** -- one dialog each: ssh destination, server executable, and
-  server-visible path(s) (protocol 1.0 does not browse the server
-  filesystem). Unchanged connection fields reuse the live session; a changed
-  destination starts a new one.
+  server-visible path(s). Unchanged connection fields reuse the live session;
+  a changed destination starts a new one. **Browse...** starts or reuses the
+  session and then opens a directory browser over it (protocol 1.1
+  `ListDirectoryRequest`: subdirectories only, plotfiles marked, at most 4096
+  entries, path resolution identical to dataset opens). A sequence picked
+  there plays in name order. Against a 1.0 server the browser reports that
+  browsing is unsupported; typed paths still work.
 - a session-status entry in diagnostics.
 
 Switching back to a local open remains supported without restarting the

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -78,7 +78,15 @@ Remote Plotfile Sequence...**: one dialog asks for the SSH destination, the
 server executable, and the plotfile path (or paths, one per line). The
 connection fields are prefilled; leaving them unchanged opens further paths
 over the current session, and entering a different destination starts a new
-one. Once open, a remote dataset is driven exactly like a local one.
+one. Instead of typing the path, **Browse...** connects (or reuses the
+session) and opens a browser of the remote machine's directories, starting at
+the last one browsed there or the home directory. Plotfiles are marked as
+such; double-click one to open it, or select several for a sequence, which
+plays in name order. Its path box accepts the same spellings as the CLI
+(`~/run`, `run`, `/scratch/run`). Browsing needs a current
+`amrexplorer-server` on the remote machine; with an older one the browser
+reports that and the path can still be typed. Once open, a remote dataset is
+driven exactly like a local one.
 
 If the destination requires a password or keyboard-interactive MFA,
 AMReXplorer opens a response dialog for each OpenSSH prompt, including the

--- a/include/amrexplorer/remote/Connection.hpp
+++ b/include/amrexplorer/remote/Connection.hpp
@@ -50,6 +50,11 @@ public:
 
     [[nodiscard]] OpenedDataset openDataset(const std::string& path,
         std::uint64_t cacheBudgetBytes, StopToken cancellation = {});
+    // Lists the subdirectories of a server-side directory (protocol 1.1);
+    // an empty path is the server's home. Throws when the server negotiated
+    // protocol 1.0, i.e. predates browsing.
+    [[nodiscard]] RemoteDirectoryListing listDirectory(
+        const std::string& path, StopToken cancellation = {});
     void closeDataset(DatasetId dataset, StopToken cancellation = {});
     void closeDatasetBestEffort(DatasetId dataset) noexcept;
     [[nodiscard]] ViewDataResult requestView(

--- a/include/amrexplorer/remote/Protocol.hpp
+++ b/include/amrexplorer/remote/Protocol.hpp
@@ -9,6 +9,7 @@
 #include <amrexplorer/io/ParticleReader.hpp>
 #include <amrexplorer/io/PlotfileMetadataReader.hpp>
 
+#include <cstddef>
 #include <cstdint>
 #include <stdexcept>
 #include <string>
@@ -106,10 +107,16 @@ struct RemoteDirectoryEntry {
     bool isPlotfile = false;
 };
 
+// The most subdirectories one DirectoryListing carries: the first this many
+// in name order, with `truncated` set when more exist. A bound both sides
+// enforce, so a listing cannot grow past what a dialog can show.
+inline constexpr std::size_t maximumDirectoryEntries = 4096;
+
 // A directory as the server sees it, with `path` resolved and normalized the
 // same way dataset paths are (see resolveDatasetPath in Server.cpp). At the
 // root `parentPath` equals `path`. `truncated` is set when the listing was
-// cut at the server's entry cap; the entries present are still sorted.
+// cut at maximumDirectoryEntries; the entries present are the first ones in
+// name order.
 struct RemoteDirectoryListing {
     std::string path;
     std::string parentPath;

--- a/include/amrexplorer/remote/Protocol.hpp
+++ b/include/amrexplorer/remote/Protocol.hpp
@@ -110,9 +110,9 @@ struct RemoteDirectoryEntry {
 // The most subdirectories one DirectoryListing carries: the first this many
 // in name order, with `truncated` set when more exist. A bound both sides
 // enforce, so a listing cannot grow past what a dialog can show. It is part
-// of protocol 1.1: a client rejects a larger listing, so raising it is a
-// minor-version change, and a server keeps sending at most this many to a
-// peer that negotiated 1.1.
+// of protocol 1.1: a 1.1 client rejects a larger listing, so it cannot simply
+// be raised -- a larger cap needs a new minor version and a server that sends
+// at most this many to a peer that negotiated 1.1 (nothing does that yet).
 inline constexpr std::size_t maximumDirectoryEntries = 4096;
 
 // A directory as the server sees it, with `path` resolved and normalized the

--- a/include/amrexplorer/remote/Protocol.hpp
+++ b/include/amrexplorer/remote/Protocol.hpp
@@ -109,7 +109,10 @@ struct RemoteDirectoryEntry {
 
 // The most subdirectories one DirectoryListing carries: the first this many
 // in name order, with `truncated` set when more exist. A bound both sides
-// enforce, so a listing cannot grow past what a dialog can show.
+// enforce, so a listing cannot grow past what a dialog can show. It is part
+// of protocol 1.1: a client rejects a larger listing, so raising it is a
+// minor-version change, and a server keeps sending at most this many to a
+// peer that negotiated 1.1.
 inline constexpr std::size_t maximumDirectoryEntries = 4096;
 
 // A directory as the server sees it, with `path` resolved and normalized the

--- a/include/amrexplorer/remote/Protocol.hpp
+++ b/include/amrexplorer/remote/Protocol.hpp
@@ -17,7 +17,7 @@
 namespace amrvis::remote {
 
 inline constexpr std::uint16_t protocolMajor = 1;
-inline constexpr std::uint16_t protocolMinorVersion = 0;
+inline constexpr std::uint16_t protocolMinorVersion = 1;
 
 enum class PayloadKind : std::uint8_t {
     None = 0,
@@ -44,7 +44,10 @@ enum class PayloadKind : std::uint8_t {
     CancelAcknowledged = 21,
     PingRequest = 22,
     PongResponse = 23,
-    ErrorResponse = 24
+    ErrorResponse = 24,
+    // Protocol 1.1: directory browsing.
+    ListDirectoryRequest = 25,
+    DirectoryListing = 26
 };
 
 enum class ErrorCode : std::uint16_t {
@@ -92,6 +95,26 @@ struct HelloResponseData {
 struct OpenDatasetData {
     std::string path;
     std::uint64_t cacheBudgetBytes = 0;
+};
+
+// One subdirectory of a listed directory. Only directories are listed:
+// plotfiles are directories, and files are not navigable. `path` is the
+// server-side absolute path of the entry.
+struct RemoteDirectoryEntry {
+    std::string name;
+    std::string path;
+    bool isPlotfile = false;
+};
+
+// A directory as the server sees it, with `path` resolved and normalized the
+// same way dataset paths are (see resolveDatasetPath in Server.cpp). At the
+// root `parentPath` equals `path`. `truncated` is set when the listing was
+// cut at the server's entry cap; the entries present are still sorted.
+struct RemoteDirectoryListing {
+    std::string path;
+    std::string parentPath;
+    std::vector<RemoteDirectoryEntry> entries;
+    bool truncated = false;
 };
 
 struct OpenedDataset {

--- a/schemas/amrexplorer_wire.fbs
+++ b/schemas/amrexplorer_wire.fbs
@@ -314,6 +314,26 @@ table ErrorResponse {
   message:string (id: 1);
 }
 
+// Protocol 1.1: directory browsing. `path` is resolved on the server like a
+// dataset path (leading tilde and relative paths anchor at the server's
+// home). Only subdirectories are listed.
+table ListDirectoryRequest {
+  path:string (id: 0);
+}
+
+table DirectoryEntry {
+  name:string (id: 0);
+  is_plotfile:bool (id: 1);
+  path:string (id: 2);
+}
+
+table DirectoryListing {
+  path:string (id: 0);
+  entries:[DirectoryEntry] (id: 1);
+  parent_path:string (id: 2);
+  truncated:bool (id: 3);
+}
+
 union Payload {
   HelloRequest = 1,
   HelloResponse = 2,
@@ -338,7 +358,9 @@ union Payload {
   CancelAcknowledged = 21,
   PingRequest = 22,
   PongResponse = 23,
-  ErrorResponse = 24
+  ErrorResponse = 24,
+  ListDirectoryRequest = 25,
+  DirectoryListing = 26
 }
 
 table Envelope {

--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -28,6 +28,8 @@ add_executable(amrexplorer_qt
     NumberFormat.hpp
     QtErrorText.hpp
     RemoteEndpoint.hpp
+    RemoteFileDialog.cpp
+    RemoteFileDialog.hpp
     ScientificDoubleSpinBox.cpp
     ScientificDoubleSpinBox.hpp
     SshConnectArguments.hpp

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -680,7 +680,8 @@ void MainWindow::promptRemoteOpen(bool sequence)
            "ssh and talks to it over that connection. Any destination that "
            "works for the ssh command works here, including aliases from "
            "~/.ssh/config. An unchanged destination keeps the current "
-           "session."),
+           "session. Enter the plotfile path, or use Browse... to pick it "
+           "on the remote machine."),
         &dialog);
     explanation->setWordWrap(true);
     layout->addRow(explanation);
@@ -733,6 +734,17 @@ void MainWindow::promptRemoteOpen(bool sequence)
     auto* buttons = new QDialogButtonBox(
         QDialogButtonBox::Ok | QDialogButtonBox::Cancel, &dialog);
     buttons->button(QDialogButtonBox::Ok)->setText(tr("Open"));
+    // Browse... needs only the connection fields: it starts (or reuses) the
+    // session and picks the path in the remote browser once it is ready.
+    auto* browseButton = buttons->addButton(
+        tr("Browse..."), QDialogButtonBox::ActionRole);
+    browseButton->setToolTip(
+        tr("Connect and choose the plotfile on the remote machine"));
+    bool browse = false;
+    connect(browseButton, &QPushButton::clicked, &dialog, [&] {
+        browse = true;
+        dialog.accept();
+    });
     connect(buttons, &QDialogButtonBox::accepted, &dialog, &QDialog::accept);
     connect(buttons, &QDialogButtonBox::rejected, &dialog, &QDialog::reject);
     layout->addRow(buttons);
@@ -741,6 +753,25 @@ void MainWindow::promptRemoteOpen(bool sequence)
     }
     const auto destination = destinationEdit->text().trimmed();
     const auto executable = executableEdit->text().trimmed();
+    const bool sessionMatches = hasRemoteConnection() && m_sshRemoteSession
+        && destination.toStdString() == m_sshRemoteSession->destination()
+        && executable.toStdString() == m_sshRemoteSession->serverExecutable();
+    if (browse) {
+        if (destination.isEmpty() || executable.isEmpty()) {
+            QMessageBox::warning(this, dialog.windowTitle(),
+                tr("The SSH destination and the server executable are "
+                   "required."));
+            return;
+        }
+        if (sessionMatches) {
+            browseRemotePlotfiles(sequence);
+        } else {
+            startSshRemoteSession(destination.toStdString(),
+                executable.toStdString(), {},
+                [this, sequence] { browseRemotePlotfiles(sequence); });
+        }
+        return;
+    }
     std::vector<std::string> paths;
     if (sequence) {
         for (const auto& line : pathsEdit->toPlainText().split(
@@ -761,10 +792,7 @@ void MainWindow::promptRemoteOpen(bool sequence)
     }
     // An unchanged destination and executable mean the current session is the
     // one asked for; open over it directly instead of starting ssh again.
-    if (hasRemoteConnection() && m_sshRemoteSession
-        && destination.toStdString() == m_sshRemoteSession->destination()
-        && executable.toStdString()
-            == m_sshRemoteSession->serverExecutable()) {
+    if (sessionMatches) {
         if (sequence) {
             openRemoteSequence(paths);
         } else {

--- a/src/qt/MainWindow.hpp
+++ b/src/qt/MainWindow.hpp
@@ -29,6 +29,7 @@
 #include <atomic>
 #include <cstdint>
 #include <filesystem>
+#include <functional>
 #include <memory>
 #include <optional>
 #include <string>
@@ -113,9 +114,15 @@ public:
     // Runs amrexplorer-server on the named OpenSSH destination with the wire
     // protocol over ssh's stdio, installs the connection once its handshake
     // completes, and opens the supplied server-visible paths. An empty path
-    // list only establishes the session.
+    // list only establishes the session. `onReady` runs after the connection
+    // is installed and any paths are opened; the browser uses it.
     void startSshRemoteSession(std::string destination,
-        std::string serverExecutable, std::vector<std::string> remotePaths);
+        std::string serverExecutable, std::vector<std::string> remotePaths,
+        std::function<void()> onReady = {});
+    // Browses the live remote session's filesystem and opens the plotfile
+    // (or plotfiles, when `sequence`) picked there. Starts at the directory
+    // last browsed on this destination, else the server's home.
+    void browseRemotePlotfiles(bool sequence);
     // Opens a plotfile sequence (the legacy "-a" file animation): frames are
     // the plotfile directories, sorted by name; requires at least two valid
     // plotfiles. Opening a single dataset closes the sequence again.

--- a/src/qt/MainWindowDataset.cpp
+++ b/src/qt/MainWindowDataset.cpp
@@ -995,7 +995,8 @@ QString MainWindow::remoteServerExecutableFor(const QString& destination)
 }
 
 void MainWindow::startSshRemoteSession(std::string destination,
-    std::string serverExecutable, std::vector<std::string> remotePaths)
+    std::string serverExecutable, std::vector<std::string> remotePaths,
+    std::function<void()> onReady)
 {
     if (destination.empty() || destination.front() == '-'
         || destination.find_first_of(" \t\r\n") != std::string::npos) {
@@ -1029,7 +1030,8 @@ void MainWindow::startSshRemoteSession(std::string destination,
     m_sshRemoteSession->start(destination, std::move(serverExecutable),
         remote::ConnectionOptions{.clientName = "AMReXplorer Qt",
             .softwareVersion = kVersion, .sessionToken = {}},
-        [this, destination, paths = std::move(remotePaths)](
+        [this, destination, paths = std::move(remotePaths),
+            onReady = std::move(onReady)](
             std::shared_ptr<remote::Connection> connection) {
             if (m_closing) {
                 return;
@@ -1047,6 +1049,9 @@ void MainWindow::startSshRemoteSession(std::string destination,
                 openRemoteDataset(paths.front());
             } else if (paths.size() > 1) {
                 openRemoteSequence(paths);
+            }
+            if (onReady) {
+                onReady();
             }
         },
         [this, destination](const QString& message) {
@@ -1070,6 +1075,43 @@ void MainWindow::startSshRemoteSession(std::string destination,
         });
     // After start(): the session reports its destination only from then on.
     updateDiagnostics();
+}
+
+void MainWindow::browseRemotePlotfiles(bool sequence)
+{
+    if (!hasRemoteConnection()) {
+        reportBackgroundError(tr("Open a remote session first "
+                                 "(File > Open Remote Plotfile...)."));
+        return;
+    }
+    // The last directory browsed is remembered per destination: a path is a
+    // property of one machine, like the server executable.
+    const auto destination = m_sshRemoteSession
+        ? QString::fromStdString(m_sshRemoteSession->destination())
+        : m_remoteLabel;
+    const auto settingsKey
+        = QStringLiteral("remote/lastDirectories/%1").arg(destination);
+    RemoteFileDialog dialog(m_remoteConnection,
+        makeSettings().value(settingsKey).toString(),
+        sequence ? RemoteFileDialog::SelectionMode::PlotfileSequence
+                 : RemoteFileDialog::SelectionMode::SinglePlotfile,
+        this);
+    if (dialog.exec() != QDialog::Accepted) {
+        return;
+    }
+    const auto paths = dialog.selectedPaths();
+    if (paths.empty()) {
+        return;
+    }
+    if (!dialog.currentDirectory().isEmpty()) {
+        makeSettings().setValue(settingsKey, dialog.currentDirectory());
+    }
+    // One plotfile picked in the sequence browser is just that plotfile.
+    if (paths.size() > 1) {
+        openRemoteSequence(paths);
+    } else {
+        openRemoteDataset(paths.front());
+    }
 }
 
 void MainWindow::openRemoteDataset(std::string remotePath)

--- a/src/qt/MainWindowInternal.hpp
+++ b/src/qt/MainWindowInternal.hpp
@@ -19,6 +19,7 @@
 #include "LinePlotRequest.hpp"
 #include "LinePlotWindow.hpp"
 #include "PlaneMapping.hpp"
+#include "RemoteFileDialog.hpp"
 #include "ScientificDoubleSpinBox.hpp"
 #include "SshRemoteSession.hpp"
 #include "SetContoursDialog.hpp"

--- a/src/qt/RemoteFileDialog.cpp
+++ b/src/qt/RemoteFileDialog.cpp
@@ -136,8 +136,10 @@ void RemoteFileDialog::loadDirectory(const QString& path)
     m_upButton->setEnabled(false);
     m_goButton->setEnabled(false);
     // Greyed out until the new listing lands: on a slow link the old one
-    // stays visible for a moment and must not read as the current one.
+    // stays visible for a moment and must not read as the current one, and
+    // Open must not act on its selection either.
     m_entries->setEnabled(false);
+    m_buttons->button(QDialogButtonBox::Open)->setEnabled(false);
     m_watcher->setFuture(QtConcurrent::run(
         [connection = m_connection, requestedPath = path.toStdString(),
             cancellation = m_browseStop.get_token()] {
@@ -161,9 +163,11 @@ void RemoteFileDialog::finishLoad()
     m_upButton->setEnabled(!m_parentDirectory.isEmpty()
         && m_parentDirectory != m_currentDirectory);
     if (!result.error.isEmpty()) {
-        // The previous listing stays up; only the message changes.
+        // The previous listing stays up, selection included; only the
+        // message changes.
         m_status->setText(
             tr("Could not list the remote directory: %1").arg(result.error));
+        updateOpenButton();
         m_pathEdit->setFocus();
         m_pathEdit->selectAll();
         return;

--- a/src/qt/RemoteFileDialog.cpp
+++ b/src/qt/RemoteFileDialog.cpp
@@ -133,6 +133,7 @@ void RemoteFileDialog::loadDirectory(const QString& path)
         return;
     }
     m_browseStop = StopSource{};
+    m_requestedPath = path;
     m_status->setText(tr("Listing %1...")
             .arg(path.isEmpty() ? tr("the home directory") : path));
     m_pathEdit->setEnabled(false);
@@ -147,7 +148,6 @@ void RemoteFileDialog::loadDirectory(const QString& path)
         [connection = m_connection, requestedPath = path.toStdString(),
             cancellation = m_browseStop.get_token()] {
             BrowseResult result;
-            result.requestedPath = QString::fromStdString(requestedPath);
             try {
                 result.listing
                     = connection->listDirectory(requestedPath, cancellation);
@@ -161,21 +161,25 @@ void RemoteFileDialog::loadDirectory(const QString& path)
 void RemoteFileDialog::finishLoad()
 {
     const auto result = m_watcher->result();
+    const bool initialLoad = std::exchange(m_initialLoad, false);
     m_pathEdit->setEnabled(true);
     m_goButton->setEnabled(true);
     m_entries->setEnabled(true);
     if (!result.error.isEmpty()) {
-        m_status->setText(
-            tr("Could not list the remote directory: %1").arg(result.error));
-        if (m_currentDirectory.isEmpty() && !result.requestedPath.isEmpty()) {
-            // Nothing is shown yet and the remembered start directory is
-            // gone; the home directory is the fallback that always exists.
+        if (initialLoad && !m_requestedPath.isEmpty()) {
+            // The remembered start directory is gone; the home directory is
+            // the fallback that always exists. Said in the status once that
+            // listing lands, so the user learns why they are not where the
+            // browser last left off.
             m_fallbackNotice
                 = tr("Could not list %1 (%2), so this is the home directory. ")
-                      .arg(result.requestedPath, result.error);
+                      .arg(m_requestedPath, result.error);
             loadDirectory(QString());
             return;
         }
+        m_fallbackNotice.clear();
+        m_status->setText(
+            tr("Could not list the remote directory: %1").arg(result.error));
         // The previous listing stays up, selection included; only the
         // message changes.
         m_upButton->setEnabled(m_parentDirectory != m_currentDirectory);

--- a/src/qt/RemoteFileDialog.cpp
+++ b/src/qt/RemoteFileDialog.cpp
@@ -1,0 +1,226 @@
+#include "RemoteFileDialog.hpp"
+
+#include <amrexplorer/remote/Connection.hpp>
+
+#include <QAbstractItemView>
+#include <QDialogButtonBox>
+#include <QHBoxLayout>
+#include <QHeaderView>
+#include <QLabel>
+#include <QLineEdit>
+#include <QPushButton>
+#include <QStyle>
+#include <QTreeWidget>
+#include <QVBoxLayout>
+#include <QtConcurrentRun>
+
+#include <exception>
+#include <utility>
+
+namespace amrvis::qt {
+namespace {
+
+constexpr int pathRole = Qt::UserRole;
+constexpr int plotfileRole = Qt::UserRole + 1;
+
+} // namespace
+
+RemoteFileDialog::RemoteFileDialog(
+    std::shared_ptr<remote::Connection> connection, QString initialPath,
+    SelectionMode mode, QWidget* parent)
+    : QDialog(parent)
+    , m_connection(std::move(connection))
+    , m_mode(mode)
+{
+    setWindowTitle(mode == SelectionMode::SinglePlotfile
+            ? tr("Open Remote Plotfile")
+            : tr("Open Remote Plotfile Sequence"));
+    resize(720, 480);
+
+    auto* layout = new QVBoxLayout(this);
+    auto* pathLayout = new QHBoxLayout;
+    m_upButton = new QPushButton(tr("Up"), this);
+    m_upButton->setIcon(style()->standardIcon(QStyle::SP_ArrowUp));
+    m_upButton->setToolTip(tr("Go to the parent directory"));
+    m_pathEdit = new QLineEdit(this);
+    m_pathEdit->setPlaceholderText(
+        tr("Directory on the remote machine, e.g. ~/run or /scratch/run"));
+    m_goButton = new QPushButton(tr("Go"), this);
+    pathLayout->addWidget(m_upButton);
+    pathLayout->addWidget(m_pathEdit, 1);
+    pathLayout->addWidget(m_goButton);
+    layout->addLayout(pathLayout);
+
+    m_entries = new QTreeWidget(this);
+    m_entries->setColumnCount(2);
+    m_entries->setHeaderLabels({tr("Name"), tr("Type")});
+    m_entries->header()->setStretchLastSection(false);
+    m_entries->header()->setSectionResizeMode(0, QHeaderView::Stretch);
+    m_entries->header()->setSectionResizeMode(1, QHeaderView::ResizeToContents);
+    m_entries->setRootIsDecorated(false);
+    m_entries->setUniformRowHeights(true);
+    m_entries->setSelectionMode(mode == SelectionMode::SinglePlotfile
+            ? QAbstractItemView::SingleSelection
+            : QAbstractItemView::ExtendedSelection);
+    layout->addWidget(m_entries, 1);
+
+    m_status = new QLabel(this);
+    m_status->setWordWrap(true);
+    layout->addWidget(m_status);
+    m_buttons = new QDialogButtonBox(
+        QDialogButtonBox::Open | QDialogButtonBox::Cancel, this);
+    m_buttons->button(QDialogButtonBox::Open)->setEnabled(false);
+    layout->addWidget(m_buttons);
+    // No default button: Enter in the path box navigates, Enter on an entry
+    // activates it, and neither may also fire Open.
+    for (auto* button : m_buttons->buttons()) {
+        if (auto* pushButton = qobject_cast<QPushButton*>(button)) {
+            pushButton->setAutoDefault(false);
+        }
+    }
+    m_upButton->setAutoDefault(false);
+    m_goButton->setAutoDefault(false);
+
+    m_watcher = new QFutureWatcher<BrowseResult>(this);
+    connect(m_watcher, &QFutureWatcher<BrowseResult>::finished, this,
+        [this] { finishLoad(); });
+    connect(m_upButton, &QPushButton::clicked, this,
+        [this] { loadDirectory(m_parentDirectory); });
+    connect(m_goButton, &QPushButton::clicked, this,
+        [this] { loadDirectory(m_pathEdit->text()); });
+    connect(m_pathEdit, &QLineEdit::returnPressed, this,
+        [this] { loadDirectory(m_pathEdit->text()); });
+    connect(m_entries, &QTreeWidget::itemActivated, this,
+        [this](QTreeWidgetItem* item, int) { activateItem(item); });
+    connect(m_entries, &QTreeWidget::itemSelectionChanged, this,
+        [this] { updateOpenButton(); });
+    connect(m_buttons, &QDialogButtonBox::accepted, this, &QDialog::accept);
+    connect(m_buttons, &QDialogButtonBox::rejected, this, &QDialog::reject);
+
+    loadDirectory(initialPath.trimmed());
+}
+
+RemoteFileDialog::~RemoteFileDialog()
+{
+    // A listing still in flight holds its own copy of the connection and
+    // finishes on the worker; this only stops it waiting for the server.
+    m_browseStop.request_stop();
+}
+
+std::vector<std::string> RemoteFileDialog::selectedPaths() const
+{
+    std::vector<std::string> paths;
+    for (int index = 0; index < m_entries->topLevelItemCount(); ++index) {
+        const auto* item = m_entries->topLevelItem(index);
+        if (item->isSelected() && item->data(0, plotfileRole).toBool()) {
+            paths.push_back(item->data(0, pathRole).toString().toStdString());
+        }
+    }
+    return paths;
+}
+
+QString RemoteFileDialog::currentDirectory() const
+{
+    return m_currentDirectory;
+}
+
+void RemoteFileDialog::loadDirectory(const QString& path)
+{
+    if (m_watcher->isRunning()) {
+        return;
+    }
+    m_browseStop = StopSource{};
+    m_status->setText(tr("Listing %1...")
+            .arg(path.isEmpty() ? tr("the home directory") : path));
+    m_pathEdit->setEnabled(false);
+    m_upButton->setEnabled(false);
+    m_goButton->setEnabled(false);
+    m_watcher->setFuture(QtConcurrent::run(
+        [connection = m_connection, requestedPath = path.toStdString(),
+            cancellation = m_browseStop.get_token()] {
+            BrowseResult result;
+            try {
+                result.listing
+                    = connection->listDirectory(requestedPath, cancellation);
+            } catch (const std::exception& error) {
+                result.error = QString::fromUtf8(error.what());
+            }
+            return result;
+        }));
+}
+
+void RemoteFileDialog::finishLoad()
+{
+    const auto result = m_watcher->result();
+    m_pathEdit->setEnabled(true);
+    m_goButton->setEnabled(true);
+    m_upButton->setEnabled(!m_parentDirectory.isEmpty()
+        && m_parentDirectory != m_currentDirectory);
+    if (!result.error.isEmpty()) {
+        // The previous listing stays up; only the message changes.
+        m_status->setText(
+            tr("Could not list the remote directory: %1").arg(result.error));
+        m_pathEdit->setFocus();
+        m_pathEdit->selectAll();
+        return;
+    }
+    m_currentDirectory = QString::fromStdString(result.listing.path);
+    m_parentDirectory = QString::fromStdString(result.listing.parentPath);
+    m_pathEdit->setText(m_currentDirectory);
+    m_upButton->setEnabled(m_parentDirectory != m_currentDirectory);
+    m_entries->clear();
+    const auto directoryIcon = style()->standardIcon(QStyle::SP_DirIcon);
+    const auto plotfileIcon = style()->standardIcon(QStyle::SP_FileIcon);
+    for (const auto& entry : result.listing.entries) {
+        auto* item = new QTreeWidgetItem(m_entries);
+        item->setText(0, QString::fromStdString(entry.name));
+        item->setText(1, entry.isPlotfile ? tr("AMReX plotfile")
+                                          : tr("Directory"));
+        item->setIcon(0, entry.isPlotfile ? plotfileIcon : directoryIcon);
+        item->setData(0, pathRole, QString::fromStdString(entry.path));
+        item->setData(0, plotfileRole, entry.isPlotfile);
+        // Only plotfiles are selectable; other directories are entered.
+        item->setFlags(entry.isPlotfile
+                ? Qt::ItemIsEnabled | Qt::ItemIsSelectable
+                : Qt::ItemIsEnabled);
+    }
+    auto status = m_mode == SelectionMode::SinglePlotfile
+        ? tr("Select a plotfile, or double-click a directory to enter it.")
+        : tr("Select one or more plotfiles; they play in name order.");
+    if (result.listing.entries.empty()) {
+        status = tr("No subdirectories here.");
+    }
+    if (result.listing.truncated) {
+        status += tr(" Only the first %1 entries are shown; enter a "
+                     "subdirectory path to narrow the listing.")
+                      .arg(result.listing.entries.size());
+    }
+    m_status->setText(status);
+    m_entries->setFocus();
+    updateOpenButton();
+}
+
+void RemoteFileDialog::updateOpenButton()
+{
+    const auto count = selectedPaths().size();
+    m_buttons->button(QDialogButtonBox::Open)
+        ->setEnabled(m_mode == SelectionMode::SinglePlotfile ? count == 1
+                                                             : count >= 1);
+}
+
+void RemoteFileDialog::activateItem(QTreeWidgetItem* item)
+{
+    if (item == nullptr) {
+        return;
+    }
+    if (item->data(0, plotfileRole).toBool()) {
+        item->setSelected(true);
+        if (m_mode == SelectionMode::SinglePlotfile) {
+            accept();
+        }
+        return;
+    }
+    loadDirectory(item->data(0, pathRole).toString());
+}
+
+} // namespace amrvis::qt

--- a/src/qt/RemoteFileDialog.cpp
+++ b/src/qt/RemoteFileDialog.cpp
@@ -66,6 +66,9 @@ RemoteFileDialog::RemoteFileDialog(
 
     m_status = new QLabel(this);
     m_status->setWordWrap(true);
+    // Server-supplied names and error text are shown verbatim, never parsed
+    // as rich text.
+    m_status->setTextFormat(Qt::PlainText);
     layout->addWidget(m_status);
     m_buttons = new QDialogButtonBox(
         QDialogButtonBox::Open | QDialogButtonBox::Cancel, this);
@@ -144,6 +147,7 @@ void RemoteFileDialog::loadDirectory(const QString& path)
         [connection = m_connection, requestedPath = path.toStdString(),
             cancellation = m_browseStop.get_token()] {
             BrowseResult result;
+            result.requestedPath = QString::fromStdString(requestedPath);
             try {
                 result.listing
                     = connection->listDirectory(requestedPath, cancellation);
@@ -160,13 +164,21 @@ void RemoteFileDialog::finishLoad()
     m_pathEdit->setEnabled(true);
     m_goButton->setEnabled(true);
     m_entries->setEnabled(true);
-    m_upButton->setEnabled(!m_parentDirectory.isEmpty()
-        && m_parentDirectory != m_currentDirectory);
     if (!result.error.isEmpty()) {
-        // The previous listing stays up, selection included; only the
-        // message changes.
         m_status->setText(
             tr("Could not list the remote directory: %1").arg(result.error));
+        if (m_currentDirectory.isEmpty() && !result.requestedPath.isEmpty()) {
+            // Nothing is shown yet and the remembered start directory is
+            // gone; the home directory is the fallback that always exists.
+            m_fallbackNotice
+                = tr("Could not list %1 (%2), so this is the home directory. ")
+                      .arg(result.requestedPath, result.error);
+            loadDirectory(QString());
+            return;
+        }
+        // The previous listing stays up, selection included; only the
+        // message changes.
+        m_upButton->setEnabled(m_parentDirectory != m_currentDirectory);
         updateOpenButton();
         m_pathEdit->setFocus();
         m_pathEdit->selectAll();
@@ -211,14 +223,16 @@ void RemoteFileDialog::finishLoad()
                      "subdirectory path to narrow the listing.")
                       .arg(result.listing.entries.size());
     }
-    m_status->setText(status);
+    m_status->setText(m_fallbackNotice + status);
+    m_fallbackNotice.clear();
     m_entries->setFocus();
     updateOpenButton();
 }
 
 void RemoteFileDialog::updateOpenButton()
 {
-    const auto count = selectedPaths().size();
+    // Only plotfiles are selectable, so the selection count is the answer.
+    const auto count = m_entries->selectedItems().size();
     m_buttons->button(QDialogButtonBox::Open)
         ->setEnabled(m_mode == SelectionMode::SinglePlotfile ? count == 1
                                                              : count >= 1);

--- a/src/qt/RemoteFileDialog.cpp
+++ b/src/qt/RemoteFileDialog.cpp
@@ -135,6 +135,9 @@ void RemoteFileDialog::loadDirectory(const QString& path)
     m_pathEdit->setEnabled(false);
     m_upButton->setEnabled(false);
     m_goButton->setEnabled(false);
+    // Greyed out until the new listing lands: on a slow link the old one
+    // stays visible for a moment and must not read as the current one.
+    m_entries->setEnabled(false);
     m_watcher->setFuture(QtConcurrent::run(
         [connection = m_connection, requestedPath = path.toStdString(),
             cancellation = m_browseStop.get_token()] {
@@ -154,6 +157,7 @@ void RemoteFileDialog::finishLoad()
     const auto result = m_watcher->result();
     m_pathEdit->setEnabled(true);
     m_goButton->setEnabled(true);
+    m_entries->setEnabled(true);
     m_upButton->setEnabled(!m_parentDirectory.isEmpty()
         && m_parentDirectory != m_currentDirectory);
     if (!result.error.isEmpty()) {
@@ -168,6 +172,11 @@ void RemoteFileDialog::finishLoad()
     m_parentDirectory = QString::fromStdString(result.listing.parentPath);
     m_pathEdit->setText(m_currentDirectory);
     m_upButton->setEnabled(m_parentDirectory != m_currentDirectory);
+    // Repopulate with updates off, then lay out and repaint the whole view in
+    // one go. Left to the view's own delayed relayout, the first row (made
+    // current by setFocus below) can repaint over the stale layout while the
+    // rest of the old listing lingers until the next repaint trigger.
+    m_entries->setUpdatesEnabled(false);
     m_entries->clear();
     const auto directoryIcon = style()->standardIcon(QStyle::SP_DirIcon);
     const auto plotfileIcon = style()->standardIcon(QStyle::SP_FileIcon);
@@ -184,6 +193,9 @@ void RemoteFileDialog::finishLoad()
                 ? Qt::ItemIsEnabled | Qt::ItemIsSelectable
                 : Qt::ItemIsEnabled);
     }
+    m_entries->doItemsLayout();
+    m_entries->scrollToTop();
+    m_entries->setUpdatesEnabled(true);
     auto status = m_mode == SelectionMode::SinglePlotfile
         ? tr("Select a plotfile, or double-click a directory to enter it.")
         : tr("Select one or more plotfiles; they play in name order.");

--- a/src/qt/RemoteFileDialog.hpp
+++ b/src/qt/RemoteFileDialog.hpp
@@ -50,6 +50,7 @@ public:
 
 private:
     struct BrowseResult {
+        QString requestedPath;
         remote::RemoteDirectoryListing listing;
         QString error;
     };
@@ -63,6 +64,9 @@ private:
     SelectionMode m_mode = SelectionMode::SinglePlotfile;
     QString m_currentDirectory;
     QString m_parentDirectory;
+    // Why the first listing fell back to the home directory, prepended to
+    // the status once that listing lands.
+    QString m_fallbackNotice;
     QLineEdit* m_pathEdit = nullptr;
     QPushButton* m_upButton = nullptr;
     QPushButton* m_goButton = nullptr;

--- a/src/qt/RemoteFileDialog.hpp
+++ b/src/qt/RemoteFileDialog.hpp
@@ -1,0 +1,76 @@
+#pragma once
+
+#include <amrexplorer/core/StopToken.hpp>
+#include <amrexplorer/remote/Protocol.hpp>
+
+#include <QDialog>
+#include <QFutureWatcher>
+#include <QString>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+class QDialogButtonBox;
+class QLabel;
+class QLineEdit;
+class QPushButton;
+class QTreeWidget;
+class QTreeWidgetItem;
+
+namespace amrvis::remote {
+class Connection;
+}
+
+namespace amrvis::qt {
+
+// Browses the directories the remote server can see and picks plotfiles
+// there, over the window's live connection: each listing is one
+// Connection::listDirectory call on a worker thread, applied on the GUI
+// thread when it lands. Only directories are shown; the ones the server
+// recognizes as plotfiles are marked and are the only selectable entries.
+// The path box accepts anything a typed dataset path accepts ("~/run",
+// "run", "/scratch/run"); the server resolves it. Selection order is not
+// tracked: a sequence plays in the listing's name order, which is what
+// plotfile numbering means.
+class RemoteFileDialog final : public QDialog {
+public:
+    enum class SelectionMode { SinglePlotfile, PlotfileSequence };
+
+    // `initialPath` empty means the server's home.
+    RemoteFileDialog(std::shared_ptr<remote::Connection> connection,
+        QString initialPath, SelectionMode mode, QWidget* parent = nullptr);
+    ~RemoteFileDialog() override;
+
+    // Server-side paths of the selected plotfiles, in listing order.
+    [[nodiscard]] std::vector<std::string> selectedPaths() const;
+    // The directory shown when the dialog closed; empty before the first
+    // listing lands.
+    [[nodiscard]] QString currentDirectory() const;
+
+private:
+    struct BrowseResult {
+        remote::RemoteDirectoryListing listing;
+        QString error;
+    };
+
+    void loadDirectory(const QString& path);
+    void finishLoad();
+    void updateOpenButton();
+    void activateItem(QTreeWidgetItem* item);
+
+    std::shared_ptr<remote::Connection> m_connection;
+    SelectionMode m_mode = SelectionMode::SinglePlotfile;
+    QString m_currentDirectory;
+    QString m_parentDirectory;
+    QLineEdit* m_pathEdit = nullptr;
+    QPushButton* m_upButton = nullptr;
+    QPushButton* m_goButton = nullptr;
+    QTreeWidget* m_entries = nullptr;
+    QLabel* m_status = nullptr;
+    QDialogButtonBox* m_buttons = nullptr;
+    QFutureWatcher<BrowseResult>* m_watcher = nullptr;
+    StopSource m_browseStop;
+};
+
+} // namespace amrvis::qt

--- a/src/qt/RemoteFileDialog.hpp
+++ b/src/qt/RemoteFileDialog.hpp
@@ -50,7 +50,6 @@ public:
 
 private:
     struct BrowseResult {
-        QString requestedPath;
         remote::RemoteDirectoryListing listing;
         QString error;
     };
@@ -64,7 +63,12 @@ private:
     SelectionMode m_mode = SelectionMode::SinglePlotfile;
     QString m_currentDirectory;
     QString m_parentDirectory;
-    // Why the first listing fell back to the home directory, prepended to
+    // The path the listing in flight was asked for, as typed or clicked.
+    QString m_requestedPath;
+    // True until the listing of the caller's initial path has been answered;
+    // only that one falls back to the home directory when it fails.
+    bool m_initialLoad = true;
+    // Why the initial listing fell back to the home directory, prepended to
     // the status once that listing lands.
     QString m_fallbackNotice;
     QLineEdit* m_pathEdit = nullptr;

--- a/src/remote/Codec.cpp
+++ b/src/remote/Codec.cpp
@@ -9,6 +9,7 @@
 #include <array>
 #include <cmath>
 #include <limits>
+#include <memory>
 #include <stdexcept>
 #include <utility>
 
@@ -44,6 +45,8 @@ AMREXPLORER_ASSERT_PAYLOAD_VALUE(CancelAcknowledged, CancelAcknowledged);
 AMREXPLORER_ASSERT_PAYLOAD_VALUE(PingRequest, PingRequest);
 AMREXPLORER_ASSERT_PAYLOAD_VALUE(PongResponse, PongResponse);
 AMREXPLORER_ASSERT_PAYLOAD_VALUE(ErrorResponse, ErrorResponse);
+AMREXPLORER_ASSERT_PAYLOAD_VALUE(ListDirectoryRequest, ListDirectoryRequest);
+AMREXPLORER_ASSERT_PAYLOAD_VALUE(DirectoryListing, DirectoryListing);
 
 #undef AMREXPLORER_ASSERT_PAYLOAD_VALUE
 
@@ -189,7 +192,7 @@ ErrorCode fromWireError(fb::ErrorCode value)
 PayloadKind payloadKind(fb::Payload value)
 {
     const auto raw = static_cast<std::uint8_t>(value);
-    if (raw > static_cast<std::uint8_t>(PayloadKind::ErrorResponse)) {
+    if (raw > static_cast<std::uint8_t>(PayloadKind::DirectoryListing)) {
         throw std::invalid_argument("unknown wire payload kind");
     }
     return static_cast<PayloadKind>(raw);
@@ -551,6 +554,52 @@ HelloResponseData fromWire(const fb::HelloResponseT& value)
     result.workerCount = value.worker_count;
     result.capabilities = value.capabilities;
     return result;
+}
+
+fb::ListDirectoryRequestT toWireDirectoryRequest(const std::string& path)
+{
+    fb::ListDirectoryRequestT wire;
+    wire.path = path;
+    return wire;
+}
+
+fb::DirectoryListingT toWire(const RemoteDirectoryListing& value)
+{
+    fb::DirectoryListingT wire;
+    wire.path = value.path;
+    wire.parent_path = value.parentPath;
+    wire.truncated = value.truncated;
+    wire.entries.reserve(value.entries.size());
+    for (const auto& entry : value.entries) {
+        auto converted = std::make_unique<fb::DirectoryEntryT>();
+        converted->name = entry.name;
+        converted->path = entry.path;
+        converted->is_plotfile = entry.isPlotfile;
+        wire.entries.push_back(std::move(converted));
+    }
+    return wire;
+}
+
+RemoteDirectoryListing fromWire(const fb::DirectoryListingT& value)
+{
+    RemoteDirectoryListing listing;
+    listing.path = value.path;
+    listing.parentPath = value.parent_path;
+    listing.truncated = value.truncated;
+    listing.entries.reserve(value.entries.size());
+    for (const auto& entry : value.entries) {
+        // A backslash is a legal filename character on the Linux servers this
+        // client browses; only genuinely impossible names are rejected.
+        if (entry == nullptr || entry->name.empty() || entry->name == "."
+            || entry->name == ".." || entry->name.find('/') != std::string::npos
+            || entry->path.empty()) {
+            throw std::invalid_argument(
+                "directory listing contains an invalid entry");
+        }
+        listing.entries.push_back(
+            {entry->name, entry->path, entry->is_plotfile});
+    }
+    return listing;
 }
 
 fb::OpenDatasetRequestT toWire(const OpenDatasetData& value)

--- a/src/remote/Codec.cpp
+++ b/src/remote/Codec.cpp
@@ -582,6 +582,12 @@ fb::DirectoryListingT toWire(const RemoteDirectoryListing& value)
 
 RemoteDirectoryListing fromWire(const fb::DirectoryListingT& value)
 {
+    if (value.entries.size() > maximumDirectoryEntries) {
+        throw std::invalid_argument("directory listing exceeds the entry cap");
+    }
+    if (value.path.empty() || value.parent_path.empty()) {
+        throw std::invalid_argument("directory listing names no directory");
+    }
     RemoteDirectoryListing listing;
     listing.path = value.path;
     listing.parentPath = value.parent_path;

--- a/src/remote/Codec.cpp
+++ b/src/remote/Codec.cpp
@@ -560,7 +560,8 @@ HelloResponseData fromWire(const fb::HelloResponseT& value)
 bool isValidDirectoryEntryName(std::string_view name) noexcept
 {
     return !name.empty() && name != "." && name != ".."
-        && name.find('/') == std::string_view::npos;
+        && name.find('/') == std::string_view::npos
+        && name.find(char{}) == std::string_view::npos;
 }
 
 fb::ListDirectoryRequestT toWireDirectoryRequest(const std::string& path)

--- a/src/remote/Codec.cpp
+++ b/src/remote/Codec.cpp
@@ -11,6 +11,7 @@
 #include <limits>
 #include <memory>
 #include <stdexcept>
+#include <string_view>
 #include <utility>
 
 namespace amrvis::remote::codec {
@@ -556,6 +557,12 @@ HelloResponseData fromWire(const fb::HelloResponseT& value)
     return result;
 }
 
+bool isValidDirectoryEntryName(std::string_view name) noexcept
+{
+    return !name.empty() && name != "." && name != ".."
+        && name.find('/') == std::string_view::npos;
+}
+
 fb::ListDirectoryRequestT toWireDirectoryRequest(const std::string& path)
 {
     fb::ListDirectoryRequestT wire;
@@ -594,10 +601,7 @@ RemoteDirectoryListing fromWire(const fb::DirectoryListingT& value)
     listing.truncated = value.truncated;
     listing.entries.reserve(value.entries.size());
     for (const auto& entry : value.entries) {
-        // A backslash is a legal filename character on the Linux servers this
-        // client browses; only genuinely impossible names are rejected.
-        if (entry == nullptr || entry->name.empty() || entry->name == "."
-            || entry->name == ".." || entry->name.find('/') != std::string::npos
+        if (entry == nullptr || !isValidDirectoryEntryName(entry->name)
             || entry->path.empty()) {
             throw std::invalid_argument(
                 "directory listing contains an invalid entry");

--- a/src/remote/Codec.hpp
+++ b/src/remote/Codec.hpp
@@ -9,6 +9,8 @@
 #include <cstdint>
 #include <memory>
 #include <span>
+#include <string>
+#include <string_view>
 #include <vector>
 
 namespace amrvis::remote::codec {
@@ -61,7 +63,7 @@ Bytes encode(std::uint64_t requestId, Payload payload,
 [[nodiscard]] OpenDatasetData fromWire(
     const fb::OpenDatasetRequestT& value);
 // A directory entry name a listing may carry: one path component, so
-// non-empty, not "." or "..", and without '/'. A backslash is a legal
+// non-empty, not "." or "..", and without '/' or NUL. A backslash is a legal
 // filename character on the Linux servers the client browses, so it passes.
 // Shared with the fuzz harness, which mirrors the check.
 [[nodiscard]] bool isValidDirectoryEntryName(std::string_view name) noexcept;

--- a/src/remote/Codec.hpp
+++ b/src/remote/Codec.hpp
@@ -60,6 +60,11 @@ Bytes encode(std::uint64_t requestId, Payload payload,
 [[nodiscard]] fb::OpenDatasetRequestT toWire(const OpenDatasetData& value);
 [[nodiscard]] OpenDatasetData fromWire(
     const fb::OpenDatasetRequestT& value);
+// A directory entry name a listing may carry: one path component, so
+// non-empty, not "." or "..", and without '/'. A backslash is a legal
+// filename character on the Linux servers the client browses, so it passes.
+// Shared with the fuzz harness, which mirrors the check.
+[[nodiscard]] bool isValidDirectoryEntryName(std::string_view name) noexcept;
 [[nodiscard]] fb::ListDirectoryRequestT toWireDirectoryRequest(
     const std::string& path);
 [[nodiscard]] fb::DirectoryListingT toWire(

--- a/src/remote/Codec.hpp
+++ b/src/remote/Codec.hpp
@@ -60,6 +60,12 @@ Bytes encode(std::uint64_t requestId, Payload payload,
 [[nodiscard]] fb::OpenDatasetRequestT toWire(const OpenDatasetData& value);
 [[nodiscard]] OpenDatasetData fromWire(
     const fb::OpenDatasetRequestT& value);
+[[nodiscard]] fb::ListDirectoryRequestT toWireDirectoryRequest(
+    const std::string& path);
+[[nodiscard]] fb::DirectoryListingT toWire(
+    const RemoteDirectoryListing& value);
+[[nodiscard]] RemoteDirectoryListing fromWire(
+    const fb::DirectoryListingT& value);
 [[nodiscard]] fb::DatasetOpenedT toWire(const OpenedDataset& value);
 [[nodiscard]] OpenedDataset fromWire(const fb::DatasetOpenedT& value);
 

--- a/src/remote/Connection.cpp
+++ b/src/remote/Connection.cpp
@@ -249,6 +249,28 @@ public:
         return opened;
     }
 
+    RemoteDirectoryListing listDirectory(
+        const std::string& path, StopToken cancellation)
+    {
+        if (m_selectedMinorVersion < 1) {
+            throw std::runtime_error(
+                "the remote server predates directory browsing (protocol "
+                "1.1); install a current amrexplorer-server or enter the "
+                "path directly");
+        }
+        // Indefinite: a large directory on a slow filesystem can take longer
+        // than the request timeout; the caller's token still cancels it.
+        const auto response = transact(codec::toWireDirectoryRequest(path),
+            PayloadKind::DirectoryListing, cancellation,
+            ResponseWait::Indefinite);
+        const auto* payload = response->payload.AsDirectoryListing();
+        if (payload == nullptr) {
+            throw std::runtime_error(
+                "server omitted directory-listing payload");
+        }
+        return codec::fromWire(*payload);
+    }
+
     void closeDataset(DatasetId dataset, StopToken cancellation)
     {
         codec::fb::CloseDatasetRequestT request;
@@ -694,6 +716,12 @@ OpenedDataset Connection::openDataset(const std::string& path,
     std::uint64_t cacheBudgetBytes, StopToken cancellation)
 {
     return m_impl->openDataset(path, cacheBudgetBytes, cancellation);
+}
+
+RemoteDirectoryListing Connection::listDirectory(
+    const std::string& path, StopToken cancellation)
+{
+    return m_impl->listDirectory(path, cancellation);
 }
 
 void Connection::closeDataset(DatasetId dataset, StopToken cancellation)

--- a/src/remote/Server.cpp
+++ b/src/remote/Server.cpp
@@ -259,7 +259,6 @@ RemoteDirectoryListing listServerDirectory(
     // scanning, so memory and work are bounded by the cap rather than by the
     // directory, and the scan stays cancellable at every entry.
     std::vector<std::string> names;
-    names.reserve(maximumDirectoryEntries + 1);
     for (std::filesystem::directory_iterator entries(path,
              std::filesystem::directory_options::skip_permission_denied,
              error),

--- a/src/remote/Server.cpp
+++ b/src/remote/Server.cpp
@@ -231,10 +231,9 @@ bool isPlotfileDirectory(const std::filesystem::path& directory)
 // are not navigable and plotfiles are directories), sorted by name, the
 // first maximumDirectoryEntries of them with the truncated flag set when
 // more exist. Path resolution is the dataset-open one, so what a user
-// browses to is what a typed path opens. The scan itself collects only
-// names; the per-entry plotfile stats are spent on the entries actually
-// returned. Entries that cannot be stat'ed are skipped rather than failing
-// the whole listing.
+// browses to is what a typed path opens. The scan keeps only the names it
+// will return; the per-entry plotfile stats are spent on those. Entries that
+// cannot be stat'ed are skipped rather than failing the whole listing.
 RemoteDirectoryListing listServerDirectory(
     const std::string& requestedPath, StopToken cancellation)
 {
@@ -256,7 +255,11 @@ RemoteDirectoryListing listServerDirectory(
     listing.path = path.string();
     listing.parentPath = path.has_parent_path() ? path.parent_path().string()
                                                 : listing.path;
-    std::vector<std::filesystem::path> subdirectories;
+    // The smallest maximumDirectoryEntries names, kept as a max-heap while
+    // scanning, so memory and work are bounded by the cap rather than by the
+    // directory, and the scan stays cancellable at every entry.
+    std::vector<std::string> names;
+    names.reserve(maximumDirectoryEntries + 1);
     for (std::filesystem::directory_iterator entries(path,
              std::filesystem::directory_options::skip_permission_denied,
              error),
@@ -266,29 +269,35 @@ RemoteDirectoryListing listServerDirectory(
             throw ReadCancelled();
         }
         std::error_code entryError;
-        if (entries->is_directory(entryError) && !entryError) {
-            subdirectories.push_back(entries->path());
+        if (!entries->is_directory(entryError) || entryError) {
+            continue;
         }
+        auto name = entries->path().filename().string();
+        if (names.size() == maximumDirectoryEntries) {
+            listing.truncated = true;
+            if (!(name < names.front())) {
+                continue;
+            }
+            std::pop_heap(names.begin(), names.end());
+            names.pop_back();
+        }
+        names.push_back(std::move(name));
+        std::push_heap(names.begin(), names.end());
     }
     if (error) {
         throw std::runtime_error(
             "could not read " + listing.path + ": " + error.message());
     }
-    std::sort(subdirectories.begin(), subdirectories.end(),
-        [](const auto& left, const auto& right) {
-            return left.filename().native() < right.filename().native();
-        });
-    if (subdirectories.size() > maximumDirectoryEntries) {
-        subdirectories.resize(maximumDirectoryEntries);
-        listing.truncated = true;
-    }
-    listing.entries.reserve(subdirectories.size());
-    for (const auto& subdirectory : subdirectories) {
+    std::sort_heap(names.begin(), names.end());
+    listing.entries.reserve(names.size());
+    for (auto& name : names) {
         if (cancellation.stop_requested()) {
             throw ReadCancelled();
         }
-        listing.entries.push_back({subdirectory.filename().string(),
-            subdirectory.string(), isPlotfileDirectory(subdirectory)});
+        auto subdirectory = path / name;
+        const bool plotfile = isPlotfileDirectory(subdirectory);
+        listing.entries.push_back(
+            {std::move(name), subdirectory.string(), plotfile});
     }
     return listing;
 }

--- a/src/remote/Server.cpp
+++ b/src/remote/Server.cpp
@@ -214,9 +214,12 @@ std::string resolveDatasetPath(const std::string& path)
 #endif
 }
 
-// An AMReX plotfile is a directory holding a Header file and per-level
-// subdirectories; Level_0 always exists. Two stats, no directory scan, so a
-// listing of thousands of entries stays cheap on a networked filesystem.
+// An AMReX plotfile is a directory holding a Header file and one Level_<n>
+// subdirectory per level; levels run from 0, so Level_0 is always present.
+// This is the Qt-side isAmrexPlotfile rule (Header plus a Level_* directory)
+// answered with two stats instead of a directory scan per entry, which is
+// what keeps a listing of thousands of entries cheap on a networked
+// filesystem.
 bool isPlotfileDirectory(const std::filesystem::path& directory)
 {
     std::error_code error;
@@ -225,15 +228,16 @@ bool isPlotfileDirectory(const std::filesystem::path& directory)
 }
 
 // The directory listing a browsing client sees: subdirectories only (files
-// are not navigable and plotfiles are directories), sorted by name, cut at
-// maximumDirectoryEntries with the truncated flag set. Path resolution is
-// the dataset-open one, so what a user browses to is what a typed path
-// opens. Entries that cannot be stat'ed are skipped rather than failing the
-// whole listing.
+// are not navigable and plotfiles are directories), sorted by name, the
+// first maximumDirectoryEntries of them with the truncated flag set when
+// more exist. Path resolution is the dataset-open one, so what a user
+// browses to is what a typed path opens. The scan itself collects only
+// names; the per-entry plotfile stats are spent on the entries actually
+// returned. Entries that cannot be stat'ed are skipped rather than failing
+// the whole listing.
 RemoteDirectoryListing listServerDirectory(
     const std::string& requestedPath, StopToken cancellation)
 {
-    constexpr std::size_t maximumDirectoryEntries = 4096;
     std::error_code error;
     auto path = std::filesystem::path(
         resolveDatasetPath(requestedPath.empty() ? "~" : requestedPath))
@@ -252,6 +256,7 @@ RemoteDirectoryListing listServerDirectory(
     listing.path = path.string();
     listing.parentPath = path.has_parent_path() ? path.parent_path().string()
                                                 : listing.path;
+    std::vector<std::filesystem::path> subdirectories;
     for (std::filesystem::directory_iterator entries(path,
              std::filesystem::directory_options::skip_permission_denied,
              error),
@@ -261,24 +266,30 @@ RemoteDirectoryListing listServerDirectory(
             throw ReadCancelled();
         }
         std::error_code entryError;
-        if (!entries->is_directory(entryError) || entryError) {
-            continue;
+        if (entries->is_directory(entryError) && !entryError) {
+            subdirectories.push_back(entries->path());
         }
-        if (listing.entries.size() >= maximumDirectoryEntries) {
-            listing.truncated = true;
-            break;
-        }
-        listing.entries.push_back({entries->path().filename().string(),
-            entries->path().string(), isPlotfileDirectory(entries->path())});
     }
     if (error) {
         throw std::runtime_error(
             "could not read " + listing.path + ": " + error.message());
     }
-    std::sort(listing.entries.begin(), listing.entries.end(),
+    std::sort(subdirectories.begin(), subdirectories.end(),
         [](const auto& left, const auto& right) {
-            return left.name < right.name;
+            return left.filename().native() < right.filename().native();
         });
+    if (subdirectories.size() > maximumDirectoryEntries) {
+        subdirectories.resize(maximumDirectoryEntries);
+        listing.truncated = true;
+    }
+    listing.entries.reserve(subdirectories.size());
+    for (const auto& subdirectory : subdirectories) {
+        if (cancellation.stop_requested()) {
+            throw ReadCancelled();
+        }
+        listing.entries.push_back({subdirectory.filename().string(),
+            subdirectory.string(), isPlotfileDirectory(subdirectory)});
+    }
     return listing;
 }
 

--- a/src/remote/Server.cpp
+++ b/src/remote/Server.cpp
@@ -26,6 +26,7 @@
 #include <stdexcept>
 #include <string>
 #include <string_view>
+#include <system_error>
 #include <thread>
 #include <unordered_map>
 #include <utility>
@@ -211,6 +212,74 @@ std::string resolveDatasetPath(const std::string& path)
     }
     return path;
 #endif
+}
+
+// An AMReX plotfile is a directory holding a Header file and per-level
+// subdirectories; Level_0 always exists. Two stats, no directory scan, so a
+// listing of thousands of entries stays cheap on a networked filesystem.
+bool isPlotfileDirectory(const std::filesystem::path& directory)
+{
+    std::error_code error;
+    return std::filesystem::is_regular_file(directory / "Header", error)
+        && std::filesystem::is_directory(directory / "Level_0", error);
+}
+
+// The directory listing a browsing client sees: subdirectories only (files
+// are not navigable and plotfiles are directories), sorted by name, cut at
+// maximumDirectoryEntries with the truncated flag set. Path resolution is
+// the dataset-open one, so what a user browses to is what a typed path
+// opens. Entries that cannot be stat'ed are skipped rather than failing the
+// whole listing.
+RemoteDirectoryListing listServerDirectory(
+    const std::string& requestedPath, StopToken cancellation)
+{
+    constexpr std::size_t maximumDirectoryEntries = 4096;
+    std::error_code error;
+    auto path = std::filesystem::path(
+        resolveDatasetPath(requestedPath.empty() ? "~" : requestedPath))
+                    .lexically_normal();
+    if (!path.has_filename() && path.has_parent_path()
+        && path.parent_path() != path) {
+        // "dir/" normalizes with a trailing separator; drop it so
+        // parent_path() is the parent rather than the directory itself.
+        path = path.parent_path();
+    }
+    if (!std::filesystem::is_directory(path, error) || error) {
+        throw std::invalid_argument(
+            "not a readable directory: " + path.string());
+    }
+    RemoteDirectoryListing listing;
+    listing.path = path.string();
+    listing.parentPath = path.has_parent_path() ? path.parent_path().string()
+                                                : listing.path;
+    for (std::filesystem::directory_iterator entries(path,
+             std::filesystem::directory_options::skip_permission_denied,
+             error),
+         end;
+         !error && entries != end; entries.increment(error)) {
+        if (cancellation.stop_requested()) {
+            throw ReadCancelled();
+        }
+        std::error_code entryError;
+        if (!entries->is_directory(entryError) || entryError) {
+            continue;
+        }
+        if (listing.entries.size() >= maximumDirectoryEntries) {
+            listing.truncated = true;
+            break;
+        }
+        listing.entries.push_back({entries->path().filename().string(),
+            entries->path().string(), isPlotfileDirectory(entries->path())});
+    }
+    if (error) {
+        throw std::runtime_error(
+            "could not read " + listing.path + ": " + error.message());
+    }
+    std::sort(listing.entries.begin(), listing.entries.end(),
+        [](const auto& left, const auto& right) {
+            return left.name < right.name;
+        });
+    return listing;
 }
 
 ErrorData classifyError(const std::exception& error)
@@ -483,6 +552,9 @@ private:
                 break;
             case PayloadKind::SetCacheBudgetRequest:
                 setCacheBudget(*envelope);
+                break;
+            case PayloadKind::ListDirectoryRequest:
+                listDirectory(*envelope, cancellation);
                 break;
             default:
                 throw std::invalid_argument(
@@ -805,6 +877,22 @@ private:
         const auto dataset = requireDataset(DatasetId{request->dataset_id});
         dataset->clearUnpinnedCache();
         sendCache(envelope.request_id, *dataset);
+    }
+
+    void listDirectory(
+        const codec::NativeEnvelope& envelope, StopToken cancellation)
+    {
+        const auto* request = envelope.payload.AsListDirectoryRequest();
+        if (request == nullptr
+            || request->path.find(char{}) != std::string::npos) {
+            throw std::invalid_argument("directory path is invalid");
+        }
+        if (m_selectedMinorVersion < 1) {
+            throw RemoteError(ErrorCode::UnsupportedProtocol,
+                "directory browsing requires protocol 1.1");
+        }
+        send(envelope.request_id,
+            codec::toWire(listServerDirectory(request->path, cancellation)));
     }
 
     void setCacheBudget(const codec::NativeEnvelope& envelope)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -484,6 +484,22 @@ if(TARGET amrexplorer_qt)
         PRIVATE amrexplorer::warnings)
     add_test(NAME ssh_connect_arguments COMMAND test_ssh_connect_arguments)
 
+    # The remote browser against a loopback Server: listing, navigation, an
+    # unreadable path, and both selection modes. Offscreen; no display needed.
+    add_executable(test_remote_file_dialog
+        unit/test_remote_file_dialog.cpp
+        "${PROJECT_SOURCE_DIR}/src/qt/RemoteFileDialog.cpp"
+        "${PROJECT_SOURCE_DIR}/src/qt/RemoteFileDialog.hpp")
+    target_include_directories(test_remote_file_dialog
+        PRIVATE "${PROJECT_SOURCE_DIR}/src/qt")
+    target_link_libraries(test_remote_file_dialog
+        PRIVATE amrexplorer::remote amrexplorer::warnings
+            Qt6::Widgets Qt6::Concurrent)
+    add_test(NAME remote_file_dialog
+        COMMAND "${CMAKE_COMMAND}" -E env QT_QPA_PLATFORM=offscreen
+            "$<TARGET_FILE:test_remote_file_dialog>")
+    set_tests_properties(remote_file_dialog PROPERTIES TIMEOUT 60)
+
     # The argument builders and the ready-line parser, then -- where the
     # transport exists -- the whole client flow against the real server binary
     # run by a stand-in ssh script: socket pair, preamble, handshake, ready

--- a/tests/fuzz/fuzz_wire_codec.cpp
+++ b/tests/fuzz/fuzz_wire_codec.cpp
@@ -194,6 +194,11 @@ void checkConverted(const fb::DirectoryListingT& wire,
             || entry.isPlotfile != wireEntry.is_plotfile) {
             fail("DirectoryListing converter did not carry an entry over");
         }
+        // The converter's own predicate: an accepted entry is one path
+        // component with a path, so its removal from fromWire shows here.
+        if (!codec::isValidDirectoryEntryName(entry.name) || entry.path.empty()) {
+            fail("DirectoryListing converter accepted an invalid entry");
+        }
     }
 }
 
@@ -624,6 +629,22 @@ std::vector<std::vector<std::uint8_t>> wireSeeds()
         error.code = fb::ErrorCode::InvalidRequest;
         error.message = "boom";
         add(std::move(error));
+    }
+    {
+        fb::DirectoryListingT listing;
+        listing.path = "/scratch/run";
+        listing.parent_path = "/scratch";
+        listing.truncated = false;
+        auto plotfile = std::make_unique<fb::DirectoryEntryT>();
+        plotfile->name = "plt00010";
+        plotfile->path = "/scratch/run/plt00010";
+        plotfile->is_plotfile = true;
+        listing.entries.push_back(std::move(plotfile));
+        auto directory = std::make_unique<fb::DirectoryEntryT>();
+        directory->name = "inputs";
+        directory->path = "/scratch/run/inputs";
+        listing.entries.push_back(std::move(directory));
+        add(std::move(listing));
     }
     return seeds;
 }

--- a/tests/fuzz/fuzz_wire_codec.cpp
+++ b/tests/fuzz/fuzz_wire_codec.cpp
@@ -181,14 +181,18 @@ void checkConverted(
 void checkConverted(const fb::DirectoryListingT& wire,
     const amrvis::remote::RemoteDirectoryListing& result)
 {
-    if (result.entries.size() != wire.entries.size()) {
-        fail("DirectoryListing converter changed the entry count");
+    if (result.path != wire.path || result.parentPath != wire.parent_path
+        || result.truncated != wire.truncated
+        || result.entries.size() != wire.entries.size()
+        || result.entries.size() > amrvis::remote::maximumDirectoryEntries) {
+        fail("DirectoryListing converter did not carry the listing over");
     }
-    for (const auto& entry : result.entries) {
-        if (entry.name.empty() || entry.name == "." || entry.name == ".."
-            || entry.name.find('/') != std::string::npos
-            || entry.path.empty()) {
-            fail("DirectoryListing converter accepted an invalid entry");
+    for (std::size_t index = 0; index < result.entries.size(); ++index) {
+        const auto& entry = result.entries[index];
+        const auto& wireEntry = *wire.entries[index];
+        if (entry.name != wireEntry.name || entry.path != wireEntry.path
+            || entry.isPlotfile != wireEntry.is_plotfile) {
+            fail("DirectoryListing converter did not carry an entry over");
         }
     }
 }

--- a/tests/fuzz/fuzz_wire_codec.cpp
+++ b/tests/fuzz/fuzz_wire_codec.cpp
@@ -194,9 +194,15 @@ void checkConverted(const fb::DirectoryListingT& wire,
             || entry.isPlotfile != wireEntry.is_plotfile) {
             fail("DirectoryListing converter did not carry an entry over");
         }
-        // The converter's own predicate: an accepted entry is one path
-        // component with a path, so its removal from fromWire shows here.
-        if (!codec::isValidDirectoryEntryName(entry.name) || entry.path.empty()) {
+        // The converter's own predicate, so its removal from fromWire shows
+        // here, and the properties spelled out, so its weakening does too:
+        // one path component -- non-empty, not "." or "..", no '/', no NUL
+        // -- with a non-empty path.
+        if (!codec::isValidDirectoryEntryName(entry.name) || entry.name.empty()
+            || entry.name == "." || entry.name == ".."
+            || entry.name.find('/') != std::string::npos
+            || entry.name.find(char{}) != std::string::npos
+            || entry.path.empty()) {
             fail("DirectoryListing converter accepted an invalid entry");
         }
     }
@@ -634,7 +640,9 @@ std::vector<std::vector<std::uint8_t>> wireSeeds()
         fb::DirectoryListingT listing;
         listing.path = "/scratch/run";
         listing.parent_path = "/scratch";
-        listing.truncated = false;
+        // Non-default, so the flag has a byte in the buffer for the
+        // corruption sweep to reach.
+        listing.truncated = true;
         auto plotfile = std::make_unique<fb::DirectoryEntryT>();
         plotfile->name = "plt00010";
         plotfile->path = "/scratch/run/plt00010";

--- a/tests/fuzz/fuzz_wire_codec.cpp
+++ b/tests/fuzz/fuzz_wire_codec.cpp
@@ -178,6 +178,21 @@ void checkConverted(
     }
 }
 
+void checkConverted(const fb::DirectoryListingT& wire,
+    const amrvis::remote::RemoteDirectoryListing& result)
+{
+    if (result.entries.size() != wire.entries.size()) {
+        fail("DirectoryListing converter changed the entry count");
+    }
+    for (const auto& entry : result.entries) {
+        if (entry.name.empty() || entry.name == "." || entry.name == ".."
+            || entry.name.find('/') != std::string::npos
+            || entry.path.empty()) {
+            fail("DirectoryListing converter accepted an invalid entry");
+        }
+    }
+}
+
 void checkConverted(
     const fb::DatasetPageRequestT& wire, const amrvis::DatasetPageRequest& result)
 {
@@ -341,7 +356,11 @@ void exerciseFromWire(const codec::NativeEnvelope& envelope)
     case fb::Payload::ErrorResponse:
         convert(envelope.payload.AsErrorResponse());
         break;
+    case fb::Payload::DirectoryListing:
+        convert(envelope.payload.AsDirectoryListing());
+        break;
     case fb::Payload::NONE:
+    case fb::Payload::ListDirectoryRequest:
     case fb::Payload::CloseDatasetRequest:
     case fb::Payload::DatasetClosed:
     case fb::Payload::ClearCacheRequest:

--- a/tests/integration/test_remote_stdio.cpp
+++ b/tests/integration/test_remote_stdio.cpp
@@ -10,6 +10,7 @@
 #include <amrexplorer/remote/Frame.hpp>
 #include <amrexplorer/remote/Server.hpp>
 
+#include <algorithm>
 #include <cerrno>
 #include <chrono>
 #include <csignal>
@@ -146,6 +147,44 @@ void exerciseDataset(amrvis::remote::Connection& connection,
                 && what.find("/~nobody-such-user") == std::string::npos,
             ("server rewrote a ~user path: " + what).c_str());
     }
+    // Directory browsing resolves paths the same way: "" and "~/" are home,
+    // where the fixture plotfile is one entry, flagged as a plotfile; the
+    // plotfile's own listing shows Level_0 as a plain directory.
+    const auto home = std::filesystem::path(datasetPath).parent_path();
+    const auto fixtureName
+        = std::filesystem::path(datasetPath).filename().string();
+    const auto atHome = connection.listDirectory("");
+    require(atHome.path == home.string(),
+        "empty browse path did not resolve to the server's home");
+    require(connection.listDirectory("~/").path == atHome.path,
+        "tilde browse path did not resolve to the server's home");
+    const auto fixtureEntry = std::find_if(atHome.entries.begin(),
+        atHome.entries.end(),
+        [&](const auto& entry) { return entry.name == fixtureName; });
+    require(fixtureEntry != atHome.entries.end() && fixtureEntry->isPlotfile
+            && fixtureEntry->path == datasetPath,
+        "home listing did not flag the fixture plotfile");
+    require(std::is_sorted(atHome.entries.begin(), atHome.entries.end(),
+                [](const auto& left, const auto& right) {
+                    return left.name < right.name;
+                }),
+        "directory listing is not sorted by name");
+    const auto inPlotfile = connection.listDirectory(fixtureName);
+    require(inPlotfile.path == datasetPath
+            && inPlotfile.parentPath == home.string(),
+        "relative browse path did not anchor at home");
+    require(std::any_of(inPlotfile.entries.begin(), inPlotfile.entries.end(),
+                [](const auto& entry) {
+                    return entry.name == "Level_0" && !entry.isPlotfile;
+                }),
+        "plotfile listing did not show Level_0 as a plain directory");
+    bool rejectedFile = false;
+    try {
+        static_cast<void>(connection.listDirectory(datasetPath + "/Header"));
+    } catch (const std::exception&) {
+        rejectedFile = true;
+    }
+    require(rejectedFile, "listing a regular file did not fail");
     const auto opened
         = connection.openDataset(datasetPath, 16ULL * 1024ULL * 1024ULL);
     require(opened.catalog.dimension == 2,

--- a/tests/unit/test_remote_codec.cpp
+++ b/tests/unit/test_remote_codec.cpp
@@ -130,6 +130,8 @@ int main()
         PayloadKind::PingRequest,
         PayloadKind::PongResponse,
         PayloadKind::ErrorResponse,
+        PayloadKind::ListDirectoryRequest,
+        PayloadKind::DirectoryListing,
     };
     for (const auto kind : payloadKinds) {
         codec::NativeEnvelope native;
@@ -138,6 +140,36 @@ int main()
         require(codec::inspect(native).payload == kind,
             "payload enum value did not round-trip");
     }
+
+    RemoteDirectoryListing listing{"/scratch/run", "/scratch",
+        {{"plt00010", "/scratch/run/plt00010", true},
+            {"inputs", "/scratch/run/inputs", false}},
+        true};
+    const auto decodedListing = codec::fromWire(codec::toWire(listing));
+    require(decodedListing.path == listing.path
+            && decodedListing.parentPath == listing.parentPath
+            && decodedListing.truncated && decodedListing.entries.size() == 2
+            && decodedListing.entries.front().isPlotfile
+            && !decodedListing.entries.back().isPlotfile
+            && decodedListing.entries.front().path
+                == listing.entries.front().path,
+        "directory listing did not round-trip");
+    // A backslash is a legal filename character on the Linux servers this
+    // client browses; the decode must not reject the whole listing for it.
+    RemoteDirectoryListing backslashListing{"/scratch/run", "/scratch",
+        {{"run\\final", "/scratch/run/run\\final", true}}, false};
+    require(codec::fromWire(codec::toWire(backslashListing)).entries.size()
+            == 1,
+        "backslash directory entry did not round-trip");
+    bool rejectedSlashEntry = false;
+    try {
+        RemoteDirectoryListing bad{"/scratch", "/",
+            {{"a/b", "/scratch/a/b", false}}, false};
+        static_cast<void>(codec::fromWire(codec::toWire(bad)));
+    } catch (const std::invalid_argument&) {
+        rejectedSlashEntry = true;
+    }
+    require(rejectedSlashEntry, "slash in a directory entry name was accepted");
 
     const std::array errorCodes{
         ErrorCode::UnsupportedProtocol,

--- a/tests/unit/test_remote_file_dialog.cpp
+++ b/tests/unit/test_remote_file_dialog.cpp
@@ -299,7 +299,10 @@ int main(int argc, char* argv[])
 #ifndef _WIN32
     // A remembered start directory that no longer exists: the browser says
     // so and shows the server's home instead of an empty tree. (A Windows
-    // server has no home resolution.)
+    // server has no home resolution.) Not covered: that only the initial
+    // listing falls back -- the case that would tell it apart from "no
+    // listing has succeeded yet" needs the home listing to fail as well,
+    // which this in-process server cannot be made to do safely.
     {
         RemoteFileDialog dialog(connection,
             QString::fromStdString((root / "gone").string()),

--- a/tests/unit/test_remote_file_dialog.cpp
+++ b/tests/unit/test_remote_file_dialog.cpp
@@ -190,10 +190,15 @@ int main(int argc, char* argv[])
                 && samePath(selected.front(), root / "plt00000"),
             "browser did not return the selected plotfile");
 
-        // Enter the subdirectory the way a double-click does.
+        // Enter the subdirectory the way a double-click does. While the
+        // listing is in flight the old one is greyed out and Open is off, so
+        // the selection made before navigating cannot be opened.
         emit entries->itemActivated(sub, 0);
+        require(!open->isEnabled() && !entries->isEnabled(),
+            "Open or the listing stayed live during a directory change");
         require(waitForEntry(application, *entries, "plt00002") != nullptr,
             "browser did not enter the subdirectory");
+        require(entries->isEnabled(), "listing stayed greyed out after loading");
         require(samePath(dialog.currentDirectory().toStdString(), root / "sub"),
             "current directory did not follow the navigation");
         require(!open->isEnabled(), "Open survived a directory change");
@@ -205,10 +210,15 @@ int main(int argc, char* argv[])
                 && samePath(dialog.currentDirectory().toStdString(), root),
             "Up did not return to the parent directory");
 
-        // A path that is not a directory: error shown, listing kept.
+        // A path that is not a directory: error shown, listing and selection
+        // kept, Open off while loading and back afterwards.
+        findEntry(*entries, "plt00001")->setSelected(true);
+        application.processEvents();
+        require(open->isEnabled(), "Open stayed disabled with a selection");
         pathEdit->setText(
             QString::fromStdString((root / "plt00000" / "Header").string()));
         goButton->click();
+        require(!open->isEnabled(), "Open stayed enabled during a listing");
         require(waitFor(application,
                     [&] {
                         return status->text().contains(
@@ -218,8 +228,13 @@ int main(int argc, char* argv[])
         require(samePath(dialog.currentDirectory().toStdString(), root)
                 && findEntry(*entries, "plt00001") != nullptr,
             "a failed listing replaced the previous one");
-        require(pathEdit->isEnabled() && goButton->isEnabled(),
+        require(pathEdit->isEnabled() && goButton->isEnabled()
+                && entries->isEnabled(),
             "controls stayed disabled after a failed listing");
+        selected = dialog.selectedPaths();
+        require(open->isEnabled() && selected.size() == 1
+                && samePath(selected.front(), root / "plt00001"),
+            "a failed listing lost the selection or left Open disabled");
     }
 
     // Sequence mode: several plotfiles, returned in name order regardless of

--- a/tests/unit/test_remote_file_dialog.cpp
+++ b/tests/unit/test_remote_file_dialog.cpp
@@ -19,6 +19,7 @@
 #include <QTreeWidget>
 
 #include <algorithm>
+#include <cstdio>
 #include <cstdlib>
 #include <exception>
 #include <filesystem>
@@ -128,17 +129,27 @@ void makeFakePlotfile(const std::filesystem::path& directory)
 
 int main(int argc, char* argv[])
 {
-    QApplication application(argc, argv);
-    using amrvis::qt::RemoteFileDialog;
-    using Mode = RemoteFileDialog::SelectionMode;
-
-    // A scratch tree: two plotfiles and a subdirectory holding a third.
+    // A scratch tree: two plotfiles, a subdirectory holding a third, and a
+    // directory with more subdirectories than one listing carries. It is
+    // also the server's home for the fallback check, set before any thread
+    // exists (setenv is not thread-safe against getenv).
     QTemporaryDir scratch;
     require(scratch.isValid(), "could not create a scratch directory");
     const auto root = std::filesystem::path(scratch.path().toStdString());
+    qputenv("HOME", scratch.path().toUtf8());
     makeFakePlotfile(root / "plt00000");
     makeFakePlotfile(root / "plt00001");
     makeFakePlotfile(root / "sub" / "plt00002");
+    const auto overCap = amrvis::remote::maximumDirectoryEntries + 5;
+    for (std::size_t index = 0; index < overCap; ++index) {
+        char name[16];
+        std::snprintf(name, sizeof(name), "d%05zu", index);
+        std::filesystem::create_directories(root / "many" / name);
+    }
+
+    QApplication application(argc, argv);
+    using amrvis::qt::RemoteFileDialog;
+    using Mode = RemoteFileDialog::SelectionMode;
 
     amrvis::remote::Server server;
     RunningServer running(server);
@@ -147,6 +158,19 @@ int main(int argc, char* argv[])
         amrvis::remote::ConnectionOptions{
             .clientName = "remote file dialog test",
             .sessionToken = server.token()});
+
+    // The listing protocol itself: over the cap, the first entries in name
+    // order are returned and the truncation is flagged.
+    {
+        const auto listing
+            = connection->listDirectory((root / "many").string());
+        require(listing.truncated
+                && listing.entries.size()
+                    == amrvis::remote::maximumDirectoryEntries
+                && listing.entries.front().name == "d00000"
+                && listing.entries.back().name == "d04095",
+            "over-cap listing was not the first entries in name order");
+    }
 
     // Single mode: listing, selection, entering a directory, up, bad path.
     {
@@ -164,6 +188,8 @@ int main(int argc, char* argv[])
             "browser did not create its widgets");
         require(entries->selectionMode() == QAbstractItemView::SingleSelection,
             "single browser allows more than one selection");
+        require(status->textFormat() == Qt::PlainText,
+            "status label would render server text as rich text");
         auto* open = buttons->button(QDialogButtonBox::Open);
         require(open != nullptr && !open->isEnabled(),
             "Open was enabled before anything was selected");
@@ -264,6 +290,28 @@ int main(int argc, char* argv[])
         require(buttons->button(QDialogButtonBox::Open)->isEnabled(),
             "Open stayed disabled with plotfiles selected");
     }
+
+#ifndef _WIN32
+    // A remembered start directory that no longer exists: the browser says
+    // so and shows the server's home instead of an empty tree. (A Windows
+    // server has no home resolution.)
+    {
+        RemoteFileDialog dialog(connection,
+            QString::fromStdString((root / "gone").string()),
+            Mode::SinglePlotfile);
+        auto* entries = dialog.findChild<QTreeWidget*>();
+        auto* status = dialog.findChild<QLabel*>();
+        require(entries != nullptr && status != nullptr,
+            "fallback browser did not create its widgets");
+        require(waitForEntry(application, *entries, "plt00000") != nullptr,
+            "browser did not fall back to the home directory");
+        require(samePath(dialog.currentDirectory().toStdString(), root),
+            "fallback did not land in the home directory");
+        require(status->text().contains(QStringLiteral("gone"))
+                && status->text().contains(QStringLiteral("home directory")),
+            "fallback did not explain itself");
+    }
+#endif
 
     connection->close();
     return 0;

--- a/tests/unit/test_remote_file_dialog.cpp
+++ b/tests/unit/test_remote_file_dialog.cpp
@@ -140,11 +140,16 @@ int main(int argc, char* argv[])
     makeFakePlotfile(root / "plt00000");
     makeFakePlotfile(root / "plt00001");
     makeFakePlotfile(root / "sub" / "plt00002");
-    const auto overCap = amrvis::remote::maximumDirectoryEntries + 5;
-    for (std::size_t index = 0; index < overCap; ++index) {
+    const auto capName = [](std::size_t index) {
         char name[16];
         std::snprintf(name, sizeof(name), "d%05zu", index);
-        std::filesystem::create_directories(root / "many" / name);
+        return std::string(name);
+    };
+    const auto many = root / "many";
+    std::filesystem::create_directory(many);
+    for (std::size_t index = 0;
+         index < amrvis::remote::maximumDirectoryEntries + 5; ++index) {
+        std::filesystem::create_directory(many / capName(index));
     }
 
     QApplication application(argc, argv);
@@ -162,13 +167,13 @@ int main(int argc, char* argv[])
     // The listing protocol itself: over the cap, the first entries in name
     // order are returned and the truncation is flagged.
     {
-        const auto listing
-            = connection->listDirectory((root / "many").string());
+        const auto listing = connection->listDirectory(many.string());
         require(listing.truncated
                 && listing.entries.size()
                     == amrvis::remote::maximumDirectoryEntries
-                && listing.entries.front().name == "d00000"
-                && listing.entries.back().name == "d04095",
+                && listing.entries.front().name == capName(0)
+                && listing.entries.back().name
+                    == capName(amrvis::remote::maximumDirectoryEntries - 1),
             "over-cap listing was not the first entries in name order");
     }
 

--- a/tests/unit/test_remote_file_dialog.cpp
+++ b/tests/unit/test_remote_file_dialog.cpp
@@ -1,0 +1,255 @@
+// The remote browser against a real loopback Server: listing, entering a
+// directory, going up, an unreadable path, and the two selection modes. The
+// dialog never runs its own event loop here; the test pumps events itself.
+
+#include "RemoteFileDialog.hpp"
+
+#include <amrexplorer/remote/Connection.hpp>
+#include <amrexplorer/remote/Server.hpp>
+
+#include <QAbstractItemView>
+#include <QApplication>
+#include <QDialogButtonBox>
+#include <QElapsedTimer>
+#include <QLabel>
+#include <QLineEdit>
+#include <QPushButton>
+#include <QTemporaryDir>
+#include <QThread>
+#include <QTreeWidget>
+
+#include <algorithm>
+#include <cstdlib>
+#include <exception>
+#include <filesystem>
+#include <fstream>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <thread>
+
+namespace {
+
+void require(bool condition, const char* message)
+{
+    if (!condition) {
+        std::cerr << "FAILED: " << message << '\n';
+        std::exit(1);
+    }
+}
+
+class RunningServer {
+public:
+    explicit RunningServer(amrvis::remote::Server& server)
+        : m_server(server)
+        , m_thread([this] {
+            try {
+                m_server.run();
+            } catch (...) {
+                m_failure = std::current_exception();
+            }
+        })
+    {
+    }
+
+    ~RunningServer()
+    {
+        m_server.requestStop();
+        m_thread.join();
+        if (m_failure) {
+            std::terminate();
+        }
+    }
+
+private:
+    amrvis::remote::Server& m_server;
+    std::thread m_thread;
+    std::exception_ptr m_failure;
+};
+
+bool waitFor(QApplication& application, const std::function<bool()>& condition)
+{
+    QElapsedTimer timeout;
+    timeout.start();
+    while (timeout.elapsed() < 5000) {
+        application.processEvents();
+        if (condition()) {
+            return true;
+        }
+        QThread::msleep(10);
+    }
+    application.processEvents();
+    return condition();
+}
+
+QTreeWidgetItem* findEntry(QTreeWidget& entries, const QString& name)
+{
+    for (int index = 0; index < entries.topLevelItemCount(); ++index) {
+        auto* item = entries.topLevelItem(index);
+        if (item->text(0) == name) {
+            return item;
+        }
+    }
+    return nullptr;
+}
+
+QTreeWidgetItem* waitForEntry(
+    QApplication& application, QTreeWidget& entries, const QString& name)
+{
+    QTreeWidgetItem* found = nullptr;
+    static_cast<void>(waitFor(application, [&] {
+        found = findEntry(entries, name);
+        return found != nullptr;
+    }));
+    return found;
+}
+
+QPushButton* buttonNamed(QDialog& dialog, const QString& text)
+{
+    const auto buttons = dialog.findChildren<QPushButton*>();
+    const auto found = std::find_if(buttons.begin(), buttons.end(),
+        [&](QPushButton* button) { return button->text() == text; });
+    return found == buttons.end() ? nullptr : *found;
+}
+
+bool samePath(const std::string& lhs, const std::filesystem::path& rhs)
+{
+    return std::filesystem::path(lhs).lexically_normal()
+        == rhs.lexically_normal();
+}
+
+void makeFakePlotfile(const std::filesystem::path& directory)
+{
+    std::filesystem::create_directories(directory / "Level_0");
+    std::ofstream(directory / "Header") << "fake plotfile header\n";
+}
+
+} // namespace
+
+int main(int argc, char* argv[])
+{
+    QApplication application(argc, argv);
+    using amrvis::qt::RemoteFileDialog;
+    using Mode = RemoteFileDialog::SelectionMode;
+
+    // A scratch tree: two plotfiles and a subdirectory holding a third.
+    QTemporaryDir scratch;
+    require(scratch.isValid(), "could not create a scratch directory");
+    const auto root = std::filesystem::path(scratch.path().toStdString());
+    makeFakePlotfile(root / "plt00000");
+    makeFakePlotfile(root / "plt00001");
+    makeFakePlotfile(root / "sub" / "plt00002");
+
+    amrvis::remote::Server server;
+    RunningServer running(server);
+    auto connection = std::make_shared<amrvis::remote::Connection>(
+        "127.0.0.1", server.port(),
+        amrvis::remote::ConnectionOptions{
+            .clientName = "remote file dialog test",
+            .sessionToken = server.token()});
+
+    // Single mode: listing, selection, entering a directory, up, bad path.
+    {
+        RemoteFileDialog dialog(connection,
+            QString::fromStdString(root.string()), Mode::SinglePlotfile);
+        auto* entries = dialog.findChild<QTreeWidget*>();
+        auto* buttons = dialog.findChild<QDialogButtonBox*>();
+        auto* status = dialog.findChild<QLabel*>();
+        auto* pathEdit = dialog.findChild<QLineEdit*>();
+        auto* upButton = buttonNamed(dialog, QStringLiteral("Up"));
+        auto* goButton = buttonNamed(dialog, QStringLiteral("Go"));
+        require(entries != nullptr && buttons != nullptr && status != nullptr
+                && pathEdit != nullptr && upButton != nullptr
+                && goButton != nullptr,
+            "browser did not create its widgets");
+        require(entries->selectionMode() == QAbstractItemView::SingleSelection,
+            "single browser allows more than one selection");
+        auto* open = buttons->button(QDialogButtonBox::Open);
+        require(open != nullptr && !open->isEnabled(),
+            "Open was enabled before anything was selected");
+
+        auto* first = waitForEntry(application, *entries, "plt00000");
+        require(first != nullptr, "browser did not list the plotfile");
+        require(first->text(1) == QStringLiteral("AMReX plotfile"),
+            "plotfile was not typed as one");
+        auto* sub = findEntry(*entries, "sub");
+        require(sub != nullptr && sub->text(1) == QStringLiteral("Directory"),
+            "plain directory was not listed as one");
+        require(!(sub->flags() & Qt::ItemIsSelectable),
+            "a plain directory was selectable");
+        require(samePath(dialog.currentDirectory().toStdString(), root)
+                && samePath(pathEdit->text().toStdString(), root),
+            "browser did not report the listed directory");
+        require(upButton->isEnabled(), "Up was disabled below the root");
+
+        first->setSelected(true);
+        application.processEvents();
+        require(open->isEnabled(), "Open stayed disabled with a selection");
+        auto selected = dialog.selectedPaths();
+        require(selected.size() == 1
+                && samePath(selected.front(), root / "plt00000"),
+            "browser did not return the selected plotfile");
+
+        // Enter the subdirectory the way a double-click does.
+        emit entries->itemActivated(sub, 0);
+        require(waitForEntry(application, *entries, "plt00002") != nullptr,
+            "browser did not enter the subdirectory");
+        require(samePath(dialog.currentDirectory().toStdString(), root / "sub"),
+            "current directory did not follow the navigation");
+        require(!open->isEnabled(), "Open survived a directory change");
+        require(dialog.selectedPaths().empty(),
+            "a selection survived a directory change");
+
+        upButton->click();
+        require(waitForEntry(application, *entries, "plt00001") != nullptr
+                && samePath(dialog.currentDirectory().toStdString(), root),
+            "Up did not return to the parent directory");
+
+        // A path that is not a directory: error shown, listing kept.
+        pathEdit->setText(
+            QString::fromStdString((root / "plt00000" / "Header").string()));
+        goButton->click();
+        require(waitFor(application,
+                    [&] {
+                        return status->text().contains(
+                            QStringLiteral("Could not list"));
+                    }),
+            "unreadable path did not report an error");
+        require(samePath(dialog.currentDirectory().toStdString(), root)
+                && findEntry(*entries, "plt00001") != nullptr,
+            "a failed listing replaced the previous one");
+        require(pathEdit->isEnabled() && goButton->isEnabled(),
+            "controls stayed disabled after a failed listing");
+    }
+
+    // Sequence mode: several plotfiles, returned in name order regardless of
+    // the order they were selected in.
+    {
+        RemoteFileDialog dialog(connection,
+            QString::fromStdString(root.string()), Mode::PlotfileSequence);
+        auto* entries = dialog.findChild<QTreeWidget*>();
+        auto* buttons = dialog.findChild<QDialogButtonBox*>();
+        require(entries != nullptr && buttons != nullptr,
+            "sequence browser did not create its widgets");
+        require(
+            entries->selectionMode() == QAbstractItemView::ExtendedSelection,
+            "sequence browser does not allow multiple selection");
+        auto* later = waitForEntry(application, *entries, "plt00001");
+        auto* earlier = findEntry(*entries, "plt00000");
+        require(later != nullptr && earlier != nullptr,
+            "sequence browser did not list the plotfiles");
+        later->setSelected(true);
+        earlier->setSelected(true);
+        application.processEvents();
+        const auto selected = dialog.selectedPaths();
+        require(selected.size() == 2
+                && samePath(selected.front(), root / "plt00000")
+                && samePath(selected.back(), root / "plt00001"),
+            "sequence browser did not return the plotfiles in name order");
+        require(buttons->button(QDialogButtonBox::Open)->isEnabled(),
+            "Open stayed disabled with plotfiles selected");
+    }
+
+    connection->close();
+    return 0;
+}


### PR DESCRIPTION
Protocol 1.1 adds ListDirectoryRequest/DirectoryListing: subdirectories of a server-resolved path, plotfiles marked, capped at 4096 entries. The Open Remote dialogs gain Browse..., which starts or reuses the ssh session and opens RemoteFileDialog over it.