### PR TITLE
report a synchronous FAB drill-down failure through openFailed

### DIFF
--- a/src/qt/FabNavigator.cpp
+++ b/src/qt/FabNavigator.cpp
@@ -8,7 +8,6 @@
 
 #include <QCoreApplication>
 #include <QFutureWatcher>
-#include <QMessageBox>
 #include <QtConcurrent>
 
 #include <exception>
@@ -21,6 +20,11 @@ FabNavigator::FabNavigator(Hooks hooks, QObject* parent)
     : QObject(parent)
     , m_hooks(std::move(hooks))
 {
+    // The other hooks default sensibly when unset (see Hooks); this one is
+    // what every navigation ends in, so it is called bare at three sites.
+    if (!m_hooks.openPrepared) {
+        throw std::invalid_argument("FabNavigator needs an openPrepared hook");
+    }
 }
 
 FabSelectorDock* FabNavigator::createDock(QWidget* parent)
@@ -177,11 +181,6 @@ std::optional<FrameSliceSpec> FabNavigator::selectedEntrySpec() const
     return spec;
 }
 
-QWidget* FabNavigator::dialogParent() const
-{
-    return m_dock ? m_dock->parentWidget() : nullptr;
-}
-
 void FabNavigator::openStandaloneFabAsync(std::filesystem::path path,
     std::optional<std::uint64_t> fileOffset, std::filesystem::path dataRoot,
     bool preserveSelector, std::optional<FrameSliceSpec> initialSpec,
@@ -289,6 +288,10 @@ void FabNavigator::viewEntry(std::size_t index)
         return;
     }
     const auto entry = entries[index];
+    // Set once the synchronous path below has moved the dock to the entry, so
+    // a failure after that puts it back (the asynchronous path carries its
+    // own rollback through the pending read).
+    std::optional<SelectorRollback> syncRollback;
     try {
         auto selectedSpec = selectedEntrySpec();
         if (entry.rawRecord) {
@@ -326,14 +329,22 @@ void FabNavigator::viewEntry(std::size_t index)
         }
         auto selected = makeSelectedFabMetadata(*m_sourceMetadata->metadata,
             entry.level, entry.blockIndex, m_dataRoot);
+        syncRollback = SelectorRollback{
+            m_fabMode, m_dock->backAvailable(), m_dock->selectedOrdinal()};
         m_fabMode = true;
         m_dock->setBackAvailable(m_multifabReturn.has_value());
         m_dock->selectEntry(entry.ordinal);
         m_hooks.openPrepared(m_sourcePath, std::move(selected), m_dataRoot,
             true, std::move(selectedSpec));
     } catch (const std::exception& error) {
-        QMessageBox::critical(
-            dialogParent(), tr("Cannot view FAB"), exceptionMessage(error));
+        if (syncRollback) {
+            applyRollback(*syncRollback);
+        }
+        // Reported the same way as an asynchronous read failure: non-modally
+        // through the host. (A modal box here never returns under the
+        // offscreen platform, so a regression would hang the unit test rather
+        // than fail it.)
+        emit openFailed(tr("Cannot view FAB"), exceptionMessage(error));
     }
 }
 

--- a/src/qt/FabNavigator.hpp
+++ b/src/qt/FabNavigator.hpp
@@ -60,7 +60,10 @@ public:
         // dataRoot, preserveSelector, initialSpec) -- the host's
         // openDatasetImpl. preserveSelector is false only for a direct
         // "Open FAB..." (the selector is rebuilt for the new file) and true
-        // for every drill-down or return within the current source.
+        // for every drill-down or return within the current source. Required
+        // (the constructor throws without it); the three above may be unset,
+        // in which case the generation is 0, shutdown never begins and no
+        // spec is known.
         std::function<void(const std::filesystem::path&, PlotfileMetadataResult,
             std::filesystem::path, bool, std::optional<FrameSliceSpec>)>
             openPrepared;
@@ -110,8 +113,9 @@ signals:
     // header read starts, -1 when its watcher fires) and its stale count.
     void loadActivityChanged(int delta);
     void staleResultDropped();
-    // A read failed while it was still the current request; the host reports
-    // it non-modally ("<title>: <message>").
+    // A read failed while it was still the current request, or a
+    // drill-down failed before or during its open; the host reports it
+    // non-modally ("<title>: <message>").
     void openFailed(const QString& title, const QString& message);
     // The dock's contents or the mode changed in a way the window title
     // reflects.
@@ -155,7 +159,6 @@ private:
         QString failureTitle, std::optional<SelectorRollback> rollback);
     void applyRollback(const SelectorRollback& rollback);
     [[nodiscard]] std::optional<FrameSliceSpec> selectedEntrySpec() const;
-    [[nodiscard]] QWidget* dialogParent() const;
 
     Hooks m_hooks;
     QPointer<FabSelectorDock> m_dock;

--- a/tests/unit/test_fab_navigator.cpp
+++ b/tests/unit/test_fab_navigator.cpp
@@ -13,6 +13,7 @@
 #include <fstream>
 #include <iostream>
 #include <optional>
+#include <stdexcept>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -90,6 +91,7 @@ void writeMultiFab(const std::filesystem::path& root)
 // What the host would see: every openPrepared call and every signal.
 struct Opened {
     std::filesystem::path path;
+    std::filesystem::path dataRoot;
     std::string fileVersion;
     std::size_t levelBlocks = 0;
     bool preserveSelector = false;
@@ -107,6 +109,8 @@ struct Host {
     int stale = 0;
     QStringList failures;
     int titleChanges = 0;
+    // When set, openPrepared throws instead of opening (a host-side failure).
+    bool refuseOpens = false;
 
     amrvis::qt::FabNavigator::Hooks hooks()
     {
@@ -125,10 +129,14 @@ struct Host {
             },
             [this](const std::filesystem::path& path,
                 amrvis::PlotfileMetadataResult metadata,
-                std::filesystem::path, bool preserve,
+                std::filesystem::path dataRoot, bool preserve,
                 std::optional<amrvis::FrameSliceSpec> spec) {
+                if (refuseOpens) {
+                    throw std::runtime_error("the host refused the open");
+                }
                 Opened entry;
                 entry.path = path;
+                entry.dataRoot = std::move(dataRoot);
                 entry.fileVersion = metadata.fileVersion;
                 entry.levelBlocks = metadata.metadata->levels.front().blocks.size();
                 entry.preserveSelector = preserve;
@@ -203,6 +211,17 @@ int main(int argc, char** argv)
     writeMultiFab(multifabRoot);
     const auto multifabPath = multifabRoot / "Cell_H";
 
+    // openPrepared is the one hook the navigator cannot do without.
+    {
+        bool refused = false;
+        try {
+            FabNavigator navigator(FabNavigator::Hooks{});
+        } catch (const std::invalid_argument&) {
+            refused = true;
+        }
+        require(refused, "a navigator without openPrepared was constructed");
+    }
+
     // A raw FAB source: the selector lists its records as raw records, the
     // navigator is in FAB mode with no source metadata, and reset() clears it.
     {
@@ -254,7 +273,9 @@ int main(int argc, char** argv)
         navigator.viewEntry(1);
         require(host.opened.size() == 1, "viewing a block did not open it");
         const auto& block = host.opened.back();
-        require(block.path == multifabPath && block.preserveSelector
+        require(block.path == multifabPath
+                && block.dataRoot == multifabPath.parent_path()
+                && block.preserveSelector
                 && block.levelBlocks == 1 && block.hadSpec
                 && block.levelSelection == -1,
             "the drilled-into block was opened wrongly");
@@ -266,7 +287,9 @@ int main(int argc, char** argv)
         navigator.backToMultiFab();
         require(host.opened.size() == 2, "Back did not reopen the source");
         const auto& source = host.opened.back();
-        require(source.path == multifabPath && source.preserveSelector
+        require(source.path == multifabPath
+                && source.dataRoot == multifabPath.parent_path()
+                && source.preserveSelector
                 && source.levelBlocks == 2 && source.hadSpec
                 && source.levelSelection == 2,
             "Back did not restore the source with its display spec");
@@ -274,6 +297,23 @@ int main(int argc, char** argv)
             "Back left FAB mode or the Back button on");
         navigator.backToMultiFab();
         require(host.opened.size() == 2, "a second Back reopened again");
+        // A drill-down whose open fails synchronously (here: the host
+        // refuses) is reported through openFailed, not a modal box, and the
+        // dock goes back to what was displayed -- the source, no Back.
+        const auto displayed = dock->selectedOrdinal();
+        host.refuseOpens = true;
+        navigator.viewEntry(0);
+        require(host.opened.size() == 2 && host.failures.size() == 1
+                && host.failures.front().startsWith(
+                    QStringLiteral("Cannot view FAB: "))
+                && !navigator.fabMode() && !dock->backAvailable()
+                && dock->selectedOrdinal() == displayed,
+            "a synchronously failed drill-down was not reported and rolled back");
+        host.refuseOpens = false;
+        navigator.viewEntry(0);
+        require(host.opened.size() == 3 && navigator.fabMode()
+                && dock->selectedOrdinal() == std::optional<std::size_t>{0},
+            "the navigator did not recover after a refused open");
     }
 
     // The direct "Open FAB...": an asynchronous header read that opens with
@@ -289,6 +329,7 @@ int main(int argc, char** argv)
             "the FAB read did not finish");
         require(host.activity == 0 && host.opened.size() == 1
                 && host.opened.back().fileVersion == "FAB"
+                && host.opened.back().dataRoot == fabPath.parent_path()
                 && !host.opened.back().preserveSelector
                 && !host.opened.back().hadSpec && host.failures.isEmpty(),
             "the raw FAB was not opened as a fresh dataset");


### PR DESCRIPTION
Non-modal like the asynchronous read failure (a modal box never returns offscreen), with the dock rolled back; openPrepared is required at construction; the test fake records the data root.