### PR TITLE
Harden sync completion and handshake

### DIFF
--- a/src/qt/MainWindow.hpp
+++ b/src/qt/MainWindow.hpp
@@ -160,6 +160,10 @@ public:
     void armVisibleSyncGateForTest();
     void releaseVisibleSyncGateForTest();
     void disarmVisibleSyncGateForTest();
+    // The next sync worker to run throws instead of rendering, so the
+    // completion's failure path can be driven: a current failure is reported,
+    // a superseded one counted stale.
+    void failNextVisibleSyncForTest();
     void setViewDisplayRangesForTest(double minimum, double maximum);
     [[nodiscard]] std::uint64_t activeViewRenderGenerationForTest() const;
     [[nodiscard]] bool visibleSyncWorkerWaitingForTest() const;

--- a/src/qt/MainWindow.hpp
+++ b/src/qt/MainWindow.hpp
@@ -28,6 +28,7 @@
 #include <array>
 #include <atomic>
 #include <cstdint>
+#include <exception>
 #include <filesystem>
 #include <memory>
 #include <optional>
@@ -550,6 +551,9 @@ private:
     // Non-modal failure report: status bar plus the model's error history
     // (which shows the dock); suppressed while closing.
     void reportBackgroundError(const QString& message);
+    // The one wording for a shared-range sync that could not be scheduled,
+    // run, or applied.
+    void reportVisibleSyncFailure(const std::exception& error);
     void updateAnimationDockVisibility();
     void updateWindowTitle();
     void restoreSettings();

--- a/src/qt/MainWindowInternal.hpp
+++ b/src/qt/MainWindowInternal.hpp
@@ -273,6 +273,7 @@ inline QPainterPath sphericalSectorPath(const PlaneMapping& mapping,
 namespace visible_sync_test {
 
 inline std::atomic<bool> gateArmed{false};
+inline std::atomic<bool> failNext{false};  // the next worker to pass throws
 inline std::atomic<int> releaseGrants{0};  // # of "proceed" grants issued
 inline std::atomic<int> passed{0};         // # of workers that have proceeded
 inline std::atomic<int> waiting{0};        // # of workers currently parked

--- a/src/qt/MainWindowInternal.hpp
+++ b/src/qt/MainWindowInternal.hpp
@@ -278,10 +278,13 @@ inline std::atomic<int> releaseGrants{0};  // # of "proceed" grants issued
 inline std::atomic<int> passed{0};         // # of workers that have proceeded
 inline std::atomic<int> waiting{0};        // # of workers currently parked
 
-inline void waitAtGate()
+// Returns whether this worker is the one asked to throw. The flag is consumed
+// before the worker stops counting as parked, so a test that sees no waiter
+// and then arms failNext cannot have it eaten by a worker already released.
+[[nodiscard]] inline bool waitAtGate()
 {
     if (!gateArmed.load()) {
-        return;
+        return failNext.exchange(false);
     }
     waiting.fetch_add(1);
     // Park until a grant is free (passed < grants) -- or the gate is disarmed,
@@ -296,7 +299,9 @@ inline void waitAtGate()
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
     }
     passed.fetch_add(1);
+    const bool fail = failNext.exchange(false);
     waiting.fetch_sub(1);
+    return fail;
 }
 
 } // namespace visible_sync_test

--- a/src/qt/MainWindowSlice.cpp
+++ b/src/qt/MainWindowSlice.cpp
@@ -461,8 +461,7 @@ void MainWindow::requestSlice(PlaneViewState& state, bool rasterDirty)
                 // the arrival path above does) rather than fail silently. The
                 // panels keep their per-view ranges until the next arrival
                 // retries.
-                reportBackgroundError(tr("Cannot synchronize views: %1")
-                    .arg(exceptionMessage(error)));
+                reportVisibleSyncFailure(error);
             }
             updateDiagnostics();
             watcher->deleteLater();
@@ -1055,125 +1054,33 @@ void MainWindow::syncVisibleRanges()
             const bool current = generation == m_generation
                 && m_viewDimension == 3 && m_dataset
                 && m_range->mode() == RangeMode::Visible;
-            // Guarded like the slice-arrival handler above: takeResult rethrows
-            // a worker exception, and applying the outcome installs up to
-            // three 16 Mpx images -- a bad_alloc from either must not escape
-            // the slot and take the application down.
-            try {
-                auto outcome = watcher->future().takeResult();
-                // All-or-nothing, keyed on the render-generation stamp captured per
-                // panel at dispatch. The shared range and log flag are joint across
-                // all three panels, so they must not land on a subset. If any panel
-                // was re-sliced while this sync ran (stamp bumped), the sync rendered
-                // it from the previous plane -- and cached-plane reuse means pointer
-                // identity can't tell (the pointer is reused), while the rerun flag
-                // is not always armed (syncVisibleRanges early-returns on a
-                // mode/dimension flip without setting it). Drop the whole outcome and
-                // let the rerun, or the superseding batch's settle, produce a fresh
-                // coherent one. Single-flight makes the common case all-current, so
-                // this drops only on a genuine mid-sync re-slice, not every tweak.
-                //
-                // Chosen tradeoff (vs. the earlier per-panel partial apply): during
-                // sweep playback or animation export, if a sync outlasts the frame
-                // delay every sync is superseded and nothing lands for the sweep's
-                // duration (it self-heals when playback stops), where partial apply
-                // kept the untouched panels coherent. Coherence-by-construction is
-                // worth that: partial apply could leave the three panels on different
-                // ranges/log flags. If sweep coherence ever matters, gate playbackTick
-                // on the sync too (it currently waits only on pendingRequests).
-                const bool allCurrent = outcome.sync.has_value() && stampsCurrent();
-                if (current && outcome.sync && allCurrent) {
-                    const auto [globalMin, globalMax] = outcome.sync->range;
-                    bool activeApplied = false;
-                    for (std::size_t index = 0; index < views.size(); ++index) {
-                        auto* state = views[index];
-                        auto& update = outcome.sync->panels[index];
-                        if (!update.applies) {
-                            continue;
-                        }
-                        state->displayMinimum = globalMin;
-                        state->displayMaximum = globalMax;
-                        // One shared log flag across the panel set (see
-                        // shared-log-range-render-throw-fails-load): keep every
-                        // panel's stored flag, and thus the color bar below, in
-                        // agreement with the raster the sync just rendered.
-                        state->displayLogarithmic = outcome.sync->logarithmic;
-                        if (update.contoursRecomputed) {
-                            state->contourPolylines
-                                = std::move(update.contourPolylines);
-                        }
-                        if (!outcome.images[index].isNull()) {
-                            // Same plane, re-colored: a virtual canvas keeps its
-                            // placement so the scroll position stays put.
-                            std::optional<ImageView::VirtualPlacement> placement;
-                            if (state->view->virtualCanvasActive()
-                                && !displayIsSpherical()) {
-                                placement = virtualPlacementFor(
-                                    *state, state->plane->physicalRegion);
-                            }
-                            state->view->setImage(outcome.images[index],
-                                ImageTransformPolicy::GeometryAware,
-                                logicalImageSize(*state, *state->plane,
-                                    outcome.images[index]),
-                                placement);
-                            // setImage clears the scene overlays; restore them.
-                            updateGridBoxes(*state);
-                            updateOverlay(*state);
-                            updateParticleOverlay(*state);
-                        }
-                        activeApplied = activeApplied || state == m_activeView;
-                    }
-                    if (activeApplied && m_activeView->plane->width > 0) {
-                        const auto fieldName = m_fieldSelector->currentText();
-                        const auto label = m_activeView->displayLogarithmic
-                            ? fieldName + tr(" (log)") : fieldName;
-                        m_colorBar->setLogarithmic(
-                            m_activeView->displayLogarithmic);
-                        m_colorBar->setFieldRange(label, globalMin, globalMax);
-                        m_range->showDisplayRange(globalMin, globalMax);
-                    }
-                    // The deferred full-domain range store (see the slice-arrival
-                    // completion): the union is only known here. This block runs
-                    // only for an all-current outcome (every panel's stamp matched),
-                    // so the stored union is over the current planes -- a stale
-                    // outcome is dropped in the else branch and never stored.
-                    if (m_pendingRangeStore) {
-                        // Only store if the pending key still describes the current
-                        // (dataset, field, level, composition): a full-domain
-                        // arrival's key can outlive its own sync (e.g. its
-                        // syncVisibleRanges early-returned because the mode was
-                        // File), and this sync's union is for the *current* field,
-                        // so storing it under the stale key would poison that
-                        // field's cached range (range-cache-staleness-races).
-                        const FieldId liveField{
-                            m_fieldSelector->currentData().toUInt()};
-                        const auto [liveComposition, liveMaximumLevel] =
-                            decodeLevelData(m_levelSelector->currentData().toInt(),
-                                m_dataset->metadata().finestLevel);
-                        const DisplayCoordinator::RangeKey liveKey{
-                            m_dataset->id(), liveField, liveMaximumLevel,
-                            liveComposition};
-                        if (*m_pendingRangeStore == liveKey) {
-                            m_displayCoordinator.storeFullDomainRange(
-                                *m_pendingRangeStore, outcome.sync->range);
-                        }
-                        m_pendingRangeStore.reset();
-                    }
-                } else if (current && outcome.sync) {
-                    // Dropped as stale (a panel was re-sliced mid-sync): the union
-                    // is over at least one now-superseded plane, so it is neither
-                    // applied nor stored -- the pending key stays for the rerun,
-                    // which recomputes the union over the current planes.
-#ifdef AMREXPLORER_QT_TEST_ACCESS
-                    // Sole writer of this test-only tally; the staleness smoke test
-                    // asserts its exact delta. The DiagnosticsModel's stale count
-                    // is not touched.
-                    ++m_visibleSyncStaleSkips;
-#endif
-                } else if (generation != m_generation) {
-                    m_pendingRangeStore.reset();
+            // Everything after the outcome is in hand, on both paths.
+            const auto finish = [this, watcher] {
+                updateDiagnostics();
+                watcher->deleteLater();
+                if (m_visibleSyncRerun) {
                     m_visibleSyncRerun = false;
+                    // Re-dispatch inside a slot: guard as at the arrival site
+                    // so a bad_alloc allocating the next worker cannot escape,
+                    // and surface it rather than fail silently.
+                    try {
+                        syncVisibleRanges();
+                    } catch (const std::exception& error) {
+                        reportVisibleSyncFailure(error);
+                    }
                 }
+                if (m_diagnosticsModel->activeRequests() == 0) {
+                    emit interactiveSlicesSettled();
+                }
+            };
+            // Only the extraction is guarded: takeResult rethrows a worker
+            // exception (a failed extrema scan or render), which must not
+            // escape the slot. The apply below is deliberately outside it --
+            // it is the one region that must not land partially, so a throw
+            // there is a crash rather than three panels on mixed state.
+            SyncOutcome outcome;
+            try {
+                outcome = watcher->future().takeResult();
             } catch (const std::exception& error) {
                 // The panels keep their per-view state until the next arrival
                 // re-syncs (as after a failed dispatch). Surface the failure
@@ -1182,8 +1089,11 @@ void MainWindow::syncVisibleRanges()
                 // stamp; a superseded worker's throw is counted stale, as the
                 // arrival path does, not reported as the user's problem.
                 if (current && stampsCurrent()) {
-                    reportBackgroundError(tr("Cannot synchronize views: %1")
-                        .arg(exceptionMessage(error)));
+                    reportVisibleSyncFailure(error);
+                    // This union will never be stored: drop the deferred key
+                    // so a later sync -- possibly over a zoomed subregion --
+                    // cannot store its own under it as the full-domain range.
+                    m_pendingRangeStore.reset();
                 } else {
                     m_diagnosticsModel->noteStaleResult();
                     if (generation != m_generation) {
@@ -1191,24 +1101,123 @@ void MainWindow::syncVisibleRanges()
                         m_visibleSyncRerun = false;
                     }
                 }
+                finish();
+                return;
             }
-            updateDiagnostics();
-            watcher->deleteLater();
-            if (m_visibleSyncRerun) {
-                m_visibleSyncRerun = false;
-                // Re-dispatch inside a slot: guard as at the arrival site so a
-                // bad_alloc allocating the next worker cannot escape, and
-                // surface it rather than fail silently.
-                try {
-                    syncVisibleRanges();
-                } catch (const std::exception& error) {
-                    reportBackgroundError(tr("Cannot synchronize views: %1")
-                        .arg(exceptionMessage(error)));
+            // All-or-nothing, keyed on the render-generation stamp captured per
+            // panel at dispatch. The shared range and log flag are joint across
+            // all three panels, so they must not land on a subset. If any panel
+            // was re-sliced while this sync ran (stamp bumped), the sync rendered
+            // it from the previous plane -- and cached-plane reuse means pointer
+            // identity can't tell (the pointer is reused), while the rerun flag
+            // is not always armed (syncVisibleRanges early-returns on a
+            // mode/dimension flip without setting it). Drop the whole outcome and
+            // let the rerun, or the superseding batch's settle, produce a fresh
+            // coherent one. Single-flight makes the common case all-current, so
+            // this drops only on a genuine mid-sync re-slice, not every tweak.
+            //
+            // Chosen tradeoff (vs. the earlier per-panel partial apply): during
+            // sweep playback or animation export, if a sync outlasts the frame
+            // delay every sync is superseded and nothing lands for the sweep's
+            // duration (it self-heals when playback stops), where partial apply
+            // kept the untouched panels coherent. Coherence-by-construction is
+            // worth that: partial apply could leave the three panels on different
+            // ranges/log flags. If sweep coherence ever matters, gate playbackTick
+            // on the sync too (it currently waits only on pendingRequests).
+            const bool allCurrent = outcome.sync.has_value() && stampsCurrent();
+            if (current && outcome.sync && allCurrent) {
+                const auto [globalMin, globalMax] = outcome.sync->range;
+                bool activeApplied = false;
+                for (std::size_t index = 0; index < views.size(); ++index) {
+                    auto* state = views[index];
+                    auto& update = outcome.sync->panels[index];
+                    if (!update.applies) {
+                        continue;
+                    }
+                    state->displayMinimum = globalMin;
+                    state->displayMaximum = globalMax;
+                    // One shared log flag across the panel set (see
+                    // shared-log-range-render-throw-fails-load): keep every
+                    // panel's stored flag, and thus the color bar below, in
+                    // agreement with the raster the sync just rendered.
+                    state->displayLogarithmic = outcome.sync->logarithmic;
+                    if (update.contoursRecomputed) {
+                        state->contourPolylines
+                            = std::move(update.contourPolylines);
+                    }
+                    if (!outcome.images[index].isNull()) {
+                        // Same plane, re-colored: a virtual canvas keeps its
+                        // placement so the scroll position stays put.
+                        std::optional<ImageView::VirtualPlacement> placement;
+                        if (state->view->virtualCanvasActive()
+                            && !displayIsSpherical()) {
+                            placement = virtualPlacementFor(
+                                *state, state->plane->physicalRegion);
+                        }
+                        state->view->setImage(outcome.images[index],
+                            ImageTransformPolicy::GeometryAware,
+                            logicalImageSize(*state, *state->plane,
+                                outcome.images[index]),
+                            placement);
+                        // setImage clears the scene overlays; restore them.
+                        updateGridBoxes(*state);
+                        updateOverlay(*state);
+                        updateParticleOverlay(*state);
+                    }
+                    activeApplied = activeApplied || state == m_activeView;
                 }
+                if (activeApplied && m_activeView->plane->width > 0) {
+                    const auto fieldName = m_fieldSelector->currentText();
+                    const auto label = m_activeView->displayLogarithmic
+                        ? fieldName + tr(" (log)") : fieldName;
+                    m_colorBar->setLogarithmic(
+                        m_activeView->displayLogarithmic);
+                    m_colorBar->setFieldRange(label, globalMin, globalMax);
+                    m_range->showDisplayRange(globalMin, globalMax);
+                }
+                // The deferred full-domain range store (see the slice-arrival
+                // completion): the union is only known here. This block runs
+                // only for an all-current outcome (every panel's stamp matched),
+                // so the stored union is over the current planes -- a stale
+                // outcome is dropped in the else branch and never stored.
+                if (m_pendingRangeStore) {
+                    // Only store if the pending key still describes the current
+                    // (dataset, field, level, composition): a full-domain
+                    // arrival's key can outlive its own sync (e.g. its
+                    // syncVisibleRanges early-returned because the mode was
+                    // File), and this sync's union is for the *current* field,
+                    // so storing it under the stale key would poison that
+                    // field's cached range (range-cache-staleness-races).
+                    const FieldId liveField{
+                        m_fieldSelector->currentData().toUInt()};
+                    const auto [liveComposition, liveMaximumLevel] =
+                        decodeLevelData(m_levelSelector->currentData().toInt(),
+                            m_dataset->metadata().finestLevel);
+                    const DisplayCoordinator::RangeKey liveKey{
+                        m_dataset->id(), liveField, liveMaximumLevel,
+                        liveComposition};
+                    if (*m_pendingRangeStore == liveKey) {
+                        m_displayCoordinator.storeFullDomainRange(
+                            *m_pendingRangeStore, outcome.sync->range);
+                    }
+                    m_pendingRangeStore.reset();
+                }
+            } else if (current && outcome.sync) {
+                // Dropped as stale (a panel was re-sliced mid-sync): the union
+                // is over at least one now-superseded plane, so it is neither
+                // applied nor stored -- the pending key stays for the rerun,
+                // which recomputes the union over the current planes.
+#ifdef AMREXPLORER_QT_TEST_ACCESS
+                // Sole writer of this test-only tally; the staleness smoke test
+                // asserts its exact delta. The DiagnosticsModel's stale count
+                // is not touched.
+                ++m_visibleSyncStaleSkips;
+#endif
+            } else if (generation != m_generation) {
+                m_pendingRangeStore.reset();
+                m_visibleSyncRerun = false;
             }
-            if (m_diagnosticsModel->activeRequests() == 0) {
-                emit interactiveSlicesSettled();
-            }
+            finish();
         });
     // Commit to "in flight" only now that the throwing allocations above
     // succeeded; the sync joins the interactive batch (adjustActivity(1) on
@@ -1255,9 +1264,14 @@ void MainWindow::syncVisibleRanges()
         m_visibleSyncInFlight = false;
         m_diagnosticsModel->adjustActivity(-1);
         watcher->deleteLater();
-        reportBackgroundError(tr("Cannot synchronize views: %1")
-            .arg(exceptionMessage(error)));
+        reportVisibleSyncFailure(error);
     }
+}
+
+void MainWindow::reportVisibleSyncFailure(const std::exception& error)
+{
+    reportBackgroundError(
+        tr("Cannot synchronize views: %1").arg(exceptionMessage(error)));
 }
 
 void MainWindow::choosePlotfileSequence()

--- a/src/qt/MainWindowSlice.cpp
+++ b/src/qt/MainWindowSlice.cpp
@@ -1055,7 +1055,13 @@ void MainWindow::syncVisibleRanges()
                 && m_viewDimension == 3 && m_dataset
                 && m_range->mode() == RangeMode::Visible;
             // Everything after the outcome is in hand, on both paths.
-            const auto finish = [this, watcher] {
+            const auto finish = [this, watcher, generation] {
+                if (generation != m_generation) {
+                    // Superseded by a new dataset (or frame): the deferred store
+                    // key and any armed rerun belong to the old generation.
+                    m_pendingRangeStore.reset();
+                    m_visibleSyncRerun = false;
+                }
                 updateDiagnostics();
                 watcher->deleteLater();
                 if (m_visibleSyncRerun) {
@@ -1096,10 +1102,6 @@ void MainWindow::syncVisibleRanges()
                     m_pendingRangeStore.reset();
                 } else {
                     m_diagnosticsModel->noteStaleResult();
-                    if (generation != m_generation) {
-                        m_pendingRangeStore.reset();
-                        m_visibleSyncRerun = false;
-                    }
                 }
                 finish();
                 return;
@@ -1213,9 +1215,6 @@ void MainWindow::syncVisibleRanges()
                 // is not touched.
                 ++m_visibleSyncStaleSkips;
 #endif
-            } else if (generation != m_generation) {
-                m_pendingRangeStore.reset();
-                m_visibleSyncRerun = false;
             }
             finish();
         });
@@ -1235,8 +1234,7 @@ void MainWindow::syncVisibleRanges()
 #ifdef AMREXPLORER_QT_TEST_ACCESS
             // Held only when the staleness test has armed the gate; the throw
             // only when it has asked for one (the failure-path checks).
-            visible_sync_test::waitAtGate();
-            if (visible_sync_test::failNext.exchange(false)) {
+            if (visible_sync_test::waitAtGate()) {
                 throw std::runtime_error("injected visible-sync failure");
             }
 #endif

--- a/src/qt/MainWindowSlice.cpp
+++ b/src/qt/MainWindowSlice.cpp
@@ -1040,131 +1040,148 @@ void MainWindow::syncVisibleRanges()
                 watcher->deleteLater();
                 return;
             }
-            auto outcome = watcher->future().takeResult();
-            const bool current = generation == m_generation
-                && m_viewDimension == 3 && m_dataset
-                && m_range->mode() == RangeMode::Visible;
-            // All-or-nothing, keyed on the render-generation stamp captured per
-            // panel at dispatch. The shared range and log flag are joint across
-            // all three panels, so they must not land on a subset. If any panel
-            // was re-sliced while this sync ran (stamp bumped), the sync rendered
-            // it from the previous plane -- and cached-plane reuse means pointer
-            // identity can't tell (the pointer is reused), while the rerun flag
-            // is not always armed (syncVisibleRanges early-returns on a
-            // mode/dimension flip without setting it). Drop the whole outcome and
-            // let the rerun, or the superseding batch's settle, produce a fresh
-            // coherent one. Single-flight makes the common case all-current, so
-            // this drops only on a genuine mid-sync re-slice, not every tweak.
-            //
-            // Chosen tradeoff (vs. the earlier per-panel partial apply): during
-            // sweep playback or animation export, if a sync outlasts the frame
-            // delay every sync is superseded and nothing lands for the sweep's
-            // duration (it self-heals when playback stops), where partial apply
-            // kept the untouched panels coherent. Coherence-by-construction is
-            // worth that: partial apply could leave the three panels on different
-            // ranges/log flags. If sweep coherence ever matters, gate playbackTick
-            // on the sync too (it currently waits only on pendingRequests).
-            bool allCurrent = outcome.sync.has_value();
-            if (outcome.sync) {
-                for (std::size_t index = 0; index < views.size(); ++index) {
-                    if (views[index]->renderGeneration
-                        != snapshotGenerations[index]) {
-                        allCurrent = false;
-                        break;
-                    }
-                }
-            }
-            if (current && outcome.sync && allCurrent) {
-                const auto [globalMin, globalMax] = outcome.sync->range;
-                bool activeApplied = false;
-                for (std::size_t index = 0; index < views.size(); ++index) {
-                    auto* state = views[index];
-                    auto& update = outcome.sync->panels[index];
-                    if (!update.applies) {
-                        continue;
-                    }
-                    state->displayMinimum = globalMin;
-                    state->displayMaximum = globalMax;
-                    // One shared log flag across the panel set (see
-                    // shared-log-range-render-throw-fails-load): keep every
-                    // panel's stored flag, and thus the color bar below, in
-                    // agreement with the raster the sync just rendered.
-                    state->displayLogarithmic = outcome.sync->logarithmic;
-                    if (update.contoursRecomputed) {
-                        state->contourPolylines
-                            = std::move(update.contourPolylines);
-                    }
-                    if (!outcome.images[index].isNull()) {
-                        // Same plane, re-colored: a virtual canvas keeps its
-                        // placement so the scroll position stays put.
-                        std::optional<ImageView::VirtualPlacement> placement;
-                        if (state->view->virtualCanvasActive()
-                            && !displayIsSpherical()) {
-                            placement = virtualPlacementFor(
-                                *state, state->plane->physicalRegion);
+            // Guarded like the slice-arrival handler above: takeResult rethrows
+            // a worker exception, and applying the outcome installs up to
+            // three 16 Mpx images -- a bad_alloc from either must not escape
+            // the slot and take the application down.
+            try {
+                auto outcome = watcher->future().takeResult();
+                const bool current = generation == m_generation
+                    && m_viewDimension == 3 && m_dataset
+                    && m_range->mode() == RangeMode::Visible;
+                // All-or-nothing, keyed on the render-generation stamp captured per
+                // panel at dispatch. The shared range and log flag are joint across
+                // all three panels, so they must not land on a subset. If any panel
+                // was re-sliced while this sync ran (stamp bumped), the sync rendered
+                // it from the previous plane -- and cached-plane reuse means pointer
+                // identity can't tell (the pointer is reused), while the rerun flag
+                // is not always armed (syncVisibleRanges early-returns on a
+                // mode/dimension flip without setting it). Drop the whole outcome and
+                // let the rerun, or the superseding batch's settle, produce a fresh
+                // coherent one. Single-flight makes the common case all-current, so
+                // this drops only on a genuine mid-sync re-slice, not every tweak.
+                //
+                // Chosen tradeoff (vs. the earlier per-panel partial apply): during
+                // sweep playback or animation export, if a sync outlasts the frame
+                // delay every sync is superseded and nothing lands for the sweep's
+                // duration (it self-heals when playback stops), where partial apply
+                // kept the untouched panels coherent. Coherence-by-construction is
+                // worth that: partial apply could leave the three panels on different
+                // ranges/log flags. If sweep coherence ever matters, gate playbackTick
+                // on the sync too (it currently waits only on pendingRequests).
+                bool allCurrent = outcome.sync.has_value();
+                if (outcome.sync) {
+                    for (std::size_t index = 0; index < views.size(); ++index) {
+                        if (views[index]->renderGeneration
+                            != snapshotGenerations[index]) {
+                            allCurrent = false;
+                            break;
                         }
-                        state->view->setImage(outcome.images[index],
-                            ImageTransformPolicy::GeometryAware,
-                            logicalImageSize(*state, *state->plane,
-                                outcome.images[index]),
-                            placement);
-                        // setImage clears the scene overlays; restore them.
-                        updateGridBoxes(*state);
-                        updateOverlay(*state);
-                        updateParticleOverlay(*state);
                     }
-                    activeApplied = activeApplied || state == m_activeView;
                 }
-                if (activeApplied && m_activeView->plane->width > 0) {
-                    const auto fieldName = m_fieldSelector->currentText();
-                    const auto label = m_activeView->displayLogarithmic
-                        ? fieldName + tr(" (log)") : fieldName;
-                    m_colorBar->setLogarithmic(
-                        m_activeView->displayLogarithmic);
-                    m_colorBar->setFieldRange(label, globalMin, globalMax);
-                    m_range->showDisplayRange(globalMin, globalMax);
-                }
-                // The deferred full-domain range store (see the slice-arrival
-                // completion): the union is only known here. This block runs
-                // only for an all-current outcome (every panel's stamp matched),
-                // so the stored union is over the current planes -- a stale
-                // outcome is dropped in the else branch and never stored.
-                if (m_pendingRangeStore) {
-                    // Only store if the pending key still describes the current
-                    // (dataset, field, level, composition): a full-domain
-                    // arrival's key can outlive its own sync (e.g. its
-                    // syncVisibleRanges early-returned because the mode was
-                    // File), and this sync's union is for the *current* field,
-                    // so storing it under the stale key would poison that
-                    // field's cached range (range-cache-staleness-races).
-                    const FieldId liveField{
-                        m_fieldSelector->currentData().toUInt()};
-                    const auto [liveComposition, liveMaximumLevel] =
-                        decodeLevelData(m_levelSelector->currentData().toInt(),
-                            m_dataset->metadata().finestLevel);
-                    const DisplayCoordinator::RangeKey liveKey{
-                        m_dataset->id(), liveField, liveMaximumLevel,
-                        liveComposition};
-                    if (*m_pendingRangeStore == liveKey) {
-                        m_displayCoordinator.storeFullDomainRange(
-                            *m_pendingRangeStore, outcome.sync->range);
+                if (current && outcome.sync && allCurrent) {
+                    const auto [globalMin, globalMax] = outcome.sync->range;
+                    bool activeApplied = false;
+                    for (std::size_t index = 0; index < views.size(); ++index) {
+                        auto* state = views[index];
+                        auto& update = outcome.sync->panels[index];
+                        if (!update.applies) {
+                            continue;
+                        }
+                        state->displayMinimum = globalMin;
+                        state->displayMaximum = globalMax;
+                        // One shared log flag across the panel set (see
+                        // shared-log-range-render-throw-fails-load): keep every
+                        // panel's stored flag, and thus the color bar below, in
+                        // agreement with the raster the sync just rendered.
+                        state->displayLogarithmic = outcome.sync->logarithmic;
+                        if (update.contoursRecomputed) {
+                            state->contourPolylines
+                                = std::move(update.contourPolylines);
+                        }
+                        if (!outcome.images[index].isNull()) {
+                            // Same plane, re-colored: a virtual canvas keeps its
+                            // placement so the scroll position stays put.
+                            std::optional<ImageView::VirtualPlacement> placement;
+                            if (state->view->virtualCanvasActive()
+                                && !displayIsSpherical()) {
+                                placement = virtualPlacementFor(
+                                    *state, state->plane->physicalRegion);
+                            }
+                            state->view->setImage(outcome.images[index],
+                                ImageTransformPolicy::GeometryAware,
+                                logicalImageSize(*state, *state->plane,
+                                    outcome.images[index]),
+                                placement);
+                            // setImage clears the scene overlays; restore them.
+                            updateGridBoxes(*state);
+                            updateOverlay(*state);
+                            updateParticleOverlay(*state);
+                        }
+                        activeApplied = activeApplied || state == m_activeView;
                     }
-                    m_pendingRangeStore.reset();
-                }
-            } else if (current && outcome.sync) {
-                // Dropped as stale (a panel was re-sliced mid-sync): the union
-                // is over at least one now-superseded plane, so it is neither
-                // applied nor stored -- the pending key stays for the rerun,
-                // which recomputes the union over the current planes.
+                    if (activeApplied && m_activeView->plane->width > 0) {
+                        const auto fieldName = m_fieldSelector->currentText();
+                        const auto label = m_activeView->displayLogarithmic
+                            ? fieldName + tr(" (log)") : fieldName;
+                        m_colorBar->setLogarithmic(
+                            m_activeView->displayLogarithmic);
+                        m_colorBar->setFieldRange(label, globalMin, globalMax);
+                        m_range->showDisplayRange(globalMin, globalMax);
+                    }
+                    // The deferred full-domain range store (see the slice-arrival
+                    // completion): the union is only known here. This block runs
+                    // only for an all-current outcome (every panel's stamp matched),
+                    // so the stored union is over the current planes -- a stale
+                    // outcome is dropped in the else branch and never stored.
+                    if (m_pendingRangeStore) {
+                        // Only store if the pending key still describes the current
+                        // (dataset, field, level, composition): a full-domain
+                        // arrival's key can outlive its own sync (e.g. its
+                        // syncVisibleRanges early-returned because the mode was
+                        // File), and this sync's union is for the *current* field,
+                        // so storing it under the stale key would poison that
+                        // field's cached range (range-cache-staleness-races).
+                        const FieldId liveField{
+                            m_fieldSelector->currentData().toUInt()};
+                        const auto [liveComposition, liveMaximumLevel] =
+                            decodeLevelData(m_levelSelector->currentData().toInt(),
+                                m_dataset->metadata().finestLevel);
+                        const DisplayCoordinator::RangeKey liveKey{
+                            m_dataset->id(), liveField, liveMaximumLevel,
+                            liveComposition};
+                        if (*m_pendingRangeStore == liveKey) {
+                            m_displayCoordinator.storeFullDomainRange(
+                                *m_pendingRangeStore, outcome.sync->range);
+                        }
+                        m_pendingRangeStore.reset();
+                    }
+                } else if (current && outcome.sync) {
+                    // Dropped as stale (a panel was re-sliced mid-sync): the union
+                    // is over at least one now-superseded plane, so it is neither
+                    // applied nor stored -- the pending key stays for the rerun,
+                    // which recomputes the union over the current planes.
 #ifdef AMREXPLORER_QT_TEST_ACCESS
-                // Sole writer of this test-only tally; the staleness smoke test
-                // asserts its exact delta. The DiagnosticsModel's stale count
-                // is not touched.
-                ++m_visibleSyncStaleSkips;
+                    // Sole writer of this test-only tally; the staleness smoke test
+                    // asserts its exact delta. The DiagnosticsModel's stale count
+                    // is not touched.
+                    ++m_visibleSyncStaleSkips;
 #endif
-            } else if (generation != m_generation) {
-                m_pendingRangeStore.reset();
-                m_visibleSyncRerun = false;
+                } else if (generation != m_generation) {
+                    m_pendingRangeStore.reset();
+                    m_visibleSyncRerun = false;
+                }
+            } catch (const std::exception& error) {
+                // The panels keep their per-view state until the next arrival
+                // re-syncs (as after a failed dispatch). Surface a current
+                // failure; count a superseded one as stale, as the arrival
+                // path does.
+                if (generation == m_generation) {
+                    reportBackgroundError(tr("Cannot synchronize views: %1")
+                        .arg(exceptionMessage(error)));
+                } else {
+                    m_diagnosticsModel->noteStaleResult();
+                }
             }
             updateDiagnostics();
             watcher->deleteLater();

--- a/src/qt/MainWindowSlice.cpp
+++ b/src/qt/MainWindowSlice.cpp
@@ -1040,15 +1040,27 @@ void MainWindow::syncVisibleRanges()
                 watcher->deleteLater();
                 return;
             }
+            // Whether the panels the worker rendered are still the ones on
+            // screen: every render-generation stamp captured at dispatch must
+            // still match. Shared by the apply below and the failure path.
+            const auto stampsCurrent = [&views, &snapshotGenerations] {
+                for (std::size_t index = 0; index < views.size(); ++index) {
+                    if (views[index]->renderGeneration
+                        != snapshotGenerations[index]) {
+                        return false;
+                    }
+                }
+                return true;
+            };
+            const bool current = generation == m_generation
+                && m_viewDimension == 3 && m_dataset
+                && m_range->mode() == RangeMode::Visible;
             // Guarded like the slice-arrival handler above: takeResult rethrows
             // a worker exception, and applying the outcome installs up to
             // three 16 Mpx images -- a bad_alloc from either must not escape
             // the slot and take the application down.
             try {
                 auto outcome = watcher->future().takeResult();
-                const bool current = generation == m_generation
-                    && m_viewDimension == 3 && m_dataset
-                    && m_range->mode() == RangeMode::Visible;
                 // All-or-nothing, keyed on the render-generation stamp captured per
                 // panel at dispatch. The shared range and log flag are joint across
                 // all three panels, so they must not land on a subset. If any panel
@@ -1069,16 +1081,7 @@ void MainWindow::syncVisibleRanges()
                 // worth that: partial apply could leave the three panels on different
                 // ranges/log flags. If sweep coherence ever matters, gate playbackTick
                 // on the sync too (it currently waits only on pendingRequests).
-                bool allCurrent = outcome.sync.has_value();
-                if (outcome.sync) {
-                    for (std::size_t index = 0; index < views.size(); ++index) {
-                        if (views[index]->renderGeneration
-                            != snapshotGenerations[index]) {
-                            allCurrent = false;
-                            break;
-                        }
-                    }
-                }
+                const bool allCurrent = outcome.sync.has_value() && stampsCurrent();
                 if (current && outcome.sync && allCurrent) {
                     const auto [globalMin, globalMax] = outcome.sync->range;
                     bool activeApplied = false;
@@ -1173,14 +1176,20 @@ void MainWindow::syncVisibleRanges()
                 }
             } catch (const std::exception& error) {
                 // The panels keep their per-view state until the next arrival
-                // re-syncs (as after a failed dispatch). Surface a current
-                // failure; count a superseded one as stale, as the arrival
-                // path does.
-                if (generation == m_generation) {
+                // re-syncs (as after a failed dispatch). Surface the failure
+                // only if the sync was still current by the same test the
+                // apply uses -- mode, dimension, dataset and every panel's
+                // stamp; a superseded worker's throw is counted stale, as the
+                // arrival path does, not reported as the user's problem.
+                if (current && stampsCurrent()) {
                     reportBackgroundError(tr("Cannot synchronize views: %1")
                         .arg(exceptionMessage(error)));
                 } else {
                     m_diagnosticsModel->noteStaleResult();
+                    if (generation != m_generation) {
+                        m_pendingRangeStore.reset();
+                        m_visibleSyncRerun = false;
+                    }
                 }
             }
             updateDiagnostics();
@@ -1215,8 +1224,12 @@ void MainWindow::syncVisibleRanges()
             contourMode = isContourMode(m_displayMode),
             contourCount = m_contourCount, palette = m_paletteController->palette()] {
 #ifdef AMREXPLORER_QT_TEST_ACCESS
-            // Held only when the staleness test has armed the gate.
+            // Held only when the staleness test has armed the gate; the throw
+            // only when it has asked for one (the failure-path checks).
             visible_sync_test::waitAtGate();
+            if (visible_sync_test::failNext.exchange(false)) {
+                throw std::runtime_error("injected visible-sync failure");
+            }
 #endif
             std::array<DisplayCoordinator::PanelSyncInput, 3> inputs;
             for (std::size_t index = 0; index < snapshots.size(); ++index) {

--- a/src/qt/MainWindowTestAccess.cpp
+++ b/src/qt/MainWindowTestAccess.cpp
@@ -25,6 +25,12 @@ void MainWindow::disarmVisibleSyncGateForTest()
 {
     // Free everything (used on test exit so no worker stays parked).
     visible_sync_test::gateArmed.store(false);
+    visible_sync_test::failNext.store(false);
+}
+
+void MainWindow::failNextVisibleSyncForTest()
+{
+    visible_sync_test::failNext.store(true);
 }
 
 bool MainWindow::visibleSyncWorkerWaitingForTest() const

--- a/src/qt/MainWindowTestAccess.cpp
+++ b/src/qt/MainWindowTestAccess.cpp
@@ -12,6 +12,7 @@ void MainWindow::armVisibleSyncGateForTest()
     visible_sync_test::releaseGrants.store(0);
     visible_sync_test::passed.store(0);
     visible_sync_test::waiting.store(0);
+    visible_sync_test::failNext.store(false);  // no throw carries over
     visible_sync_test::gateArmed.store(true);
 }
 

--- a/src/qt/SmokeHarness.cpp
+++ b/src/qt/SmokeHarness.cpp
@@ -20,7 +20,6 @@
 #include <QPainter>
 #include <QPushButton>
 #include <QSignalBlocker>
-#include <QStatusBar>
 #include <QRunnable>
 #include <QTableView>
 #include <QTextStream>

--- a/src/qt/SmokeHarness.cpp
+++ b/src/qt/SmokeHarness.cpp
@@ -1539,6 +1539,10 @@ Outcome dispatch(Context& context)
         // plane -- slicesInFlight is zero again right after scheduleSliceRequest.
         auto zoomGen = std::make_shared<std::uint64_t>(0);
         auto sentinelsHeld = std::make_shared<bool>(false);
+        // Reported-failure count before the two injected throws; the failure
+        // phases assert on its delta (monotonic, unlike the status-bar text,
+        // which clearMessage or a "Loading..." can overwrite between polls).
+        auto baselineErrors = std::make_shared<int>(0);
         const auto finish = [&application, poll, &window](int code) {
             window.disarmVisibleSyncGateForTest();  // free any parked worker
             poll->stop();  // no stray timeout fires after we ask to exit
@@ -1578,7 +1582,8 @@ Outcome dispatch(Context& context)
                 window.configureContourSyncForTest(3, false, {0.5, 0.5, 0.5});
             });
         QObject::connect(poll, &QTimer::timeout, &application,
-            [&window, finish, phase, attempts, zoomGen, sentinelsHeld] {
+            [&window, finish, phase, attempts, zoomGen, sentinelsHeld,
+                baselineErrors] {
                 if (++*attempts > 3000) {
                     finish(3);
                     return;
@@ -1636,13 +1641,15 @@ Outcome dispatch(Context& context)
                         return;
                     }
                     if (window.visibleSyncWorkerWaitingForTest()
-                        || window.slicesInFlightForTest() != 0) {
+                        || window.slicesInFlightForTest() != 0
+                        || window.sliceRequestPendingForTest()) {
                         return;  // the rerun is still applying
                     }
                     // Failure path, superseded: park a sync that will throw,
                     // invalidate a panel under it, release it. Its throw must
                     // be counted stale, not reported -- the panels it rendered
                     // are gone. (The self-healing rerun then parks.)
+                    *baselineErrors = window.backgroundErrorCountForTest();
                     *zoomGen = window.activeViewRenderGenerationForTest();
                     window.armVisibleSyncGateForTest();
                     window.failNextVisibleSyncForTest();
@@ -1667,12 +1674,14 @@ Outcome dispatch(Context& context)
                     return;
                 }
                 if (*phase == 7) {
-                    // The rerun (armed by the re-slice arrival) parks next.
+                    // The rerun (armed by the re-slice arrival) parks next; it
+                    // is dispatched from the throwing sync's completion, so by
+                    // now that completion has decided whether to report.
                     if (!window.visibleSyncWorkerWaitingForTest()) {
                         return;
                     }
-                    if (window.statusBar()->currentMessage().contains(
-                            QStringLiteral("Cannot synchronize views"))) {
+                    if (window.backgroundErrorCountForTest()
+                        != *baselineErrors) {
                         finish(10);  // a superseded failure was reported
                         return;
                     }
@@ -1682,7 +1691,8 @@ Outcome dispatch(Context& context)
                 }
                 if (*phase == 8) {
                     if (window.visibleSyncWorkerWaitingForTest()
-                        || window.slicesInFlightForTest() != 0) {
+                        || window.slicesInFlightForTest() != 0
+                        || window.sliceRequestPendingForTest()) {
                         return;
                     }
                     // Failure path, current: the same throw with nothing
@@ -1702,12 +1712,14 @@ Outcome dispatch(Context& context)
                     return;
                 }
                 if (*phase == 10) {
-                    if (window.visibleSyncWorkerWaitingForTest()) {
-                        return;
-                    }
-                    if (!window.statusBar()->currentMessage().contains(
-                            QStringLiteral("Cannot synchronize views"))) {
+                    const auto reported = window.backgroundErrorCountForTest()
+                        - *baselineErrors;
+                    if (reported == 0) {
                         return;  // the completion has not run yet
+                    }
+                    if (reported != 1) {
+                        finish(11);  // one throw, one report
+                        return;
                     }
                     finish(0);
                 }

--- a/src/qt/SmokeHarness.cpp
+++ b/src/qt/SmokeHarness.cpp
@@ -20,6 +20,7 @@
 #include <QPainter>
 #include <QPushButton>
 #include <QSignalBlocker>
+#include <QStatusBar>
 #include <QRunnable>
 #include <QTableView>
 #include <QTextStream>
@@ -1630,7 +1631,85 @@ Outcome dispatch(Context& context)
                     return;
                 }
                 if (*phase == 4) {
-                    finish(*sentinelsHeld ? 0 : 6);
+                    if (!*sentinelsHeld) {
+                        finish(6);
+                        return;
+                    }
+                    if (window.visibleSyncWorkerWaitingForTest()
+                        || window.slicesInFlightForTest() != 0) {
+                        return;  // the rerun is still applying
+                    }
+                    // Failure path, superseded: park a sync that will throw,
+                    // invalidate a panel under it, release it. Its throw must
+                    // be counted stale, not reported -- the panels it rendered
+                    // are gone. (The self-healing rerun then parks.)
+                    *zoomGen = window.activeViewRenderGenerationForTest();
+                    window.armVisibleSyncGateForTest();
+                    window.failNextVisibleSyncForTest();
+                    window.requestVisibleSyncForTest();
+                    *phase = 5;
+                    return;
+                }
+                if (*phase == 5) {
+                    if (!window.visibleSyncWorkerWaitingForTest()) {
+                        return;
+                    }
+                    window.zoomActiveViewForTest();
+                    *phase = 6;
+                    return;
+                }
+                if (*phase == 6) {
+                    if (window.activeViewRenderGenerationForTest() <= *zoomGen) {
+                        return;  // wait for the re-slice to rewrite the plane
+                    }
+                    window.releaseVisibleSyncGateForTest();  // the throwing sync lands
+                    *phase = 7;
+                    return;
+                }
+                if (*phase == 7) {
+                    // The rerun (armed by the re-slice arrival) parks next.
+                    if (!window.visibleSyncWorkerWaitingForTest()) {
+                        return;
+                    }
+                    if (window.statusBar()->currentMessage().contains(
+                            QStringLiteral("Cannot synchronize views"))) {
+                        finish(10);  // a superseded failure was reported
+                        return;
+                    }
+                    window.releaseVisibleSyncGateForTest();  // let the rerun apply
+                    *phase = 8;
+                    return;
+                }
+                if (*phase == 8) {
+                    if (window.visibleSyncWorkerWaitingForTest()
+                        || window.slicesInFlightForTest() != 0) {
+                        return;
+                    }
+                    // Failure path, current: the same throw with nothing
+                    // superseding it is the user's problem and is reported.
+                    window.armVisibleSyncGateForTest();
+                    window.failNextVisibleSyncForTest();
+                    window.requestVisibleSyncForTest();
+                    *phase = 9;
+                    return;
+                }
+                if (*phase == 9) {
+                    if (!window.visibleSyncWorkerWaitingForTest()) {
+                        return;
+                    }
+                    window.releaseVisibleSyncGateForTest();
+                    *phase = 10;
+                    return;
+                }
+                if (*phase == 10) {
+                    if (window.visibleSyncWorkerWaitingForTest()) {
+                        return;
+                    }
+                    if (!window.statusBar()->currentMessage().contains(
+                            QStringLiteral("Cannot synchronize views"))) {
+                        return;  // the completion has not run yet
+                    }
+                    finish(0);
                 }
             });
         QTimer::singleShot(20000, &application,

--- a/src/remote/Connection.cpp
+++ b/src/remote/Connection.cpp
@@ -174,7 +174,7 @@ public:
         }
         try {
             auto bytes = codec::encode(
-                requestId, std::move(payload), m_selectedMinorVersion.load());
+                requestId, std::move(payload), m_selectedMinorVersion);
             send(bytes, writeDeadline);
         } catch (...) {
             erasePending(requestId);
@@ -252,7 +252,7 @@ public:
     RemoteDirectoryListing listDirectory(
         const std::string& path, StopToken cancellation)
     {
-        if (m_selectedMinorVersion.load() < 1) {
+        if (m_selectedMinorVersion < 1) {
             throw std::runtime_error(
                 "the remote server predates directory browsing (protocol "
                 "1.1); install a current amrexplorer-server or enter the "
@@ -507,7 +507,7 @@ private:
                     pending = found->second;
                     if (pending->expected != PayloadKind::HelloResponse
                         && info.protocolMinorVersion
-                            != m_selectedMinorVersion.load()) {
+                            != m_selectedMinorVersion) {
                         protocolViolation
                             = "remote server changed protocol minor version";
                     } else if (info.payload != pending->expected
@@ -598,7 +598,7 @@ private:
         request.target_request_id = target;
         try {
             auto bytes = codec::encode(
-                cancelId, std::move(request), m_selectedMinorVersion.load());
+                cancelId, std::move(request), m_selectedMinorVersion);
             send(bytes, deadline);
         } catch (...) {
             erasePending(cancelId);
@@ -659,13 +659,7 @@ private:
 
     std::chrono::steady_clock::time_point m_connectionDeadline;
     std::unique_ptr<Channel> m_channel;
-    // Written by the constructor's handshake after the receiver thread (started
-    // in the initializer list) is already running. The receiver only reads it
-    // for a pending non-hello request, which cannot exist until the
-    // constructor has returned, so the pending-table lock orders every read
-    // after the write today; atomic like m_maximumFrameBytes so that ordering
-    // is not the only thing standing between a receive-loop edit and a race.
-    std::atomic<std::uint16_t> m_selectedMinorVersion{protocolMinorVersion};
+    std::uint16_t m_selectedMinorVersion = protocolMinorVersion;
     std::atomic<std::uint32_t> m_maximumFrameBytes;
     std::chrono::milliseconds m_requestTimeout;
     StopSource m_lifecycleStop;

--- a/src/remote/Connection.cpp
+++ b/src/remote/Connection.cpp
@@ -174,7 +174,7 @@ public:
         }
         try {
             auto bytes = codec::encode(
-                requestId, std::move(payload), m_selectedMinorVersion);
+                requestId, std::move(payload), m_selectedMinorVersion.load());
             send(bytes, writeDeadline);
         } catch (...) {
             erasePending(requestId);
@@ -252,7 +252,7 @@ public:
     RemoteDirectoryListing listDirectory(
         const std::string& path, StopToken cancellation)
     {
-        if (m_selectedMinorVersion < 1) {
+        if (m_selectedMinorVersion.load() < 1) {
             throw std::runtime_error(
                 "the remote server predates directory browsing (protocol "
                 "1.1); install a current amrexplorer-server or enter the "
@@ -507,7 +507,7 @@ private:
                     pending = found->second;
                     if (pending->expected != PayloadKind::HelloResponse
                         && info.protocolMinorVersion
-                            != m_selectedMinorVersion) {
+                            != m_selectedMinorVersion.load()) {
                         protocolViolation
                             = "remote server changed protocol minor version";
                     } else if (info.payload != pending->expected
@@ -598,7 +598,7 @@ private:
         request.target_request_id = target;
         try {
             auto bytes = codec::encode(
-                cancelId, std::move(request), m_selectedMinorVersion);
+                cancelId, std::move(request), m_selectedMinorVersion.load());
             send(bytes, deadline);
         } catch (...) {
             erasePending(cancelId);
@@ -659,7 +659,13 @@ private:
 
     std::chrono::steady_clock::time_point m_connectionDeadline;
     std::unique_ptr<Channel> m_channel;
-    std::uint16_t m_selectedMinorVersion = protocolMinorVersion;
+    // Written by the constructor's handshake after the receiver thread (started
+    // in the initializer list) is already running. The receiver only reads it
+    // for a pending non-hello request, which cannot exist until the
+    // constructor has returned, so the pending-table lock orders every read
+    // after the write today; atomic like m_maximumFrameBytes so that ordering
+    // is not the only thing standing between a receive-loop edit and a race.
+    std::atomic<std::uint16_t> m_selectedMinorVersion{protocolMinorVersion};
     std::atomic<std::uint32_t> m_maximumFrameBytes;
     std::chrono::milliseconds m_requestTimeout;
     StopSource m_lifecycleStop;


### PR DESCRIPTION
* make the negotiated protocol minor version atomic

    Written by the constructor after the receiver thread is running; today
    every receiver read is ordered after the write by the pending-table
    lock, so this only removes the dependence on that ordering, matching
    m_maximumFrameBytes.

* guard the visible-sync completion against a throwing outcome

    The 3-D shared-range sync's completion slot was the one completion
    handler without a try/catch: takeResult rethrows a worker exception, and
    applying the outcome installs three large images, so a bad_alloc on
    either terminated the application. Wrap it like the slice-arrival
    handler: report a current failure, count a superseded one as stale.