### PR TITLE
ssh session follow-ups: owned timers, stderr cap, option-like paths

### DIFF
--- a/src/qt/RemoteSessionController.cpp
+++ b/src/qt/RemoteSessionController.cpp
@@ -198,6 +198,15 @@ void RemoteSessionController::promptOpen(QWidget* parent, bool sequence)
                "plotfile path are required."));
         return;
     }
+    // Checked here for both routes: over a new session the ready handler
+    // would otherwise open a lone path as a single dataset, silently
+    // dropping the sequence the dialog was for.
+    if (sequence && paths.size() < 2) {
+        QMessageBox::warning(parent, dialog.windowTitle(),
+            tr("Enter two or more plotfile paths, one per line, in playback "
+               "order."));
+        return;
+    }
     // An unchanged destination and executable mean the current session is the
     // one asked for; open over it directly instead of starting ssh again.
     if (matches) {

--- a/src/qt/SshConnectArguments.hpp
+++ b/src/qt/SshConnectArguments.hpp
@@ -22,9 +22,14 @@ struct SshConnectParseResult {
     std::string error;
 };
 
+// After the destination and the optional --server PATH, every token is a
+// remote path -- except one that starts with '-', which is an option this
+// program does not have (a mistyped --server, say) and is refused rather
+// than sent to the server as a path. A path that really starts with '-'
+// goes after a "--" token.
 inline SshConnectParseResult parseSshConnectArguments(std::span<const std::string_view> arguments) {
     constexpr std::string_view usage = "usage: amrexplorer --ssh SSH_DESTINATION [--server PATH] "
-                                       "[REMOTE_PATH ...]";
+                                       "[--] [REMOTE_PATH ...]";
     if (arguments.empty() || arguments.front().empty()) {
         return {{}, std::string(usage)};
     }
@@ -44,9 +49,17 @@ inline SshConnectParseResult parseSshConnectArguments(std::span<const std::strin
         pathBegin = 3;
     }
     request.paths.reserve(arguments.size() - pathBegin);
+    bool optionsEnded = false;
     for (const auto path : arguments.subspan(pathBegin)) {
         if (path.empty()) {
             return {{}, "remote paths must not be empty"};
+        }
+        if (!optionsEnded && path == "--") {
+            optionsEnded = true;
+            continue;
+        }
+        if (!optionsEnded && path.front() == '-') {
+            return {{}, "unknown option: " + std::string(path) + "\n" + std::string(usage)};
         }
         request.paths.emplace_back(path);
     }

--- a/src/qt/SshRemoteSession.cpp
+++ b/src/qt/SshRemoteSession.cpp
@@ -163,11 +163,25 @@ SshRemoteSession::SshRemoteSession(QObject* parent)
     : QObject(parent)
     , m_process(new QProcess(this))
     , m_startupTimer(new QTimer(this))
+    , m_terminateTimer(new QTimer(this))
+    , m_streamEndTimer(new QTimer(this))
 {
     m_startupTimer->setSingleShot(true);
     connect(m_startupTimer, &QTimer::timeout, this, [this] {
         drainProcessErrors(true);
         fail(tr("Timed out while starting the remote AMReXplorer session.%1")
+                .arg(errorSuffix()));
+    });
+    m_terminateTimer->setSingleShot(true);
+    connect(m_terminateTimer, &QTimer::timeout, this, [this] {
+        if (m_process->state() != QProcess::NotRunning) {
+            m_process->terminate();
+        }
+    });
+    m_streamEndTimer->setSingleShot(true);
+    connect(m_streamEndTimer, &QTimer::timeout, this, [this] {
+        drainProcessErrors(true);
+        fail(tr("The remote server ended the stream before it was ready.%1")
                 .arg(errorSuffix()));
     });
     connect(m_process, &QProcess::readyReadStandardError, this,
@@ -225,6 +239,8 @@ void SshRemoteSession::start(std::string destination,
     m_errorPending.clear();
     m_connection.reset();
     m_handshakeStop = StopSource{};
+    m_terminateTimer->stop();
+    m_streamEndTimer->stop();
     m_startupTimer->start(startupTimeoutMilliseconds);
 
 #ifdef _WIN32
@@ -307,12 +323,7 @@ void SshRemoteSession::readPreamble()
             // exit report it -- that path has the whole of stderr -- and only
             // fall back to a report of our own if ssh lingers.
             closeWire();
-            QTimer::singleShot(1500, this, [this] {
-                drainProcessErrors(true);
-                fail(tr("The remote server ended the stream before it was "
-                        "ready.%1")
-                        .arg(errorSuffix()));
-            });
+            m_streamEndTimer->start(1500);
             return;
         }
         m_preamble.append(buffer, static_cast<std::size_t>(count));
@@ -396,6 +407,12 @@ void SshRemoteSession::drainProcessErrors(bool flush)
     // stderr in stdio mode.
     m_errorPending
         += QString::fromLocal8Bit(m_process->readAllStandardError());
+    // A newline-free flood must not grow the pending fragment without bound;
+    // like the kept tail, only its last part is worth anything.
+    constexpr qsizetype maximumErrorCharacters = 8192;
+    if (m_errorPending.size() > maximumErrorCharacters) {
+        m_errorPending = m_errorPending.right(maximumErrorCharacters);
+    }
     const auto appendLine = [this](const QString& line) {
         if (!line.trimmed().isEmpty()) {
             m_errors += line.trimmed() + QLatin1Char('\n');
@@ -410,18 +427,17 @@ void SshRemoteSession::drainProcessErrors(bool flush)
         appendLine(m_errorPending);
         m_errorPending.clear();
     }
-    constexpr qsizetype maximumErrorCharacters = 8192;
     if (m_errors.size() > maximumErrorCharacters) {
         m_errors = m_errors.right(maximumErrorCharacters);
-    }
-    if (flush) {
-        m_errors = m_errors.trimmed();
     }
 }
 
 QString SshRemoteSession::errorSuffix() const
 {
-    return m_errors.isEmpty() ? QString() : QStringLiteral("\n") + m_errors;
+    // Trimmed for display only: the stored lines keep their separators, so
+    // a line drained after a flush does not run into the previous one.
+    const auto errors = m_errors.trimmed();
+    return errors.isEmpty() ? QString() : QStringLiteral("\n") + errors;
 }
 
 void SshRemoteSession::closeWire()
@@ -450,12 +466,9 @@ void SshRemoteSession::stop()
         // reads it, and ssh exits when the server does.
         m_connection->close();
     }
+    m_streamEndTimer->stop();
     if (m_process->state() != QProcess::NotRunning) {
-        QTimer::singleShot(2000, m_process, [process = m_process] {
-            if (process->state() != QProcess::NotRunning) {
-                process->terminate();
-            }
-        });
+        m_terminateTimer->start(2000);
     }
 }
 

--- a/src/qt/SshRemoteSession.cpp
+++ b/src/qt/SshRemoteSession.cpp
@@ -434,8 +434,11 @@ void SshRemoteSession::drainProcessErrors(bool flush)
 
 QString SshRemoteSession::errorSuffix() const
 {
-    // Trimmed for display only: the stored lines keep their separators, so
-    // a line drained after a flush does not run into the previous one.
+    // Trimmed for display only. The stored lines keep their separators, so
+    // if a drain ever followed a flush its line would not run into the
+    // previous one -- today every flush is followed by the failure or exit
+    // that ends the session, so this holds by construction rather than by
+    // need.
     const auto errors = m_errors.trimmed();
     return errors.isEmpty() ? QString() : QStringLiteral("\n") + errors;
 }

--- a/src/qt/SshRemoteSession.hpp
+++ b/src/qt/SshRemoteSession.hpp
@@ -74,7 +74,10 @@ public:
     SshRemoteSession(const SshRemoteSession&) = delete;
     SshRemoteSession& operator=(const SshRemoteSession&) = delete;
 
-    // options.sessionToken is filled in from the ready line.
+    // options.sessionToken is filled in from the ready line. One session is
+    // one process: start() is called once, and a new destination is a new
+    // object (RemoteSessionController replaces the session, never restarts
+    // it).
     void start(std::string destination, std::string serverExecutable,
         remote::ConnectionOptions options, ReadyHandler ready,
         ErrorHandler error, LostHandler lost);
@@ -102,6 +105,11 @@ private:
 
     QProcess* m_process;
     QTimer* m_startupTimer;
+    // stop()'s grace period before ssh is terminated, and the fallback report
+    // when the stream ends before the ready line; both members so start() and
+    // stop() own them rather than leaving detached single-shots armed.
+    QTimer* m_terminateTimer;
+    QTimer* m_streamEndTimer;
     QSocketNotifier* m_wireNotifier = nullptr;
     // Our end of the socket pair, until the handshake takes it over.
     int m_wire = -1;

--- a/src/qt/main.cpp
+++ b/src/qt/main.cpp
@@ -37,7 +37,7 @@ void printUsage(std::FILE* output)
 {
     std::fprintf(output,
         "usage: amrexplorer [PLOTFILE...]\n"
-        "       amrexplorer --ssh SSH_DESTINATION [--server PATH] "
+        "       amrexplorer --ssh SSH_DESTINATION [--server PATH] [--] "
         "[REMOTE_PLOTFILE...]\n\n"
         "Open one plotfile directory, or several to play them as a\n"
         "sequence, or none for an empty window.\n\n"

--- a/tests/unit/test_remote_session_controller.cpp
+++ b/tests/unit/test_remote_session_controller.cpp
@@ -393,6 +393,28 @@ int main(int argc, char* argv[])
                 "the sequence dialog did not ask for a sequence");
         }
         {
+            // One path in the sequence dialog is refused up front, for the
+            // live session and a new one alike.
+            bool warned = false;
+            Driver driver([&warned] {
+                if (auto* warning = visibleDialog<QMessageBox>()) {
+                    warned = true;
+                    warning->buttons().first()->click();
+                    return true;
+                }
+                if (auto* dialog = visibleDialog<RemoteOpenDialog>()) {
+                    dialog->findChild<QPlainTextEdit*>()->setPlainText(
+                        QStringLiteral("/a/plt00010\n"));
+                    buttonNamed(*dialog, QStringLiteral("Open"))->click();
+                }
+                return false;
+            });
+            controller.promptOpen(nullptr, true);
+            require(driver.done() && warned && observed.opens.size() == 4
+                    && observed.statuses.size() == statusesBefore,
+                "a one-path sequence was opened, or the warning did not show");
+        }
+        {
             bool warned = false;
             Driver driver([&warned] {
                 if (auto* warning = visibleDialog<QMessageBox>()) {

--- a/tests/unit/test_ssh_connect_arguments.cpp
+++ b/tests/unit/test_ssh_connect_arguments.cpp
@@ -65,6 +65,24 @@ int main()
     constexpr std::array<std::string_view, 2> emptyPath{"frontier", ""};
     require(!amrvis::qt::parseSshConnectArguments(emptyPath).request,
         "empty remote path was accepted");
+    // A mistyped option is refused, not sent to the server as a path; a path
+    // that starts with '-' is spelled after "--".
+    constexpr std::array<std::string_view, 3> mistypedOption{
+        "frontier", "--sever", "/remote/plt00010"};
+    const auto mistyped = amrvis::qt::parseSshConnectArguments(mistypedOption);
+    require(!mistyped.request
+            && mistyped.error.find("unknown option: --sever") == 0,
+        "an option-like remote path was accepted");
+    constexpr std::array<std::string_view, 5> dashPaths{"frontier", "--server",
+        "~/bin/amrexplorer-server", "--", "-plt00010"};
+    const auto dashed = amrvis::qt::parseSshConnectArguments(dashPaths);
+    require(dashed.request && dashed.request->paths.size() == 1
+            && dashed.request->paths.front() == "-plt00010",
+        "a dash-prefixed path after -- was not accepted");
+    constexpr std::array<std::string_view, 3> lateServer{
+        "frontier", "/remote/plt00010", "--server"};
+    require(!amrvis::qt::parseSshConnectArguments(lateServer).request,
+        "--server after a path was accepted as a path");
     require(!amrvis::qt::parseSshConnectArguments({}).request,
         "empty argument list was accepted");
     return 0;


### PR DESCRIPTION
stop()'s terminate and the stream-ended fallback are member timers reset by start(); the pending stderr fragment is capped and keeps its separator; --ssh refuses an option-like token after the destination ("--" ends options); the sequence dialog refuses a single path up front.