### PR TITLE
extract RangeController from MainWindow

### DIFF
--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -37,6 +37,8 @@ add_executable(amrexplorer_qt
     ParticleController.cpp
     ParticleController.hpp
     QtErrorText.hpp
+    RangeController.cpp
+    RangeController.hpp
     RemoteEndpoint.hpp
     RemoteFileDialog.cpp
     RemoteFileDialog.hpp

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -191,30 +191,11 @@ MainWindow::MainWindow(QWidget* parent)
     auto* rangeToolbar = m_rangeToolbar;
     rangeToolbar->setMovable(false);
     rangeToolbar->addWidget(new QLabel(tr("Range:"), rangeToolbar));
-    m_rangeMode = new QComboBox(rangeToolbar);
-    m_rangeMode->setObjectName(QStringLiteral("rangeModeSelector"));
-    m_rangeMode->addItem(tr("File"), static_cast<int>(RangeMode::File));
-    m_rangeMode->addItem(tr("Level"), static_cast<int>(RangeMode::Level));
-    m_rangeMode->addItem(tr("Visible"), static_cast<int>(RangeMode::Visible));
-    m_rangeMode->addItem(tr("User"), static_cast<int>(RangeMode::User));
-    rangeToolbar->addWidget(m_rangeMode);
-    m_rangeMinimum = new ScientificDoubleSpinBox(rangeToolbar);
-    m_rangeMaximum = new ScientificDoubleSpinBox(rangeToolbar);
-    for (auto* range : {m_rangeMinimum, m_rangeMaximum}) {
-        range->setRange(-std::numeric_limits<double>::max(),
-            std::numeric_limits<double>::max());
-        range->setMinimumWidth(110);
-        range->setEnabled(false);
-        rangeToolbar->addWidget(range);
-    }
-    m_rangeMinimum->setPrefix(tr("min "));
-    m_rangeMaximum->setPrefix(tr("max "));
-    m_rangeMaximum->setValue(1.0);
-    // Separate the Range group (mode + min/max) from Log and Palette, matching
-    // the per-group separators on the Slice Controls toolbar.
-    rangeToolbar->addSeparator();
-    m_logarithmic = new QCheckBox(tr("Log"), rangeToolbar);
-    rangeToolbar->addWidget(m_logarithmic);
+    // The range mode, User min/max and Log, and the per-field memory behind
+    // them; the separator before Log matches the per-group separators on the
+    // Slice Controls toolbar, as does the one before Palette below.
+    m_range = new RangeController(this);
+    m_range->createToolbarWidgets(rangeToolbar);
     rangeToolbar->addSeparator();
     rangeToolbar->addWidget(new QLabel(tr("Palette:"), rangeToolbar));
     rangeToolbar->addWidget(m_paletteController->createSelector(rangeToolbar));
@@ -234,12 +215,7 @@ MainWindow::MainWindow(QWidget* parent)
             // animation blocks signals and preserves the index, so the range
             // stays constant across frames.
             if (m_controlsReady && index >= 0) {
-                const auto newField = m_fieldSelector->itemData(index).toUInt();
-                if (newField != m_trackedField) {
-                    commitFieldRange(m_trackedField);
-                    m_trackedField = newField;
-                    applyFieldRange(newField);
-                }
+                m_range->switchField(m_fieldSelector->itemData(index).toUInt());
             }
             // A deferred full-domain range store (m_pendingRangeStore) is keyed
             // to the field/level/mode in effect when it was queued. Changing any
@@ -257,36 +233,21 @@ MainWindow::MainWindow(QWidget* parent)
             updateRangeModeAvailability();
             scheduleSliceRequest();
         });
-    connect(m_rangeMode, qOverload<int>(&QComboBox::currentIndexChanged),
-        this, [this](int) {
-            m_pendingRangeStore.reset();  // see the field selector above
-            updateRangeModeAvailability();
-            const auto userRange = static_cast<RangeMode>(
-                m_rangeMode->currentData().toInt()) == RangeMode::User;
-            m_rangeMinimum->setEnabled(userRange && m_controlsReady);
-            m_rangeMaximum->setEnabled(userRange && m_controlsReady);
-            scheduleSliceRequest();
+    connect(m_range, &RangeController::modeChanged, this, [this] {
+        m_pendingRangeStore.reset();  // see the field selector above
+        updateRangeModeAvailability();
+        scheduleSliceRequest();
+    });
+    connect(m_range, &RangeController::userRangeChanged, this,
+        [this] { scheduleSliceRequest(); });
+    connect(m_range, &RangeController::logarithmicChanged, this,
+        [this] { scheduleSliceRequest(); });
+    connect(m_range, &RangeController::statusMessage, this,
+        [this](const QString& message, int timeoutMs) {
+            statusBar()->showMessage(message, timeoutMs);
         });
-    connect(m_rangeMinimum, qOverload<double>(&QDoubleSpinBox::valueChanged),
-        this, [this](double) {
-            if (static_cast<RangeMode>(m_rangeMode->currentData().toInt())
-                == RangeMode::User) {
-                scheduleSliceRequest();
-            }
-        });
-    connect(m_rangeMaximum, qOverload<double>(&QDoubleSpinBox::valueChanged),
-        this, [this](double) {
-            if (static_cast<RangeMode>(m_rangeMode->currentData().toInt())
-                == RangeMode::User) {
-                scheduleSliceRequest();
-            }
-        });
-    connect(m_logarithmic, &QCheckBox::toggled,
-        this, [this](bool) { scheduleSliceRequest(); });
     m_fieldSelector->setEnabled(false);
     m_levelSelector->setEnabled(false);
-    m_rangeMode->setEnabled(false);
-    m_logarithmic->setEnabled(false);
 
     m_metadataDock = new QDockWidget(tr("Dataset Metadata"), this);
     m_metadataTree = new QTreeWidget(m_metadataDock);
@@ -607,8 +568,8 @@ MainWindow::MainWindow(QWidget* parent)
         this, [this](int) { syncMenuChecks(); });
     // No saveSettings here: range mode is deliberately not persisted (see
     // saveSettings), so the call only ever rewrote unrelated keys.
-    connect(m_logarithmic, &QCheckBox::toggled,
-        this, [this](bool) { saveSettings(); });
+    connect(m_range, &RangeController::logarithmicChanged, this,
+        [this] { saveSettings(); });
 
     wireView(m_view2d);
     for (auto& state : m_planeViews) {
@@ -779,16 +740,9 @@ void MainWindow::syncActiveViewColorControls(const PlaneViewState& state)
     m_colorBar->setFieldRange(state.displayLogarithmic
         ? state.fieldName + tr(" (log)") : state.fieldName,
         state.displayMinimum, state.displayMaximum);
-    if (m_logarithmic->isChecked() != state.displayLogarithmic) {
-        const QSignalBlocker logarithmicBlocker(m_logarithmic);
-        m_logarithmic->setChecked(state.displayLogarithmic);
-    }
-    if (static_cast<RangeMode>(m_rangeMode->currentData().toInt())
-        != RangeMode::User) {
-        const QSignalBlocker minimumBlocker(m_rangeMinimum);
-        const QSignalBlocker maximumBlocker(m_rangeMaximum);
-        m_rangeMinimum->setValue(state.displayMinimum);
-        m_rangeMaximum->setValue(state.displayMaximum);
+    m_range->showLogarithmic(state.displayLogarithmic);
+    if (m_range->mode() != RangeMode::User) {
+        m_range->showDisplayRange(state.displayMinimum, state.displayMaximum);
     }
 }
 

--- a/src/qt/MainWindow.hpp
+++ b/src/qt/MainWindow.hpp
@@ -79,6 +79,7 @@ class DiagnosticsModel;
 class FabNavigator;
 class PaletteController;
 class ParticleController;
+class RangeController;
 class RemoteSessionController;
 class SequenceController;
 struct PlaneMapping;
@@ -514,14 +515,11 @@ private:
     // effective palette to the color bar, iso widget, overlays and a
     // re-render.
     void refreshPaletteDisplay();
-    // Per-field user range: each field remembers its own RangeMode and, when
-    // User, its min/max. commitFieldRange snapshots the current widgets for a
-    // field, applyFieldRange loads a field's snapshot (or the Visible default)
-    // back into the widgets, and resetRangeState clears everything for a fresh
-    // dataset.
-    void commitFieldRange(std::uint32_t field);
-    void applyFieldRange(std::uint32_t field);
+    // Range state for a fresh dataset: the controller's widgets and per-field
+    // memory, plus this window's full-domain range cache and pending store.
     void resetRangeState();
+    // Which metadata-backed range modes the current field/level offers,
+    // handed to the RangeController (which falls back to Visible if needed).
     void updateRangeModeAvailability();
     void showContoursDialog();
     // Draws the ParticleController's samples into a view: the projection and
@@ -790,19 +788,9 @@ private:
     UserGuideDialog* m_userGuideDialog = nullptr;
     QComboBox* m_fieldSelector = nullptr;
     QComboBox* m_levelSelector = nullptr;
-    QComboBox* m_rangeMode = nullptr;
-    QCheckBox* m_logarithmic = nullptr;
-    ScientificDoubleSpinBox* m_rangeMinimum = nullptr;
-    ScientificDoubleSpinBox* m_rangeMaximum = nullptr;
-    // Per-field range state for the current dataset. m_trackedField is the
-    // field the range widgets currently represent; the field selector swaps
-    // snapshots through this map when the user changes fields.
-    struct FieldRange {
-        RangeMode mode = RangeMode::File;
-        std::optional<std::pair<double, double>> userRange;
-    };
-    std::unordered_map<std::uint32_t, FieldRange> m_fieldRanges;
-    std::uint32_t m_trackedField = 0;
+    // Owns the range mode, User min/max and Log widgets and the per-field
+    // range memory; selection() feeds every slice request and frame spec.
+    RangeController* m_range = nullptr;
     QWidget* m_slicePositionControls = nullptr;
     QAction* m_positionSeparator = nullptr;
     std::array<QSpinBox*, 3> m_sliceSpinboxes{nullptr, nullptr, nullptr};

--- a/src/qt/MainWindow.hpp
+++ b/src/qt/MainWindow.hpp
@@ -39,7 +39,6 @@
 
 class QAction;
 class QActionGroup;
-class QCheckBox;
 class QCloseEvent;
 class QComboBox;
 class QDockWidget;

--- a/src/qt/MainWindowDataset.cpp
+++ b/src/qt/MainWindowDataset.cpp
@@ -59,19 +59,15 @@ void MainWindow::restoreSettings()
     m_paletteController->restore(settings);
     m_colorBar->setPalette(&m_paletteController->palette());
 
-    {
-        const QSignalBlocker logarithmicBlocker(m_logarithmic);
-        m_logarithmic->setChecked(
-            settings.value(QStringLiteral("range/logarithmic"), false).toBool());
-    }
+    m_range->showLogarithmic(
+        settings.value(QStringLiteral("range/logarithmic"), false).toBool());
     {
         // A stored format that no longer validates falls back to the default.
         const auto format = settings.value(QStringLiteral("numberFormat"),
             defaultNumberFormat()).toString();
         m_numberFormat = isValidNumberFormat(format) ? format
             : defaultNumberFormat();
-        m_rangeMinimum->setNumberFormat(m_numberFormat);
-        m_rangeMaximum->setNumberFormat(m_numberFormat);
+        m_range->setNumberFormat(m_numberFormat);
         m_colorBar->setNumberFormat(m_numberFormat);
     }
     m_animationPanel->setSpeedValue(
@@ -126,7 +122,7 @@ void MainWindow::saveSettings()
     // Range mode is deliberately not persisted: the correct default (File)
     // depends on the dataset and restoring a different mode from a previous
     // session would produce unexpected color bars.
-    settings.setValue(QStringLiteral("range/logarithmic"), m_logarithmic->isChecked());
+    settings.setValue(QStringLiteral("range/logarithmic"), m_range->logarithmic());
     m_paletteController->save(settings);
     settings.setValue(QStringLiteral("numberFormat"), m_numberFormat);
     settings.setValue(QStringLiteral("animation/speed"),
@@ -723,12 +719,9 @@ void MainWindow::openDatasetImpl(const std::filesystem::path& path,
     m_diagnosticsModel->resetDatasetMetrics();
     m_fieldSelector->setEnabled(false);
     m_levelSelector->setEnabled(false);
-    m_rangeMode->setEnabled(false);
-    m_logarithmic->setEnabled(false);
+    m_range->setControlsReady(false);
     m_boxesAction->setEnabled(false);
     m_slicePlanesAction->setEnabled(false);
-    m_rangeMinimum->setEnabled(false);
-    m_rangeMaximum->setEnabled(false);
     setSlicePositionControlsVisible(false);
     m_animationPanel->setSweepVisible(false);
     m_levelMenu->setEnabled(false);
@@ -982,8 +975,6 @@ void MainWindow::requestInitialSlice(
                     if (restoredSpec) {
                         const QSignalBlocker fieldBlocker(m_fieldSelector);
                         const QSignalBlocker levelBlocker(m_levelSelector);
-                        const QSignalBlocker rangeBlocker(m_rangeMode);
-                        const QSignalBlocker logBlocker(m_logarithmic);
                         const auto fieldIndex = m_fieldSelector->findData(
                             restoredSpec->field);
                         if (fieldIndex >= 0) {
@@ -994,27 +985,18 @@ void MainWindow::requestInitialSlice(
                         if (levelIndex >= 0) {
                             m_levelSelector->setCurrentIndex(levelIndex);
                         }
-                        m_rangeMode->setCurrentIndex(
-                            m_rangeMode->findData(
-                                static_cast<int>(restoredSpec->rangeMode)));
-                        m_logarithmic->setChecked(restoredSpec->logarithmic);
-                        m_trackedField =
-                            m_fieldSelector->currentData().toUInt();
-                        m_fieldRanges[m_trackedField] = {
-                            restoredSpec->rangeMode, restoredSpec->userRange};
+                        m_range->setSelection({restoredSpec->rangeMode,
+                            restoredSpec->userRange, restoredSpec->logarithmic});
+                        m_range->setTrackedField(
+                            m_fieldSelector->currentData().toUInt());
+                        m_range->commitFieldRange(m_range->trackedField());
+                        // Before the extraction the User bounds were written
+                        // unblocked here, which scheduled a (redundant)
+                        // re-slice; kept so this path renders as it did.
                         if (restoredSpec->userRange) {
-                            m_rangeMinimum->setValue(
-                                restoredSpec->userRange->first);
-                            m_rangeMaximum->setValue(
-                                restoredSpec->userRange->second);
+                            scheduleSliceRequest();
                         }
                         updateRangeModeAvailability();
-                        const auto userRange =
-                            static_cast<RangeMode>(
-                                m_rangeMode->currentData().toInt())
-                            == RangeMode::User;
-                        m_rangeMinimum->setEnabled(userRange);
-                        m_rangeMaximum->setEnabled(userRange);
                         configureSlicePositionControls();
                         syncMenuChecks();
                     }

--- a/src/qt/MainWindowInteraction.cpp
+++ b/src/qt/MainWindowInteraction.cpp
@@ -94,8 +94,7 @@ void MainWindow::applyNumberFormat(const QString& format)
         return;
     }
     m_numberFormat = format;
-    m_rangeMinimum->setNumberFormat(format);
-    m_rangeMaximum->setNumberFormat(format);
+    m_range->setNumberFormat(format);
     m_colorBar->setNumberFormat(format);
     // Open child windows repaint against the stored format; a null pointer
     // means the window picks the format up when it is next created.

--- a/src/qt/MainWindowInternal.hpp
+++ b/src/qt/MainWindowInternal.hpp
@@ -50,7 +50,6 @@
 #include <QActionGroup>
 #include <QApplication>
 #include <QWheelEvent>
-#include <QCheckBox>
 #include <QCloseEvent>
 #include <QColorDialog>
 #include <QComboBox>
@@ -60,7 +59,6 @@
 #include <QDir>
 #include <QDockWidget>
 #include <QObject>
-#include <QDoubleSpinBox>
 #include <QFileDialog>
 #include <QFileInfo>
 #include <QFontMetrics>
@@ -94,7 +92,6 @@
 #include <QSignalBlocker>
 #include <QSpinBox>
 #include <QStackedWidget>
-#include <QStandardItemModel>
 #include <QStatusBar>
 #include <QString>
 #include <QStringList>
@@ -119,7 +116,6 @@
 #include <exception>
 #include <filesystem>
 #include <fstream>
-#include <limits>
 #include <map>
 #include <memory>
 #include <mutex>

--- a/src/qt/MainWindowInternal.hpp
+++ b/src/qt/MainWindowInternal.hpp
@@ -13,6 +13,7 @@
 #include "FabNavigator.hpp"
 #include "PaletteController.hpp"
 #include "ParticleController.hpp"
+#include "RangeController.hpp"
 #include "SequenceController.hpp"
 #include "AnimationPanel.hpp"
 #include "CacheConfig.hpp"

--- a/src/qt/MainWindowSlice.cpp
+++ b/src/qt/MainWindowSlice.cpp
@@ -32,14 +32,9 @@ void MainWindow::enableDatasetControls(const DatasetMetadata& metadata)
     m_controlsReady = true;
     m_fieldSelector->setEnabled(true);
     m_levelSelector->setEnabled(true);
-    m_rangeMode->setEnabled(true);
-    m_logarithmic->setEnabled(true);
+    m_range->setControlsReady(true);
     m_boxesAction->setEnabled(true);
     m_slicePlanesAction->setEnabled(metadata.dimension == 3);
-    const auto userRange = static_cast<RangeMode>(
-        m_rangeMode->currentData().toInt()) == RangeMode::User;
-    m_rangeMinimum->setEnabled(userRange);
-    m_rangeMaximum->setEnabled(userRange);
     rebuildLevelMenu();
     m_levelMenu->setEnabled(true);
     m_contoursAction->setEnabled(true);
@@ -259,15 +254,14 @@ void MainWindow::requestSlice(PlaneViewState& state, bool rasterDirty)
     request.sphericalSupersample = m_sphericalSupersample;
     request.sphericalDisplay = m_sphericalDisplay;
 
-    const auto requestedRangeMode = static_cast<RangeMode>(
-        m_rangeMode->currentData().toInt());
+    const auto selection = m_range->selection();
     const auto rangeMode = effectiveRangeMode(dataset, request.field,
-        maximumLevel, composition, requestedRangeMode);
+        maximumLevel, composition, selection.mode);
     std::optional<std::pair<double, double>> userRange;
     if (rangeMode == RangeMode::User) {
-        userRange = std::pair{m_rangeMinimum->value(), m_rangeMaximum->value()};
+        userRange = selection.userRange;
     }
-    const auto logarithmic = m_logarithmic->isChecked();
+    const auto logarithmic = selection.logarithmic;
     const auto palette = m_paletteController->palette();
     const auto displayMode = m_displayMode;
     // Each 3-D panel uses a different pair of vector components:
@@ -973,9 +967,7 @@ void MainWindow::syncVisibleRanges()
     if (m_viewDimension != 3 || !m_dataset) {
         return;
     }
-    const auto rangeMode = static_cast<RangeMode>(
-        m_rangeMode->currentData().toInt());
-    if (rangeMode != RangeMode::Visible) {
+    if (m_range->mode() != RangeMode::Visible) {
         return;
     }
     // Single-flight: dispatch one sync only once the panel slice batch has
@@ -1049,11 +1041,9 @@ void MainWindow::syncVisibleRanges()
                 return;
             }
             auto outcome = watcher->future().takeResult();
-            const auto nowMode = static_cast<RangeMode>(
-                m_rangeMode->currentData().toInt());
             const bool current = generation == m_generation
                 && m_viewDimension == 3 && m_dataset
-                && nowMode == RangeMode::Visible;
+                && m_range->mode() == RangeMode::Visible;
             // All-or-nothing, keyed on the render-generation stamp captured per
             // panel at dispatch. The shared range and log flag are joint across
             // all three panels, so they must not land on a subset. If any panel
@@ -1132,10 +1122,7 @@ void MainWindow::syncVisibleRanges()
                     m_colorBar->setLogarithmic(
                         m_activeView->displayLogarithmic);
                     m_colorBar->setFieldRange(label, globalMin, globalMax);
-                    const QSignalBlocker minBlocker(m_rangeMinimum);
-                    const QSignalBlocker maxBlocker(m_rangeMaximum);
-                    m_rangeMinimum->setValue(globalMin);
-                    m_rangeMaximum->setValue(globalMax);
+                    m_range->showDisplayRange(globalMin, globalMax);
                 }
                 // The deferred full-domain range store (see the slice-arrival
                 // completion): the union is only known here. This block runs
@@ -1207,7 +1194,7 @@ void MainWindow::syncVisibleRanges()
     m_diagnosticsModel->adjustActivity(1);
     try {
         watcher->setFuture(QtConcurrent::run([cachedRange, snapshots,
-            logarithmic = m_logarithmic->isChecked(),
+            logarithmic = m_range->logarithmic(),
             contourMode = isContourMode(m_displayMode),
             contourCount = m_contourCount, palette = m_paletteController->palette()] {
 #ifdef AMREXPLORER_QT_TEST_ACCESS
@@ -1591,51 +1578,11 @@ void MainWindow::configureSequenceControls(bool defaultPositions)
     updateRangeModeAvailability();
 }
 
-void MainWindow::commitFieldRange(std::uint32_t field)
-{
-    FieldRange range;
-    range.mode = static_cast<RangeMode>(m_rangeMode->currentData().toInt());
-    if (range.mode == RangeMode::User) {
-        range.userRange = std::pair{m_rangeMinimum->value(), m_rangeMaximum->value()};
-    }
-    m_fieldRanges[field] = std::move(range);
-}
-
-void MainWindow::applyFieldRange(std::uint32_t field)
-{
-    const auto it = m_fieldRanges.find(field);
-    const auto range = (it != m_fieldRanges.end()) ? it->second : FieldRange{};
-    {
-        const QSignalBlocker modeBlocker(m_rangeMode);
-        const QSignalBlocker minBlocker(m_rangeMinimum);
-        const QSignalBlocker maxBlocker(m_rangeMaximum);
-        m_rangeMode->setCurrentIndex(
-            m_rangeMode->findData(static_cast<int>(range.mode)));
-        if (range.userRange.has_value()) {
-            m_rangeMinimum->setValue(range.userRange->first);
-            m_rangeMaximum->setValue(range.userRange->second);
-        }
-    }
-    const auto isUser = range.mode == RangeMode::User;
-    m_rangeMinimum->setEnabled(isUser && m_controlsReady);
-    m_rangeMaximum->setEnabled(isUser && m_controlsReady);
-}
-
 void MainWindow::resetRangeState()
 {
-    m_fieldRanges.clear();
-    m_trackedField = 0;
+    m_range->reset();
     m_displayCoordinator.invalidateRangeCache();
     m_pendingRangeStore.reset();
-    const QSignalBlocker modeBlocker(m_rangeMode);
-    const QSignalBlocker minBlocker(m_rangeMinimum);
-    const QSignalBlocker maxBlocker(m_rangeMaximum);
-    m_rangeMode->setCurrentIndex(
-        m_rangeMode->findData(static_cast<int>(RangeMode::File)));
-    m_rangeMinimum->setValue(0.0);
-    m_rangeMaximum->setValue(1.0);
-    m_rangeMinimum->setEnabled(false);
-    m_rangeMaximum->setEnabled(false);
 }
 
 void MainWindow::updateRangeModeAvailability()
@@ -1644,55 +1591,18 @@ void MainWindow::updateRangeModeAvailability()
         || m_levelSelector->currentIndex() < 0) {
         return;
     }
-
     const auto& metadata = m_dataset->metadata();
     const FieldId field{m_fieldSelector->currentData().toUInt()};
     const auto [composition, maximumLevel] = decodeLevelData(
         m_levelSelector->currentData().toInt(), metadata.finestLevel);
-    const auto fileAvailable = m_dataset->rangeAvailable(
-        RangeRequest{field, maximumLevel, composition, RangeScope::File});
-    const auto levelAvailable = m_dataset->rangeAvailable(
-        RangeRequest{field, maximumLevel, composition, RangeScope::Level});
-
-    auto* model = qobject_cast<QStandardItemModel*>(m_rangeMode->model());
-    if (model == nullptr) {
-        return;
-    }
-    const auto unavailableText = tr(
-        "Unavailable because this data does not provide complete range statistics.");
-    const auto setAvailable = [&](RangeMode mode, bool available) {
-        const auto index = m_rangeMode->findData(static_cast<int>(mode));
-        if (index < 0) {
-            return;
-        }
-        if (auto* item = model->item(index)) {
-            item->setEnabled(available);
-            item->setToolTip(available ? QString() : unavailableText);
-        }
-    };
-    setAvailable(RangeMode::File, fileAvailable);
-    setAvailable(RangeMode::Level, levelAvailable);
-
-    const auto current = static_cast<RangeMode>(
-        m_rangeMode->currentData().toInt());
-    const auto currentAvailable =
-        (current != RangeMode::File || fileAvailable)
-        && (current != RangeMode::Level || levelAvailable);
-    if (currentAvailable) {
-        return;
-    }
-
-    {
-        const QSignalBlocker blocker(m_rangeMode);
-        m_rangeMode->setCurrentIndex(
-            m_rangeMode->findData(static_cast<int>(RangeMode::Visible)));
-    }
-    m_rangeMinimum->setEnabled(false);
-    m_rangeMaximum->setEnabled(false);
-    auto& fieldRange = m_fieldRanges[field.value];
-    fieldRange.mode = RangeMode::Visible;
-    statusBar()->showMessage(
-        tr("Metadata range unavailable; using the visible-data range."));
+    m_range->updateAvailability(
+        RangeController::Availability{
+            .file = m_dataset->rangeAvailable(RangeRequest{
+                field, maximumLevel, composition, RangeScope::File}),
+            .level = m_dataset->rangeAvailable(RangeRequest{
+                field, maximumLevel, composition, RangeScope::Level}),
+        },
+        field.value);
 }
 
 FrameSliceSpec MainWindow::buildFrameSpec()
@@ -1703,11 +1613,11 @@ FrameSliceSpec MainWindow::buildFrameSpec()
     spec.contourCount = m_contourCount;
     spec.sphericalSupersample = m_sphericalSupersample;
     spec.sphericalDisplay = m_sphericalDisplay;
-    spec.logarithmic = m_logarithmic->isChecked();
-    spec.rangeMode = static_cast<RangeMode>(m_rangeMode->currentData().toInt());
-    if (spec.rangeMode == RangeMode::User) {
-        spec.userRange = std::pair{m_rangeMinimum->value(),
-            m_rangeMaximum->value()};
+    {
+        const auto selection = m_range->selection();
+        spec.logarithmic = selection.logarithmic;
+        spec.rangeMode = selection.mode;
+        spec.userRange = selection.userRange;
     }
     spec.field = m_controlsReady && m_fieldSelector->currentIndex() >= 0
         ? m_fieldSelector->currentData().toUInt() : 0U;

--- a/src/qt/MainWindowTestAccess.cpp
+++ b/src/qt/MainWindowTestAccess.cpp
@@ -60,20 +60,9 @@ void MainWindow::configureContourSyncForTest(
         return;
     }
     m_slicePosition3d = slicePositions;
-    // Set range/log through the widgets (requestSlice reads them) but block
-    // their signals so only the single scheduleSliceRequest below re-slices.
-    {
-        const QSignalBlocker rangeBlocker(m_rangeMode);
-        const auto index = m_rangeMode->findData(
-            static_cast<int>(RangeMode::Visible));
-        if (index >= 0) {
-            m_rangeMode->setCurrentIndex(index);
-        }
-    }
-    {
-        const QSignalBlocker logBlocker(m_logarithmic);
-        m_logarithmic->setChecked(logarithmic);
-    }
+    // Set range/log through the controller (requestSlice reads it) without
+    // signals, so only the single scheduleSliceRequest below re-slices.
+    m_range->setSelection({RangeMode::Visible, std::nullopt, logarithmic});
     m_displayMode = DisplayMode::RasterContours;
     m_contourCount = count;
     scheduleSliceRequest(false);
@@ -105,14 +94,8 @@ void MainWindow::enableVisibleRasterForTest()
     if (!m_dataset) {
         return;
     }
-    {
-        const QSignalBlocker rangeBlocker(m_rangeMode);
-        const auto index = m_rangeMode->findData(
-            static_cast<int>(RangeMode::Visible));
-        if (index >= 0) {
-            m_rangeMode->setCurrentIndex(index);
-        }
-    }
+    m_range->setSelection(
+        {RangeMode::Visible, std::nullopt, m_range->logarithmic()});
     m_displayMode = DisplayMode::Raster;
     scheduleSliceRequest(false);
 }

--- a/src/qt/RangeController.cpp
+++ b/src/qt/RangeController.cpp
@@ -1,0 +1,234 @@
+#include "RangeController.hpp"
+
+#include "ScientificDoubleSpinBox.hpp"
+
+#include <QCheckBox>
+#include <QComboBox>
+#include <QSignalBlocker>
+#include <QStandardItemModel>
+#include <QToolBar>
+
+#include <limits>
+#include <utility>
+
+namespace amrvis::qt {
+
+RangeController::RangeController(QObject* parent)
+    : QObject(parent)
+{
+}
+
+void RangeController::createToolbarWidgets(QToolBar* toolbar)
+{
+    m_mode = new QComboBox(toolbar);
+    m_mode->setObjectName(QStringLiteral("rangeModeSelector"));
+    m_mode->addItem(tr("File"), static_cast<int>(RangeMode::File));
+    m_mode->addItem(tr("Level"), static_cast<int>(RangeMode::Level));
+    m_mode->addItem(tr("Visible"), static_cast<int>(RangeMode::Visible));
+    m_mode->addItem(tr("User"), static_cast<int>(RangeMode::User));
+    toolbar->addWidget(m_mode);
+    m_minimum = new ScientificDoubleSpinBox(toolbar);
+    m_maximum = new ScientificDoubleSpinBox(toolbar);
+    for (auto* range : {m_minimum, m_maximum}) {
+        range->setRange(-std::numeric_limits<double>::max(),
+            std::numeric_limits<double>::max());
+        range->setMinimumWidth(110);
+        range->setEnabled(false);
+        toolbar->addWidget(range);
+    }
+    m_minimum->setPrefix(tr("min "));
+    m_maximum->setPrefix(tr("max "));
+    m_maximum->setValue(1.0);
+    // Separate the Range group (mode + min/max) from Log, matching the
+    // per-group separators on the Slice Controls toolbar.
+    toolbar->addSeparator();
+    m_logarithmic = new QCheckBox(tr("Log"), toolbar);
+    toolbar->addWidget(m_logarithmic);
+    m_mode->setEnabled(false);
+    m_logarithmic->setEnabled(false);
+
+    connect(m_mode, qOverload<int>(&QComboBox::currentIndexChanged), this,
+        [this](int) {
+            updateUserRangeEnabled();
+            emit modeChanged();
+        });
+    connect(m_minimum, qOverload<double>(&QDoubleSpinBox::valueChanged), this,
+        [this](double) {
+            if (mode() == RangeMode::User) {
+                emit userRangeChanged();
+            }
+        });
+    connect(m_maximum, qOverload<double>(&QDoubleSpinBox::valueChanged), this,
+        [this](double) {
+            if (mode() == RangeMode::User) {
+                emit userRangeChanged();
+            }
+        });
+    connect(m_logarithmic, &QCheckBox::toggled, this,
+        [this](bool) { emit logarithmicChanged(); });
+}
+
+RangeController::Selection RangeController::selection() const
+{
+    Selection selection;
+    selection.mode = mode();
+    if (selection.mode == RangeMode::User) {
+        selection.userRange = std::pair{m_minimum->value(), m_maximum->value()};
+    }
+    selection.logarithmic = logarithmic();
+    return selection;
+}
+
+RangeMode RangeController::mode() const
+{
+    return static_cast<RangeMode>(m_mode->currentData().toInt());
+}
+
+bool RangeController::logarithmic() const
+{
+    return m_logarithmic->isChecked();
+}
+
+void RangeController::setMode(RangeMode mode)
+{
+    const QSignalBlocker blocker(m_mode);
+    m_mode->setCurrentIndex(m_mode->findData(static_cast<int>(mode)));
+}
+
+void RangeController::updateUserRangeEnabled()
+{
+    const bool user = mode() == RangeMode::User;
+    m_minimum->setEnabled(user && m_controlsReady);
+    m_maximum->setEnabled(user && m_controlsReady);
+}
+
+void RangeController::setSelection(const Selection& selection)
+{
+    const QSignalBlocker minBlocker(m_minimum);
+    const QSignalBlocker maxBlocker(m_maximum);
+    const QSignalBlocker logBlocker(m_logarithmic);
+    setMode(selection.mode);
+    m_logarithmic->setChecked(selection.logarithmic);
+    if (selection.userRange) {
+        m_minimum->setValue(selection.userRange->first);
+        m_maximum->setValue(selection.userRange->second);
+    }
+    updateUserRangeEnabled();
+}
+
+void RangeController::showDisplayRange(double minimum, double maximum)
+{
+    const QSignalBlocker minBlocker(m_minimum);
+    const QSignalBlocker maxBlocker(m_maximum);
+    m_minimum->setValue(minimum);
+    m_maximum->setValue(maximum);
+}
+
+void RangeController::showLogarithmic(bool logarithmic)
+{
+    if (m_logarithmic->isChecked() != logarithmic) {
+        const QSignalBlocker blocker(m_logarithmic);
+        m_logarithmic->setChecked(logarithmic);
+    }
+}
+
+void RangeController::setControlsReady(bool ready)
+{
+    m_controlsReady = ready;
+    m_mode->setEnabled(ready);
+    m_logarithmic->setEnabled(ready);
+    updateUserRangeEnabled();
+}
+
+void RangeController::setNumberFormat(const QString& format)
+{
+    m_minimum->setNumberFormat(format);
+    m_maximum->setNumberFormat(format);
+}
+
+void RangeController::switchField(std::uint32_t field)
+{
+    if (field == m_trackedField) {
+        return;
+    }
+    commitFieldRange(m_trackedField);
+    m_trackedField = field;
+    applyFieldRange(field);
+}
+
+void RangeController::commitFieldRange(std::uint32_t field)
+{
+    FieldRange range;
+    range.mode = mode();
+    if (range.mode == RangeMode::User) {
+        range.userRange = std::pair{m_minimum->value(), m_maximum->value()};
+    }
+    m_fieldRanges[field] = std::move(range);
+}
+
+void RangeController::applyFieldRange(std::uint32_t field)
+{
+    const auto it = m_fieldRanges.find(field);
+    const auto range = it != m_fieldRanges.end() ? it->second : FieldRange{};
+    {
+        const QSignalBlocker minBlocker(m_minimum);
+        const QSignalBlocker maxBlocker(m_maximum);
+        setMode(range.mode);
+        if (range.userRange.has_value()) {
+            m_minimum->setValue(range.userRange->first);
+            m_maximum->setValue(range.userRange->second);
+        }
+    }
+    updateUserRangeEnabled();
+}
+
+void RangeController::reset()
+{
+    m_fieldRanges.clear();
+    m_trackedField = 0;
+    const QSignalBlocker minBlocker(m_minimum);
+    const QSignalBlocker maxBlocker(m_maximum);
+    setMode(RangeMode::File);
+    m_minimum->setValue(0.0);
+    m_maximum->setValue(1.0);
+    m_minimum->setEnabled(false);
+    m_maximum->setEnabled(false);
+}
+
+void RangeController::updateAvailability(
+    const Availability& availability, std::uint32_t field)
+{
+    auto* model = qobject_cast<QStandardItemModel*>(m_mode->model());
+    if (model == nullptr) {
+        return;
+    }
+    const auto unavailableText = tr(
+        "Unavailable because this data does not provide complete range statistics.");
+    const auto setAvailable = [&](RangeMode mode, bool available) {
+        const auto index = m_mode->findData(static_cast<int>(mode));
+        if (index < 0) {
+            return;
+        }
+        if (auto* item = model->item(index)) {
+            item->setEnabled(available);
+            item->setToolTip(available ? QString() : unavailableText);
+        }
+    };
+    setAvailable(RangeMode::File, availability.file);
+    setAvailable(RangeMode::Level, availability.level);
+
+    const auto current = mode();
+    const auto currentAvailable = (current != RangeMode::File || availability.file)
+        && (current != RangeMode::Level || availability.level);
+    if (currentAvailable) {
+        return;
+    }
+    setMode(RangeMode::Visible);
+    m_minimum->setEnabled(false);
+    m_maximum->setEnabled(false);
+    m_fieldRanges[field].mode = RangeMode::Visible;
+    emit statusMessage(
+        tr("Metadata range unavailable; using the visible-data range."), 0);
+}
+
+} // namespace amrvis::qt

--- a/src/qt/RangeController.hpp
+++ b/src/qt/RangeController.hpp
@@ -1,0 +1,121 @@
+#pragma once
+
+#include <amrexplorer/pipeline/SlicePipeline.hpp>
+
+#include <QObject>
+#include <QString>
+
+#include <cstdint>
+#include <optional>
+#include <unordered_map>
+#include <utility>
+
+class QCheckBox;
+class QComboBox;
+class QToolBar;
+
+namespace amrvis::qt {
+
+class ScientificDoubleSpinBox;
+
+// The range controls of the Color and Overlay toolbar -- the range mode
+// (File / Level / Visible / User), the User min/max, and Log -- with the
+// per-field memory behind them: each field remembers its own mode and User
+// range for the current dataset, swapped in and out as the field selector
+// changes. The host reads selection() into its slice requests and frame
+// specs, and writes back through blocked setters (restore, colour controls,
+// sync completions) that emit nothing; only a user's edit emits a change
+// signal. The visible-range sync that keeps three 3-D panels on
+// one range is the host's slice-result coordination, not this class's.
+class RangeController final : public QObject {
+    Q_OBJECT
+
+public:
+    struct Selection {
+        RangeMode mode = RangeMode::File;
+        // The User min/max, present when mode is User.
+        std::optional<std::pair<double, double>> userRange;
+        bool logarithmic = false;
+    };
+    // Which metadata-backed modes the current field/level can offer.
+    struct Availability {
+        bool file = true;
+        bool level = true;
+    };
+
+    explicit RangeController(QObject* parent = nullptr);
+
+    // Builds the mode combo, the min/max spin boxes and the Log checkbox into
+    // the toolbar, in that order (Log after a separator). Owned by the
+    // toolbar; call once.
+    void createToolbarWidgets(QToolBar* toolbar);
+
+    [[nodiscard]] Selection selection() const;
+    [[nodiscard]] RangeMode mode() const;
+    [[nodiscard]] bool logarithmic() const;
+
+    // Blocked writes: none of these emits a change signal.
+    // The whole selection, as a restore does; the min/max are written only
+    // when a User range is given.
+    void setSelection(const Selection& selection);
+    // The active view's display range and log flag, mirrored into the boxes
+    // and checkbox (the min/max unconditionally: the caller decides whether
+    // a User range must be left alone).
+    void showDisplayRange(double minimum, double maximum);
+    void showLogarithmic(bool logarithmic);
+    // Whether a dataset is open: mode and Log enabled iff ready, min/max iff
+    // ready and the mode is User.
+    void setControlsReady(bool ready);
+    void setNumberFormat(const QString& format);
+
+    // Per-field memory. The widgets represent trackedField(); switchField
+    // snapshots them for that field and loads the new field's snapshot (or
+    // the default: File, no range) -- a no-op for the same field. commit
+    // snapshots the widgets for a field outright (a restore, after
+    // setSelection). reset forgets every field for a fresh dataset and puts
+    // the widgets back to File, 0..1, min/max disabled.
+    void switchField(std::uint32_t field);
+    void commitFieldRange(std::uint32_t field);
+    void reset();
+    [[nodiscard]] std::uint32_t trackedField() const noexcept
+    {
+        return m_trackedField;
+    }
+    void setTrackedField(std::uint32_t field) noexcept
+    {
+        m_trackedField = field;
+    }
+    // Enables or disables the File and Level entries for what `field` at the
+    // current level can offer. A selected mode that became unavailable falls
+    // back to Visible (recorded in the field's snapshot) with a status
+    // message; that fallback is silent otherwise -- no modeChanged.
+    void updateAvailability(const Availability& availability, std::uint32_t field);
+
+signals:
+    // A user's edit of the mode, of a User bound, or of Log. Blocked writes
+    // emit none of these.
+    void modeChanged();
+    void userRangeChanged();
+    void logarithmicChanged();
+    void statusMessage(const QString& message, int timeoutMs);
+
+private:
+    struct FieldRange {
+        RangeMode mode = RangeMode::File;
+        std::optional<std::pair<double, double>> userRange;
+    };
+
+    void setMode(RangeMode mode);
+    void applyFieldRange(std::uint32_t field);
+    void updateUserRangeEnabled();
+
+    QComboBox* m_mode = nullptr;
+    ScientificDoubleSpinBox* m_minimum = nullptr;
+    ScientificDoubleSpinBox* m_maximum = nullptr;
+    QCheckBox* m_logarithmic = nullptr;
+    bool m_controlsReady = false;
+    std::unordered_map<std::uint32_t, FieldRange> m_fieldRanges;
+    std::uint32_t m_trackedField = 0;
+};
+
+} // namespace amrvis::qt

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -491,6 +491,33 @@ if(TARGET amrexplorer_qt)
         COMMAND "${CMAKE_COMMAND}" -E env QT_QPA_PLATFORM=offscreen
             "$<TARGET_FILE:test_palette_controller>")
 
+    add_executable(test_range_controller
+        unit/test_range_controller.cpp
+        "${PROJECT_SOURCE_DIR}/src/qt/RangeController.cpp"
+        "${PROJECT_SOURCE_DIR}/src/qt/RangeController.hpp"
+        "${PROJECT_SOURCE_DIR}/src/qt/ScientificDoubleSpinBox.cpp"
+        "${PROJECT_SOURCE_DIR}/src/qt/ScientificDoubleSpinBox.hpp"
+        "${PROJECT_SOURCE_DIR}/src/qt/NumberFormat.cpp"
+        "${PROJECT_SOURCE_DIR}/src/qt/NumberFormat.hpp"
+    )
+    set_target_properties(test_range_controller PROPERTIES AUTOMOC ON)
+    target_include_directories(test_range_controller
+        PRIVATE "${PROJECT_SOURCE_DIR}/src/qt")
+    target_link_libraries(test_range_controller
+        PRIVATE
+            amrexplorer::pipeline
+            amrexplorer::warnings
+            Qt6::Core
+            Qt6::Gui
+            Qt6::Widgets
+    )
+    # The controller builds real widgets into a toolbar; offscreen keeps it
+    # headless.
+    add_test(NAME range_controller
+        COMMAND "${CMAKE_COMMAND}" -E env QT_QPA_PLATFORM=offscreen
+            "$<TARGET_FILE:test_range_controller>")
+    set_tests_properties(range_controller PROPERTIES TIMEOUT 60)
+
     add_executable(test_particle_controller
         unit/test_particle_controller.cpp
         "${PROJECT_SOURCE_DIR}/src/qt/ParticleController.cpp"

--- a/tests/unit/test_range_controller.cpp
+++ b/tests/unit/test_range_controller.cpp
@@ -183,8 +183,9 @@ int main(int argc, char* argv[])
                 && observed.logarithmic == 0,
             "a blocked write announced a change");
         controller.setNumberFormat(QStringLiteral("%.3f"));
-        require(widgets.minimum->text().contains(QStringLiteral("6.000")),
-            "the number format did not reach the bounds");
+        require(widgets.minimum->text().contains(QStringLiteral("6.000"))
+                && widgets.maximum->text().contains(QStringLiteral("7.000")),
+            "the number format did not reach both bounds");
     }
 
     // Per-field memory: switching fields snapshots the old field and loads
@@ -212,7 +213,14 @@ int main(int argc, char* argv[])
         controller.switchField(3);
         require(controller.mode() == RangeMode::File,
             "switching to the same field changed something");
-        selectMode(*widgets.mode, RangeMode::Level);
+        // Field 3 gets its own User range, different from field 0's, so each
+        // swap really rewrites the boxes -- and must do so silently: a swap
+        // that announced userRangeChanged would re-slice on every field
+        // change.
+        selectMode(*widgets.mode, RangeMode::User);
+        widgets.minimum->setValue(-5.0);
+        widgets.maximum->setValue(5.0);
+        const auto edits = observed.userRange;
         controller.switchField(0);
         require(controller.trackedField() == 0
                 && controller.mode() == RangeMode::User
@@ -220,10 +228,9 @@ int main(int argc, char* argv[])
                 && widgets.minimum->isEnabled(),
             "switching back did not restore the field's User range");
         controller.switchField(3);
-        require(controller.mode() == RangeMode::Level,
+        require(controller.selection().userRange == std::pair{-5.0, 5.0},
             "the other field's snapshot was not kept");
-        // The swaps are blocked writes.
-        require(observed.mode == 2 && observed.userRange == 2,
+        require(observed.userRange == edits && observed.mode == 2,
             "a field switch announced a change");
         controller.setSelection({RangeMode::Visible, std::nullopt, false});
         controller.setTrackedField(7);

--- a/tests/unit/test_range_controller.cpp
+++ b/tests/unit/test_range_controller.cpp
@@ -1,0 +1,297 @@
+// RangeController: the range toolbar widgets and the per-field memory behind
+// them. What a user's edits emit, what blocked writes do not, how snapshots
+// swap with the field, and how availability disables modes and falls back.
+
+#include "RangeController.hpp"
+#include "ScientificDoubleSpinBox.hpp"
+
+#include <QApplication>
+#include <QCheckBox>
+#include <QComboBox>
+#include <QDoubleSpinBox>
+#include <QStandardItemModel>
+#include <QToolBar>
+
+#include <cstdlib>
+#include <iostream>
+
+namespace {
+
+void require(bool condition, const char* message)
+{
+    if (!condition) {
+        std::cerr << "FAILED: " << message << '\n';
+        std::exit(1);
+    }
+}
+
+struct Observed {
+    int mode = 0;
+    int userRange = 0;
+    int logarithmic = 0;
+    QStringList statuses;
+};
+
+void observe(amrvis::qt::RangeController& controller, Observed& observed)
+{
+    QObject::connect(&controller, &amrvis::qt::RangeController::modeChanged,
+        &controller, [&observed] { ++observed.mode; });
+    QObject::connect(&controller,
+        &amrvis::qt::RangeController::userRangeChanged, &controller,
+        [&observed] { ++observed.userRange; });
+    QObject::connect(&controller,
+        &amrvis::qt::RangeController::logarithmicChanged, &controller,
+        [&observed] { ++observed.logarithmic; });
+    QObject::connect(&controller, &amrvis::qt::RangeController::statusMessage,
+        &controller, [&observed](const QString& message, int) {
+            observed.statuses << message;
+        });
+}
+
+// The widgets, found by what they are: the one combo, the two spin boxes in
+// toolbar order, the one checkbox.
+struct Widgets {
+    QComboBox* mode = nullptr;
+    amrvis::qt::ScientificDoubleSpinBox* minimum = nullptr;
+    amrvis::qt::ScientificDoubleSpinBox* maximum = nullptr;
+    QCheckBox* logarithmic = nullptr;
+};
+
+Widgets widgetsOf(QToolBar& toolbar)
+{
+    Widgets widgets;
+    widgets.mode = toolbar.findChild<QComboBox*>();
+    // ScientificDoubleSpinBox has no Q_OBJECT; find the QDoubleSpinBoxes and
+    // downcast (there are exactly the two).
+    const auto boxes = toolbar.findChildren<QDoubleSpinBox*>();
+    if (boxes.size() == 2) {
+        widgets.minimum
+            = dynamic_cast<amrvis::qt::ScientificDoubleSpinBox*>(boxes[0]);
+        widgets.maximum
+            = dynamic_cast<amrvis::qt::ScientificDoubleSpinBox*>(boxes[1]);
+    }
+    widgets.logarithmic = toolbar.findChild<QCheckBox*>();
+    return widgets;
+}
+
+void selectMode(QComboBox& combo, amrvis::RangeMode mode)
+{
+    combo.setCurrentIndex(combo.findData(static_cast<int>(mode)));
+}
+
+} // namespace
+
+int main(int argc, char* argv[])
+{
+    QApplication application(argc, argv);
+    using amrvis::RangeMode;
+    using amrvis::qt::RangeController;
+
+    // Creation and initial state; a user's edits emit, per widget, and only
+    // when they mean something (a bound edit outside User mode is silent);
+    // enablement follows readiness and mode.
+    {
+        QToolBar toolbar;
+        Observed observed;
+        RangeController controller;
+        observe(controller, observed);
+        controller.createToolbarWidgets(&toolbar);
+        const auto widgets = widgetsOf(toolbar);
+        require(widgets.mode != nullptr && widgets.minimum != nullptr
+                && widgets.maximum != nullptr && widgets.logarithmic != nullptr,
+            "the toolbar widgets were not created");
+        require(widgets.mode->objectName() == QStringLiteral("rangeModeSelector")
+                && widgets.mode->count() == 4,
+            "the mode combo is not the one the smoke tests look for");
+        const auto initial = controller.selection();
+        require(initial.mode == RangeMode::File && !initial.userRange
+                && !initial.logarithmic && widgets.minimum->value() == 0.0
+                && widgets.maximum->value() == 1.0,
+            "the initial selection is not File, 0..1, linear");
+        require(!widgets.mode->isEnabled() && !widgets.logarithmic->isEnabled()
+                && !widgets.minimum->isEnabled() && !widgets.maximum->isEnabled(),
+            "the controls start enabled without a dataset");
+
+        widgets.minimum->setValue(0.25);
+        require(observed.userRange == 0,
+            "a bound edit outside User mode was announced");
+        selectMode(*widgets.mode, RangeMode::User);
+        require(observed.mode == 1 && controller.mode() == RangeMode::User
+                && !widgets.minimum->isEnabled(),
+            "selecting User did not announce, or enabled the bounds while not "
+            "ready");
+        controller.setControlsReady(true);
+        require(widgets.mode->isEnabled() && widgets.logarithmic->isEnabled()
+                && widgets.minimum->isEnabled() && widgets.maximum->isEnabled(),
+            "readiness did not enable the controls for User mode");
+        widgets.maximum->setValue(4.0);
+        require(observed.userRange == 1
+                && controller.selection().userRange
+                    == std::pair{0.25, 4.0},
+            "a User bound edit was not announced with the new range");
+        widgets.logarithmic->setChecked(true);
+        require(observed.logarithmic == 1 && controller.logarithmic()
+                && controller.selection().logarithmic,
+            "Log was not announced");
+        selectMode(*widgets.mode, RangeMode::Visible);
+        require(observed.mode == 2 && !widgets.minimum->isEnabled()
+                && !controller.selection().userRange,
+            "leaving User kept the bounds enabled or in the selection");
+        controller.setControlsReady(false);
+        require(!widgets.mode->isEnabled() && !widgets.logarithmic->isEnabled(),
+            "un-readiness left the controls enabled");
+        require(observed.mode == 2 && observed.userRange == 1
+                && observed.logarithmic == 1,
+            "readiness changes announced something");
+    }
+
+    // Blocked writes: setSelection, showDisplayRange, showLogarithmic emit
+    // nothing and land in the widgets; showDisplayRange writes even in User
+    // mode (the caller decides).
+    {
+        QToolBar toolbar;
+        Observed observed;
+        RangeController controller;
+        observe(controller, observed);
+        controller.createToolbarWidgets(&toolbar);
+        controller.setControlsReady(true);
+        const auto widgets = widgetsOf(toolbar);
+        controller.setSelection({RangeMode::User, std::pair{-1.0, 2.0}, true});
+        require(controller.mode() == RangeMode::User
+                && widgets.minimum->value() == -1.0
+                && widgets.maximum->value() == 2.0
+                && widgets.logarithmic->isChecked()
+                && widgets.minimum->isEnabled(),
+            "setSelection did not land in the widgets");
+        controller.setSelection({RangeMode::Level, std::nullopt, false});
+        require(controller.mode() == RangeMode::Level
+                && widgets.minimum->value() == -1.0
+                && !widgets.logarithmic->isChecked()
+                && !widgets.minimum->isEnabled(),
+            "setSelection without a range touched the bounds, or kept them "
+            "enabled");
+        controller.showDisplayRange(3.0, 5.0);
+        controller.showLogarithmic(true);
+        require(widgets.minimum->value() == 3.0 && widgets.maximum->value() == 5.0
+                && widgets.logarithmic->isChecked(),
+            "the display range or log flag was not mirrored");
+        controller.setSelection({RangeMode::User, std::nullopt, true});
+        controller.showDisplayRange(6.0, 7.0);
+        require(widgets.minimum->value() == 6.0,
+            "showDisplayRange skipped User mode on its own");
+        require(observed.mode == 0 && observed.userRange == 0
+                && observed.logarithmic == 0,
+            "a blocked write announced a change");
+        controller.setNumberFormat(QStringLiteral("%.3f"));
+        require(widgets.minimum->text().contains(QStringLiteral("6.000")),
+            "the number format did not reach the bounds");
+    }
+
+    // Per-field memory: switching fields snapshots the old field and loads
+    // the new one's (default File for an unknown field); switching back
+    // restores; the same field is a no-op; commit records outright; reset
+    // forgets and restores the defaults.
+    {
+        QToolBar toolbar;
+        Observed observed;
+        RangeController controller;
+        observe(controller, observed);
+        controller.createToolbarWidgets(&toolbar);
+        controller.setControlsReady(true);
+        const auto widgets = widgetsOf(toolbar);
+        require(controller.trackedField() == 0, "tracked field does not start at 0");
+        selectMode(*widgets.mode, RangeMode::User);
+        widgets.minimum->setValue(10.0);
+        widgets.maximum->setValue(20.0);
+        controller.switchField(3);
+        require(controller.trackedField() == 3
+                && controller.mode() == RangeMode::File
+                && !controller.selection().userRange
+                && !widgets.minimum->isEnabled(),
+            "an unknown field did not load the default");
+        controller.switchField(3);
+        require(controller.mode() == RangeMode::File,
+            "switching to the same field changed something");
+        selectMode(*widgets.mode, RangeMode::Level);
+        controller.switchField(0);
+        require(controller.trackedField() == 0
+                && controller.mode() == RangeMode::User
+                && controller.selection().userRange == std::pair{10.0, 20.0}
+                && widgets.minimum->isEnabled(),
+            "switching back did not restore the field's User range");
+        controller.switchField(3);
+        require(controller.mode() == RangeMode::Level,
+            "the other field's snapshot was not kept");
+        // The swaps are blocked writes.
+        require(observed.mode == 2 && observed.userRange == 2,
+            "a field switch announced a change");
+        controller.setSelection({RangeMode::Visible, std::nullopt, false});
+        controller.setTrackedField(7);
+        controller.commitFieldRange(7);
+        controller.switchField(0);
+        controller.switchField(7);
+        require(controller.mode() == RangeMode::Visible,
+            "commit did not record the field's mode");
+        controller.reset();
+        require(controller.trackedField() == 0
+                && controller.mode() == RangeMode::File
+                && widgets.minimum->value() == 0.0
+                && widgets.maximum->value() == 1.0
+                && !widgets.minimum->isEnabled(),
+            "reset did not restore the defaults");
+        controller.switchField(3);
+        require(controller.mode() == RangeMode::File,
+            "reset did not forget the fields");
+    }
+
+    // Availability: File/Level entries disabled with a tooltip; a selected
+    // mode that becomes unavailable falls back to Visible silently (status
+    // message, no modeChanged), recorded in the field's snapshot.
+    {
+        QToolBar toolbar;
+        Observed observed;
+        RangeController controller;
+        observe(controller, observed);
+        controller.createToolbarWidgets(&toolbar);
+        controller.setControlsReady(true);
+        const auto widgets = widgetsOf(toolbar);
+        auto* model = qobject_cast<QStandardItemModel*>(widgets.mode->model());
+        require(model != nullptr, "the mode combo has no item model");
+        const auto item = [&](RangeMode mode) {
+            return model->item(widgets.mode->findData(static_cast<int>(mode)));
+        };
+        selectMode(*widgets.mode, RangeMode::Level);
+        controller.updateAvailability({.file = true, .level = false}, 0);
+        require(!item(RangeMode::Level)->isEnabled()
+                && !item(RangeMode::Level)->toolTip().isEmpty()
+                && item(RangeMode::File)->isEnabled()
+                && item(RangeMode::File)->toolTip().isEmpty(),
+            "availability did not disable Level with a tooltip");
+        require(controller.mode() == RangeMode::Visible
+                && observed.statuses.size() == 1
+                && observed.statuses.front().contains(
+                    QStringLiteral("visible-data range")),
+            "an unavailable mode did not fall back to Visible with a message");
+        require(observed.mode == 1,
+            "the fallback announced a mode change (only the user's Level pick "
+            "should have)");
+        controller.switchField(1);
+        controller.switchField(0);
+        require(controller.mode() == RangeMode::Visible,
+            "the fallback was not recorded in the field's snapshot");
+        controller.updateAvailability({.file = true, .level = true}, 0);
+        require(item(RangeMode::Level)->isEnabled()
+                && item(RangeMode::Level)->toolTip().isEmpty()
+                && controller.mode() == RangeMode::Visible
+                && observed.statuses.size() == 1,
+            "restored availability changed the mode or re-announced");
+        selectMode(*widgets.mode, RangeMode::User);
+        controller.updateAvailability({.file = false, .level = false}, 0);
+        require(controller.mode() == RangeMode::User
+                && widgets.minimum->isEnabled(),
+            "User was disturbed by metadata modes going away");
+    }
+
+    std::cout << "range controller tests passed\n";
+    return 0;
+}


### PR DESCRIPTION
The range mode, User min/max and Log widgets and the per-field range memory move into an owned collaborator; MainWindow reads selection() into its slice requests and frame specs, and keeps the visible-range sync (its slice-result coordination) as it was.