### PR TITLE
retire the palette-labels smoke test

### DIFF
--- a/src/qt/MainWindow.hpp
+++ b/src/qt/MainWindow.hpp
@@ -23,7 +23,6 @@
 #include <QMainWindow>
 #include <QRectF>
 #include <QSize>
-#include <QStringList>
 
 #include <array>
 #include <atomic>
@@ -201,14 +200,6 @@ public:
     // any panel holds an image instead. A failed open must leave a settled
     // placeholder naming what failed, never the "Loading..." one it replaced.
     [[nodiscard]] QString viewPlaceholderForTest();
-
-    // Test-only: the builtin palette names as the Palette menu and the palette
-    // selector each show them. Two accessors rather than one because the point
-    // is that the two agree: they are built in different units from the same
-    // helper, and they disagreed for as long as the capitalization was spelled
-    // out at the call sites instead of living in that helper.
-    [[nodiscard]] QStringList paletteMenuLabelsForTest() const;
-    [[nodiscard]] QStringList paletteSelectorLabelsForTest() const;
 
     // Test-only: true when the active view's displayed raster is byte-identical
     // to its plane re-rendered against the current display (color-bar) range —

--- a/src/qt/MainWindowTestAccess.cpp
+++ b/src/qt/MainWindowTestAccess.cpp
@@ -130,16 +130,6 @@ void MainWindow::setAnimationDockVisibleForTest(bool visible)
     }
 }
 
-QStringList MainWindow::paletteMenuLabelsForTest() const
-{
-    return m_paletteController->menuLabels();
-}
-
-QStringList MainWindow::paletteSelectorLabelsForTest() const
-{
-    return m_paletteController->selectorLabels();
-}
-
 QString MainWindow::viewPlaceholderForTest()
 {
     QString shared;

--- a/src/qt/PaletteController.cpp
+++ b/src/qt/PaletteController.cpp
@@ -306,7 +306,11 @@ void PaletteController::syncSelector()
     }
     // Reversal is a global modifier, so every palette name carries the "_r"
     // suffix (the plasma_r convention) while it is on -- including the closed
-    // selector, which shows the active one.
+    // selector, which shows the active one. The suffix is selector-only: the
+    // menu actions keep the bare name (the Reverse Colormap action shows the
+    // state there). Moving it into builtinPaletteLabel so both agree is
+    // follow-up work; test_palette_controller compares the two lists with
+    // reversal off.
     const QString suffix
         = m_state.reversed ? QStringLiteral("_r") : QString();
     for (int item = 0; item < m_selector->count(); ++item) {

--- a/src/qt/SmokeHarnessRange.cpp
+++ b/src/qt/SmokeHarnessRange.cpp
@@ -22,10 +22,10 @@
 #include <string_view>
 #include <vector>
 
-// Range: the display-state scenarios: range mode and range cache, palette
-// labels, contour sync, visible-range sync staleness, particles. Every
-// branch drives MainWindow through its ForTest accessors and arms
-// connections and timers for main() to run; see SmokeHarness.hpp.
+// Range: the display-state scenarios: range mode and range cache, contour
+// sync, visible-range sync staleness, particles. Every branch drives
+// MainWindow through its ForTest accessors and arms connections and timers
+// for main() to run; see SmokeHarness.hpp.
 
 namespace amrvis::qt::smoke {
 
@@ -135,45 +135,7 @@ Outcome dispatchRange(Context& context)
     const int argc = context.argc;
     char** argv = context.argv;
 
-    if (argc == 2
-        && std::string_view(argv[1]) == "--palette-labels-smoke-test") {
-        // The Palette menu and the palette selector are built in different
-        // translation units from one label helper, and must therefore show the
-        // same names. They did not: the menu used the helper's result raw while
-        // the selector capitalized it by hand, so the menu read "rainbow" where
-        // the selector read "Rainbow". Needs no dataset -- both lists are built
-        // during construction.
-        const auto menu = window.paletteMenuLabelsForTest();
-        auto selector = window.paletteSelectorLabelsForTest();
-        // The reversal suffix is a selector-only presentation rule: with
-        // "Reverse Colormap" on, the selector appends "_r" while the
-        // menu actions keep their original text. That divergence is real and
-        // outside what this case is about, so it is normalized away rather
-        // than asserted on -- the property here is that the two agree on the
-        // *name*. Isolated settings make reversal off anyway; this keeps the
-        // case honest on the platforms where XDG_CONFIG_HOME does not isolate
-        // QSettings, and stops it claiming an invariant the product does not
-        // hold. Unifying the suffix into the shared helper is follow-up work.
-        for (auto& label : selector) {
-            if (label.endsWith(QStringLiteral("_r"))) {
-                label.chop(2);
-            }
-        }
-        if (menu.isEmpty() || menu != selector) {
-            qCritical("palette menu labels %s do not match the selector's %s",
-                qPrintable(menu.join(QStringLiteral(","))),
-                qPrintable(selector.join(QStringLiteral(","))));
-            return {true, 1};
-        }
-        // Pinned as a literal rather than derived from the same helper the
-        // widgets used, which would pass whatever that helper produced.
-        if (menu.front() != QStringLiteral("Rainbow")) {
-            qCritical("the first palette is labelled '%s', not 'Rainbow'",
-                qPrintable(menu.front()));
-            return {true, 1};
-        }
-        return {true, 0};
-    } else if (argc == 3
+    if (argc == 3
         && std::string_view(argv[1]) == "--missing-range-smoke-test") {
         const std::filesystem::path path(argv[2]);
         QObject::connect(&window, &amrvis::qt::MainWindow::initialSliceFinished,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -689,21 +689,6 @@ if(TARGET amrexplorer_qt)
         PASS_REGULAR_EXPRESSION "usage: amrexplorer"
         TIMEOUT 10)
 
-    # The Palette menu and the palette selector are built in different
-    # translation units and must agree. Needs no fixture: both lists exist as
-    # soon as the window is constructed -- but it does need an isolated
-    # XDG_CONFIG_HOME, like qt_smoke_driver.cmake gives the fixture-based
-    # cases. Without it the run inherits the developer's real QSettings, and a
-    # persisted "Reverse Colormap" makes the selector read "Rainbow_r" against
-    # the menu's "Rainbow".
-    add_test(
-        NAME qt_palette_labels_smoke
-        COMMAND "${CMAKE_COMMAND}" -E env QT_QPA_PLATFORM=offscreen
-            "XDG_CONFIG_HOME=${CMAKE_CURRENT_BINARY_DIR}/config_palette_labels"
-            "$<TARGET_FILE:amrexplorer_qt>" --palette-labels-smoke-test
-    )
-    set_tests_properties(qt_palette_labels_smoke PROPERTIES TIMEOUT 30)
-
     add_test(
         NAME qt_remote_slice_smoke
         COMMAND "${CMAKE_COMMAND}" -E env QT_QPA_PLATFORM=offscreen


### PR DESCRIPTION
test_palette_controller pins the same property (menu and selector agree on the builtin names, Rainbow first); its two forwarding accessors go with it.