### PR TITLE
reject a non-positive plotfile cell size where it is read

### DIFF
--- a/src/io/plotfile/PlotfileMetadataReader.cpp
+++ b/src/io/plotfile/PlotfileMetadataReader.cpp
@@ -548,9 +548,16 @@ PlotfileMetadataResult PlotfileMetadataReader::read(
     }
     for (auto& level : metadata->levels) {
         for (int axis = 0; axis < metadata->dimension; ++axis) {
-            level.cellSize[static_cast<std::size_t>(axis)] =
-                readRequired<double>(input, "level cell size");
             const auto i = static_cast<std::size_t>(axis);
+            level.cellSize[i] = readRequired<double>(input, "level cell size");
+            // Checked here, not left to validateMetadata: the grid records
+            // below divide by it, so a zero would be reported as out-of-range
+            // grid bounds instead of the field that is corrupt. (readRequired
+            // has already refused inf and nan.)
+            if (!(level.cellSize[i] > 0.0)) {
+                throw MetadataReadError(
+                    "plotfile level cell size must be positive");
+            }
             level.indexOrigin[i] = metadata->physicalDomain.lower[i]
                 - static_cast<double>(level.domain.lower[i]) * level.cellSize[i];
         }

--- a/tests/unit/test_plotfile_header.cpp
+++ b/tests/unit/test_plotfile_header.cpp
@@ -309,6 +309,35 @@ int main()
         "an unterminated over-long line was not rejected",
         "header line exceeds the supported length");
 
+    // A corrupt cell size is named as such. Every grid record is divided by
+    // it, so without the check at the read site a zero was reported as
+    // out-of-range grid bounds; inf and nan are already refused by the
+    // double reader, and stay refused as the cell-size field.
+    const auto withCellSizes = [](const char* level0) {
+        return
+            "HyperCLaw-V1.1\n1\ndensity\n2\n0.0\n1\n0.0\n0.0\n1.0\n1.0\n2\n"
+            "((0,0) (7,7) (0,0))\n((0,0) (15,15) (0,0))\n0\n0\n"
+            + std::string(level0) + "\n0.0625 0.0625\n0\n0\n"
+            "0 1 0.0 0\n0.0 1.0 0.0 1.0\nLevel_0/Cell\n"
+            "1 1 0.0 0\n0.0 1.0 0.0 1.0\nLevel_1/Cell\n";
+    };
+    expectHeaderRejected(scratch / "zero_cell_size",
+        withCellSizes("0.125 0"),
+        "a zero cell size was not rejected",
+        "cell size must be positive");
+    expectHeaderRejected(scratch / "negative_cell_size",
+        withCellSizes("-0.125 0.125"),
+        "a negative cell size was not rejected",
+        "cell size must be positive");
+    expectHeaderRejected(scratch / "infinite_cell_size",
+        withCellSizes("inf 0.125"),
+        "an infinite cell size was not rejected",
+        "while reading level cell size");
+    expectHeaderRejected(scratch / "nan_cell_size",
+        withCellSizes("nan 0.125"),
+        "a NaN cell size was not rejected",
+        "while reading level cell size");
+
     std::error_code removeError;
     std::filesystem::remove_all(scratch, removeError);
 


### PR DESCRIPTION
The grid records divide by it, so a zero was reported as out-of-range grid bounds rather than as the corrupt field; a negative one was caught, but only by validateMetadata after the geometry had been built on it.