### PR TITLE
drop the ${HOME} install prefix from the HPC instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -100,16 +100,16 @@ module load gcc            # or gcc-native on a Cray system
 module load cmake          # if the system cmake is older than 3.25
 cmake --preset remote --fresh -DCMAKE_CXX_COMPILER=g++
 cmake --build --preset remote --parallel 4
-cmake --install build-remote --prefix ${HOME}
+cmake --install build-remote
 ```
 
-That installs one file, `${HOME}/bin/amrexplorer-server`.
+That installs one file, `~/.local/bin/amrexplorer-server`.
 
 Use `--fresh` whenever you change the compiler; without it the configure fails
 again with the same message and has to be run twice.
 
-If your `${HOME}` is shared between machines, give each its own prefix so one
-build does not overwrite another:
+If your home directory is shared between machines, give each its own prefix so
+one build does not overwrite another:
 
 ```bash
 cmake --install build-remote --prefix ${HOME}/perlmutter

--- a/include/amrexplorer/remote/Server.hpp
+++ b/include/amrexplorer/remote/Server.hpp
@@ -29,7 +29,7 @@ struct ServerOptions {
     // therefore also has to fit in
     //   responseWriteStallTimeout + size / responseWriteMinimumBytesPerSecond,
     // so a trickle-reader is retired within a bound the operator can compute.
-    // The default floor, 64 KiB/s, is far below any usable SSH tunnel; lower it
+    // The default floor, 64 KiB/s, is far below any usable SSH link; lower it
     // for a genuinely slow link (1 allows roughly 18 hours for a 64 MiB
     // response). Zero is rejected: it would restore the unbounded case.
     std::uint64_t responseWriteMinimumBytesPerSecond = 64U * 1024U;


### PR DESCRIPTION
Suggesting --prefix ${HOME} put the server at ${HOME}/bin, which is not where anything else lands and reads as a special case for login nodes. The remote preset inherits AMREXPLORER_USER_INSTALL_PREFIX=ON from default, so a plain `cmake --install build-remote` already installs ~/.local/bin/amrexplorer-server, the same prefix the desktop install uses. --prefix stays documented for the case it is actually needed: a home directory shared between machines, where each needs its own.