### PR TITLE
keep a palette file that failed to load; make re-selection a no-op

### DIFF
--- a/include/amrexplorer/render2d/Palette.hpp
+++ b/include/amrexplorer/render2d/Palette.hpp
@@ -34,6 +34,7 @@ public:
         std::uint8_t red = 0;
         std::uint8_t green = 0;
         std::uint8_t blue = 0;
+        friend bool operator==(const Rgb&, const Rgb&) = default;
     };
 
     Palette() = default;
@@ -68,6 +69,9 @@ public:
     // Loads a legacy sequential palette file (768 or 1024 bytes).  Throws
     // std::runtime_error when the file cannot be read or has another size.
     [[nodiscard]] static Palette load(const std::filesystem::path& path);
+
+    // Slot-for-slot equality (the reserved slots included).
+    friend bool operator==(const Palette&, const Palette&) = default;
 
 private:
     std::array<Rgb, slotCount> slots_{};

--- a/src/qt/MainWindowDataset.cpp
+++ b/src/qt/MainWindowDataset.cpp
@@ -56,7 +56,14 @@ void MainWindow::restoreSettings()
 {
     const auto settings = makeSettings();
 
-    m_paletteController->restore(settings);
+    if (const auto error = m_paletteController->restore(settings)) {
+        // The stored file palette did not load; the controller fell back to
+        // a builtin and keeps the file as the wanted selection, so say so
+        // rather than silently showing a different palette.
+        reportBackgroundError(tr("Cannot load palette file %1: %2")
+            .arg(settings.value(QStringLiteral("palette/filePath")).toString(),
+                *error));
+    }
     m_colorBar->setPalette(&m_paletteController->palette());
 
     m_range->showLogarithmic(

--- a/src/qt/PaletteController.cpp
+++ b/src/qt/PaletteController.cpp
@@ -126,6 +126,7 @@ void PaletteController::selectBuiltin(int index)
     state.builtinIndex = index;
     state.fromFile = false;
     state.filePath.clear();
+    m_unloadedFilePath.clear();
     install(builtinPalette(builtinPalettes[static_cast<std::size_t>(index)]),
         std::move(state));
 }
@@ -141,6 +142,7 @@ std::optional<QString> PaletteController::loadFile(const QString& path)
     State state = m_state;
     state.fromFile = true;
     state.filePath = path;
+    m_unloadedFilePath.clear();
     install(std::move(loaded), std::move(state));
     return std::nullopt;
 }
@@ -155,7 +157,7 @@ void PaletteController::setReversed(bool reversed)
     install(m_basePalette, std::move(state));
 }
 
-void PaletteController::apply(const State& requested)
+std::optional<QString> PaletteController::apply(const State& requested)
 {
     State state = requested;
     // An index the builtins do not have (an imported state from a build with
@@ -165,26 +167,33 @@ void PaletteController::apply(const State& requested)
         || state.builtinIndex >= static_cast<int>(builtinPalettes.size())) {
         state.builtinIndex = 0;
     }
+    std::optional<QString> error;
     if (state.fromFile && !state.filePath.isEmpty()) {
         std::optional<Palette> loaded;
         try {
             loaded = Palette::load(state.filePath.toStdString());
-        } catch (const std::exception&) {
+        } catch (const std::exception& failure) {
             // Fall through to the builtin the state carries.
+            error = QString::fromUtf8(failure.what());
         }
         if (loaded) {
+            m_unloadedFilePath.clear();
             install(std::move(*loaded), std::move(state));
-            return;
+            return std::nullopt;
         }
     }
+    // Keep the wanted file (see m_unloadedFilePath) only when there was one
+    // and it failed; a state without a file replaces any earlier one.
+    m_unloadedFilePath = error ? state.filePath : QString();
     state.fromFile = false;
     state.filePath.clear();
     install(builtinPalette(
                 builtinPalettes[static_cast<std::size_t>(state.builtinIndex)]),
         std::move(state));
+    return error;
 }
 
-void PaletteController::restore(const QSettings& settings)
+std::optional<QString> PaletteController::restore(const QSettings& settings)
 {
     State state;
     state.fromFile
@@ -204,13 +213,16 @@ void PaletteController::restore(const QSettings& settings)
     // Restore is not a change: block the signal the widgets and consumers are
     // not yet wired for, and let the host read palette() when it is ready.
     const QSignalBlocker blocker(this);
-    apply(state);
+    return apply(state);
 }
 
 void PaletteController::save(QSettings& settings) const
 {
-    settings.setValue(QStringLiteral("palette/fromFile"), m_state.fromFile);
-    settings.setValue(QStringLiteral("palette/filePath"), m_state.filePath);
+    // A file that failed to load is still the wanted selection on disk.
+    const bool fileWanted = m_state.fromFile || !m_unloadedFilePath.isEmpty();
+    settings.setValue(QStringLiteral("palette/fromFile"), fileWanted);
+    settings.setValue(QStringLiteral("palette/filePath"),
+        m_state.fromFile ? m_state.filePath : m_unloadedFilePath);
     settings.setValue(QStringLiteral("palette/builtin"),
         builtinPaletteKey(static_cast<std::size_t>(m_state.builtinIndex)));
     settings.setValue(QStringLiteral("palette/reversed"), m_state.reversed);
@@ -247,12 +259,23 @@ QStringList PaletteController::selectorLabels() const
 
 void PaletteController::install(Palette basePalette, State state)
 {
+    // The base palette is compared as well as the state: reloading the same
+    // file path picks up an edited file, which the state alone cannot tell.
+    const bool changed = state.builtinIndex != m_state.builtinIndex
+        || state.fromFile != m_state.fromFile
+        || state.filePath != m_state.filePath
+        || state.reversed != m_state.reversed
+        || basePalette != m_basePalette;
     m_basePalette = std::move(basePalette);
     m_state = std::move(state);
     m_palette = m_state.reversed ? m_basePalette.reversed() : m_basePalette;
+    // Always resync: a click on the checked action of the ExclusiveOptional
+    // menu group has just unchecked it, no-op or not.
     syncMenu();
     syncSelector();
-    emit paletteChanged();
+    if (changed) {
+        emit paletteChanged();
+    }
 }
 
 void PaletteController::syncMenu()

--- a/src/qt/PaletteController.cpp
+++ b/src/qt/PaletteController.cpp
@@ -126,9 +126,8 @@ void PaletteController::selectBuiltin(int index)
     state.builtinIndex = index;
     state.fromFile = false;
     state.filePath.clear();
-    m_unloadedFilePath.clear();
     install(builtinPalette(builtinPalettes[static_cast<std::size_t>(index)]),
-        std::move(state));
+        std::move(state), QString());
 }
 
 std::optional<QString> PaletteController::loadFile(const QString& path)
@@ -142,8 +141,7 @@ std::optional<QString> PaletteController::loadFile(const QString& path)
     State state = m_state;
     state.fromFile = true;
     state.filePath = path;
-    m_unloadedFilePath.clear();
-    install(std::move(loaded), std::move(state));
+    install(std::move(loaded), std::move(state), QString());
     return std::nullopt;
 }
 
@@ -154,7 +152,8 @@ void PaletteController::setReversed(bool reversed)
     }
     State state = m_state;
     state.reversed = reversed;
-    install(m_basePalette, std::move(state));
+    // Reversing does not change which file is wanted.
+    install(m_basePalette, std::move(state), m_unloadedFilePath);
 }
 
 std::optional<QString> PaletteController::apply(const State& requested)
@@ -177,19 +176,18 @@ std::optional<QString> PaletteController::apply(const State& requested)
             error = QString::fromUtf8(failure.what());
         }
         if (loaded) {
-            m_unloadedFilePath.clear();
-            install(std::move(*loaded), std::move(state));
+            install(std::move(*loaded), std::move(state), QString());
             return std::nullopt;
         }
     }
     // Keep the wanted file (see m_unloadedFilePath) only when there was one
     // and it failed; a state without a file replaces any earlier one.
-    m_unloadedFilePath = error ? state.filePath : QString();
+    QString unloadedFilePath = error ? state.filePath : QString();
     state.fromFile = false;
     state.filePath.clear();
     install(builtinPalette(
                 builtinPalettes[static_cast<std::size_t>(state.builtinIndex)]),
-        std::move(state));
+        std::move(state), std::move(unloadedFilePath));
     return error;
 }
 
@@ -257,17 +255,19 @@ QStringList PaletteController::selectorLabels() const
     return labels;
 }
 
-void PaletteController::install(Palette basePalette, State state)
+void PaletteController::install(
+    Palette basePalette, State state, QString unloadedFilePath)
 {
     // The base palette is compared as well as the state: reloading the same
     // file path picks up an edited file, which the state alone cannot tell.
-    const bool changed = state.builtinIndex != m_state.builtinIndex
-        || state.fromFile != m_state.fromFile
-        || state.filePath != m_state.filePath
-        || state.reversed != m_state.reversed
-        || basePalette != m_basePalette;
+    // So is the unloaded file: re-selecting the builtin a failed file fell
+    // back to changes nothing visible, but drops the wanted file, which the
+    // host must be told to persist.
+    const bool changed = state != m_state || basePalette != m_basePalette
+        || unloadedFilePath != m_unloadedFilePath;
     m_basePalette = std::move(basePalette);
     m_state = std::move(state);
+    m_unloadedFilePath = std::move(unloadedFilePath);
     m_palette = m_state.reversed ? m_basePalette.reversed() : m_basePalette;
     // Always resync: a click on the checked action of the ExclusiveOptional
     // menu group has just unchecked it, no-op or not.

--- a/src/qt/PaletteController.hpp
+++ b/src/qt/PaletteController.hpp
@@ -103,6 +103,9 @@ public:
     [[nodiscard]] const Palette& palette() const noexcept { return m_palette; }
     [[nodiscard]] const State& state() const noexcept { return m_state; }
 
+    // Re-selecting what is already selected (the checked menu action, the
+    // same state again) resyncs the widgets but does not emit paletteChanged,
+    // so it costs no settings write and no re-render.
     void selectBuiltin(int index);
     // Loads a legacy palette file and makes it the selection. On failure the
     // selection is unchanged and the error text is returned for the host to
@@ -110,16 +113,21 @@ public:
     [[nodiscard]] std::optional<QString> loadFile(const QString& path);
     void setReversed(bool reversed);
     // Restores a whole selection (settings restore, viewer-state import). A
-    // file palette that no longer loads falls back to the builtin index the
-    // state carries, so the caller always ends up with a usable palette.
-    void apply(const State& state);
+    // file palette that does not load falls back to the builtin index the
+    // state carries, so the caller always ends up with a usable palette, and
+    // the load error is returned for the caller to report. The file is not
+    // forgotten: save() keeps persisting it as the wanted selection until an
+    // explicit selection replaces it, so a transient failure (an unmounted
+    // filesystem at startup) does not drop the preference.
+    [[nodiscard]] std::optional<QString> apply(const State& state);
 
     // The palette keys of the application settings ("palette/…"). restore()
     // does not emit paletteChanged: it reproduces a saved selection rather
     // than changing one, so a host that has already wired the signal (persist,
     // re-render) is not made to write the settings straight back and redraw
-    // nothing. The host reads palette() itself once restored.
-    void restore(const QSettings& settings);
+    // nothing. The host reads palette() itself once restored. Returns the
+    // load error of a stored file palette that fell back, as apply() does.
+    [[nodiscard]] std::optional<QString> restore(const QSettings& settings);
     void save(QSettings& settings) const;
 
     // The builtin names as the menu actions and the selector items show them
@@ -139,7 +147,9 @@ signals:
 
 private:
     // Installs a selection and its base palette, syncs the widgets, derives
-    // the effective palette and emits paletteChanged.
+    // the effective palette and emits paletteChanged -- unless neither the
+    // selection nor the base palette changed, in which case only the widgets
+    // are resynced.
     void install(Palette basePalette, State state);
     void syncMenu();
     void syncSelector();
@@ -149,6 +159,10 @@ private:
     Palette m_basePalette = builtinPalette(BuiltinPalette::Rainbow);
     Palette m_palette = builtinPalette(BuiltinPalette::Rainbow);
     State m_state;
+    // The file palette the last apply() asked for and could not load: the
+    // selection fell back to a builtin, but save() persists this as the
+    // wanted file until selectBuiltin, loadFile or apply replaces it.
+    QString m_unloadedFilePath;
     QPointer<QActionGroup> m_menuGroup;
     QPointer<QAction> m_reverseAction;
     QPointer<QComboBox> m_selector;

--- a/src/qt/PaletteController.hpp
+++ b/src/qt/PaletteController.hpp
@@ -83,6 +83,7 @@ public:
         bool fromFile = false;
         QString filePath;
         bool reversed = false;
+        friend bool operator==(const State&, const State&) = default;
     };
 
     explicit PaletteController(QObject* parent = nullptr);
@@ -146,11 +147,12 @@ signals:
     void loadFileRequested();
 
 private:
-    // Installs a selection and its base palette, syncs the widgets, derives
-    // the effective palette and emits paletteChanged -- unless neither the
-    // selection nor the base palette changed, in which case only the widgets
-    // are resynced.
-    void install(Palette basePalette, State state);
+    // Installs a selection, its base palette and the wanted-but-unloaded file
+    // (empty for none), syncs the widgets, derives the effective palette and
+    // emits paletteChanged -- unless none of the three changed, in which case
+    // only the widgets are resynced. Everything save() persists is one of the
+    // three, so a change in what is persisted always emits.
+    void install(Palette basePalette, State state, QString unloadedFilePath);
     void syncMenu();
     void syncSelector();
 
@@ -161,7 +163,8 @@ private:
     State m_state;
     // The file palette the last apply() asked for and could not load: the
     // selection fell back to a builtin, but save() persists this as the
-    // wanted file until selectBuiltin, loadFile or apply replaces it.
+    // wanted file until selectBuiltin, loadFile or apply replaces it. Set
+    // only by install, which counts its transitions as a change.
     QString m_unloadedFilePath;
     QPointer<QActionGroup> m_menuGroup;
     QPointer<QAction> m_reverseAction;

--- a/tests/unit/test_palette.cpp
+++ b/tests/unit/test_palette.cpp
@@ -202,6 +202,20 @@ int main(int argc, char** argv)
     }
     require(involution, "reversing twice did not restore the palette");
 
+    // operator== is slot-for-slot: the involution above is equality, the
+    // reversal is not, and a single differing slot breaks it.
+    require(restored == rainbow && !(reversedRainbow == rainbow),
+        "Palette equality does not follow the slots");
+    {
+        auto slots = std::array<amrvis::Palette::Rgb, amrvis::Palette::slotCount>{};
+        for (int index = 0; index < amrvis::Palette::slotCount; ++index) {
+            slots[static_cast<std::size_t>(index)] = rainbow.slot(index);
+        }
+        slots[amrvis::Palette::whiteIndex].red ^= 1U;
+        require(!(amrvis::Palette(slots) == rainbow),
+            "Palette equality ignored a reserved slot");
+    }
+
     // These seven strings are not just menu labels: the Qt layer writes the
     // active one into QSettings under "palette/builtin" and matches it back on
     // startup, so changing one silently resets that user's palette to rainbow

--- a/tests/unit/test_palette_controller.cpp
+++ b/tests/unit/test_palette_controller.cpp
@@ -324,12 +324,25 @@ int main(int argc, char** argv)
                 "the kept file preference did not load once available");
         }
         {
-            // An explicit selection replaces the wanted file.
+            // An explicit selection replaces the wanted file -- even the
+            // builtin the failed file fell back to, which changes nothing
+            // visible. That still has to emit: the host persists only on
+            // paletteChanged, and what save() writes just changed.
             require(QFile::remove(path), "could not remove the palette fixture");
             QSettings settings(settingsPath, QSettings::IniFormat);
             PaletteController controller;
-            require(controller.restore(settings).has_value(), "fixture restore");
-            controller.selectBuiltin(1);
+            require(controller.restore(settings).has_value()
+                    && controller.state().builtinIndex == 4,
+                "fixture restore");
+            int changes = 0;
+            QObject::connect(&controller, &PaletteController::paletteChanged,
+                [&changes] { ++changes; });
+            controller.selectBuiltin(4);
+            require(changes == 1,
+                "re-selecting the fallback builtin did not emit paletteChanged");
+            controller.selectBuiltin(4);
+            require(changes == 1,
+                "re-selecting the builtin again emitted paletteChanged");
             controller.save(settings);
             require(!settings.value(QStringLiteral("palette/fromFile")).toBool()
                     && settings.value(QStringLiteral("palette/filePath"))

--- a/tests/unit/test_palette_controller.cpp
+++ b/tests/unit/test_palette_controller.cpp
@@ -259,7 +259,8 @@ int main(int argc, char** argv)
             int changes = 0;
             QObject::connect(&controller, &PaletteController::paletteChanged,
                 [&changes] { ++changes; });
-            controller.restore(settings);
+            require(!controller.restore(settings).has_value(),
+                "restore of a builtin selection reported an error");
             require(changes == 0, "restore emitted paletteChanged");
             require(controller.state().builtinIndex == 4
                     && controller.state().reversed
@@ -282,20 +283,59 @@ int main(int argc, char** argv)
         {
             QSettings settings(settingsPath, QSettings::IniFormat);
             PaletteController controller;
-            controller.restore(settings);
-            require(controller.state().fromFile
+            require(!controller.restore(settings).has_value()
+                    && controller.state().fromFile
                     && controller.state().filePath == path
                     && controller.palette().slotArgb(200) == 0xFFC80000U,
                 "restore did not reload the file palette");
         }
         require(QFile::remove(path), "could not remove the palette fixture");
         {
+            // A vanished file: the builtin the state carries is shown, the
+            // failure is reported -- and the file stays the wanted selection
+            // on disk through later, unrelated saves, so a transient failure
+            // does not drop the preference.
             QSettings settings(settingsPath, QSettings::IniFormat);
             PaletteController controller;
-            controller.restore(settings);
-            require(!controller.state().fromFile
+            const auto error = controller.restore(settings);
+            require(error.has_value() && !error->isEmpty()
+                    && !controller.state().fromFile
                     && controller.state().builtinIndex == 4,
                 "a vanished file palette did not fall back to the builtin");
+            controller.setReversed(true);
+            controller.save(settings);
+            require(settings.value(QStringLiteral("palette/fromFile")).toBool()
+                    && settings.value(QStringLiteral("palette/filePath"))
+                            .toString()
+                        == path
+                    && settings.value(QStringLiteral("palette/reversed"))
+                           .toBool(),
+                "a failed file load was persisted as a dropped preference");
+        }
+        {
+            // The file is back: the kept preference loads again.
+            require(writePaletteFile(dir, "saved.pal") == path, "fixture path");
+            QSettings settings(settingsPath, QSettings::IniFormat);
+            PaletteController controller;
+            require(!controller.restore(settings).has_value()
+                    && controller.state().fromFile
+                    && controller.state().filePath == path
+                    && controller.state().reversed,
+                "the kept file preference did not load once available");
+        }
+        {
+            // An explicit selection replaces the wanted file.
+            require(QFile::remove(path), "could not remove the palette fixture");
+            QSettings settings(settingsPath, QSettings::IniFormat);
+            PaletteController controller;
+            require(controller.restore(settings).has_value(), "fixture restore");
+            controller.selectBuiltin(1);
+            controller.save(settings);
+            require(!settings.value(QStringLiteral("palette/fromFile")).toBool()
+                    && settings.value(QStringLiteral("palette/filePath"))
+                           .toString()
+                           .isEmpty(),
+                "selecting a builtin did not replace the wanted file");
         }
         {
             QSettings settings(settingsPath, QSettings::IniFormat);
@@ -303,8 +343,8 @@ int main(int argc, char** argv)
             settings.setValue(QStringLiteral("palette/builtin"),
                 QStringLiteral("no-such-palette"));
             PaletteController controller;
-            controller.restore(settings);
-            require(controller.state().builtinIndex == 0,
+            require(!controller.restore(settings).has_value()
+                    && controller.state().builtinIndex == 0,
                 "an unknown builtin name did not fall back to the first");
         }
     }
@@ -318,21 +358,89 @@ int main(int argc, char** argv)
         int changes = 0;
         QObject::connect(&controller, &PaletteController::paletteChanged,
             [&changes] { ++changes; });
-        controller.apply(PaletteController::State{6, false, {}, true});
+        require(!controller.apply(PaletteController::State{6, false, {}, true})
+                    .has_value(),
+            "apply of a builtin state reported an error");
         require(changes == 1 && controller.state().builtinIndex == 6
                 && controller.state().reversed,
             "apply did not install the state");
-        controller.apply(PaletteController::State{
-            2, true, QStringLiteral("/nonexistent/palette.pal"), false});
+        require(controller.apply(PaletteController::State{2, true,
+                    QStringLiteral("/nonexistent/palette.pal"), false})
+                    .has_value(),
+            "apply with an unloadable file did not report it");
         require(changes == 2 && !controller.state().fromFile
                 && controller.state().builtinIndex == 2,
             "apply with an unloadable file did not fall back");
-        controller.apply(PaletteController::State{99, false, {}, false});
-        require(changes == 3 && controller.state().builtinIndex == 0,
+        require(!controller.apply(PaletteController::State{99, false, {}, false})
+                    .has_value()
+                && changes == 3 && controller.state().builtinIndex == 0,
             "apply with an unknown builtin index did not fall back");
-        controller.apply(PaletteController::State{-1, false, {}, false});
-        require(changes == 4 && controller.state().builtinIndex == 0,
+        // (Reversed, so the fallback is a change from the one just above.)
+        require(!controller.apply(PaletteController::State{-1, false, {}, true})
+                    .has_value()
+                && changes == 4 && controller.state().builtinIndex == 0
+                && controller.state().reversed,
             "apply with a negative builtin index did not fall back");
+        // A state without a file replaces the wanted file an earlier failed
+        // apply kept (see the settings round trip above for the keeping).
+        QTemporaryDir dir;
+        require(dir.isValid(), "no temporary directory");
+        QSettings settings(dir.filePath("settings.ini"), QSettings::IniFormat);
+        controller.save(settings);
+        require(!settings.value(QStringLiteral("palette/fromFile")).toBool()
+                && settings.value(QStringLiteral("palette/filePath"))
+                       .toString()
+                       .isEmpty(),
+            "a later fileless apply did not replace the wanted file");
+    }
+
+    // Re-selecting what is already selected is not a change: the checked
+    // menu action (which the ExclusiveOptional group has just unchecked) is
+    // re-checked, but nothing is emitted, so the host neither writes settings
+    // nor re-renders. Reloading the same file path is a change only if the
+    // file's contents changed.
+    {
+        QTemporaryDir dir;
+        require(dir.isValid(), "no temporary directory");
+        PaletteController controller;
+        QWidget host;
+        auto* menu = controller.createMenu(&host);
+        auto* selector = controller.createSelector(&host);
+        int changes = 0;
+        QObject::connect(&controller, &PaletteController::paletteChanged,
+            [&changes] { ++changes; });
+        controller.selectBuiltin(3);
+        require(changes == 1, "fixture selection");
+        controller.selectBuiltin(3);
+        require(changes == 1 && checkedMenuIndex(*menu) == 3,
+            "re-selecting the current builtin emitted paletteChanged");
+        auto* checked = menu->findChild<QActionGroup*>()->actions()[3];
+        checked->trigger();
+        require(changes == 1 && checked->isChecked()
+                && checkedMenuIndex(*menu) == 3
+                && selector->currentData().toInt() == 3,
+            "clicking the checked menu action emitted or unchecked it");
+        require(!controller.apply(controller.state()).has_value()
+                && changes == 1,
+            "re-applying the current state emitted paletteChanged");
+        const auto path = writePaletteFile(dir, "same.pal");
+        require(!controller.loadFile(path).has_value() && changes == 2,
+            "loading a file did not emit");
+        require(!controller.loadFile(path).has_value() && changes == 2,
+            "reloading the unchanged file emitted paletteChanged");
+        {
+            // Edit the file in place: the same path now holds a green ramp.
+            QFile file(path);
+            require(file.open(QIODevice::WriteOnly), "could not rewrite");
+            QByteArray bytes(768, '\0');
+            for (int slot = 0; slot < 256; ++slot) {
+                bytes[256 + slot] = static_cast<char>(slot);
+            }
+            require(file.write(bytes) == bytes.size(), "short rewrite");
+        }
+        require(!controller.loadFile(path).has_value() && changes == 3
+                && controller.palette().slotArgb(200) == 0xFF00C800U,
+            "reloading an edited file did not install the new contents");
     }
 
     std::cout << "palette controller tests passed\n";


### PR DESCRIPTION
The wanted .pal stays persisted until an explicit selection replaces it, and apply()/restore() return the load error for the host to report. install() emits paletteChanged only on a real change.