### PR TITLE
add the volume-render request types and a shared orthographic camera

### DIFF
--- a/.codespell-ignore-words
+++ b/.codespell-ignore-words
@@ -1,2 +1,3 @@
 statics
 physicaly
+pixelx

--- a/include/amrexplorer/core/OrthoProjection.hpp
+++ b/include/amrexplorer/core/OrthoProjection.hpp
@@ -9,7 +9,9 @@ namespace amrvis {
 // extent, rotated by `azimuth` about z and then by `elevation` about the
 // rotated x axis, and projected along the view depth. Both the Qt view that
 // draws the wireframe and the ray caster that draws the volume use these
-// functions, so the two can never disagree about where a point lands.
+// functions, so the two can never disagree about where a point lands --
+// provided both are given the same `domain` box, since the normalisation is
+// about that box's own centre and largest extent.
 struct OrthoCamera {
     double azimuth = 0.0;    // radians, about z
     double elevation = 0.0;  // radians, about the rotated x axis
@@ -56,7 +58,9 @@ struct ProjectedPoint {
 // origin lies outside the domain on the viewer's side, and the unit
 // direction points away from the viewer, so marching t >= 0 from the origin
 // crosses the domain front to back. The inverse of projectPoint: the ray
-// through a projected point's (x, y) passes through the point.
+// through a projected point's (x, y) passes through the point. The viewport
+// position is continuous, with the domain centre at (width / 2, height / 2):
+// a raster caster passes pixel centres, (column + 0.5, row + 0.5).
 struct Ray {
     Real3 origin;
     Real3 direction;

--- a/include/amrexplorer/core/OrthoProjection.hpp
+++ b/include/amrexplorer/core/OrthoProjection.hpp
@@ -1,0 +1,69 @@
+#pragma once
+
+#include <amrexplorer/core/Geometry.hpp>
+
+namespace amrvis {
+
+// The orthographic camera of the 3-D overview (the iso quadrant) and of the
+// volume renderer: the domain is normalised about its centre by its largest
+// extent, rotated by `azimuth` about z and then by `elevation` about the
+// rotated x axis, and projected along the view depth. Both the Qt view that
+// draws the wireframe and the ray caster that draws the volume use these
+// functions, so the two can never disagree about where a point lands.
+struct OrthoCamera {
+    double azimuth = 0.0;    // radians, about z
+    double elevation = 0.0;  // radians, about the rotated x axis
+    double zoom = 1.0;
+    friend bool operator==(const OrthoCamera&, const OrthoCamera&) = default;
+};
+
+// The camera angles the XY / XZ / YZ preset buttons select: XY looks down -z
+// with +y up, XZ looks along +y with +z up, YZ looks along -x with +z up.
+inline constexpr OrthoCamera orthoPresetXY{0.0, 0.0, 1.0};
+inline constexpr OrthoCamera orthoPresetXZ{0.0, -1.5707963267948966, 1.0};
+inline constexpr OrthoCamera orthoPresetYZ{
+    -1.5707963267948966, -1.5707963267948966, 1.0};
+
+// Where the projection lands in a viewport of the given pixel size: the
+// centre, and the pixel scale of one normalised unit (the normalised domain
+// spans [-0.5, 0.5], so a scale of half the shorter side minus the margin
+// keeps the whole domain inside the viewport at zoom 1 in every orientation).
+struct ViewportFrame {
+    double centerX = 0.0;
+    double centerY = 0.0;
+    double scale = 1.0;
+};
+
+inline constexpr double orthoViewportMargin = 12.0;
+
+[[nodiscard]] ViewportFrame viewportFrame(
+    int width, int height, double margin = orthoViewportMargin) noexcept;
+
+// A point projected into the viewport: pixel x (right), pixel y (down), and
+// its depth along the view axis in normalised units, increasing toward the
+// viewer.
+struct ProjectedPoint {
+    double x = 0.0;
+    double y = 0.0;
+    double depth = 0.0;
+};
+
+[[nodiscard]] ProjectedPoint projectPoint(const OrthoCamera& camera,
+    const ViewportFrame& frame, const RealBox& domain,
+    const Real3& point) noexcept;
+
+// The view ray through a viewport position, in physical coordinates: the
+// origin lies outside the domain on the viewer's side, and the unit
+// direction points away from the viewer, so marching t >= 0 from the origin
+// crosses the domain front to back. The inverse of projectPoint: the ray
+// through a projected point's (x, y) passes through the point.
+struct Ray {
+    Real3 origin;
+    Real3 direction;
+};
+
+[[nodiscard]] Ray pixelRay(const OrthoCamera& camera,
+    const ViewportFrame& frame, const RealBox& domain, double pixelX,
+    double pixelY) noexcept;
+
+} // namespace amrvis

--- a/include/amrexplorer/core/Volume.hpp
+++ b/include/amrexplorer/core/Volume.hpp
@@ -1,0 +1,127 @@
+#pragma once
+
+#include <amrexplorer/core/Geometry.hpp>
+#include <amrexplorer/core/OrthoProjection.hpp>
+#include <amrexplorer/core/Request.hpp>
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace amrvis {
+
+// Direct volume rendering of a 3-D dataset: the field is sampled into a
+// bounded uniform grid and ray-cast with an orthographic camera and a
+// transfer function (a colour and an opacity per lookup entry). The request
+// is what a session renders, locally or on the remote server; the frame is
+// the viewport-sized image that comes back. Field data never travels: the
+// server renders and returns pixels.
+
+// The colour and opacity lookup the renderer maps values through, entry 0
+// for the bottom of the range and the last entry for the top; built by the
+// client from its palette and opacity controls, so the server needs neither.
+struct VolumeTransferFunction {
+    std::vector<std::uint32_t> colors;   // 0x00RRGGBB per entry
+    std::vector<float> opacities;        // [0, 1] per entry, per voxel
+    friend bool operator==(const VolumeTransferFunction&,
+        const VolumeTransferFunction&) = default;
+};
+
+// The value range the transfer function spans, linear or logarithmic.
+struct VolumeRange {
+    double minimum = 0.0;
+    double maximum = 1.0;
+    bool logarithmic = false;
+    friend bool operator==(const VolumeRange&, const VolumeRange&) = default;
+};
+
+inline constexpr int maxVolumeOutputDimension = 4096;
+inline constexpr std::size_t maxVolumeTransferEntries = 1024;
+inline constexpr int maxVolumeSamplesPerVoxel = 8;
+inline constexpr double minVolumeZoom = 0.01;
+inline constexpr double maxVolumeZoom = 100.0;
+// The sampled grid's voxel budget: the default (256^3, 64 MiB of floats) and
+// the cap either side enforces (512^3).
+inline constexpr std::uint64_t defaultVolumeVoxelBudget
+    = 256ULL * 256ULL * 256ULL;
+inline constexpr std::uint64_t maxVolumeVoxelBudget = 512ULL * 512ULL * 512ULL;
+
+struct VolumeRenderRequest {
+    DatasetId dataset;
+    FieldId field;
+    int component = 0;
+    // The finest level to sample and how the levels compose (as slices).
+    int maximumLevel = 0;
+    CompositionPolicy composition = CompositionPolicy::FinestAvailable;
+    // The physical sub-box to sample; the whole domain to start with.
+    RealBox region;
+    OrthoCamera camera;
+    std::array<int, 2> outputSize{0, 0};   // width, height in pixels
+    // The range the colours span; nullopt asks the renderer to use the
+    // sampled grid's finite extrema (the "Visible" range) and report them
+    // back, with `logarithmic` as the requested mapping (falling back to
+    // linear when the data is not strictly positive).
+    std::optional<VolumeRange> range;
+    bool logarithmic = false;
+    VolumeTransferFunction transfer;
+    // Ray samples per voxel along the ray (the step is the smallest voxel
+    // pitch divided by this).
+    int samplesPerVoxel = 2;
+    std::uint64_t maximumVoxels = defaultVolumeVoxelBudget;
+    friend bool operator==(const VolumeRenderRequest&,
+        const VolumeRenderRequest&) = default;
+};
+
+// The field sampled onto a uniform grid over `region`: voxel (i, j, k) is
+// centred at lower + (i + 0.5) * pitch per axis, x fastest; NaN marks a voxel
+// no level covers (or a non-finite value), which the renderer treats as
+// transparent.
+struct VolumeGrid {
+    std::array<int, 3> dims{0, 0, 0};
+    RealBox region;
+    std::vector<float> values;
+    std::uint64_t coveredVoxels = 0;
+    int maximumLevel = 0;   // the finest level that contributed
+};
+
+struct VolumeRenderMetrics {
+    std::array<int, 3> gridDims{0, 0, 0};
+    std::uint64_t coveredVoxels = 0;
+    int sampledMaximumLevel = 0;
+    bool gridFromCache = false;
+    std::uint64_t sampleMilliseconds = 0;
+    std::uint64_t renderMilliseconds = 0;
+    std::uint64_t candidateBlocks = 0;
+    std::uint64_t blocksRead = 0;
+    std::uint64_t cacheHits = 0;
+    std::uint64_t payloadBytesRead = 0;
+    friend bool operator==(const VolumeRenderMetrics&,
+        const VolumeRenderMetrics&) = default;
+};
+
+// The rendered image: premultiplied 0xAARRGGBB pixels, row 0 at the top,
+// alpha 0 where no ray sample landed, so it composites over any background.
+struct VolumeFrame {
+    int width = 0;
+    int height = 0;
+    std::vector<std::uint32_t> pixels;
+    VolumeRange usedRange;   // the range the colours were mapped with
+    VolumeRenderMetrics metrics;
+    // A cache-pressure fallback to a coarser composite level, as slices
+    // report it; -1 when none happened.
+    int cacheFallbackFromLevel = -1;
+    int cacheFallbackToLevel = -1;
+    friend bool operator==(const VolumeFrame&, const VolumeFrame&) = default;
+};
+
+// Structural validity of a request, before a session checks it against its
+// dataset: every field bounded and finite. Empty when valid.
+[[nodiscard]] std::vector<std::string> validateVolumeTransferFunction(
+    const VolumeTransferFunction& transfer);
+[[nodiscard]] std::vector<std::string> validateVolumeRenderRequest(
+    const VolumeRenderRequest& request, int datasetDimension);
+
+} // namespace amrvis

--- a/include/amrexplorer/core/Volume.hpp
+++ b/include/amrexplorer/core/Volume.hpp
@@ -63,7 +63,8 @@ struct VolumeRenderRequest {
     // The range the colours span; nullopt asks the renderer to use the
     // sampled grid's finite extrema (the "Visible" range) and report them
     // back, with `logarithmic` as the requested mapping (falling back to
-    // linear when the data is not strictly positive).
+    // linear when the data is not strictly positive). `logarithmic` is
+    // ignored when `range` is set: the range carries its own mapping.
     std::optional<VolumeRange> range;
     bool logarithmic = false;
     VolumeTransferFunction transfer;

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -1,8 +1,10 @@
 add_library(amrexplorer_core
     CoordinateSystem.cpp
     Metadata.cpp
+    OrthoProjection.cpp
     Request.cpp
     Statistics.cpp
+    Volume.cpp
 )
 add_library(amrexplorer::core ALIAS amrexplorer_core)
 

--- a/src/core/OrthoProjection.cpp
+++ b/src/core/OrthoProjection.cpp
@@ -1,0 +1,114 @@
+#include <amrexplorer/core/OrthoProjection.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+
+namespace amrvis {
+namespace {
+
+struct Normalisation {
+    Real3 center;
+    double extent = 1.0;
+};
+
+// The domain's centre and its largest extent (1 for a degenerate box), the
+// frame every camera quantity is measured in.
+Normalisation normalisation(const RealBox& domain) noexcept
+{
+    Normalisation result;
+    double extent = 0.0;
+    for (std::size_t axis = 0; axis < 3; ++axis) {
+        result.center[axis] = 0.5 * (domain.lower[axis] + domain.upper[axis]);
+        extent = std::max(extent, domain.upper[axis] - domain.lower[axis]);
+    }
+    result.extent = extent > 0.0 ? extent : 1.0;
+    return result;
+}
+
+// View coordinates of a normalised point: x1 right, y2 up, depth toward the
+// viewer -- Rz(azimuth) followed by the elevation rotation about x.
+struct ViewPoint {
+    double x1 = 0.0;
+    double y2 = 0.0;
+    double depth = 0.0;
+};
+
+ViewPoint toView(const OrthoCamera& camera, const Real3& normalised) noexcept
+{
+    const auto cosAz = std::cos(camera.azimuth);
+    const auto sinAz = std::sin(camera.azimuth);
+    const auto cosEl = std::cos(camera.elevation);
+    const auto sinEl = std::sin(camera.elevation);
+    const auto x1 = normalised[0] * cosAz - normalised[1] * sinAz;
+    const auto y1 = normalised[0] * sinAz + normalised[1] * cosAz;
+    return {x1, y1 * cosEl - normalised[2] * sinEl,
+        y1 * sinEl + normalised[2] * cosEl};
+}
+
+// The inverse rotation: a view-space vector back to normalised space.
+Real3 toWorld(const OrthoCamera& camera, const ViewPoint& view) noexcept
+{
+    const auto cosAz = std::cos(camera.azimuth);
+    const auto sinAz = std::sin(camera.azimuth);
+    const auto cosEl = std::cos(camera.elevation);
+    const auto sinEl = std::sin(camera.elevation);
+    // Undo the elevation (transpose of the x rotation), then the azimuth.
+    const auto y1 = view.y2 * cosEl + view.depth * sinEl;
+    const auto z = -view.y2 * sinEl + view.depth * cosEl;
+    Real3 world;
+    world[0] = view.x1 * cosAz + y1 * sinAz;
+    world[1] = -view.x1 * sinAz + y1 * cosAz;
+    world[2] = z;
+    return world;
+}
+
+} // namespace
+
+ViewportFrame viewportFrame(int width, int height, double margin) noexcept
+{
+    ViewportFrame frame;
+    frame.centerX = static_cast<double>(width) / 2.0;
+    frame.centerY = static_cast<double>(height) / 2.0;
+    frame.scale = std::max(
+        std::min(frame.centerX, frame.centerY) - margin, 1.0);
+    return frame;
+}
+
+ProjectedPoint projectPoint(const OrthoCamera& camera,
+    const ViewportFrame& frame, const RealBox& domain,
+    const Real3& point) noexcept
+{
+    const auto norm = normalisation(domain);
+    Real3 normalised;
+    for (std::size_t axis = 0; axis < 3; ++axis) {
+        normalised[axis] = (point[axis] - norm.center[axis]) / norm.extent;
+    }
+    const auto view = toView(camera, normalised);
+    const auto pixels = frame.scale * camera.zoom;
+    return {frame.centerX + pixels * view.x1, frame.centerY - pixels * view.y2,
+        view.depth};
+}
+
+Ray pixelRay(const OrthoCamera& camera, const ViewportFrame& frame,
+    const RealBox& domain, double pixelX, double pixelY) noexcept
+{
+    const auto norm = normalisation(domain);
+    const auto pixels = frame.scale * camera.zoom;
+    // The normalised domain lies within [-0.5, 0.5]^3, so a depth of 2 is
+    // outside it in every orientation; the ray starts there and runs toward
+    // negative depth.
+    constexpr double startDepth = 2.0;
+    const ViewPoint start{(pixelX - frame.centerX) / pixels,
+        (frame.centerY - pixelY) / pixels, startDepth};
+    const auto origin = toWorld(camera, start);
+    const auto direction = toWorld(camera, ViewPoint{0.0, 0.0, -1.0});
+    Ray ray;
+    for (std::size_t axis = 0; axis < 3; ++axis) {
+        ray.origin[axis] = norm.center[axis] + origin[axis] * norm.extent;
+        ray.direction[axis] = direction[axis];
+    }
+    return ray;
+}
+
+} // namespace amrvis

--- a/src/core/Volume.cpp
+++ b/src/core/Volume.cpp
@@ -20,6 +20,13 @@ std::vector<std::string> validateVolumeTransferFunction(
         || transfer.opacities.size() > maxVolumeTransferEntries) {
         errors.emplace_back("transfer function exceeds the entry limit");
     }
+    for (const auto color : transfer.colors) {
+        if (color > 0x00FFFFFFU) {
+            errors.emplace_back(
+                "transfer function colors must be 0x00RRGGBB");
+            break;
+        }
+    }
     for (const auto opacity : transfer.opacities) {
         if (!(opacity >= 0.0F) || !(opacity <= 1.0F)) {
             errors.emplace_back(
@@ -67,8 +74,10 @@ std::vector<std::string> validateVolumeRenderRequest(
     if (request.range) {
         const auto& range = *request.range;
         if (!std::isfinite(range.minimum) || !std::isfinite(range.maximum)
-            || !(range.minimum < range.maximum)) {
-            errors.emplace_back("range must be finite with minimum < maximum");
+            || !(range.minimum < range.maximum)
+            || !std::isfinite(range.maximum - range.minimum)) {
+            errors.emplace_back(
+                "range must be finite with minimum < maximum and a finite span");
         } else if (range.logarithmic && !(range.minimum > 0.0)) {
             errors.emplace_back("a logarithmic range must be strictly positive");
         }

--- a/src/core/Volume.cpp
+++ b/src/core/Volume.cpp
@@ -1,0 +1,90 @@
+#include <amrexplorer/core/Volume.hpp>
+
+#include <cmath>
+#include <cstddef>
+
+namespace amrvis {
+
+std::vector<std::string> validateVolumeTransferFunction(
+    const VolumeTransferFunction& transfer)
+{
+    std::vector<std::string> errors;
+    if (transfer.colors.size() != transfer.opacities.size()) {
+        errors.emplace_back(
+            "transfer function colors and opacities must have the same size");
+    }
+    if (transfer.colors.size() < 2) {
+        errors.emplace_back("transfer function must have at least two entries");
+    }
+    if (transfer.colors.size() > maxVolumeTransferEntries
+        || transfer.opacities.size() > maxVolumeTransferEntries) {
+        errors.emplace_back("transfer function exceeds the entry limit");
+    }
+    for (const auto opacity : transfer.opacities) {
+        if (!(opacity >= 0.0F) || !(opacity <= 1.0F)) {
+            errors.emplace_back(
+                "transfer function opacities must be finite and within [0, 1]");
+            break;
+        }
+    }
+    return errors;
+}
+
+std::vector<std::string> validateVolumeRenderRequest(
+    const VolumeRenderRequest& request, int datasetDimension)
+{
+    std::vector<std::string> errors;
+    if (request.dataset.value == 0) {
+        errors.emplace_back("dataset id must be nonzero");
+    }
+    if (datasetDimension != 3) {
+        errors.emplace_back("volume rendering requires a 3-D dataset");
+    }
+    if (request.component < 0) {
+        errors.emplace_back("component must be non-negative");
+    }
+    if (request.maximumLevel < 0) {
+        errors.emplace_back("maximum level must be non-negative");
+    }
+    if (!request.region.valid(3)) {
+        errors.emplace_back("region must have finite positive extent");
+    }
+    if (!std::isfinite(request.camera.azimuth)
+        || !std::isfinite(request.camera.elevation)) {
+        errors.emplace_back("camera angles must be finite");
+    }
+    if (!(request.camera.zoom >= minVolumeZoom)
+        || !(request.camera.zoom <= maxVolumeZoom)) {
+        errors.emplace_back("camera zoom is outside the supported range");
+    }
+    for (const auto extent : request.outputSize) {
+        if (extent < 1 || extent > maxVolumeOutputDimension) {
+            errors.emplace_back(
+                "output dimensions must be within [1, 4096]");
+            break;
+        }
+    }
+    if (request.range) {
+        const auto& range = *request.range;
+        if (!std::isfinite(range.minimum) || !std::isfinite(range.maximum)
+            || !(range.minimum < range.maximum)) {
+            errors.emplace_back("range must be finite with minimum < maximum");
+        } else if (range.logarithmic && !(range.minimum > 0.0)) {
+            errors.emplace_back("a logarithmic range must be strictly positive");
+        }
+    }
+    for (const auto& error : validateVolumeTransferFunction(request.transfer)) {
+        errors.push_back(error);
+    }
+    if (request.samplesPerVoxel < 1
+        || request.samplesPerVoxel > maxVolumeSamplesPerVoxel) {
+        errors.emplace_back("samples per voxel must be within [1, 8]");
+    }
+    if (request.maximumVoxels < 1
+        || request.maximumVoxels > maxVolumeVoxelBudget) {
+        errors.emplace_back("voxel budget is outside the supported range");
+    }
+    return errors;
+}
+
+} // namespace amrvis

--- a/src/qt/IsoWidget.cpp
+++ b/src/qt/IsoWidget.cpp
@@ -33,8 +33,7 @@ constexpr std::array<std::array<int, 2>, 12> boxEdges{{
 
 IsoWidget::IsoWidget(QWidget* parent)
     : QWidget(parent)
-    , m_azimuth(30.0 * pi / 180.0)
-    , m_elevation(30.0 * pi / 180.0)
+    , m_camera{30.0 * pi / 180.0, 30.0 * pi / 180.0, 1.0}
 {
     setMinimumSize(200, 150);
     setMouseTracking(true);
@@ -58,13 +57,13 @@ IsoWidget::IsoWidget(QWidget* parent)
     m_btnYZ = makeBtn(QStringLiteral("YZ"));
 
     connect(m_btnXY, &QPushButton::clicked, this, [this] {
-        setViewAngles(0.0, 0.0);
+        setViewAngles(orthoPresetXY.azimuth, orthoPresetXY.elevation);
     });
     connect(m_btnXZ, &QPushButton::clicked, this, [this] {
-        setViewAngles(0.0, -pi / 2.0);
+        setViewAngles(orthoPresetXZ.azimuth, orthoPresetXZ.elevation);
     });
     connect(m_btnYZ, &QPushButton::clicked, this, [this] {
-        setViewAngles(-pi / 2.0, -pi / 2.0);
+        setViewAngles(orthoPresetYZ.azimuth, orthoPresetYZ.elevation);
     });
 }
 
@@ -119,54 +118,36 @@ void IsoWidget::paintEvent(QPaintEvent* event)
     }
     painter.setRenderHint(QPainter::Antialiasing, true);
 
-    Projection projection;
-    constexpr double margin = 12.0;
-    projection.centerX = static_cast<double>(width()) / 2.0;
-    projection.centerY = static_cast<double>(height()) / 2.0;
-    // Normalized coordinates span [-1, 1] after the two rotations.
-    projection.scale = std::max(
-        std::min(projection.centerX, projection.centerY) - margin, 1.0);
-
+    const auto frame = viewportFrame(width(), height());
     for (const auto& level : m_levels) {
         const QPen pen(levelOutlineColor(level.level), 1);
         for (const auto& box : level.boxes) {
-            drawBox(painter, projection, physicalBox(level, box), pen);
+            drawBox(painter, frame, physicalBox(level, box), pen);
         }
     }
-    drawBox(painter, projection, m_domain, QPen(Qt::white, 1));
+    drawBox(painter, frame, m_domain, QPen(Qt::white, 1));
     // Translucent slice planes overlay the wireframe so the user can see where
     // the XY/XZ/YZ slices sit in the domain.
     if (m_slicePlanesVisible) {
         for (int axis = 0; axis < 3; ++axis) {
-            drawSlicePlane(painter, projection, axis);
+            drawSlicePlane(painter, frame, axis);
         }
     }
     drawAxisIndicator(painter);
 }
 
-QPointF IsoWidget::project(const Projection& projection,
+QPointF IsoWidget::project(const ViewportFrame& frame,
     double x, double y, double z) const
 {
-    const auto extent = std::max({m_domain.upper[0] - m_domain.lower[0],
-        m_domain.upper[1] - m_domain.lower[1],
-        m_domain.upper[2] - m_domain.lower[2]});
-    const auto safeExtent = extent > 0.0 ? extent : 1.0;
-    const auto nx = (x - 0.5 * (m_domain.lower[0] + m_domain.upper[0]))
-        / safeExtent;
-    const auto ny = (y - 0.5 * (m_domain.lower[1] + m_domain.upper[1]))
-        / safeExtent;
-    const auto nz = (z - 0.5 * (m_domain.lower[2] + m_domain.upper[2]))
-        / safeExtent;
-    const auto cosAz = std::cos(m_azimuth);
-    const auto sinAz = std::sin(m_azimuth);
-    const auto x1 = nx * cosAz - ny * sinAz;
-    const auto y1 = nx * sinAz + ny * cosAz;
-    const auto y2 = y1 * std::cos(m_elevation) - nz * std::sin(m_elevation);
-    return QPointF(projection.centerX + projection.scale * m_zoom * x1,
-        projection.centerY - projection.scale * m_zoom * y2);
+    Real3 point;
+    point[0] = x;
+    point[1] = y;
+    point[2] = z;
+    const auto projected = projectPoint(m_camera, frame, m_domain, point);
+    return QPointF(projected.x, projected.y);
 }
 
-void IsoWidget::drawBox(QPainter& painter, const Projection& projection,
+void IsoWidget::drawBox(QPainter& painter, const ViewportFrame& frame,
     const RealBox& box, const QPen& pen) const
 {
     std::array<QPointF, 8> corners;
@@ -174,7 +155,7 @@ void IsoWidget::drawBox(QPainter& painter, const Projection& projection,
         const auto x = (corner & 1U) != 0U ? box.upper[0] : box.lower[0];
         const auto y = (corner & 2U) != 0U ? box.upper[1] : box.lower[1];
         const auto z = (corner & 4U) != 0U ? box.upper[2] : box.lower[2];
-        corners[corner] = project(projection, x, y, z);
+        corners[corner] = project(frame, x, y, z);
     }
     painter.setPen(pen);
     painter.setBrush(Qt::NoBrush);
@@ -184,7 +165,7 @@ void IsoWidget::drawBox(QPainter& painter, const Projection& projection,
     }
 }
 
-void IsoWidget::drawSlicePlane(QPainter& painter, const Projection& projection,
+void IsoWidget::drawSlicePlane(QPainter& painter, const ViewportFrame& frame,
     int axis) const
 {
     const auto index = static_cast<std::size_t>(axis);
@@ -200,7 +181,7 @@ void IsoWidget::drawSlicePlane(QPainter& painter, const Projection& projection,
         point[index] = position;
         point[a] = (corner & 1U) != 0U ? m_domain.upper[a] : m_domain.lower[a];
         point[b] = (corner & 2U) != 0U ? m_domain.upper[b] : m_domain.lower[b];
-        polygon << project(projection, point[0], point[1], point[2]);
+        polygon << project(frame, point[0], point[1], point[2]);
     }
     auto fill = slicePlaneColor(axis);
     fill.setAlpha(96);
@@ -267,10 +248,12 @@ void IsoWidget::mouseMoveEvent(QMouseEvent* event)
         const auto delta = event->pos() - m_lastMousePos;
         m_lastMousePos = event->pos();
         constexpr double sensitivity = 0.008;
-        m_azimuth -= static_cast<double>(delta.x()) * sensitivity;
-        m_elevation += static_cast<double>(delta.y()) * sensitivity;
-        m_elevation = std::clamp(m_elevation, -pi / 2.0 + 0.01, pi / 2.0 - 0.01);
+        m_camera.azimuth -= static_cast<double>(delta.x()) * sensitivity;
+        m_camera.elevation += static_cast<double>(delta.y()) * sensitivity;
+        m_camera.elevation = std::clamp(
+            m_camera.elevation, -pi / 2.0 + 0.01, pi / 2.0 - 0.01);
         update();
+        emit cameraChanged();
         event->accept();
         return;
     }
@@ -282,6 +265,7 @@ void IsoWidget::mouseReleaseEvent(QMouseEvent* event)
     if (event->button() == Qt::LeftButton && m_dragging) {
         m_dragging = false;
         setCursor(Qt::ArrowCursor);
+        emit interactionEnded();
         event->accept();
         return;
     }
@@ -301,8 +285,9 @@ void IsoWidget::wheelEvent(QWheelEvent* event)
     }
     constexpr double zoomStep = 1.15;
     const auto factor = vertical > 0 ? zoomStep : 1.0 / zoomStep;
-    m_zoom = std::clamp(m_zoom * factor, 0.1, 10.0);
+    m_camera.zoom = std::clamp(m_camera.zoom * factor, 0.1, 10.0);
     update();
+    emit cameraChanged();
     event->accept();
 }
 
@@ -316,10 +301,10 @@ void IsoWidget::drawAxisIndicator(QPainter& painter) const
     const QPointF origin(static_cast<qreal>(originX),
         static_cast<qreal>(h - originY));
 
-    const auto cosAz = std::cos(m_azimuth);
-    const auto sinAz = std::sin(m_azimuth);
-    const auto cosEl = std::cos(m_elevation);
-    const auto sinEl = std::sin(m_elevation);
+    const auto cosAz = std::cos(m_camera.azimuth);
+    const auto sinAz = std::sin(m_camera.azimuth);
+    const auto cosEl = std::cos(m_camera.elevation);
+    const auto sinEl = std::sin(m_camera.elevation);
 
     auto projectDir = [&](double dx, double dy, double dz) -> QPointF {
         const auto x1 = dx * cosAz - dy * sinAz;
@@ -371,9 +356,20 @@ void IsoWidget::drawAxisIndicator(QPainter& painter) const
 
 void IsoWidget::setViewAngles(double azimuth, double elevation)
 {
-    m_azimuth = azimuth;
-    m_elevation = elevation;
+    m_camera.azimuth = azimuth;
+    m_camera.elevation = elevation;
     update();
+    emit cameraChanged();
+}
+
+void IsoWidget::setCamera(const OrthoCamera& camera)
+{
+    if (camera == m_camera) {
+        return;
+    }
+    m_camera = camera;
+    update();
+    emit cameraChanged();
 }
 
 void IsoWidget::resizeEvent(QResizeEvent* event)

--- a/src/qt/IsoWidget.hpp
+++ b/src/qt/IsoWidget.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <amrexplorer/core/Metadata.hpp>
+#include <amrexplorer/core/OrthoProjection.hpp>
 
 #include <QColor>
 #include <QPoint>
@@ -25,7 +26,9 @@ namespace amrvis::qt {
 // The bottom-right quadrant of the 3-D layout: an orthographic wireframe
 // of the physical domain and the per-level grid boxes, with the three
 // current slice planes drawn as translucent quads.  Drag to rotate, wheel
-// to zoom, matching the legacy Amrvis iso view interaction.
+// to zoom, matching the legacy Amrvis iso view interaction. The projection
+// is the shared OrthoCamera (core/OrthoProjection.hpp), the one the volume
+// renderer uses, so a rendered volume placed under this wireframe lines up.
 class IsoWidget final : public QWidget {
     Q_OBJECT
 
@@ -37,6 +40,16 @@ public:
     void setSlicePositions(double x, double y, double z);
     void setSlicePlanesVisible(bool visible);
     void setColorPalette(const Palette* palette);
+
+    // The camera the widget draws with; drag, wheel and the preset buttons
+    // change it and emit cameraChanged, a release after a drag emits
+    // interactionEnded.
+    [[nodiscard]] const OrthoCamera& camera() const noexcept { return m_camera; }
+    void setCamera(const OrthoCamera& camera);
+
+signals:
+    void cameraChanged();
+    void interactionEnded();
 
 protected:
     void paintEvent(QPaintEvent* event) override;
@@ -54,17 +67,11 @@ private:
         Real3 indexOrigin;
         std::vector<IntBox> boxes;
     };
-    struct Projection {
-        double centerX = 0.0;
-        double centerY = 0.0;
-        double scale = 1.0;
-    };
-
-    [[nodiscard]] QPointF project(const Projection& projection,
+    [[nodiscard]] QPointF project(const ViewportFrame& frame,
         double x, double y, double z) const;
-    void drawBox(QPainter& painter, const Projection& projection,
+    void drawBox(QPainter& painter, const ViewportFrame& frame,
         const RealBox& box, const QPen& pen) const;
-    void drawSlicePlane(QPainter& painter, const Projection& projection,
+    void drawSlicePlane(QPainter& painter, const ViewportFrame& frame,
         int axis) const;
     void drawAxisIndicator(QPainter& painter) const;
     [[nodiscard]] RealBox physicalBox(const LevelBoxes& level,
@@ -81,9 +88,7 @@ private:
     const Palette* m_palette = nullptr;
     bool m_hasGeometry = false;
 
-    double m_azimuth = 0.0;
-    double m_elevation = 0.0;
-    double m_zoom = 1.0;
+    OrthoCamera m_camera;
     QPoint m_lastMousePos;
     bool m_dragging = false;
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -22,6 +22,14 @@ add_executable(test_core_metadata unit/test_core_metadata.cpp)
 target_link_libraries(test_core_metadata PRIVATE amrexplorer::core amrexplorer::warnings)
 add_test(NAME core_metadata COMMAND test_core_metadata)
 
+add_executable(test_ortho_projection unit/test_ortho_projection.cpp)
+target_link_libraries(test_ortho_projection PRIVATE amrexplorer::core amrexplorer::warnings)
+add_test(NAME ortho_projection COMMAND test_ortho_projection)
+
+add_executable(test_volume_types unit/test_volume_types.cpp)
+target_link_libraries(test_volume_types PRIVATE amrexplorer::core amrexplorer::warnings)
+add_test(NAME volume_types COMMAND test_volume_types)
+
 add_executable(test_geometry unit/test_geometry.cpp)
 target_link_libraries(test_geometry PRIVATE amrexplorer::core amrexplorer::warnings)
 add_test(NAME geometry COMMAND test_geometry)

--- a/tests/unit/test_ortho_projection.cpp
+++ b/tests/unit/test_ortho_projection.cpp
@@ -5,7 +5,9 @@
 
 #include <amrexplorer/core/OrthoProjection.hpp>
 
+#include <algorithm>
 #include <cmath>
+#include <cstddef>
 #include <cstdlib>
 #include <iostream>
 

--- a/tests/unit/test_ortho_projection.cpp
+++ b/tests/unit/test_ortho_projection.cpp
@@ -1,0 +1,164 @@
+// The shared orthographic camera: the projection the iso view draws with and
+// the ray caster renders with. Pins the numbers the iso view produced before
+// the math moved here (so the quadrant cannot drift), the preset views, and
+// that pixelRay inverts projectPoint.
+
+#include <amrexplorer/core/OrthoProjection.hpp>
+
+#include <cmath>
+#include <cstdlib>
+#include <iostream>
+
+namespace {
+
+void require(bool condition, const char* message)
+{
+    if (!condition) {
+        std::cerr << "FAILED: " << message << '\n';
+        std::exit(1);
+    }
+}
+
+bool near(double actual, double expected, double tolerance = 1e-6)
+{
+    return std::abs(actual - expected) <= tolerance;
+}
+
+amrvis::Real3 point(double x, double y, double z)
+{
+    amrvis::Real3 result;
+    result[0] = x;
+    result[1] = y;
+    result[2] = z;
+    return result;
+}
+
+} // namespace
+
+int main()
+{
+    constexpr double pi = 3.14159265358979323846;
+    // An anisotropic domain, so the normalisation by the largest extent is
+    // exercised: [0,2] x [0,1] x [0,1], centre (1, 0.5, 0.5), extent 2.
+    const amrvis::RealBox domain{point(0.0, 0.0, 0.0), point(2.0, 1.0, 1.0)};
+
+    // The viewport frame is IsoWidget's: centre of the widget, scale = the
+    // shorter half-side minus the margin, never below one pixel.
+    const auto frame = amrvis::viewportFrame(400, 300);
+    require(near(frame.centerX, 200.0) && near(frame.centerY, 150.0)
+            && near(frame.scale, 138.0),
+        "the viewport frame is not the iso view's");
+    require(near(amrvis::viewportFrame(10, 10).scale, 1.0),
+        "a tiny viewport did not clamp the scale to one pixel");
+
+    // Pinned from the iso view's projection formula: the upper corner under
+    // azimuth 30 deg, elevation 30 deg, zoom 1.
+    const amrvis::OrthoCamera oblique{30.0 * pi / 180.0, 30.0 * pi / 180.0, 1.0};
+    const auto corner = amrvis::projectPoint(
+        oblique, frame, domain, point(2.0, 1.0, 1.0));
+    require(near(corner.x, 242.505752861) && near(corner.y, 111.497123569)
+            && near(corner.depth, 0.449759526),
+        "the oblique projection does not match the iso view's numbers");
+    // Zoom scales about the viewport centre.
+    const amrvis::OrthoCamera zoomed{oblique.azimuth, oblique.elevation, 2.0};
+    const auto zoomedCorner = amrvis::projectPoint(
+        zoomed, frame, domain, point(2.0, 1.0, 1.0));
+    require(near(zoomedCorner.x - 200.0, 2.0 * (corner.x - 200.0))
+            && near(zoomedCorner.y - 150.0, 2.0 * (corner.y - 150.0))
+            && near(zoomedCorner.depth, corner.depth),
+        "zoom did not scale about the viewport centre");
+    // The domain centre projects to the viewport centre at zero depth.
+    const auto centre = amrvis::projectPoint(
+        oblique, frame, domain, point(1.0, 0.5, 0.5));
+    require(near(centre.x, 200.0) && near(centre.y, 150.0)
+            && near(centre.depth, 0.0),
+        "the domain centre did not project to the viewport centre");
+
+    // Presets. XY: screen right = +x, up = +y, depth = +z (the eye is above).
+    {
+        const auto p = amrvis::projectPoint(
+            amrvis::orthoPresetXY, frame, domain, point(2.0, 1.0, 1.0));
+        require(near(p.x, 200.0 + 138.0 * 0.5) && near(p.y, 150.0 - 138.0 * 0.25)
+                && near(p.depth, 0.25),
+            "the XY preset is not a top-down view");
+    }
+    // XZ: right = +x, up = +z, the eye on the -y side (depth = -y).
+    {
+        const auto p = amrvis::projectPoint(
+            amrvis::orthoPresetXZ, frame, domain, point(2.0, 1.0, 1.0));
+        require(near(p.x, 200.0 + 138.0 * 0.5) && near(p.y, 150.0 - 138.0 * 0.25)
+                && near(p.depth, -0.25),
+            "the XZ preset is not a front view");
+    }
+    // YZ: right = +y, up = +z, the eye on the +x side (depth = +x).
+    {
+        const auto p = amrvis::projectPoint(
+            amrvis::orthoPresetYZ, frame, domain, point(2.0, 1.0, 1.0));
+        require(near(p.x, 200.0 + 138.0 * 0.25) && near(p.y, 150.0 - 138.0 * 0.25)
+                && near(p.depth, 0.5),
+            "the YZ preset is not a side view");
+    }
+
+    // pixelRay inverts projectPoint: the ray through a point's projection
+    // passes through the point, starts on the viewer's side outside the
+    // domain, and points away from the viewer (toward decreasing depth).
+    for (const auto& camera : {oblique, zoomed, amrvis::orthoPresetXY,
+             amrvis::orthoPresetXZ, amrvis::orthoPresetYZ,
+             amrvis::OrthoCamera{-2.3, 1.1, 0.7}}) {
+        for (const auto& target : {point(2.0, 1.0, 1.0), point(0.0, 0.0, 0.0),
+                 point(1.3, 0.2, 0.9), point(1.0, 0.5, 0.5)}) {
+            const auto projected = amrvis::projectPoint(
+                camera, frame, domain, target);
+            const auto ray = amrvis::pixelRay(
+                camera, frame, domain, projected.x, projected.y);
+            // Unit direction.
+            const auto length = std::sqrt(ray.direction[0] * ray.direction[0]
+                + ray.direction[1] * ray.direction[1]
+                + ray.direction[2] * ray.direction[2]);
+            require(near(length, 1.0, 1e-12), "the ray direction is not unit");
+            // The point lies on the ray at t = distance from the origin, and
+            // ahead of the origin.
+            double t = 0.0;
+            for (std::size_t axis = 0; axis < 3; ++axis) {
+                t += (target[axis] - ray.origin[axis]) * ray.direction[axis];
+            }
+            require(t > 0.0, "the ray origin is not on the viewer's side");
+            double miss = 0.0;
+            for (std::size_t axis = 0; axis < 3; ++axis) {
+                const auto onRay = ray.origin[axis] + t * ray.direction[axis];
+                miss = std::max(miss, std::abs(onRay - target[axis]));
+            }
+            require(miss <= 1e-9, "the pixel ray does not pass through the point");
+            // Marching along the ray lowers the depth.
+            amrvis::Real3 ahead;
+            for (std::size_t axis = 0; axis < 3; ++axis) {
+                ahead[axis] = target[axis] + 0.1 * ray.direction[axis];
+            }
+            const auto aheadDepth = amrvis::projectPoint(
+                camera, frame, domain, ahead).depth;
+            require(aheadDepth < projected.depth,
+                "the ray direction does not point away from the viewer");
+            // The origin is outside the domain.
+            bool outside = false;
+            for (std::size_t axis = 0; axis < 3; ++axis) {
+                outside = outside || ray.origin[axis] < domain.lower[axis]
+                    || ray.origin[axis] > domain.upper[axis];
+            }
+            require(outside, "the ray origin starts inside the domain");
+        }
+    }
+    // The preset rays are axis-aligned with the expected sign.
+    {
+        const auto xy = amrvis::pixelRay(
+            amrvis::orthoPresetXY, frame, domain, 200.0, 150.0);
+        const auto xz = amrvis::pixelRay(
+            amrvis::orthoPresetXZ, frame, domain, 200.0, 150.0);
+        const auto yz = amrvis::pixelRay(
+            amrvis::orthoPresetYZ, frame, domain, 200.0, 150.0);
+        require(near(xy.direction[2], -1.0, 1e-12)
+                && near(xz.direction[1], 1.0, 1e-12)
+                && near(yz.direction[0], -1.0, 1e-12),
+            "the preset rays are not axis-aligned as labelled");
+    }
+    return 0;
+}

--- a/tests/unit/test_volume_types.cpp
+++ b/tests/unit/test_volume_types.cpp
@@ -53,6 +53,30 @@ int main()
         request.range = amrvis::VolumeRange{0.5, 2.0, true};
         require(!rejected(request), "a positive logarithmic range was rejected");
     }
+    {
+        // The bounds are inclusive.
+        auto request = validRequest();
+        request.camera.zoom = amrvis::minVolumeZoom;
+        require(!rejected(request), "the minimum zoom was rejected");
+        request.camera.zoom = amrvis::maxVolumeZoom;
+        require(!rejected(request), "the maximum zoom was rejected");
+        request = validRequest();
+        request.outputSize = {1, amrvis::maxVolumeOutputDimension};
+        require(!rejected(request), "the output size limits were rejected");
+        request = validRequest();
+        request.samplesPerVoxel = amrvis::maxVolumeSamplesPerVoxel;
+        require(!rejected(request), "the maximum samples per voxel was rejected");
+        request = validRequest();
+        request.maximumVoxels = amrvis::maxVolumeVoxelBudget;
+        require(!rejected(request), "the maximum voxel budget was rejected");
+        request = validRequest();
+        request.transfer.colors.assign(amrvis::maxVolumeTransferEntries, 0xFFFFFFU);
+        request.transfer.opacities.assign(amrvis::maxVolumeTransferEntries, 1.0F);
+        require(!rejected(request), "a full-size transfer function was rejected");
+        request = validRequest();
+        request.transfer.opacities = {0.0F, 1.0F, 1.0F};
+        require(!rejected(request), "opacities of exactly 0 and 1 were rejected");
+    }
 
     require(rejected(validRequest(), 2), "a 2-D dataset was accepted");
     {
@@ -106,6 +130,10 @@ int main()
         require(rejected(request), "a NaN range was accepted");
         request.range = amrvis::VolumeRange{-1.0, 2.0, true};
         require(rejected(request), "a non-positive logarithmic range was accepted");
+        request.range = amrvis::VolumeRange{
+            -std::numeric_limits<double>::max(),
+            std::numeric_limits<double>::max(), false};
+        require(rejected(request), "a range with an infinite span was accepted");
     }
     {
         auto request = validRequest();
@@ -120,6 +148,9 @@ int main()
         require(rejected(request), "an opacity above one was accepted");
         request.transfer.opacities[1] = std::numeric_limits<float>::quiet_NaN();
         require(rejected(request), "a NaN opacity was accepted");
+        request = validRequest();
+        request.transfer.colors[1] = 0xFF00FF00U;
+        require(rejected(request), "a colour with a non-zero high byte was accepted");
         request = validRequest();
         request.transfer.colors.assign(amrvis::maxVolumeTransferEntries + 1, 0U);
         request.transfer.opacities.assign(

--- a/tests/unit/test_volume_types.cpp
+++ b/tests/unit/test_volume_types.cpp
@@ -1,0 +1,144 @@
+// The volume-render request's structural validator: every bounded field
+// rejects out-of-range and non-finite input, and a well-formed request passes.
+
+#include <amrexplorer/core/Volume.hpp>
+
+#include <cmath>
+#include <cstdlib>
+#include <iostream>
+#include <limits>
+
+namespace {
+
+void require(bool condition, const char* message)
+{
+    if (!condition) {
+        std::cerr << "FAILED: " << message << '\n';
+        std::exit(1);
+    }
+}
+
+amrvis::VolumeRenderRequest validRequest()
+{
+    amrvis::VolumeRenderRequest request;
+    request.dataset.value = 7;
+    request.field.value = 1;
+    request.maximumLevel = 1;
+    request.region.lower = {{0.0, 0.0, 0.0}};
+    request.region.upper = {{1.0, 2.0, 3.0}};
+    request.camera = {0.4, -0.3, 1.5};
+    request.outputSize = {320, 240};
+    request.transfer.colors = {0x0000FFU, 0x00FF00U, 0xFF0000U};
+    request.transfer.opacities = {0.0F, 0.5F, 1.0F};
+    return request;
+}
+
+bool rejected(const amrvis::VolumeRenderRequest& request, int dimension = 3)
+{
+    return !amrvis::validateVolumeRenderRequest(request, dimension).empty();
+}
+
+} // namespace
+
+int main()
+{
+    constexpr auto nan = std::numeric_limits<double>::quiet_NaN();
+    constexpr auto infinity = std::numeric_limits<double>::infinity();
+
+    require(!rejected(validRequest()), "a well-formed request was rejected");
+    {
+        auto request = validRequest();
+        request.range = amrvis::VolumeRange{0.5, 2.0, false};
+        require(!rejected(request), "an explicit range was rejected");
+        request.range = amrvis::VolumeRange{0.5, 2.0, true};
+        require(!rejected(request), "a positive logarithmic range was rejected");
+    }
+
+    require(rejected(validRequest(), 2), "a 2-D dataset was accepted");
+    {
+        auto request = validRequest();
+        request.dataset.value = 0;
+        require(rejected(request), "a zero dataset id was accepted");
+    }
+    {
+        auto request = validRequest();
+        request.component = -1;
+        require(rejected(request), "a negative component was accepted");
+        request = validRequest();
+        request.maximumLevel = -1;
+        require(rejected(request), "a negative maximum level was accepted");
+    }
+    {
+        auto request = validRequest();
+        request.region.upper[1] = request.region.lower[1];
+        require(rejected(request), "a degenerate region was accepted");
+        request = validRequest();
+        request.region.upper[0] = infinity;
+        require(rejected(request), "an infinite region was accepted");
+    }
+    {
+        auto request = validRequest();
+        request.camera.azimuth = nan;
+        require(rejected(request), "a NaN azimuth was accepted");
+        request = validRequest();
+        request.camera.elevation = infinity;
+        require(rejected(request), "an infinite elevation was accepted");
+        request = validRequest();
+        request.camera.zoom = 0.0;
+        require(rejected(request), "a zero zoom was accepted");
+        request.camera.zoom = nan;
+        require(rejected(request), "a NaN zoom was accepted");
+        request.camera.zoom = amrvis::maxVolumeZoom * 2.0;
+        require(rejected(request), "an oversized zoom was accepted");
+    }
+    {
+        auto request = validRequest();
+        request.outputSize = {0, 240};
+        require(rejected(request), "a zero-width output was accepted");
+        request.outputSize = {320, amrvis::maxVolumeOutputDimension + 1};
+        require(rejected(request), "an over-limit output height was accepted");
+    }
+    {
+        auto request = validRequest();
+        request.range = amrvis::VolumeRange{2.0, 2.0, false};
+        require(rejected(request), "an empty range was accepted");
+        request.range = amrvis::VolumeRange{nan, 2.0, false};
+        require(rejected(request), "a NaN range was accepted");
+        request.range = amrvis::VolumeRange{-1.0, 2.0, true};
+        require(rejected(request), "a non-positive logarithmic range was accepted");
+    }
+    {
+        auto request = validRequest();
+        request.transfer.opacities.pop_back();
+        require(rejected(request), "mismatched transfer sizes were accepted");
+        request = validRequest();
+        request.transfer.colors = {0x0U};
+        request.transfer.opacities = {1.0F};
+        require(rejected(request), "a one-entry transfer function was accepted");
+        request = validRequest();
+        request.transfer.opacities[1] = 1.5F;
+        require(rejected(request), "an opacity above one was accepted");
+        request.transfer.opacities[1] = std::numeric_limits<float>::quiet_NaN();
+        require(rejected(request), "a NaN opacity was accepted");
+        request = validRequest();
+        request.transfer.colors.assign(amrvis::maxVolumeTransferEntries + 1, 0U);
+        request.transfer.opacities.assign(
+            amrvis::maxVolumeTransferEntries + 1, 0.5F);
+        require(rejected(request), "an over-limit transfer function was accepted");
+    }
+    {
+        auto request = validRequest();
+        request.samplesPerVoxel = 0;
+        require(rejected(request), "zero samples per voxel was accepted");
+        request.samplesPerVoxel = amrvis::maxVolumeSamplesPerVoxel + 1;
+        require(rejected(request), "too many samples per voxel was accepted");
+    }
+    {
+        auto request = validRequest();
+        request.maximumVoxels = 0;
+        require(rejected(request), "a zero voxel budget was accepted");
+        request.maximumVoxels = amrvis::maxVolumeVoxelBudget + 1;
+        require(rejected(request), "an over-cap voxel budget was accepted");
+    }
+    return 0;
+}


### PR DESCRIPTION
Volume.hpp carries the request a session will render (camera, region, output size, optional range, transfer-function lookup, sampling budget) and the frame it returns, with a structural validator. The iso view's projection moves to core/OrthoProjection.hpp -- the same functions the ray caster will use, plus the inverse pixel ray -- and IsoWidget draws through it, exposing its camera and change signals; its numbers are pinned so the quadrant does not drift.