### PR TITLE
extract RemoteSessionController from MainWindow

### DIFF
--- a/src/qt/AppSettings.hpp
+++ b/src/qt/AppSettings.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <QSettings>
+#include <QString>
+
+#include <memory>
+
+namespace amrvis::qt {
+
+// The one QSettings store every window and controller of this application
+// reads and writes. Collaborators that persist state take a settings factory
+// through their Hooks rather than calling this directly, so their unit tests
+// can point them at a scratch file.
+inline constexpr auto kSettingsOrganization = "amrex-codes";
+inline constexpr auto kSettingsApplication = "amrexplorer";
+
+inline QSettings makeSettings()
+{
+    return QSettings(QString::fromLatin1(kSettingsOrganization),
+        QString::fromLatin1(kSettingsApplication));
+}
+
+inline std::unique_ptr<QSettings> makeSettingsPtr()
+{
+    return std::make_unique<QSettings>(
+        QString::fromLatin1(kSettingsOrganization),
+        QString::fromLatin1(kSettingsApplication));
+}
+
+} // namespace amrvis::qt

--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -3,6 +3,7 @@ add_executable(amrexplorer_qt
     AnimationExporter.hpp
     AnimationPanel.cpp
     AnimationPanel.hpp
+    AppSettings.hpp
     CacheConfig.hpp
     ColorBarWidget.cpp
     ColorBarWidget.hpp
@@ -39,6 +40,10 @@ add_executable(amrexplorer_qt
     RemoteEndpoint.hpp
     RemoteFileDialog.cpp
     RemoteFileDialog.hpp
+    RemoteOpenDialog.cpp
+    RemoteOpenDialog.hpp
+    RemoteSessionController.cpp
+    RemoteSessionController.hpp
     ScientificDoubleSpinBox.cpp
     ScientificDoubleSpinBox.hpp
     SshConnectArguments.hpp

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -298,6 +298,39 @@ MainWindow::MainWindow(QWidget* parent)
     addDockWidget(Qt::LeftDockWidgetArea, m_metadataDock);
     m_metadataDock->setVisible(false);
 
+    // The remote session: the ssh-launched server, its connection, and the
+    // Open Remote dialogs and browser. It says what to open; this window opens
+    // it over the connection and shows the session's messages.
+    m_remoteSession = new RemoteSessionController(
+        RemoteSessionController::Hooks{
+            [this] { return m_closing; },
+            [this]() -> std::optional<std::string> {
+                if (auto remoteSession = std::dynamic_pointer_cast<
+                        remote::RemoteDatasetSession>(m_dataset)) {
+                    return remoteSession->remotePath();
+                }
+                return std::nullopt;
+            },
+            [] { return makeSettingsPtr(); },
+        },
+        kVersion, this);
+    connect(m_remoteSession, &RemoteSessionController::sessionChanged, this,
+        [this] { updateDiagnostics(); });
+    connect(m_remoteSession, &RemoteSessionController::openRequested, this,
+        [this](const std::vector<std::string>& paths, bool sequence) {
+            if (sequence) {
+                openRemoteSequence(paths);
+            } else {
+                openRemoteDataset(paths.front());
+            }
+        });
+    connect(m_remoteSession, &RemoteSessionController::statusMessage, this,
+        [this](const QString& message, int timeoutMs) {
+            statusBar()->showMessage(message, timeoutMs);
+        });
+    connect(m_remoteSession, &RemoteSessionController::errorReported, this,
+        [this](const QString& message) { reportBackgroundError(message); });
+
     // The Diagnostics panel's counters, metrics and histories live in their
     // model; it renders the dock, and this window supplies the lines only it
     // knows.
@@ -305,7 +338,7 @@ MainWindow::MainWindow(QWidget* parent)
         DiagnosticsModel::Hooks{
             [this] { return m_generation; },
             [this] { return m_sequenceController->lastFrameSwitchMs(); },
-            [this] { return remoteDiagnosticsLines(); },
+            [this] { return m_remoteSession->diagnosticsLines(); },
         },
         this);
     m_diagnosticsDock = m_diagnosticsModel->createDock(this);
@@ -614,144 +647,6 @@ MainWindow::MainWindow(QWidget* parent)
 
 MainWindow::~MainWindow() = default;
 
-void MainWindow::promptRemoteOpen(bool sequence)
-{
-    QDialog dialog(this);
-    dialog.setWindowTitle(sequence ? tr("Open Remote Plotfile Sequence")
-                                   : tr("Open Remote Plotfile"));
-    // Wide enough that a typical scratch-filesystem path is visible whole.
-    dialog.setMinimumWidth(560);
-    auto* layout = new QFormLayout(&dialog);
-    auto* explanation = new QLabel(
-        tr("AMReXplorer runs amrexplorer-server on the destination through "
-           "ssh and talks to it over that connection. Any destination that "
-           "works for the ssh command works here, including aliases from "
-           "~/.ssh/config. An unchanged destination keeps the current "
-           "session. Enter the plotfile path, or use Browse... to pick it "
-           "on the remote machine."),
-        &dialog);
-    explanation->setWordWrap(true);
-    layout->addRow(explanation);
-    // Prefill from the live session so opening another path reuses it; a
-    // fresh window falls back to the last destination used anywhere.
-    const auto sessionDestination = m_sshRemoteSession
-        ? QString::fromStdString(m_sshRemoteSession->destination())
-        : QString();
-    auto* destinationEdit = new QLineEdit(
-        sessionDestination.isEmpty()
-            ? makeSettings()
-                  .value(QStringLiteral("remote/sshDestination"))
-                  .toString()
-            : sessionDestination,
-        &dialog);
-    destinationEdit->setPlaceholderText(tr("user@host or ssh alias"));
-    layout->addRow(tr("SSH destination:"), destinationEdit);
-    auto* executableEdit = new QLineEdit(
-        remoteServerExecutableFor(destinationEdit->text().trimmed()),
-        &dialog);
-    executableEdit->setToolTip(
-        tr("Name on the remote PATH, or a path such as "
-           "~/bin/amrexplorer-server. Remembered per destination."));
-    layout->addRow(tr("Remote amrexplorer-server:"), executableEdit);
-    // The executable follows the destination (each remembers its own) until
-    // the user edits it in this dialog; textEdited fires only on user edits.
-    auto executableEdited = std::make_shared<bool>(false);
-    connect(executableEdit, &QLineEdit::textEdited, &dialog,
-        [executableEdited] { *executableEdited = true; });
-    connect(destinationEdit, &QLineEdit::textChanged, &dialog,
-        [executableEdit, executableEdited](const QString& text) {
-            if (!*executableEdited) {
-                executableEdit->setText(
-                    remoteServerExecutableFor(text.trimmed()));
-            }
-        });
-    QLineEdit* pathEdit = nullptr;
-    QPlainTextEdit* pathsEdit = nullptr;
-    if (sequence) {
-        pathsEdit = new QPlainTextEdit(&dialog);
-        pathsEdit->setPlaceholderText(
-            tr("One plotfile path per line, in playback order"));
-        pathsEdit->setTabChangesFocus(true);
-        layout->addRow(tr("Plotfile paths on the remote machine:"), pathsEdit);
-    } else {
-        pathEdit = new QLineEdit(&dialog);
-        pathEdit->setPlaceholderText(tr("/path/to/plt00010 or ~/run/plt00010"));
-        layout->addRow(tr("Plotfile path on the remote machine:"), pathEdit);
-    }
-    auto* buttons = new QDialogButtonBox(
-        QDialogButtonBox::Ok | QDialogButtonBox::Cancel, &dialog);
-    buttons->button(QDialogButtonBox::Ok)->setText(tr("Open"));
-    // Browse... needs only the connection fields: it starts (or reuses) the
-    // session and picks the path in the remote browser once it is ready.
-    auto* browseButton = buttons->addButton(
-        tr("Browse..."), QDialogButtonBox::ActionRole);
-    browseButton->setToolTip(
-        tr("Connect and choose the plotfile on the remote machine"));
-    bool browse = false;
-    connect(browseButton, &QPushButton::clicked, &dialog, [&] {
-        browse = true;
-        dialog.accept();
-    });
-    connect(buttons, &QDialogButtonBox::accepted, &dialog, &QDialog::accept);
-    connect(buttons, &QDialogButtonBox::rejected, &dialog, &QDialog::reject);
-    layout->addRow(buttons);
-    if (dialog.exec() != QDialog::Accepted) {
-        return;
-    }
-    const auto destination = destinationEdit->text().trimmed();
-    const auto executable = executableEdit->text().trimmed();
-    const bool sessionMatches = hasRemoteConnection() && m_sshRemoteSession
-        && destination.toStdString() == m_sshRemoteSession->destination()
-        && executable.toStdString() == m_sshRemoteSession->serverExecutable();
-    if (browse) {
-        if (destination.isEmpty() || executable.isEmpty()) {
-            QMessageBox::warning(this, dialog.windowTitle(),
-                tr("The SSH destination and the server executable are "
-                   "required."));
-            return;
-        }
-        if (sessionMatches) {
-            browseRemotePlotfiles(sequence);
-        } else {
-            startSshRemoteSession(destination.toStdString(),
-                executable.toStdString(), {},
-                [this, sequence] { browseRemotePlotfiles(sequence); });
-        }
-        return;
-    }
-    std::vector<std::string> paths;
-    if (sequence) {
-        for (const auto& line : pathsEdit->toPlainText().split(
-                 QLatin1Char('\n'), Qt::SkipEmptyParts)) {
-            const auto path = line.trimmed();
-            if (!path.isEmpty()) {
-                paths.push_back(path.toStdString());
-            }
-        }
-    } else if (!pathEdit->text().trimmed().isEmpty()) {
-        paths.push_back(pathEdit->text().trimmed().toStdString());
-    }
-    if (destination.isEmpty() || executable.isEmpty() || paths.empty()) {
-        QMessageBox::warning(this, dialog.windowTitle(),
-            tr("The SSH destination, the server executable, and at least one "
-               "plotfile path are required."));
-        return;
-    }
-    // An unchanged destination and executable mean the current session is the
-    // one asked for; open over it directly instead of starting ssh again.
-    if (sessionMatches) {
-        if (sequence) {
-            openRemoteSequence(paths);
-        } else {
-            openRemoteDataset(paths.front());
-        }
-        return;
-    }
-    startSshRemoteSession(
-        destination.toStdString(), executable.toStdString(),
-        std::move(paths));
-}
-
 void MainWindow::wireView(PlaneViewState& state)
 {
     auto* view = state.view;
@@ -1050,12 +945,12 @@ void MainWindow::createMenus()
     auto* openRemoteAction = new QAction(
         tr("Open Remote &Plotfile..."), this);
     connect(openRemoteAction, &QAction::triggered, this,
-        [this] { promptRemoteOpen(false); });
+        [this] { m_remoteSession->promptOpen(this, false); });
 
     auto* openRemoteSequenceAction = new QAction(
         tr("Open &Remote Plotfile Sequence..."), this);
     connect(openRemoteSequenceAction, &QAction::triggered, this,
-        [this] { promptRemoteOpen(true); });
+        [this] { m_remoteSession->promptOpen(this, true); });
 
     auto* openFabAction = new QAction(tr("Open &FAB..."), this);
     connect(openFabAction, &QAction::triggered, this,

--- a/src/qt/MainWindow.hpp
+++ b/src/qt/MainWindow.hpp
@@ -29,7 +29,6 @@
 #include <atomic>
 #include <cstdint>
 #include <filesystem>
-#include <functional>
 #include <memory>
 #include <optional>
 #include <string>
@@ -80,8 +79,8 @@ class DiagnosticsModel;
 class FabNavigator;
 class PaletteController;
 class ParticleController;
+class RemoteSessionController;
 class SequenceController;
-class SshRemoteSession;
 struct PlaneMapping;
 class UserGuideDialog;
 
@@ -101,30 +100,18 @@ public:
     ~MainWindow() override;
 
     void openDataset(const std::filesystem::path& path, bool metadataOnly = false);
-    // Installs the connection every remote open goes through, with its
-    // handshake already complete: the SSH session's once it is ready, or a
-    // loopback one from a test harness. Replaces any previous connection;
-    // datasets open on that one fail on their next request.
+    // The remote session (ssh-launched server, its connection, the Open
+    // Remote dialogs and browser) lives in RemoteSessionController; these two
+    // forward to it for the command line and the test harnesses. See
+    // RemoteSessionController::install and ::start.
     void useRemoteConnection(
         std::shared_ptr<remote::Connection> connection, QString label);
-    // True while an installed remote connection is live.
-    [[nodiscard]] bool hasRemoteConnection() const;
+    void startSshRemoteSession(std::string destination,
+        std::string serverExecutable, std::vector<std::string> remotePaths);
     // Open a server-visible path, or a sequence of them, over the installed
     // remote connection.
     void openRemoteDataset(std::string remotePath);
     void openRemoteSequence(const std::vector<std::string>& remotePaths);
-    // Runs amrexplorer-server on the named OpenSSH destination with the wire
-    // protocol over ssh's stdio, installs the connection once its handshake
-    // completes, and opens the supplied server-visible paths. An empty path
-    // list only establishes the session. `onReady` runs after the connection
-    // is installed and any paths are opened; the browser uses it.
-    void startSshRemoteSession(std::string destination,
-        std::string serverExecutable, std::vector<std::string> remotePaths,
-        std::function<void()> onReady = {});
-    // Browses the live remote session's filesystem and opens the plotfile
-    // (or plotfiles, when `sequence`) picked there. Starts at the directory
-    // last browsed on this destination, else the server's home.
-    void browseRemotePlotfiles(bool sequence);
     // Opens a plotfile sequence (the legacy "-a" file animation): frames are
     // the plotfile directories, sorted by name; requires at least two valid
     // plotfiles. Opening a single dataset closes the sequence again.
@@ -503,16 +490,6 @@ private:
         std::filesystem::path dataRoot, bool preserveFabSelector,
         std::optional<FrameSliceSpec> initialSpec,
         std::optional<RemoteOpen> remoteOpen = std::nullopt);
-    // One dialog for the Open Remote actions: SSH destination, server
-    // executable, and the path (or paths, when `sequence`). Reuses the live
-    // session when the connection fields are unchanged; otherwise starts a
-    // new one and opens the paths once it is ready.
-    void promptRemoteOpen(bool sequence);
-    // The server executable to use for a destination: the one last used for
-    // it, else "amrexplorer-server".
-    [[nodiscard]] static QString remoteServerExecutableFor(
-        const QString& destination);
-
     // A fresh independent top-level window (WA_DeleteOnClose) for the
     // "Open New Window" menu action; it shares no view/cache state with this one.
     MainWindow* createNewWindow();
@@ -569,7 +546,6 @@ private:
     // Re-renders the Diagnostics panel; the model owns the counters, this
     // window only supplies the lines it alone knows (see the model's Hooks).
     void updateDiagnostics();
-    [[nodiscard]] QString remoteDiagnosticsLines() const;
     // Non-modal failure report: status bar plus the model's error history
     // (which shows the dock); suppressed while closing.
     void reportBackgroundError(const QString& message);
@@ -935,12 +911,12 @@ private:
     // progress indicator; the host draws its samples into the views.
     ParticleController* m_particleController = nullptr;
     std::filesystem::path m_datasetPath;
-    std::shared_ptr<remote::Connection> m_remoteConnection;
-    QString m_remoteLabel;
-    // Counts installed connections. Server DatasetIds restart at one per
-    // connection, so dataset-scoped caches are keyed by this as well.
-    std::uint64_t m_remoteConnectionGeneration = 0;
-    std::unique_ptr<SshRemoteSession> m_sshRemoteSession;
+    // Owns the ssh session and the connection every remote open goes
+    // through, and the Open Remote dialogs and browser; asks this window to
+    // open what the user picked. Server DatasetIds restart at one per
+    // connection, so dataset-scoped caches are keyed by its
+    // connectionGeneration() as well.
+    RemoteSessionController* m_remoteSession = nullptr;
     bool m_remoteSequence = false;
     std::uint64_t m_remoteSequenceConnectionGeneration = 0;
     // Owns the palette selection, its widgets and persistence; palette() is

--- a/src/qt/MainWindowDataset.cpp
+++ b/src/qt/MainWindowDataset.cpp
@@ -610,165 +610,27 @@ void MainWindow::openDataset(
 void MainWindow::useRemoteConnection(
     std::shared_ptr<remote::Connection> connection, QString label)
 {
-    m_remoteConnection = std::move(connection);
-    m_remoteLabel = std::move(label);
-    ++m_remoteConnectionGeneration;
-    updateDiagnostics();
-}
-
-bool MainWindow::hasRemoteConnection() const
-{
-    return m_remoteConnection && m_remoteConnection->connected();
-}
-
-QString MainWindow::remoteServerExecutableFor(const QString& destination)
-{
-    // An explicit executable path is a property of one machine, so nothing
-    // stored for another destination is consulted: a destination without its
-    // own entry gets the name every install puts on the remote PATH. (An
-    // earlier revision fell back to the executable last used anywhere, which
-    // let one machine's path break the destinations that worked by default.)
-    auto settings = makeSettings();
-    const auto forDestination
-        = settings
-              .value(QStringLiteral("remote/serverExecutables/%1")
-                      .arg(destination))
-              .toString()
-              .trimmed();
-    return forDestination.isEmpty() ? QStringLiteral("amrexplorer-server")
-                                    : forDestination;
+    m_remoteSession->install(std::move(connection), std::move(label));
 }
 
 void MainWindow::startSshRemoteSession(std::string destination,
-    std::string serverExecutable, std::vector<std::string> remotePaths,
-    std::function<void()> onReady)
+    std::string serverExecutable, std::vector<std::string> remotePaths)
 {
-    if (destination.empty() || destination.front() == '-'
-        || destination.find_first_of(" \t\r\n") != std::string::npos) {
-        reportBackgroundError(tr("Invalid SSH destination."));
-        return;
-    }
-    const auto destinationText = QString::fromStdString(destination);
-    if (serverExecutable.empty()) {
-        serverExecutable
-            = remoteServerExecutableFor(destinationText).toStdString();
-    }
-    {
-        // Remember this destination and its executable; the CLI teaches the
-        // dialog this way too. Per destination only -- see
-        // remoteServerExecutableFor.
-        auto settings = makeSettings();
-        settings.setValue(
-            QStringLiteral("remote/sshDestination"), destinationText);
-        settings.setValue(QStringLiteral("remote/serverExecutables/%1")
-                              .arg(destinationText),
-            QString::fromStdString(serverExecutable));
-    }
-    // A previous session's connection is closed with it; a dataset still open
-    // on it fails on its next request, and the new server gets fresh opens.
-    m_sshRemoteSession.reset();
-    m_remoteConnection.reset();
-    m_remoteLabel.clear();
-    m_sshRemoteSession = std::make_unique<SshRemoteSession>(this);
-    statusBar()->showMessage(tr("Starting remote session on %1...")
-            .arg(QString::fromStdString(destination)));
-    m_sshRemoteSession->start(destination, std::move(serverExecutable),
-        remote::ConnectionOptions{.clientName = "AMReXplorer Qt",
-            .softwareVersion = kVersion, .sessionToken = {}},
-        [this, destination, paths = std::move(remotePaths),
-            onReady = std::move(onReady)](
-            std::shared_ptr<remote::Connection> connection) {
-            if (m_closing) {
-                return;
-            }
-            const auto& server = connection->serverInfo();
-            useRemoteConnection(std::move(connection),
-                tr("ssh %1").arg(QString::fromStdString(destination)));
-            statusBar()->showMessage(
-                tr("Remote session on %1 is ready (%2 %3, %4 worker threads)")
-                    .arg(QString::fromStdString(destination),
-                        QString::fromStdString(server.serverName),
-                        QString::fromStdString(server.softwareVersion))
-                    .arg(server.workerCount));
-            if (paths.size() == 1) {
-                openRemoteDataset(paths.front());
-            } else if (paths.size() > 1) {
-                openRemoteSequence(paths);
-            }
-            if (onReady) {
-                onReady();
-            }
-        },
-        [this, destination](const QString& message) {
-            if (m_closing) {
-                return;
-            }
-            statusBar()->showMessage(tr("Could not start the remote session"));
-            reportBackgroundError(tr("Could not start the remote session on "
-                                     "%1: %2")
-                    .arg(QString::fromStdString(destination), message));
-            updateDiagnostics();
-        },
-        [this, destination](const QString& message) {
-            if (m_closing) {
-                return;
-            }
-            statusBar()->showMessage(tr("Remote session ended"));
-            reportBackgroundError(tr("The remote session on %1 ended: %2")
-                    .arg(QString::fromStdString(destination), message));
-            updateDiagnostics();
-        });
-    // After start(): the session reports its destination only from then on.
-    updateDiagnostics();
-}
-
-void MainWindow::browseRemotePlotfiles(bool sequence)
-{
-    if (!hasRemoteConnection()) {
-        reportBackgroundError(tr("Open a remote session first "
-                                 "(File > Open Remote Plotfile...)."));
-        return;
-    }
-    // The last directory browsed is remembered per destination: a path is a
-    // property of one machine, like the server executable.
-    const auto destination = m_sshRemoteSession
-        ? QString::fromStdString(m_sshRemoteSession->destination())
-        : m_remoteLabel;
-    const auto settingsKey
-        = QStringLiteral("remote/lastDirectories/%1").arg(destination);
-    RemoteFileDialog dialog(m_remoteConnection,
-        makeSettings().value(settingsKey).toString(),
-        sequence ? RemoteFileDialog::SelectionMode::PlotfileSequence
-                 : RemoteFileDialog::SelectionMode::SinglePlotfile,
-        this);
-    if (dialog.exec() != QDialog::Accepted) {
-        return;
-    }
-    const auto paths = dialog.selectedPaths();
-    if (paths.empty()) {
-        return;
-    }
-    if (!dialog.currentDirectory().isEmpty()) {
-        makeSettings().setValue(settingsKey, dialog.currentDirectory());
-    }
-    // One plotfile picked in the sequence browser is just that plotfile.
-    if (paths.size() > 1) {
-        openRemoteSequence(paths);
-    } else {
-        openRemoteDataset(paths.front());
-    }
+    m_remoteSession->start(std::move(destination), std::move(serverExecutable),
+        std::move(remotePaths));
 }
 
 void MainWindow::openRemoteDataset(std::string remotePath)
 {
-    if (!m_remoteConnection) {
+    auto connection = m_remoteSession->connection();
+    if (!connection) {
         reportBackgroundError(tr("Open a remote session first "
                                  "(File > Open Remote Plotfile...)."));
         return;
     }
     const auto displayPath = std::filesystem::path(remotePath);
     openDatasetImpl(displayPath, false, std::nullopt, {}, false,
-        std::nullopt, RemoteOpen{m_remoteConnection, std::move(remotePath)});
+        std::nullopt, RemoteOpen{std::move(connection), std::move(remotePath)});
 }
 
 void MainWindow::openDatasetImpl(const std::filesystem::path& path,

--- a/src/qt/MainWindowInteraction.cpp
+++ b/src/qt/MainWindowInteraction.cpp
@@ -1525,7 +1525,7 @@ void MainWindow::closeEvent(QCloseEvent* event)
     // queued work; the pool clear happens only on aboutToQuit (see
     // cancelInFlight).
     cancelInFlight();
-    m_sshRemoteSession.reset();
+    m_remoteSession->shutdown();
     // Secondary top-level windows are parentless or non-modal; close them with
     // the main window so none lingers and keeps the process alive.
     if (m_linePlotWindow != nullptr) {

--- a/src/qt/MainWindowInternal.hpp
+++ b/src/qt/MainWindowInternal.hpp
@@ -8,6 +8,7 @@
 #include "MainWindow.hpp"
 #include "QtErrorText.hpp"
 #include "AnimationExporter.hpp"
+#include "AppSettings.hpp"
 #include "DiagnosticsModel.hpp"
 #include "FabNavigator.hpp"
 #include "PaletteController.hpp"
@@ -23,9 +24,8 @@
 #include "LinePlotRequest.hpp"
 #include "LinePlotWindow.hpp"
 #include "PlaneMapping.hpp"
-#include "RemoteFileDialog.hpp"
+#include "RemoteSessionController.hpp"
 #include "ScientificDoubleSpinBox.hpp"
-#include "SshRemoteSession.hpp"
 #include "SetContoursDialog.hpp"
 #include "Theme.hpp"
 #include "UserGuideDialog.hpp"
@@ -160,11 +160,6 @@ inline QImage displayImageFor(const ImageBuffer& image)
 #else
     return wrapped.mirrored(false, true).copy();
 #endif
-}
-
-inline QSettings makeSettings()
-{
-    return QSettings(QStringLiteral("amrex-codes"), QStringLiteral("amrexplorer"));
 }
 
 // An AMReX plotfile directory holds a Header file plus one Level_N

--- a/src/qt/MainWindowSlice.cpp
+++ b/src/qt/MainWindowSlice.cpp
@@ -1351,7 +1351,8 @@ void MainWindow::prepareSequence(std::size_t frameCount)
 void MainWindow::openRemoteSequence(
     const std::vector<std::string>& remotePaths)
 {
-    if (!m_remoteConnection) {
+    auto connection = m_remoteSession->connection();
+    if (!connection) {
         emit sequenceFrameFailed();
         reportBackgroundError(tr("Open a remote session first "
                                  "(File > Open Remote Plotfile...)."));
@@ -1380,8 +1381,8 @@ void MainWindow::openRemoteSequence(
     // multiplexes their requests. There is no reconnect: the connection lives
     // as long as the ssh session, and a lost session is reported to the user
     // rather than silently re-established.
-    auto loader = [connection = m_remoteConnection,
-                      generation = m_remoteConnectionGeneration](
+    auto loader = [connection = std::move(connection),
+                      generation = m_remoteSession->connectionGeneration()](
                       const std::filesystem::path& path, DatasetId,
                       const FrameSliceSpec& spec, StopToken cancellation) {
         if (!connection->connected()) {
@@ -1840,28 +1841,6 @@ void MainWindow::reportBackgroundError(const QString& message)
     }
     statusBar()->showMessage(message.section(QLatin1Char('\n'), 0, 0));
     m_diagnosticsModel->reportBackgroundError(message);
-}
-
-QString MainWindow::remoteDiagnosticsLines() const
-{
-    QString text;
-    if (m_remoteConnection) {
-        text += tr("\nremote session: %1 (%2)")
-                    .arg(m_remoteLabel,
-                        m_remoteConnection->connected() ? tr("connected")
-                                                        : tr("disconnected"));
-        if (auto remoteSession = std::dynamic_pointer_cast<
-                remote::RemoteDatasetSession>(m_dataset)) {
-            text += tr("\nremote path: %1")
-                        .arg(QString::fromStdString(
-                            remoteSession->remotePath()));
-        }
-    } else if (m_sshRemoteSession) {
-        text += tr("\nremote session: ssh %1 (starting)")
-                    .arg(QString::fromStdString(
-                        m_sshRemoteSession->destination()));
-    }
-    return text;
 }
 
 void MainWindow::updateDiagnostics()

--- a/src/qt/MainWindowSlice.cpp
+++ b/src/qt/MainWindowSlice.cpp
@@ -1351,7 +1351,10 @@ void MainWindow::prepareSequence(std::size_t frameCount)
 void MainWindow::openRemoteSequence(
     const std::vector<std::string>& remotePaths)
 {
+    // Read together, before anything else runs: the generation belongs to
+    // this connection and must be the one the loader captures.
     auto connection = m_remoteSession->connection();
+    const auto connectionGeneration = m_remoteSession->connectionGeneration();
     if (!connection) {
         emit sequenceFrameFailed();
         reportBackgroundError(tr("Open a remote session first "
@@ -1382,7 +1385,7 @@ void MainWindow::openRemoteSequence(
     // as long as the ssh session, and a lost session is reported to the user
     // rather than silently re-established.
     auto loader = [connection = std::move(connection),
-                      generation = m_remoteSession->connectionGeneration()](
+                      generation = connectionGeneration](
                       const std::filesystem::path& path, DatasetId,
                       const FrameSliceSpec& spec, StopToken cancellation) {
         if (!connection->connected()) {

--- a/src/qt/RemoteOpenDialog.cpp
+++ b/src/qt/RemoteOpenDialog.cpp
@@ -1,0 +1,114 @@
+#include "RemoteOpenDialog.hpp"
+
+#include <QDialogButtonBox>
+#include <QFormLayout>
+#include <QLabel>
+#include <QLineEdit>
+#include <QPlainTextEdit>
+#include <QPushButton>
+
+#include <utility>
+
+namespace amrvis::qt {
+
+RemoteOpenDialog::RemoteOpenDialog(bool sequence,
+    const QString& sessionDestination, const QString& lastDestination,
+    std::function<QString(const QString&)> executableFor, QWidget* parent)
+    : QDialog(parent)
+{
+    setWindowTitle(sequence ? tr("Open Remote Plotfile Sequence")
+                            : tr("Open Remote Plotfile"));
+    // Wide enough that a typical scratch-filesystem path is visible whole.
+    setMinimumWidth(560);
+    auto* layout = new QFormLayout(this);
+    auto* explanation = new QLabel(
+        tr("AMReXplorer runs amrexplorer-server on the destination through "
+           "ssh and talks to it over that connection. Any destination that "
+           "works for the ssh command works here, including aliases from "
+           "~/.ssh/config. An unchanged destination keeps the current "
+           "session. Enter the plotfile path, or use Browse... to pick it "
+           "on the remote machine."),
+        this);
+    explanation->setWordWrap(true);
+    layout->addRow(explanation);
+    // Prefill from the live session so opening another path reuses it; a
+    // fresh window falls back to the last destination used anywhere.
+    m_destinationEdit = new QLineEdit(
+        sessionDestination.isEmpty() ? lastDestination : sessionDestination,
+        this);
+    m_destinationEdit->setPlaceholderText(tr("user@host or ssh alias"));
+    layout->addRow(tr("SSH destination:"), m_destinationEdit);
+    m_executableEdit = new QLineEdit(
+        executableFor(m_destinationEdit->text().trimmed()), this);
+    m_executableEdit->setToolTip(
+        tr("Name on the remote PATH, or a path such as "
+           "~/bin/amrexplorer-server. Remembered per destination."));
+    layout->addRow(tr("Remote amrexplorer-server:"), m_executableEdit);
+    // The executable follows the destination (each remembers its own) until
+    // the user edits it in this dialog; textEdited fires only on user edits.
+    connect(m_executableEdit, &QLineEdit::textEdited, this,
+        [this] { m_executableEdited = true; });
+    connect(m_destinationEdit, &QLineEdit::textChanged, this,
+        [this, executableFor = std::move(executableFor)](const QString& text) {
+            if (!m_executableEdited) {
+                m_executableEdit->setText(executableFor(text.trimmed()));
+            }
+        });
+    if (sequence) {
+        m_pathsEdit = new QPlainTextEdit(this);
+        m_pathsEdit->setPlaceholderText(
+            tr("One plotfile path per line, in playback order"));
+        m_pathsEdit->setTabChangesFocus(true);
+        layout->addRow(tr("Plotfile paths on the remote machine:"), m_pathsEdit);
+    } else {
+        m_pathEdit = new QLineEdit(this);
+        m_pathEdit->setPlaceholderText(
+            tr("/path/to/plt00010 or ~/run/plt00010"));
+        layout->addRow(tr("Plotfile path on the remote machine:"), m_pathEdit);
+    }
+    auto* buttons = new QDialogButtonBox(
+        QDialogButtonBox::Ok | QDialogButtonBox::Cancel, this);
+    buttons->button(QDialogButtonBox::Ok)->setText(tr("Open"));
+    // Browse... needs only the connection fields: it starts (or reuses) the
+    // session and picks the path in the remote browser once it is ready.
+    auto* browseButton
+        = buttons->addButton(tr("Browse..."), QDialogButtonBox::ActionRole);
+    browseButton->setToolTip(
+        tr("Connect and choose the plotfile on the remote machine"));
+    connect(browseButton, &QPushButton::clicked, this, [this] {
+        m_browseRequested = true;
+        accept();
+    });
+    connect(buttons, &QDialogButtonBox::accepted, this, &QDialog::accept);
+    connect(buttons, &QDialogButtonBox::rejected, this, &QDialog::reject);
+    layout->addRow(buttons);
+}
+
+QString RemoteOpenDialog::destination() const
+{
+    return m_destinationEdit->text().trimmed();
+}
+
+QString RemoteOpenDialog::executable() const
+{
+    return m_executableEdit->text().trimmed();
+}
+
+std::vector<std::string> RemoteOpenDialog::paths() const
+{
+    std::vector<std::string> paths;
+    if (m_pathsEdit != nullptr) {
+        for (const auto& line : m_pathsEdit->toPlainText().split(
+                 QLatin1Char('\n'), Qt::SkipEmptyParts)) {
+            const auto path = line.trimmed();
+            if (!path.isEmpty()) {
+                paths.push_back(path.toStdString());
+            }
+        }
+    } else if (!m_pathEdit->text().trimmed().isEmpty()) {
+        paths.push_back(m_pathEdit->text().trimmed().toStdString());
+    }
+    return paths;
+}
+
+} // namespace amrvis::qt

--- a/src/qt/RemoteOpenDialog.hpp
+++ b/src/qt/RemoteOpenDialog.hpp
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <QDialog>
+#include <QString>
+
+#include <functional>
+#include <string>
+#include <vector>
+
+class QLineEdit;
+class QPlainTextEdit;
+
+namespace amrvis::qt {
+
+// The Open Remote Plotfile / Open Remote Plotfile Sequence dialog: the SSH
+// destination, the remote amrexplorer-server executable, and the plotfile
+// path (or paths, one per line, when `sequence`). Open accepts with the
+// fields; Browse... accepts with browseRequested() set, and only the
+// connection fields matter then. The executable follows the destination --
+// each destination remembers its own, looked up through `executableFor` --
+// until the user edits it here. What to do with the answer (reuse the live
+// session, start one, browse) is RemoteSessionController's decision, so the
+// dialog just reports the fields, trimmed.
+class RemoteOpenDialog final : public QDialog {
+public:
+    // `sessionDestination` prefills the destination while a session is live
+    // (opening another path reuses it); otherwise `lastDestination`, the one
+    // last used anywhere.
+    RemoteOpenDialog(bool sequence, const QString& sessionDestination,
+        const QString& lastDestination,
+        std::function<QString(const QString&)> executableFor,
+        QWidget* parent = nullptr);
+
+    [[nodiscard]] QString destination() const;
+    [[nodiscard]] QString executable() const;
+    // The typed path(s), trimmed, empties dropped; one entry at most unless
+    // the dialog is the sequence one.
+    [[nodiscard]] std::vector<std::string> paths() const;
+    [[nodiscard]] bool browseRequested() const noexcept
+    {
+        return m_browseRequested;
+    }
+
+private:
+    QLineEdit* m_destinationEdit = nullptr;
+    QLineEdit* m_executableEdit = nullptr;
+    QLineEdit* m_pathEdit = nullptr;
+    QPlainTextEdit* m_pathsEdit = nullptr;
+    bool m_executableEdited = false;
+    bool m_browseRequested = false;
+};
+
+} // namespace amrvis::qt

--- a/src/qt/RemoteSessionController.cpp
+++ b/src/qt/RemoteSessionController.cpp
@@ -1,0 +1,271 @@
+#include "RemoteSessionController.hpp"
+
+#include "RemoteFileDialog.hpp"
+#include "RemoteOpenDialog.hpp"
+#include "SshRemoteSession.hpp"
+
+#include <amrexplorer/remote/Connection.hpp>
+
+#include <QDialog>
+#include <QMessageBox>
+#include <QSettings>
+
+#include <utility>
+
+namespace amrvis::qt {
+
+RemoteSessionController::RemoteSessionController(
+    Hooks hooks, std::string softwareVersion, QObject* parent)
+    : QObject(parent)
+    , m_hooks(std::move(hooks))
+    , m_softwareVersion(std::move(softwareVersion))
+{
+}
+
+RemoteSessionController::~RemoteSessionController() = default;
+
+void RemoteSessionController::install(
+    std::shared_ptr<remote::Connection> connection, QString label)
+{
+    m_connection = std::move(connection);
+    m_label = std::move(label);
+    ++m_connectionGeneration;
+    emit sessionChanged();
+}
+
+std::shared_ptr<remote::Connection> RemoteSessionController::connection() const
+{
+    return m_connection;
+}
+
+bool RemoteSessionController::connected() const
+{
+    return m_connection && m_connection->connected();
+}
+
+QString RemoteSessionController::sessionDestination() const
+{
+    return m_session ? QString::fromStdString(m_session->destination())
+                     : QString();
+}
+
+bool RemoteSessionController::sessionMatches(
+    const QString& destination, const QString& executable) const
+{
+    return connected() && m_session
+        && destination.toStdString() == m_session->destination()
+        && executable.toStdString() == m_session->serverExecutable();
+}
+
+QString RemoteSessionController::serverExecutableFor(
+    const QString& destination) const
+{
+    // An explicit executable path is a property of one machine, so nothing
+    // stored for another destination is consulted: a destination without its
+    // own entry gets the name every install puts on the remote PATH. (An
+    // earlier revision fell back to the executable last used anywhere, which
+    // let one machine's path break the destinations that worked by default.)
+    const auto settings = m_hooks.settings();
+    const auto forDestination
+        = settings
+              ->value(QStringLiteral("remote/serverExecutables/%1")
+                      .arg(destination))
+              .toString()
+              .trimmed();
+    return forDestination.isEmpty() ? QStringLiteral("amrexplorer-server")
+                                    : forDestination;
+}
+
+void RemoteSessionController::rememberDestination(
+    const QString& destination, const QString& executable)
+{
+    // Remember this destination and its executable; the CLI teaches the
+    // dialog this way too. Per destination only -- see serverExecutableFor.
+    const auto settings = m_hooks.settings();
+    settings->setValue(QStringLiteral("remote/sshDestination"), destination);
+    settings->setValue(
+        QStringLiteral("remote/serverExecutables/%1").arg(destination),
+        executable);
+}
+
+void RemoteSessionController::start(std::string destination,
+    std::string serverExecutable, std::vector<std::string> remotePaths,
+    std::function<void()> onReady)
+{
+    if (destination.empty() || destination.front() == '-'
+        || destination.find_first_of(" \t\r\n") != std::string::npos) {
+        emit errorReported(tr("Invalid SSH destination."));
+        return;
+    }
+    const auto destinationText = QString::fromStdString(destination);
+    if (serverExecutable.empty()) {
+        serverExecutable = serverExecutableFor(destinationText).toStdString();
+    }
+    rememberDestination(
+        destinationText, QString::fromStdString(serverExecutable));
+    // A previous session's connection is closed with it; a dataset still open
+    // on it fails on its next request, and the new server gets fresh opens.
+    m_session.reset();
+    m_connection.reset();
+    m_label.clear();
+    m_session = std::make_unique<SshRemoteSession>(this);
+    emit statusMessage(
+        tr("Starting remote session on %1...").arg(destinationText), 0);
+    m_session->start(destination, std::move(serverExecutable),
+        remote::ConnectionOptions{.clientName = "AMReXplorer Qt",
+            .softwareVersion = m_softwareVersion, .sessionToken = {}},
+        [this, destination, paths = std::move(remotePaths),
+            onReady = std::move(onReady)](
+            std::shared_ptr<remote::Connection> connection) {
+            if (m_hooks.isShuttingDown && m_hooks.isShuttingDown()) {
+                return;
+            }
+            const auto& server = connection->serverInfo();
+            install(std::move(connection),
+                tr("ssh %1").arg(QString::fromStdString(destination)));
+            emit statusMessage(
+                tr("Remote session on %1 is ready (%2 %3, %4 worker threads)")
+                    .arg(QString::fromStdString(destination),
+                        QString::fromStdString(server.serverName),
+                        QString::fromStdString(server.softwareVersion))
+                    .arg(server.workerCount),
+                0);
+            if (!paths.empty()) {
+                emit openRequested(paths, paths.size() > 1);
+            }
+            if (onReady) {
+                onReady();
+            }
+        },
+        [this, destination](const QString& message) {
+            if (m_hooks.isShuttingDown && m_hooks.isShuttingDown()) {
+                return;
+            }
+            emit statusMessage(tr("Could not start the remote session"), 0);
+            emit errorReported(
+                tr("Could not start the remote session on %1: %2")
+                    .arg(QString::fromStdString(destination), message));
+            emit sessionChanged();
+        },
+        [this, destination](const QString& message) {
+            if (m_hooks.isShuttingDown && m_hooks.isShuttingDown()) {
+                return;
+            }
+            emit statusMessage(tr("Remote session ended"), 0);
+            emit errorReported(tr("The remote session on %1 ended: %2")
+                    .arg(QString::fromStdString(destination), message));
+            emit sessionChanged();
+        });
+    // After start(): the session reports its destination only from then on.
+    emit sessionChanged();
+}
+
+void RemoteSessionController::promptOpen(QWidget* parent, bool sequence)
+{
+    RemoteOpenDialog dialog(sequence, sessionDestination(),
+        m_hooks.settings()
+            ->value(QStringLiteral("remote/sshDestination"))
+            .toString(),
+        [this](const QString& destination) {
+            return serverExecutableFor(destination);
+        },
+        parent);
+    if (dialog.exec() != QDialog::Accepted) {
+        return;
+    }
+    const auto destination = dialog.destination();
+    const auto executable = dialog.executable();
+    const bool matches = sessionMatches(destination, executable);
+    if (dialog.browseRequested()) {
+        if (destination.isEmpty() || executable.isEmpty()) {
+            QMessageBox::warning(parent, dialog.windowTitle(),
+                tr("The SSH destination and the server executable are "
+                   "required."));
+            return;
+        }
+        if (matches) {
+            browse(parent, sequence);
+        } else {
+            start(destination.toStdString(), executable.toStdString(), {},
+                [this, parent, sequence] { browse(parent, sequence); });
+        }
+        return;
+    }
+    auto paths = dialog.paths();
+    if (destination.isEmpty() || executable.isEmpty() || paths.empty()) {
+        QMessageBox::warning(parent, dialog.windowTitle(),
+            tr("The SSH destination, the server executable, and at least one "
+               "plotfile path are required."));
+        return;
+    }
+    // An unchanged destination and executable mean the current session is the
+    // one asked for; open over it directly instead of starting ssh again.
+    if (matches) {
+        emit openRequested(std::move(paths), sequence);
+        return;
+    }
+    start(destination.toStdString(), executable.toStdString(),
+        std::move(paths));
+}
+
+void RemoteSessionController::browse(QWidget* parent, bool sequence)
+{
+    if (!connected()) {
+        emit errorReported(tr("Open a remote session first "
+                              "(File > Open Remote Plotfile...)."));
+        return;
+    }
+    // The last directory browsed is remembered per destination: a path is a
+    // property of one machine, like the server executable.
+    const auto destination
+        = m_session ? sessionDestination() : m_label;
+    const auto settingsKey
+        = QStringLiteral("remote/lastDirectories/%1").arg(destination);
+    RemoteFileDialog dialog(m_connection,
+        m_hooks.settings()->value(settingsKey).toString(),
+        sequence ? RemoteFileDialog::SelectionMode::PlotfileSequence
+                 : RemoteFileDialog::SelectionMode::SinglePlotfile,
+        parent);
+    if (dialog.exec() != QDialog::Accepted) {
+        return;
+    }
+    auto paths = dialog.selectedPaths();
+    if (paths.empty()) {
+        return;
+    }
+    if (!dialog.currentDirectory().isEmpty()) {
+        m_hooks.settings()->setValue(settingsKey, dialog.currentDirectory());
+    }
+    // One plotfile picked in the sequence browser is just that plotfile.
+    const bool asSequence = paths.size() > 1;
+    emit openRequested(std::move(paths), asSequence);
+}
+
+QString RemoteSessionController::diagnosticsLines() const
+{
+    QString text;
+    if (m_connection) {
+        text += tr("\nremote session: %1 (%2)")
+                    .arg(m_label,
+                        m_connection->connected() ? tr("connected")
+                                                  : tr("disconnected"));
+        const auto remotePath = m_hooks.currentRemotePath
+            ? m_hooks.currentRemotePath()
+            : std::nullopt;
+        if (remotePath) {
+            text += tr("\nremote path: %1")
+                        .arg(QString::fromStdString(*remotePath));
+        }
+    } else if (m_session) {
+        text += tr("\nremote session: ssh %1 (starting)")
+                    .arg(sessionDestination());
+    }
+    return text;
+}
+
+void RemoteSessionController::shutdown()
+{
+    m_session.reset();
+}
+
+} // namespace amrvis::qt

--- a/src/qt/RemoteSessionController.hpp
+++ b/src/qt/RemoteSessionController.hpp
@@ -1,0 +1,119 @@
+#pragma once
+
+#include <QObject>
+#include <QString>
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+class QSettings;
+class QWidget;
+
+namespace amrvis::remote {
+class Connection;
+}
+
+namespace amrvis::qt {
+
+class SshRemoteSession;
+
+// The window's remote session: the ssh-launched server (SshRemoteSession),
+// the one connection every remote open goes through, and the ways a user
+// reaches it -- the Open Remote dialogs, the remote directory browser, the
+// per-destination settings (last destination, server executable, last
+// browsed directory). It says what to open through openRequested(); the host
+// owns the datasets and opens them over connection(). Status-bar text and
+// background errors go out as signals; the host decides where they show.
+class RemoteSessionController final : public QObject {
+    Q_OBJECT
+
+public:
+    struct Hooks {
+        // True once the host began closing; late session callbacks then do
+        // nothing (the host is tearing the session down itself).
+        std::function<bool()> isShuttingDown;
+        // The server-side path of the dataset the host currently shows, when
+        // it came over the remote connection; for the diagnostics lines.
+        std::function<std::optional<std::string>()> currentRemotePath;
+        // The application's settings store, opened per use.
+        std::function<std::unique_ptr<QSettings>()> settings;
+    };
+
+    // `softwareVersion` is what the client reports in the protocol handshake.
+    RemoteSessionController(
+        Hooks hooks, std::string softwareVersion, QObject* parent = nullptr);
+    ~RemoteSessionController() override;
+
+    // Installs the connection every remote open goes through, with its
+    // handshake already complete: the SSH session's once it is ready, or a
+    // loopback one from a test harness. Replaces any previous connection;
+    // datasets open on that one fail on their next request.
+    void install(std::shared_ptr<remote::Connection> connection, QString label);
+    [[nodiscard]] std::shared_ptr<remote::Connection> connection() const;
+    // True while an installed connection is live.
+    [[nodiscard]] bool connected() const;
+    // Bumped by every install(); a sequence's frame loader captures it so a
+    // frame from a replaced connection can be told apart.
+    [[nodiscard]] std::uint64_t connectionGeneration() const noexcept
+    {
+        return m_connectionGeneration;
+    }
+
+    // Runs amrexplorer-server on the named OpenSSH destination with the wire
+    // protocol over ssh's stdio, installs the connection once its handshake
+    // completes, and asks the host to open the supplied server-visible paths
+    // (openRequested). An empty path list only establishes the session.
+    // `onReady` runs after that. An empty executable means the one
+    // remembered for the destination, else "amrexplorer-server".
+    void start(std::string destination, std::string serverExecutable,
+        std::vector<std::string> remotePaths,
+        std::function<void()> onReady = {});
+    // The Open Remote Plotfile / Sequence dialog, modal on `parent`. Reuses
+    // the live session when the connection fields are unchanged; otherwise
+    // starts a new one and opens the paths once it is ready. Browse... goes
+    // through browse() the same way.
+    void promptOpen(QWidget* parent, bool sequence);
+    // The remote directory browser over the live connection, modal on
+    // `parent`; what it picks goes out through openRequested(). Starts at the
+    // directory last browsed on this destination, else the server's home.
+    void browse(QWidget* parent, bool sequence);
+    // The server executable to use for a destination: the one last used for
+    // it, else "amrexplorer-server". Per destination only: an explicit path
+    // is a property of one machine.
+    [[nodiscard]] QString serverExecutableFor(const QString& destination) const;
+    // The Diagnostics panel's remote lines, or empty when there is no session.
+    [[nodiscard]] QString diagnosticsLines() const;
+    // Ends the ssh session; the host's close path.
+    void shutdown();
+
+signals:
+    // The connection was installed or replaced, or the session started or
+    // ended: the diagnostics line changed.
+    void sessionChanged();
+    // The host should open these server-visible paths over connection(): as
+    // a sequence when `sequence`, else the (single) path as a dataset.
+    void openRequested(std::vector<std::string> paths, bool sequence);
+    void statusMessage(const QString& message, int timeoutMs);
+    void errorReported(const QString& message);
+
+private:
+    [[nodiscard]] QString sessionDestination() const;
+    // Whether the live session is the one these fields describe.
+    [[nodiscard]] bool sessionMatches(
+        const QString& destination, const QString& executable) const;
+    void rememberDestination(
+        const QString& destination, const QString& executable);
+
+    Hooks m_hooks;
+    std::string m_softwareVersion;
+    std::unique_ptr<SshRemoteSession> m_session;
+    std::shared_ptr<remote::Connection> m_connection;
+    QString m_label;
+    std::uint64_t m_connectionGeneration = 0;
+};
+
+} // namespace amrvis::qt

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -575,6 +575,48 @@ if(TARGET amrexplorer_qt)
         PRIVATE amrexplorer::warnings)
     add_test(NAME ssh_connect_arguments COMMAND test_ssh_connect_arguments)
 
+    # The Open Remote dialog as a widget: prefill, the executable following
+    # the destination, the path fields, Browse... versus Open.
+    add_executable(test_remote_open_dialog
+        unit/test_remote_open_dialog.cpp
+        "${PROJECT_SOURCE_DIR}/src/qt/RemoteOpenDialog.cpp"
+        "${PROJECT_SOURCE_DIR}/src/qt/RemoteOpenDialog.hpp")
+    target_include_directories(test_remote_open_dialog
+        PRIVATE "${PROJECT_SOURCE_DIR}/src/qt")
+    target_link_libraries(test_remote_open_dialog
+        PRIVATE amrexplorer::warnings Qt6::Widgets)
+    add_test(NAME remote_open_dialog
+        COMMAND "${CMAKE_COMMAND}" -E env QT_QPA_PLATFORM=offscreen
+            "$<TARGET_FILE:test_remote_open_dialog>")
+    set_tests_properties(remote_open_dialog PROPERTIES TIMEOUT 60)
+
+    # RemoteSessionController: install() over a loopback Server, start() over
+    # the stand-in ssh script running the real server, per-destination
+    # settings, diagnostics lines. Never opens a modal dialog.
+    add_executable(test_remote_session_controller
+        unit/test_remote_session_controller.cpp
+        "${PROJECT_SOURCE_DIR}/src/qt/RemoteSessionController.cpp"
+        "${PROJECT_SOURCE_DIR}/src/qt/RemoteSessionController.hpp"
+        "${PROJECT_SOURCE_DIR}/src/qt/RemoteOpenDialog.cpp"
+        "${PROJECT_SOURCE_DIR}/src/qt/RemoteOpenDialog.hpp"
+        "${PROJECT_SOURCE_DIR}/src/qt/RemoteFileDialog.cpp"
+        "${PROJECT_SOURCE_DIR}/src/qt/RemoteFileDialog.hpp"
+        "${PROJECT_SOURCE_DIR}/src/qt/SshRemoteSession.cpp"
+        "${PROJECT_SOURCE_DIR}/src/qt/SshRemoteSession.hpp")
+    set_target_properties(test_remote_session_controller
+        PROPERTIES AUTOMOC ON)
+    target_include_directories(test_remote_session_controller
+        PRIVATE "${PROJECT_SOURCE_DIR}/src/qt")
+    target_link_libraries(test_remote_session_controller
+        PRIVATE amrexplorer::remote amrexplorer::warnings
+            Qt6::Widgets Qt6::Concurrent)
+    add_test(NAME remote_session_controller
+        COMMAND "${CMAKE_COMMAND}" -E env QT_QPA_PLATFORM=offscreen
+            "$<TARGET_FILE:test_remote_session_controller>"
+            "$<TARGET_FILE:amrexplorer_server>"
+            "${CMAKE_CURRENT_SOURCE_DIR}/fake_ssh.sh")
+    set_tests_properties(remote_session_controller PROPERTIES TIMEOUT 120)
+
     # The remote browser against a loopback Server: listing, navigation, an
     # unreadable path, and both selection modes. Offscreen; no display needed.
     add_executable(test_remote_file_dialog

--- a/tests/unit/test_remote_open_dialog.cpp
+++ b/tests/unit/test_remote_open_dialog.cpp
@@ -1,0 +1,129 @@
+// The Open Remote dialog as a widget: prefill rules, the executable following
+// the destination until edited, the path fields, and Browse... versus Open.
+// What to do with the answer is RemoteSessionController's business.
+
+#include "RemoteOpenDialog.hpp"
+
+#include <QApplication>
+#include <QDialogButtonBox>
+#include <QLineEdit>
+#include <QPlainTextEdit>
+#include <QPushButton>
+
+#include <algorithm>
+#include <cstdlib>
+#include <iostream>
+#include <map>
+
+namespace {
+
+void require(bool condition, const char* message)
+{
+    if (!condition) {
+        std::cerr << "FAILED: " << message << '\n';
+        std::exit(1);
+    }
+}
+
+QPushButton* buttonNamed(QDialog& dialog, const QString& text)
+{
+    const auto buttons = dialog.findChildren<QPushButton*>();
+    const auto found = std::find_if(buttons.begin(), buttons.end(),
+        [&](QPushButton* button) { return button->text() == text; });
+    return found == buttons.end() ? nullptr : *found;
+}
+
+} // namespace
+
+int main(int argc, char* argv[])
+{
+    QApplication application(argc, argv);
+    using amrvis::qt::RemoteOpenDialog;
+
+    // Per-destination executables, the way the controller remembers them.
+    std::map<QString, QString> executables{
+        {QStringLiteral("frontier"), QStringLiteral("~/bin/amrexplorer-server")}};
+    const auto executableFor = [&](const QString& destination) {
+        const auto found = executables.find(destination);
+        return found == executables.end()
+            ? QStringLiteral("amrexplorer-server")
+            : found->second;
+    };
+
+    // Single mode: prefill from the live session, executable follows the
+    // destination, Open reports the trimmed fields and the one path.
+    {
+        RemoteOpenDialog dialog(false, QStringLiteral("frontier"),
+            QStringLiteral("perlmutter"), executableFor);
+        const auto edits = dialog.findChildren<QLineEdit*>();
+        require(edits.size() == 3, "single dialog does not have three fields");
+        auto* destination = edits[0];
+        auto* executable = edits[1];
+        auto* path = edits[2];
+        require(destination->text() == QStringLiteral("frontier"),
+            "the live session's destination was not prefilled");
+        require(executable->text() == QStringLiteral("~/bin/amrexplorer-server"),
+            "the destination's executable was not prefilled");
+        destination->setText(QStringLiteral("perlmutter"));
+        require(executable->text() == QStringLiteral("amrexplorer-server"),
+            "the executable did not follow the destination");
+        // A user edit pins the executable; a later destination change leaves
+        // it alone. textEdited only fires for user edits, so simulate one.
+        executable->setText(QStringLiteral("/opt/amrexplorer-server"));
+        emit executable->textEdited(executable->text());
+        destination->setText(QStringLiteral("frontier"));
+        require(executable->text() == QStringLiteral("/opt/amrexplorer-server"),
+            "a user-edited executable was overwritten");
+        path->setText(QStringLiteral("  ~/run/plt00010  "));
+        require(dialog.destination() == QStringLiteral("frontier")
+                && dialog.executable() == QStringLiteral("/opt/amrexplorer-server")
+                && dialog.paths().size() == 1
+                && dialog.paths().front() == "~/run/plt00010"
+                && !dialog.browseRequested(),
+            "the single dialog did not report its trimmed fields");
+        auto* buttons = dialog.findChild<QDialogButtonBox*>();
+        require(buttons != nullptr
+                && buttons->button(QDialogButtonBox::Ok)->text()
+                    == QStringLiteral("Open"),
+            "the accept button is not labelled Open");
+        buttons->button(QDialogButtonBox::Ok)->click();
+        require(dialog.result() == QDialog::Accepted && !dialog.browseRequested(),
+            "Open did not accept without a browse request");
+    }
+
+    // No live session: the last destination used anywhere is the prefill;
+    // Browse... accepts with the flag set.
+    {
+        RemoteOpenDialog dialog(
+            false, QString(), QStringLiteral("perlmutter"), executableFor);
+        require(dialog.destination() == QStringLiteral("perlmutter"),
+            "the last destination was not prefilled");
+        auto* browse = buttonNamed(dialog, QStringLiteral("Browse..."));
+        require(browse != nullptr, "the dialog has no Browse... button");
+        browse->click();
+        require(dialog.result() == QDialog::Accepted && dialog.browseRequested(),
+            "Browse... did not accept with the flag set");
+    }
+
+    // Sequence mode: one path per line, blanks and surrounding space dropped,
+    // order kept.
+    {
+        RemoteOpenDialog dialog(
+            true, QString(), QString(), executableFor);
+        require(dialog.windowTitle().contains(QStringLiteral("Sequence")),
+            "the sequence dialog is not titled as one");
+        auto* paths = dialog.findChild<QPlainTextEdit*>();
+        require(paths != nullptr, "the sequence dialog has no paths field");
+        paths->setPlainText(
+            QStringLiteral("/scratch/plt00010\n\n  /scratch/plt00020  \n"));
+        const auto listed = dialog.paths();
+        require(listed.size() == 2 && listed[0] == "/scratch/plt00010"
+                && listed[1] == "/scratch/plt00020",
+            "the sequence dialog did not report its paths in order");
+        require(dialog.executable() == QStringLiteral("amrexplorer-server"),
+            "an unknown destination did not default the executable");
+    }
+
+    std::cout << "remote open dialog tests passed\n";
+    return 0;
+}

--- a/tests/unit/test_remote_open_dialog.cpp
+++ b/tests/unit/test_remote_open_dialog.cpp
@@ -122,6 +122,11 @@ int main(int argc, char* argv[])
             "the sequence dialog did not report its paths in order");
         require(dialog.executable() == QStringLiteral("amrexplorer-server"),
             "an unknown destination did not default the executable");
+        auto* buttons = dialog.findChild<QDialogButtonBox*>();
+        require(buttons != nullptr, "the sequence dialog has no buttons");
+        buttons->button(QDialogButtonBox::Cancel)->click();
+        require(dialog.result() == QDialog::Rejected && !dialog.browseRequested(),
+            "Cancel did not reject, or set the browse flag");
     }
 
     std::cout << "remote open dialog tests passed\n";

--- a/tests/unit/test_remote_session_controller.cpp
+++ b/tests/unit/test_remote_session_controller.cpp
@@ -1,20 +1,35 @@
 // RemoteSessionController against a loopback Server (install) and the real
 // amrexplorer-server run by the stand-in ssh script (start): what it installs,
 // what it asks the host to open, what it remembers per destination, and what
-// its diagnostics lines say in each state. The dialogs it owns are covered by
-// their own tests; this one never opens a modal dialog.
+// its diagnostics lines say in each state, plus the Open Remote dialog and
+// the browser driven from inside their exec() by a timer, the way a user
+// would drive them.
 
+#include "RemoteFileDialog.hpp"
+#include "RemoteOpenDialog.hpp"
 #include "RemoteSessionController.hpp"
 
 #include <amrexplorer/remote/Connection.hpp>
 #include <amrexplorer/remote/Server.hpp>
 
+#include <QAbstractButton>
 #include <QApplication>
 #include <QCoreApplication>
+#include <QDialogButtonBox>
 #include <QElapsedTimer>
 #include <QEventLoop>
+#include <QLineEdit>
+#include <QMessageBox>
+#include <QPlainTextEdit>
+#include <QPushButton>
 #include <QSettings>
 #include <QTemporaryDir>
+#include <QTimer>
+#include <QTreeWidget>
+
+#include <algorithm>
+#include <filesystem>
+#include <fstream>
 
 #include <cstdlib>
 #include <exception>
@@ -77,6 +92,53 @@ bool waitUntil(const std::function<bool()>& predicate, int milliseconds)
     }
     return true;
 }
+
+// The visible top-level dialog of a type, if one is up (a modal exec() is
+// running under it).
+template <typename Dialog>
+Dialog* visibleDialog()
+{
+    for (auto* widget : QApplication::topLevelWidgets()) {
+        // dynamic_cast: the dialogs have no Q_OBJECT (nothing to moc).
+        if (auto* dialog = dynamic_cast<Dialog*>(widget);
+            dialog != nullptr && dialog->isVisible()) {
+            return dialog;
+        }
+    }
+    return nullptr;
+}
+
+QPushButton* buttonNamed(QWidget& dialog, const QString& text)
+{
+    const auto buttons = dialog.findChildren<QPushButton*>();
+    const auto found = std::find_if(buttons.begin(), buttons.end(),
+        [&](QPushButton* button) { return button->text() == text; });
+    return found == buttons.end() ? nullptr : *found;
+}
+
+// Drives a modal dialog from inside its own exec() loop: `step` runs every
+// few milliseconds until it returns true. What a user would do with the
+// mouse, done by a timer.
+class Driver {
+public:
+    explicit Driver(std::function<bool()> step)
+        : m_step(std::move(step))
+    {
+        QObject::connect(&m_timer, &QTimer::timeout, &m_timer, [this] {
+            if (m_step()) {
+                m_done = true;
+                m_timer.stop();
+            }
+        });
+        m_timer.start(20);
+    }
+    [[nodiscard]] bool done() const noexcept { return m_done; }
+
+private:
+    std::function<bool()> m_step;
+    QTimer m_timer;
+    bool m_done = false;
+};
 
 // Everything the host would react to.
 struct Observed {
@@ -181,10 +243,20 @@ int main(int argc, char* argv[])
         Observed observed;
         RemoteSessionController controller(hooks(), "test");
         observe(controller, observed);
-        controller.start("-bad", "", {});
-        require(observed.errors.size() == 1
-                && observed.errors.front()
-                    == QStringLiteral("Invalid SSH destination.")
+        // The destination goes into ssh's argv after "--", so an option-like
+        // or multi-word one is refused before anything is remembered or
+        // started: neither "-oProxyCommand=..." nor "host -o ProxyCommand=..."
+        // nor a shell-looking "host; touch /tmp/x" may reach ssh.
+        for (const char* bad : {"-bad", "-oProxyCommand=touch /tmp/x",
+                 "host -o ProxyCommand=touch /tmp/x", "host; touch /tmp/x",
+                 "host\tuser", "host\n", ""}) {
+            controller.start(bad, "", {});
+        }
+        require(observed.errors.size() == 7
+                && std::all_of(observed.errors.begin(), observed.errors.end(),
+                    [](const QString& error) {
+                        return error == QStringLiteral("Invalid SSH destination.");
+                    })
                 && observed.sessionChanges == 0
                 && controller.diagnosticsLines().isEmpty(),
             "an invalid destination was not rejected up front");
@@ -202,6 +274,13 @@ int main(int argc, char* argv[])
     }
     const std::string serverBinary = argv[1];
     qputenv("AMREXPLORER_SSH", argv[2]);
+    // The server the stand-in ssh runs inherits this process's HOME; point it
+    // at the scratch directory holding one fake plotfile so the browser has
+    // something to pick.
+    const auto home = std::filesystem::path(scratch.path().toStdString());
+    std::filesystem::create_directories(home / "plt00000" / "Level_0");
+    std::ofstream(home / "plt00000" / "Header") << "fake plotfile header\n";
+    qputenv("HOME", scratch.path().toUtf8());
 
     // start() over the stand-in ssh: the connection is installed, the paths
     // go to the host (one as a dataset, two as a sequence), onReady runs
@@ -251,6 +330,11 @@ int main(int argc, char* argv[])
         require(controller.serverExecutableFor(QStringLiteral("fake-destination"))
                 == QString::fromStdString(serverBinary),
             "serverExecutableFor did not read the remembered executable");
+        // Per destination only: what one machine remembers must not leak to
+        // another (the bug the executable key's comment describes).
+        require(controller.serverExecutableFor(QStringLiteral("elsewhere"))
+                == QStringLiteral("amrexplorer-server"),
+            "a remembered executable leaked to another destination");
 
         // A second start with the remembered executable (empty argument) and
         // two paths replaces the session and asks for a sequence.
@@ -262,9 +346,154 @@ int main(int argc, char* argv[])
                 && observed.opens.back().size() == 2
                 && controller.connectionGeneration() == 2,
             "two paths were not requested as a sequence over a new session");
+
+        // The Open Remote dialog, driven from inside its exec(): with the
+        // live session's fields left alone, Open asks the host to open the
+        // typed path directly (no new session); the sequence dialog asks for
+        // a sequence; an empty path is refused with a warning; Cancel does
+        // nothing; a different destination starts a new session; Browse...
+        // opens the remote browser over the live session, whose pick is
+        // opened.
+        using amrvis::qt::RemoteOpenDialog;
+        const auto statusesBefore = observed.statuses.size();
+        {
+            Driver driver([] {
+                auto* dialog = visibleDialog<RemoteOpenDialog>();
+                if (dialog == nullptr) {
+                    return false;
+                }
+                dialog->findChildren<QLineEdit*>()[2]->setText(
+                    QStringLiteral("/scratch/plt00030"));
+                buttonNamed(*dialog, QStringLiteral("Open"))->click();
+                return true;
+            });
+            controller.promptOpen(nullptr, false);
+            require(driver.done() && observed.opens.size() == 3
+                    && observed.opens.back()
+                        == std::vector<std::string>{"/scratch/plt00030"}
+                    && !observed.openAsSequence.back()
+                    && observed.statuses.size() == statusesBefore,
+                "Open over the live session did not open the path directly");
+        }
+        {
+            Driver driver([] {
+                auto* dialog = visibleDialog<RemoteOpenDialog>();
+                if (dialog == nullptr) {
+                    return false;
+                }
+                dialog->findChild<QPlainTextEdit*>()->setPlainText(
+                    QStringLiteral("/a/plt00010\n/a/plt00020\n"));
+                buttonNamed(*dialog, QStringLiteral("Open"))->click();
+                return true;
+            });
+            controller.promptOpen(nullptr, true);
+            require(driver.done() && observed.opens.size() == 4
+                    && observed.opens.back().size() == 2
+                    && observed.openAsSequence.back(),
+                "the sequence dialog did not ask for a sequence");
+        }
+        {
+            bool warned = false;
+            Driver driver([&warned] {
+                if (auto* warning = visibleDialog<QMessageBox>()) {
+                    warned = true;
+                    warning->buttons().first()->click();
+                    return true;
+                }
+                if (auto* dialog = visibleDialog<RemoteOpenDialog>()) {
+                    buttonNamed(*dialog, QStringLiteral("Open"))->click();
+                }
+                return false;
+            });
+            controller.promptOpen(nullptr, false);
+            require(driver.done() && warned && observed.opens.size() == 4
+                    && observed.statuses.size() == statusesBefore,
+                "an empty path was opened, or the warning did not show");
+        }
+        {
+            Driver driver([] {
+                auto* dialog = visibleDialog<RemoteOpenDialog>();
+                if (dialog == nullptr) {
+                    return false;
+                }
+                buttonNamed(*dialog, QStringLiteral("Cancel"))->click();
+                return true;
+            });
+            controller.promptOpen(nullptr, false);
+            require(driver.done() && observed.opens.size() == 4
+                    && observed.statuses.size() == statusesBefore,
+                "Cancel opened or started something");
+        }
+        {
+            Driver driver([&serverBinary] {
+                auto* dialog = visibleDialog<RemoteOpenDialog>();
+                if (dialog == nullptr) {
+                    return false;
+                }
+                const auto edits = dialog->findChildren<QLineEdit*>();
+                edits[0]->setText(QStringLiteral("other-destination"));
+                edits[1]->setText(QString::fromStdString(serverBinary));
+                edits[2]->setText(QStringLiteral("/scratch/plt00040"));
+                buttonNamed(*dialog, QStringLiteral("Open"))->click();
+                return true;
+            });
+            controller.promptOpen(nullptr, false);
+            require(driver.done()
+                    && observed.statuses.size() == statusesBefore + 1
+                    && observed.statuses.back().contains(QStringLiteral(
+                        "Starting remote session on other-destination")),
+                "a changed destination did not start a new session");
+            require(waitUntil([&] { return observed.opens.size() == 5; }, 20000),
+                "the new session did not open the typed path");
+            require(observed.opens.back()
+                        == std::vector<std::string>{"/scratch/plt00040"}
+                    && controller.connectionGeneration() == 3
+                    && controller.diagnosticsLines().contains(
+                        QStringLiteral("ssh other-destination (connected)")),
+                "the new session did not replace the old one");
+        }
+        {
+            // Browse... over the (matching) live session: the browser lists
+            // the server's home -- the scratch directory -- and picking its
+            // plotfile opens it.
+            Driver driver([] {
+                if (auto* browser
+                    = visibleDialog<amrvis::qt::RemoteFileDialog>()) {
+                    auto* entries = browser->findChild<QTreeWidget*>();
+                    for (int index = 0; index < entries->topLevelItemCount();
+                         ++index) {
+                        auto* item = entries->topLevelItem(index);
+                        if (item->text(0) == QStringLiteral("plt00000")) {
+                            item->setSelected(true);
+                            browser->findChild<QDialogButtonBox*>()
+                                ->button(QDialogButtonBox::Open)
+                                ->click();
+                            return true;
+                        }
+                    }
+                    return false;
+                }
+                if (auto* dialog = visibleDialog<RemoteOpenDialog>()) {
+                    buttonNamed(*dialog, QStringLiteral("Browse..."))->click();
+                }
+                return false;
+            });
+            controller.promptOpen(nullptr, false);
+            require(driver.done() && observed.opens.size() == 6
+                    && observed.opens.back()
+                        == std::vector<std::string>{(home / "plt00000").string()}
+                    && !observed.openAsSequence.back(),
+                "Browse... did not open the picked plotfile");
+            require(QSettings(settingsFile, QSettings::IniFormat)
+                        .value(QStringLiteral(
+                            "remote/lastDirectories/other-destination"))
+                        .toString()
+                    == QString::fromStdString(home.string()),
+                "the browsed directory was not remembered per destination");
+        }
         controller.shutdown();
         require(controller.diagnosticsLines().contains(
-                    QStringLiteral("remote session: ssh fake-destination")),
+                    QStringLiteral("remote session: ssh other-destination")),
             "shutdown dropped the installed connection's line");
     }
 

--- a/tests/unit/test_remote_session_controller.cpp
+++ b/tests/unit/test_remote_session_controller.cpp
@@ -1,0 +1,311 @@
+// RemoteSessionController against a loopback Server (install) and the real
+// amrexplorer-server run by the stand-in ssh script (start): what it installs,
+// what it asks the host to open, what it remembers per destination, and what
+// its diagnostics lines say in each state. The dialogs it owns are covered by
+// their own tests; this one never opens a modal dialog.
+
+#include "RemoteSessionController.hpp"
+
+#include <amrexplorer/remote/Connection.hpp>
+#include <amrexplorer/remote/Server.hpp>
+
+#include <QApplication>
+#include <QCoreApplication>
+#include <QElapsedTimer>
+#include <QEventLoop>
+#include <QSettings>
+#include <QTemporaryDir>
+
+#include <cstdlib>
+#include <exception>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace {
+
+void require(bool condition, const char* message)
+{
+    if (!condition) {
+        std::cerr << "FAILED: " << message << '\n';
+        std::exit(1);
+    }
+}
+
+class RunningServer {
+public:
+    explicit RunningServer(amrvis::remote::Server& server)
+        : m_server(server)
+        , m_thread([this] {
+            try {
+                m_server.run();
+            } catch (...) {
+                m_failure = std::current_exception();
+            }
+        })
+    {
+    }
+
+    ~RunningServer()
+    {
+        m_server.requestStop();
+        m_thread.join();
+        if (m_failure) {
+            std::terminate();
+        }
+    }
+
+private:
+    amrvis::remote::Server& m_server;
+    std::thread m_thread;
+    std::exception_ptr m_failure;
+};
+
+bool waitUntil(const std::function<bool()>& predicate, int milliseconds)
+{
+    QElapsedTimer elapsed;
+    elapsed.start();
+    while (!predicate()) {
+        if (elapsed.elapsed() > milliseconds) {
+            return false;
+        }
+        QCoreApplication::processEvents(QEventLoop::AllEvents, 20);
+    }
+    return true;
+}
+
+// Everything the host would react to.
+struct Observed {
+    int sessionChanges = 0;
+    std::vector<std::vector<std::string>> opens;
+    std::vector<bool> openAsSequence;
+    QStringList statuses;
+    QStringList errors;
+};
+
+void observe(amrvis::qt::RemoteSessionController& controller, Observed& observed)
+{
+    QObject::connect(&controller,
+        &amrvis::qt::RemoteSessionController::sessionChanged, &controller,
+        [&observed] { ++observed.sessionChanges; });
+    QObject::connect(&controller,
+        &amrvis::qt::RemoteSessionController::openRequested, &controller,
+        [&observed](const std::vector<std::string>& paths, bool sequence) {
+            observed.opens.push_back(paths);
+            observed.openAsSequence.push_back(sequence);
+        });
+    QObject::connect(&controller,
+        &amrvis::qt::RemoteSessionController::statusMessage, &controller,
+        [&observed](const QString& message, int) {
+            observed.statuses << message;
+        });
+    QObject::connect(&controller,
+        &amrvis::qt::RemoteSessionController::errorReported, &controller,
+        [&observed](const QString& message) { observed.errors << message; });
+}
+
+} // namespace
+
+int main(int argc, char* argv[])
+{
+    QApplication application(argc, argv);
+    using amrvis::qt::RemoteSessionController;
+
+    QTemporaryDir scratch;
+    require(scratch.isValid(), "could not create a scratch directory");
+    const auto settingsFile = scratch.filePath(QStringLiteral("settings.ini"));
+    bool shuttingDown = false;
+    std::optional<std::string> currentRemotePath;
+    const auto hooks = [&] {
+        return RemoteSessionController::Hooks{
+            [&shuttingDown] { return shuttingDown; },
+            [&currentRemotePath] { return currentRemotePath; },
+            [settingsFile] {
+                return std::make_unique<QSettings>(
+                    settingsFile, QSettings::IniFormat);
+            },
+        };
+    };
+
+    // install(): the connection, its label, the generation, the diagnostics
+    // lines with and without a remote dataset on show.
+    {
+        amrvis::remote::Server server;
+        RunningServer running(server);
+        auto connection = std::make_shared<amrvis::remote::Connection>(
+            "127.0.0.1", server.port(),
+            amrvis::remote::ConnectionOptions{
+                .clientName = "remote session controller test",
+                .sessionToken = server.token()});
+
+        Observed observed;
+        RemoteSessionController controller(hooks(), "test");
+        observe(controller, observed);
+        require(!controller.connection() && !controller.connected()
+                && controller.connectionGeneration() == 0
+                && controller.diagnosticsLines().isEmpty(),
+            "a fresh controller reports a session");
+        controller.install(connection, QStringLiteral("127.0.0.1:test"));
+        require(controller.connection() == connection && controller.connected()
+                && controller.connectionGeneration() == 1
+                && observed.sessionChanges == 1,
+            "install did not install the connection");
+        require(controller.diagnosticsLines()
+                == QStringLiteral("\nremote session: 127.0.0.1:test (connected)"),
+            "diagnostics did not describe the connected session");
+        currentRemotePath = "/scratch/run/plt00010";
+        require(controller.diagnosticsLines().contains(
+                    QStringLiteral("\nremote path: /scratch/run/plt00010")),
+            "diagnostics did not name the remote dataset's path");
+        currentRemotePath.reset();
+        controller.install(connection, QStringLiteral("again"));
+        require(controller.connectionGeneration() == 2
+                && observed.sessionChanges == 2,
+            "a second install did not bump the generation");
+        connection->close();
+        require(!controller.connected() && controller.connection() == connection
+                && controller.diagnosticsLines().contains(
+                    QStringLiteral("(disconnected)")),
+            "a closed connection still reads as connected");
+        require(controller.serverExecutableFor(QStringLiteral("anywhere"))
+                == QStringLiteral("amrexplorer-server"),
+            "an unknown destination did not default the executable");
+    }
+
+    // start(): destination validation never touches the settings.
+    {
+        Observed observed;
+        RemoteSessionController controller(hooks(), "test");
+        observe(controller, observed);
+        controller.start("-bad", "", {});
+        require(observed.errors.size() == 1
+                && observed.errors.front()
+                    == QStringLiteral("Invalid SSH destination.")
+                && observed.sessionChanges == 0
+                && controller.diagnosticsLines().isEmpty(),
+            "an invalid destination was not rejected up front");
+        require(QSettings(settingsFile, QSettings::IniFormat)
+                    .value(QStringLiteral("remote/sshDestination"))
+                    .toString()
+                    .isEmpty(),
+            "an invalid destination was remembered");
+    }
+
+#ifndef _WIN32
+    if (argc < 3) {
+        std::cerr << "usage: test_remote_session_controller SERVER FAKE_SSH\n";
+        return 2;
+    }
+    const std::string serverBinary = argv[1];
+    qputenv("AMREXPLORER_SSH", argv[2]);
+
+    // start() over the stand-in ssh: the connection is installed, the paths
+    // go to the host (one as a dataset, two as a sequence), onReady runs
+    // after, the destination and executable are remembered per destination.
+    {
+        Observed observed;
+        RemoteSessionController controller(hooks(), "test");
+        observe(controller, observed);
+        int readyCalls = 0;
+        controller.start("fake-destination", serverBinary,
+            {"/scratch/plt00010"}, [&] { ++readyCalls; });
+        require(observed.statuses.size() == 1
+                && observed.statuses.front().contains(
+                    QStringLiteral("Starting remote session on fake-destination"))
+                && observed.sessionChanges == 1
+                && controller.diagnosticsLines()
+                    == QStringLiteral(
+                        "\nremote session: ssh fake-destination (starting)"),
+            "start did not announce the session");
+        require(waitUntil([&] { return readyCalls == 1; }, 20000),
+            "the session did not become ready");
+        require(controller.connected() && controller.connectionGeneration() == 1
+                && observed.sessionChanges == 2,
+            "the ready session did not install its connection");
+        require(observed.opens.size() == 1
+                && observed.opens.front()
+                    == std::vector<std::string>{"/scratch/plt00010"}
+                && observed.openAsSequence.front() == false,
+            "the ready session did not ask to open the path as a dataset");
+        require(observed.statuses.size() == 2
+                && observed.statuses.back().contains(
+                    QStringLiteral("Remote session on fake-destination is ready")),
+            "the ready session did not report itself");
+        require(controller.diagnosticsLines()
+                == QStringLiteral(
+                    "\nremote session: ssh fake-destination (connected)"),
+            "diagnostics did not describe the ssh session");
+        QSettings settings(settingsFile, QSettings::IniFormat);
+        require(settings.value(QStringLiteral("remote/sshDestination")).toString()
+                    == QStringLiteral("fake-destination")
+                && settings
+                        .value(QStringLiteral(
+                            "remote/serverExecutables/fake-destination"))
+                        .toString()
+                    == QString::fromStdString(serverBinary),
+            "the destination and executable were not remembered");
+        require(controller.serverExecutableFor(QStringLiteral("fake-destination"))
+                == QString::fromStdString(serverBinary),
+            "serverExecutableFor did not read the remembered executable");
+
+        // A second start with the remembered executable (empty argument) and
+        // two paths replaces the session and asks for a sequence.
+        controller.start("fake-destination", "",
+            {"/scratch/plt00010", "/scratch/plt00020"});
+        require(waitUntil([&] { return observed.opens.size() == 2; }, 20000),
+            "the second session did not become ready");
+        require(observed.openAsSequence.back()
+                && observed.opens.back().size() == 2
+                && controller.connectionGeneration() == 2,
+            "two paths were not requested as a sequence over a new session");
+        controller.shutdown();
+        require(controller.diagnosticsLines().contains(
+                    QStringLiteral("remote session: ssh fake-destination")),
+            "shutdown dropped the installed connection's line");
+    }
+
+    // A session that cannot start: the error is reported once, nothing is
+    // installed, and the diagnostics line goes back to nothing.
+    {
+        qputenv("AMREXPLORER_FAKE_SSH_MODE", "fail");
+        Observed observed;
+        RemoteSessionController controller(hooks(), "test");
+        observe(controller, observed);
+        controller.start("fake-destination", serverBinary, {});
+        require(waitUntil([&] { return !observed.errors.isEmpty(); }, 20000),
+            "the failed session did not report");
+        require(observed.errors.size() == 1
+                && observed.errors.front().startsWith(QStringLiteral(
+                    "Could not start the remote session on fake-destination"))
+                && !controller.connected() && observed.opens.empty()
+                && observed.statuses.back()
+                    == QStringLiteral("Could not start the remote session"),
+            "the failed session installed something or reported twice");
+        qunsetenv("AMREXPLORER_FAKE_SSH_MODE");
+    }
+
+    // Once the host is shutting down, a late ready callback does nothing.
+    {
+        Observed observed;
+        RemoteSessionController controller(hooks(), "test");
+        observe(controller, observed);
+        controller.start("fake-destination", serverBinary, {"/scratch/plt"});
+        shuttingDown = true;
+        static_cast<void>(waitUntil([] { return false; }, 1500));
+        require(!controller.connected() && observed.opens.empty()
+                && observed.errors.isEmpty(),
+            "a ready callback acted on a host that is shutting down");
+        shuttingDown = false;
+    }
+#else
+    static_cast<void>(argc);
+    static_cast<void>(argv);
+#endif
+
+    std::cout << "remote session controller tests passed\n";
+    return 0;
+}


### PR DESCRIPTION
The ssh session, the connection every remote open goes through, the Open Remote dialogs (now RemoteOpenDialog), the remote browser and the per-destination settings move into an owned collaborator that says what to open through openRequested; MainWindow opens it over the connection and keeps only the dataset-side remote code. makeSettings moves to AppSettings.hpp so the controller can take a settings factory hook.