### PR TITLE
record the MultiFab return state only once the drill-down has opened

### DIFF
--- a/src/qt/FabNavigator.cpp
+++ b/src/qt/FabNavigator.cpp
@@ -321,10 +321,17 @@ void FabNavigator::viewEntry(std::size_t index)
             throw std::runtime_error(
                 "the source MultiFab is no longer available");
         }
+        // The first drill-down records where Back returns to. The spec is
+        // read now, while the source is still displayed, but the record is
+        // kept only once the FAB has opened: a failed drill-down must not
+        // leave one behind, or a later drill-down (after the user has moved
+        // the slice controls) would find it and skip re-capture, and Back
+        // would land on the spec of the failed attempt.
+        std::optional<MultiFabReturnState> firstReturn;
         if (!m_multifabReturn) {
             auto returnSpec
                 = m_hooks.currentSpec ? m_hooks.currentSpec() : std::nullopt;
-            m_multifabReturn = MultiFabReturnState{m_sourcePath, m_dataRoot,
+            firstReturn = MultiFabReturnState{m_sourcePath, m_dataRoot,
                 *m_sourceMetadata, returnSpec.value_or(FrameSliceSpec{})};
         }
         auto selected = makeSelectedFabMetadata(*m_sourceMetadata->metadata,
@@ -332,10 +339,13 @@ void FabNavigator::viewEntry(std::size_t index)
         syncRollback = SelectorRollback{
             m_fabMode, m_dock->backAvailable(), m_dock->selectedOrdinal()};
         m_fabMode = true;
-        m_dock->setBackAvailable(m_multifabReturn.has_value());
+        m_dock->setBackAvailable(true);  // one of the two is about to hold
         m_dock->selectEntry(entry.ordinal);
         m_hooks.openPrepared(m_sourcePath, std::move(selected), m_dataRoot,
             true, std::move(selectedSpec));
+        if (firstReturn) {
+            m_multifabReturn = std::move(firstReturn);
+        }
     } catch (const std::exception& error) {
         if (syncRollback) {
             applyRollback(*syncRollback);

--- a/tests/unit/test_fab_navigator.cpp
+++ b/tests/unit/test_fab_navigator.cpp
@@ -111,6 +111,9 @@ struct Host {
     int titleChanges = 0;
     // When set, openPrepared throws instead of opening (a host-side failure).
     bool refuseOpens = false;
+    // The level the current display spec reports; the test moves it to stand
+    // in for the user changing the slice controls.
+    int levelSelection = 2;
 
     amrvis::qt::FabNavigator::Hooks hooks()
     {
@@ -122,7 +125,7 @@ struct Host {
                     return std::nullopt;
                 }
                 amrvis::FrameSliceSpec spec;
-                spec.levelSelection = 2;
+                spec.levelSelection = levelSelection;
                 spec.rangeMode = amrvis::RangeMode::User;
                 spec.userRange = std::pair{0.0, 1.0};
                 return spec;
@@ -309,11 +312,20 @@ int main(int argc, char** argv)
                 && !navigator.fabMode() && !dock->backAvailable()
                 && dock->selectedOrdinal() == displayed,
             "a synchronously failed drill-down was not reported and rolled back");
+        // The failed attempt left no return record: the user moves the slice
+        // controls, drills down for real, and Back returns to that display,
+        // not to the one the failed attempt saw.
         host.refuseOpens = false;
+        host.levelSelection = 4;
         navigator.viewEntry(0);
         require(host.opened.size() == 3 && navigator.fabMode()
+                && dock->backAvailable()
                 && dock->selectedOrdinal() == std::optional<std::size_t>{0},
             "the navigator did not recover after a refused open");
+        navigator.backToMultiFab();
+        require(host.opened.size() == 4 && host.opened.back().hadSpec
+                && host.opened.back().levelSelection == 4,
+            "Back returned to the spec captured by the failed drill-down");
     }
 
     // The direct "Open FAB...": an asynchronous header read that opens with


### PR DESCRIPTION
A drill-down that failed after capturing the return record left it in place, so a later successful one skipped re-capture and Back returned to the spec of the failed attempt rather than the display the user left.