### PR TITLE
sample a 3-D field onto a bounded uniform grid (VolumeQuery)

### DIFF
--- a/include/amrexplorer/query/VolumeQuery.hpp
+++ b/include/amrexplorer/query/VolumeQuery.hpp
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <amrexplorer/core/Metadata.hpp>
+#include <amrexplorer/core/Request.hpp>
+#include <amrexplorer/core/StopToken.hpp>
+#include <amrexplorer/core/Volume.hpp>
+#include <amrexplorer/io/PlotfileDataset.hpp>
+#include <amrexplorer/query/SliceQuery.hpp>
+
+#include <array>
+#include <cstdint>
+
+namespace amrvis {
+
+// Samples a 3-D field over a physical region onto a uniform grid, composing
+// the AMR levels the way a slice does (the finest participating level that
+// covers a voxel's centre wins), for the volume renderer to ray-cast. The
+// grid is bounded by a voxel budget: it is the finest requested level's
+// native cell counts over the region, scaled down uniformly when those
+// exceed the budget.
+struct VolumeSampleRequest {
+    DatasetId dataset;
+    FieldId field;
+    int component = 0;
+    int maximumLevel = 0;
+    CompositionPolicy composition = CompositionPolicy::FinestAvailable;
+    RealBox region;
+    std::uint64_t maximumVoxels = defaultVolumeVoxelBudget;
+};
+
+struct VolumeQueryResult {
+    VolumeGrid grid;
+    SliceQueryMetrics metrics;
+};
+
+// The grid dimensions a request resolves to: the native cell counts of
+// `maximumLevel` (clamped to the finest level) across `region`, each at
+// least one, scaled by cbrt(budget / product) and trimmed until the product
+// fits `maximumVoxels`. Pure, so the server can bound a request with it.
+[[nodiscard]] std::array<int, 3> volumeGridDims(const DatasetMetadata& metadata,
+    const RealBox& region, int maximumLevel, std::uint64_t maximumVoxels);
+
+class VolumeQuery {
+public:
+    explicit VolumeQuery(PlotfileDataset& dataset)
+        : m_dataset(dataset)
+    {
+    }
+
+    // Reads every block that intersects the region at each participating
+    // level -- coarse to fine, each pinned only while it is painted -- and
+    // writes each block's cells into the voxels whose centres they contain,
+    // so a finer level overwrites a coarser one. Voxels no level covers, and
+    // non-finite values, are NaN. Throws std::invalid_argument for a request
+    // this dataset cannot serve and ReadCancelled when the token stops.
+    [[nodiscard]] VolumeQueryResult execute(
+        const VolumeSampleRequest& request, StopToken cancellation = {});
+
+private:
+    PlotfileDataset& m_dataset;
+};
+
+} // namespace amrvis

--- a/src/query/CMakeLists.txt
+++ b/src/query/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(amrexplorer_query LineQuery.cpp SliceQuery.cpp)
+add_library(amrexplorer_query LineQuery.cpp SliceQuery.cpp VolumeQuery.cpp)
 add_library(amrexplorer::query ALIAS amrexplorer_query)
 
 target_include_directories(amrexplorer_query

--- a/src/query/VolumeQuery.cpp
+++ b/src/query/VolumeQuery.cpp
@@ -1,0 +1,262 @@
+#include <amrexplorer/query/VolumeQuery.hpp>
+#include <amrexplorer/query/detail/BlockLookup.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+namespace amrvis {
+namespace {
+
+using detail::intersects;
+using detail::requireBlockPayload;
+using detail::valueOffset;
+
+constexpr auto quietNaN = std::numeric_limits<float>::quiet_NaN();
+
+std::uint64_t product(const std::array<int, 3>& dims)
+{
+    std::uint64_t result = 1;
+    for (const auto extent : dims) {
+        result *= static_cast<std::uint64_t>(extent);
+    }
+    return result;
+}
+
+// The index box `region` covers at `level`: the cells whose sample positions
+// fall inside it, the upper edge nudged inward so a region that ends on a
+// cell boundary does not claim the next cell (as the slice planner does).
+IntBox regionIndexBox(const RealBox& region, const LevelMetadata& level)
+{
+    auto result = level.domain;
+    for (int axis = 0; axis < 3; ++axis) {
+        const auto i = static_cast<std::size_t>(axis);
+        result.lower[i] = sampleIndex(level, axis, region.lower[i]);
+        result.upper[i] = sampleIndex(level, axis,
+            std::nextafter(region.upper[i],
+                -std::numeric_limits<double>::infinity()));
+    }
+    return result;
+}
+
+} // namespace
+
+std::array<int, 3> volumeGridDims(const DatasetMetadata& metadata,
+    const RealBox& region, int maximumLevel, std::uint64_t maximumVoxels)
+{
+    if (metadata.levels.empty()) {
+        return {1, 1, 1};
+    }
+    const auto& level = metadata.levels[static_cast<std::size_t>(
+        std::clamp(maximumLevel, 0, metadata.finestLevel))];
+    // Native cell counts, kept far below any product overflow: a single axis
+    // never needs more voxels than the whole budget can hold.
+    const auto ceiling = static_cast<double>(
+        std::max<std::uint64_t>(maximumVoxels, 1));
+    std::array<int, 3> dims{};
+    for (std::size_t axis = 0; axis < 3; ++axis) {
+        const auto extent = region.upper[axis] - region.lower[axis];
+        const auto cells = std::round(extent / level.cellSize[axis]);
+        dims[axis] = static_cast<int>(
+            std::clamp(cells, 1.0, std::min(ceiling, 1.0e9)));
+    }
+    const auto budget = std::max<std::uint64_t>(maximumVoxels, 1);
+    if (product(dims) > budget) {
+        const auto scale = std::cbrt(static_cast<double>(budget)
+            / static_cast<double>(product(dims)));
+        for (auto& extent : dims) {
+            // The nudge keeps an exact ratio (64 -> 8 is exactly 1/2 per
+            // axis) from flooring to the size below when cbrt lands a hair
+            // under; the trim below repairs any overshoot it lets through.
+            extent = std::max(1, static_cast<int>(
+                std::floor(static_cast<double>(extent) * scale + 1.0e-9)));
+        }
+        // Rounding can leave the product a hair over: trim the largest axis.
+        while (product(dims) > budget) {
+            auto& largest = *std::max_element(dims.begin(), dims.end());
+            if (largest <= 1) {
+                break;
+            }
+            --largest;
+        }
+    }
+    return dims;
+}
+
+VolumeQueryResult VolumeQuery::execute(
+    const VolumeSampleRequest& request, StopToken cancellation)
+{
+    const auto& metadata = m_dataset.metadata();
+    if (metadata.dimension != 3) {
+        throw std::invalid_argument("volume sampling requires a 3-D dataset");
+    }
+    if (request.dataset != m_dataset.id()) {
+        throw std::invalid_argument("volume request targets a different dataset");
+    }
+    if (request.field.value >= metadata.fields.size()) {
+        throw std::invalid_argument("volume field is unavailable");
+    }
+    if (request.component != 0) {
+        throw std::invalid_argument("the initial plotfile fields are scalar");
+    }
+    if (request.maximumLevel < 0) {
+        throw std::invalid_argument("maximum level must be non-negative");
+    }
+    if (!request.region.valid(3)) {
+        throw std::invalid_argument("volume region must have positive extent");
+    }
+    if (request.maximumVoxels < 1 || request.maximumVoxels > maxVolumeVoxelBudget) {
+        throw std::invalid_argument("voxel budget is outside the supported range");
+    }
+    // The region must lie within the domain (a hair of tolerance for a
+    // region computed from the domain itself).
+    const auto domain = datasetSampleBounds(metadata);
+    for (std::size_t axis = 0; axis < 3; ++axis) {
+        const auto tolerance = 1.0e-9
+            * (domain.upper[axis] - domain.lower[axis]);
+        if (request.region.lower[axis] < domain.lower[axis] - tolerance
+            || request.region.upper[axis] > domain.upper[axis] + tolerance) {
+            throw std::invalid_argument("volume region lies outside the dataset");
+        }
+    }
+
+    const auto maximumLevel = std::min(request.maximumLevel, metadata.finestLevel);
+    const auto minimumLevel = request.composition == CompositionPolicy::ExactLevel
+        ? maximumLevel : 0;
+    const auto dims = volumeGridDims(
+        metadata, request.region, maximumLevel, request.maximumVoxels);
+
+    VolumeQueryResult result;
+    auto& grid = result.grid;
+    grid.dims = dims;
+    grid.region = request.region;
+    grid.maximumLevel = maximumLevel;
+    grid.values.assign(static_cast<std::size_t>(product(dims)), quietNaN);
+
+    std::array<double, 3> pitch{};
+    for (std::size_t axis = 0; axis < 3; ++axis) {
+        pitch[axis] = (request.region.upper[axis] - request.region.lower[axis])
+            / static_cast<double>(dims[axis]);
+    }
+    const auto voxelCentre = [&](std::size_t axis, int index) {
+        return request.region.lower[axis]
+            + (static_cast<double>(index) + 0.5) * pitch[axis];
+    };
+
+    // Coarse to fine, so a finer level's cells overwrite the coarser ones
+    // beneath them; within a level the grids run backwards, so on a
+    // (malformed) overlap the lowest grid index wins, as the slice lookup's
+    // first match does.
+    for (int levelIndex = minimumLevel; levelIndex <= maximumLevel; ++levelIndex) {
+        const auto& level = metadata.levels[static_cast<std::size_t>(levelIndex)];
+        const auto queryBox = regionIndexBox(request.region, level);
+        for (std::size_t reverse = level.blocks.size(); reverse > 0; --reverse) {
+            if (cancellation.stop_requested()) {
+                throw ReadCancelled();
+            }
+            const auto gridIndex = reverse - 1;
+            const auto& block = level.blocks[gridIndex];
+            if (!intersects(block.box, queryBox, 3)) {
+                continue;
+            }
+            ++result.metrics.candidateBlocks;
+            BlockRequest blockRequest;
+            blockRequest.dataset = request.dataset;
+            blockRequest.level = levelIndex;
+            blockRequest.gridIndex = static_cast<int>(gridIndex);
+            blockRequest.field = request.field;
+            auto access = m_dataset.requestBlock(blockRequest, cancellation);
+            if (access.cacheHit) {
+                ++result.metrics.cacheHits;
+            } else {
+                ++result.metrics.blocksRead;
+                result.metrics.payloadBytesRead += access.io.bytesRead;
+            }
+            const auto& fab = *access.handle;
+            requireBlockPayload(fab, block.box, 3);
+
+            // The voxels whose centres fall inside the block's cells: per
+            // axis, the index range of centres within the block's physical
+            // bounds, and each centre's cell index (or -1 when the centre
+            // lands in a nodal box's half-cell halo outside the valid box).
+            const auto bounds = sampleBounds(level, block.box, 3);
+            std::array<int, 3> first{};
+            std::array<int, 3> last{};
+            std::array<std::vector<int>, 3> cellIndex;
+            bool empty = false;
+            for (std::size_t axis = 0; axis < 3; ++axis) {
+                const auto lower = (bounds.lower[axis] - request.region.lower[axis])
+                    / pitch[axis] - 0.5;
+                const auto upper = (std::nextafter(bounds.upper[axis],
+                        -std::numeric_limits<double>::infinity())
+                    - request.region.lower[axis]) / pitch[axis] - 0.5;
+                first[axis] = static_cast<int>(
+                    std::clamp(std::ceil(lower), 0.0,
+                        static_cast<double>(dims[axis])));
+                last[axis] = static_cast<int>(
+                    std::clamp(std::floor(upper), -1.0,
+                        static_cast<double>(dims[axis] - 1)));
+                if (last[axis] < first[axis]) {
+                    empty = true;
+                    break;
+                }
+                auto& indices = cellIndex[axis];
+                indices.resize(static_cast<std::size_t>(last[axis] - first[axis] + 1));
+                for (int voxel = first[axis]; voxel <= last[axis]; ++voxel) {
+                    const auto cell = sampleIndex(level, static_cast<int>(axis),
+                        voxelCentre(axis, voxel));
+                    indices[static_cast<std::size_t>(voxel - first[axis])]
+                        = cell >= block.box.lower[axis] && cell <= block.box.upper[axis]
+                        ? cell : -1;
+                }
+            }
+            if (empty) {
+                continue;
+            }
+            const auto rowStride = static_cast<std::size_t>(dims[0]);
+            const auto slabStride = rowStride * static_cast<std::size_t>(dims[1]);
+            for (int k = first[2]; k <= last[2]; ++k) {
+                if ((k - first[2]) % 32 == 31 && cancellation.stop_requested()) {
+                    throw ReadCancelled();
+                }
+                const auto cellK = cellIndex[2][static_cast<std::size_t>(k - first[2])];
+                if (cellK < 0) {
+                    continue;
+                }
+                for (int j = first[1]; j <= last[1]; ++j) {
+                    const auto cellJ = cellIndex[1][static_cast<std::size_t>(j - first[1])];
+                    if (cellJ < 0) {
+                        continue;
+                    }
+                    auto* row = grid.values.data() + slabStride * static_cast<std::size_t>(k)
+                        + rowStride * static_cast<std::size_t>(j);
+                    for (int i = first[0]; i <= last[0]; ++i) {
+                        const auto cellI = cellIndex[0][static_cast<std::size_t>(i - first[0])];
+                        if (cellI < 0) {
+                            continue;
+                        }
+                        Int3 cell;
+                        cell[0] = cellI;
+                        cell[1] = cellJ;
+                        cell[2] = cellK;
+                        const auto value = fab.values[valueOffset(fab.box, cell, 3)];
+                        row[static_cast<std::size_t>(i)] = std::isfinite(value)
+                            ? static_cast<float>(value) : quietNaN;
+                    }
+                }
+            }
+        }
+    }
+
+    grid.coveredVoxels = static_cast<std::uint64_t>(std::count_if(
+        grid.values.begin(), grid.values.end(),
+        [](float value) { return !std::isnan(value); }));
+    return result;
+}
+
+} // namespace amrvis

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -394,6 +394,10 @@ add_executable(test_slice_query integration/test_slice_query.cpp)
 target_link_libraries(test_slice_query PRIVATE amrexplorer::query amrexplorer::warnings)
 add_test(NAME slice_query COMMAND test_slice_query)
 
+add_executable(test_volume_query integration/test_volume_query.cpp)
+target_link_libraries(test_volume_query PRIVATE amrexplorer::query amrexplorer::warnings)
+add_test(NAME volume_query COMMAND test_volume_query)
+
 add_executable(test_spherical_display integration/test_spherical_display.cpp)
 target_link_libraries(
     test_spherical_display

--- a/tests/integration/test_volume_query.cpp
+++ b/tests/integration/test_volume_query.cpp
@@ -1,0 +1,377 @@
+// VolumeQuery: the AMR hierarchy sampled onto a bounded uniform grid.
+// Synthesised plotfiles (as test_slice_query does): a single-level 4x4x4
+// analytic field q(i, j, k) = (i + j + k) / 9 pins exact values, the voxel
+// budget, sub-regions and the grid geometry; a two-level fixture pins the
+// composition (fine over coarse, ExactLevel, a coarser maximum level).
+
+#include <amrexplorer/query/VolumeQuery.hpp>
+
+#include <array>
+#include <chrono>
+#include <cmath>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <span>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace {
+
+constexpr std::string_view realDescriptor =
+    "((8, (64 11 52 0 1 12 0 1023)),(8, (8 7 6 5 4 3 2 1)))";
+
+void require(bool condition, const char* message)
+{
+    if (!condition) {
+        std::cerr << "FAILED: " << message << '\n';
+        std::exit(1);
+    }
+}
+
+void writeText(const std::filesystem::path& path, const std::string& text)
+{
+    std::ofstream output(path, std::ios::binary);
+    require(static_cast<bool>(output), "could not create fixture text");
+    output << text;
+}
+
+void writeFab(const std::filesystem::path& path, std::string_view box,
+    std::span<const double> values)
+{
+    std::ofstream output(path, std::ios::binary);
+    require(static_cast<bool>(output), "could not create fixture FAB");
+    output << "FAB " << realDescriptor << box << " 1\n";
+    output.write(reinterpret_cast<const char*>(values.data()),
+        static_cast<std::streamsize>(values.size() * sizeof(double)));
+}
+
+// The single-level analytic fixture: 4^3 cells over [0,1]^3, cell size 0.25.
+std::filesystem::path writeAnalyticFixture(const std::filesystem::path& root)
+{
+    std::filesystem::create_directories(root / "Level_0");
+    writeText(root / "Header",
+        "HyperCLaw-V1.1\n"
+        "1\nq\n"
+        "3\n0.0\n0\n"
+        "0.0 0.0 0.0\n1.0 1.0 1.0\n\n"
+        "((0,0,0) (3,3,3) (0,0,0))\n"
+        "0\n"
+        "0.25 0.25 0.25\n"
+        "0\n0\n"
+        "0 1 0.0\n0\n"
+        "0.0 1.0\n0.0 1.0\n0.0 1.0\n"
+        "Level_0/Cell\n");
+    writeText(root / "Level_0" / "Cell_H",
+        "1\n1\n1\n0\n"
+        "(1 0\n((0,0,0) (3,3,3) (0,0,0))\n)\n"
+        "1\nFabOnDisk: Cell_D_00000 0\n\n"
+        "1,1\n0.0,\n\n1,1\n1.0,\n\n");
+    std::vector<double> values;
+    for (int k = 0; k <= 3; ++k) {
+        for (int j = 0; j <= 3; ++j) {
+            for (int i = 0; i <= 3; ++i) {
+                values.push_back(static_cast<double>(i + j + k) / 9.0);
+            }
+        }
+    }
+    writeFab(root / "Level_0" / "Cell_D_00000", "((0,0,0) (3,3,3) (0,0,0))",
+        values);
+    return root;
+}
+
+// Two levels over [0,1]^3: coarse 4^3 = 1.0 everywhere, a fine 4^3 block
+// (level-1 indices 2..5, i.e. the central [0.25,0.75]^3) = 2.0.
+std::filesystem::path writeTwoLevelFixture(const std::filesystem::path& root)
+{
+    std::filesystem::create_directories(root / "Level_0");
+    std::filesystem::create_directories(root / "Level_1");
+    writeText(root / "Header",
+        "HyperCLaw-V1.1\n"
+        "1\nphi\n"
+        "3\n0.0\n1\n"
+        "0.0 0.0 0.0\n1.0 1.0 1.0\n2\n"
+        "((0,0,0) (3,3,3) (0,0,0))\n"
+        "((0,0,0) (7,7,7) (0,0,0))\n"
+        "0 0\n"
+        "0.25 0.25 0.25\n0.125 0.125 0.125\n"
+        "0\n0\n"
+        "0 1 0.0\n0\n"
+        "0.0 1.0\n0.0 1.0\n0.0 1.0\n"
+        "Level_0/Cell\n"
+        "1 1 0.0\n0\n"
+        "0.25 0.75\n0.25 0.75\n0.25 0.75\n"
+        "Level_1/Cell\n");
+    writeText(root / "Level_0" / "Cell_H",
+        "1\n1\n1\n0\n"
+        "(1 0\n((0,0,0) (3,3,3) (0,0,0))\n)\n"
+        "1\nFabOnDisk: Cell_D_00000 0\n\n"
+        "1,1\n1.0,\n\n1,1\n1.0,\n\n");
+    writeText(root / "Level_1" / "Cell_H",
+        "1\n1\n1\n0\n"
+        "(1 0\n((2,2,2) (5,5,5) (0,0,0))\n)\n"
+        "1\nFabOnDisk: Cell_D_00000 0\n\n"
+        "1,1\n2.0,\n\n1,1\n2.0,\n\n");
+    std::array<double, 64> coarse{};
+    std::array<double, 64> fine{};
+    coarse.fill(1.0);
+    fine.fill(2.0);
+    writeFab(root / "Level_0" / "Cell_D_00000", "((0,0,0) (3,3,3) (0,0,0))",
+        coarse);
+    writeFab(root / "Level_1" / "Cell_D_00000", "((2,2,2) (5,5,5) (0,0,0))",
+        fine);
+    return root;
+}
+
+std::size_t voxel(const amrvis::VolumeGrid& grid, int i, int j, int k)
+{
+    return static_cast<std::size_t>(i)
+        + static_cast<std::size_t>(grid.dims[0])
+            * (static_cast<std::size_t>(j)
+                + static_cast<std::size_t>(grid.dims[1]) * static_cast<std::size_t>(k));
+}
+
+amrvis::RealBox box(double x0, double y0, double z0, double x1, double y1,
+    double z1)
+{
+    amrvis::RealBox result;
+    result.lower = {{x0, y0, z0}};
+    result.upper = {{x1, y1, z1}};
+    return result;
+}
+
+} // namespace
+
+int main()
+{
+    const auto unique = std::chrono::steady_clock::now().time_since_epoch().count();
+    const auto scratch = std::filesystem::temp_directory_path()
+        / ("amrexplorer-volume-query-" + std::to_string(unique));
+    const auto analyticRoot = writeAnalyticFixture(scratch / "analytic");
+    const auto twoLevelRoot = writeTwoLevelFixture(scratch / "two-level");
+
+    // --- the analytic single-level field ---------------------------------
+    {
+        amrvis::PlotfileDataset dataset(
+            analyticRoot, amrvis::DatasetId{3}, 1024 * 1024);
+        amrvis::VolumeQuery query(dataset);
+        amrvis::VolumeSampleRequest request;
+        request.dataset.value = 3;
+        request.field.value = 0;
+        request.maximumLevel = 0;
+        request.region = box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0);
+
+        // Whole domain within budget: native 4x4x4, every voxel exact.
+        request.maximumVoxels = 64;
+        const auto native = query.execute(request);
+        require(native.grid.dims == (std::array<int, 3>{4, 4, 4}),
+            "the native grid is not one voxel per cell");
+        require(native.grid.values.size() == 64
+                && native.grid.coveredVoxels == 64
+                && native.grid.maximumLevel == 0
+                && native.grid.region == request.region,
+            "the native grid's shape or coverage is wrong");
+        require(native.metrics.candidateBlocks == 1
+                && native.metrics.blocksRead == 1
+                && native.metrics.cacheHits == 0,
+            "the single block was not read exactly once");
+        for (int k = 0; k < 4; ++k) {
+            for (int j = 0; j < 4; ++j) {
+                for (int i = 0; i < 4; ++i) {
+                    const auto expected
+                        = static_cast<float>(static_cast<double>(i + j + k) / 9.0);
+                    require(native.grid.values[voxel(native.grid, i, j, k)]
+                            == expected,
+                        "a native voxel does not carry its cell's value");
+                }
+            }
+        }
+        // A second execute hits the cache.
+        const auto again = query.execute(request);
+        require(again.metrics.cacheHits == 1 && again.metrics.blocksRead == 0
+                && again.grid.values == native.grid.values,
+            "the second sample did not come from the block cache");
+
+        // Over budget: 4^3 = 64 into a budget of 8 -> 2x2x2, each voxel the
+        // cell that contains its centre (0.25 -> cell 1, 0.75 -> cell 3).
+        request.maximumVoxels = 8;
+        const auto coarse = query.execute(request);
+        require(coarse.grid.dims == (std::array<int, 3>{2, 2, 2})
+                && coarse.grid.coveredVoxels == 8,
+            "the budget did not scale the grid down uniformly");
+        for (int k = 0; k < 2; ++k) {
+            for (int j = 0; j < 2; ++j) {
+                for (int i = 0; i < 2; ++i) {
+                    const auto cell = [](int index) { return index == 0 ? 1 : 3; };
+                    const auto expected = static_cast<float>(
+                        static_cast<double>(cell(i) + cell(j) + cell(k)) / 9.0);
+                    require(coarse.grid.values[voxel(coarse.grid, i, j, k)]
+                            == expected,
+                        "a downsampled voxel is not the cell under its centre");
+                }
+            }
+        }
+        // A budget of 1 collapses to a single voxel: the centre cell (2,2,2).
+        request.maximumVoxels = 1;
+        const auto single = query.execute(request);
+        require(single.grid.dims == (std::array<int, 3>{1, 1, 1})
+                && single.grid.values[0] == static_cast<float>(6.0 / 9.0),
+            "a one-voxel grid is not the centre cell");
+
+        // A sub-region: [0.5,1] x [0,1] x [0.25,0.75] at native pitch is
+        // 2 x 4 x 2 voxels over cells i=2..3, j=0..3, k=1..2.
+        request.maximumVoxels = 4096;
+        request.region = box(0.5, 0.0, 0.25, 1.0, 1.0, 0.75);
+        const auto sub = query.execute(request);
+        require(sub.grid.dims == (std::array<int, 3>{2, 4, 2})
+                && sub.grid.coveredVoxels == 16,
+            "the sub-region grid has the wrong shape");
+        for (int k = 0; k < 2; ++k) {
+            for (int j = 0; j < 4; ++j) {
+                for (int i = 0; i < 2; ++i) {
+                    const auto expected = static_cast<float>(
+                        static_cast<double>((i + 2) + j + (k + 1)) / 9.0);
+                    require(sub.grid.values[voxel(sub.grid, i, j, k)] == expected,
+                        "a sub-region voxel does not carry its cell's value");
+                }
+            }
+        }
+        // volumeGridDims agrees with what execute produced, and is pure.
+        require(amrvis::volumeGridDims(dataset.metadata(), request.region, 0, 4096)
+                    == sub.grid.dims
+                && amrvis::volumeGridDims(dataset.metadata(),
+                       box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0), 0, 8)
+                    == (std::array<int, 3>{2, 2, 2}),
+            "volumeGridDims disagrees with the sampled grid");
+
+        // Refusals: a region outside the domain, a bad field, a foreign
+        // dataset id, and a cancelled token.
+        bool threw = false;
+        try {
+            request.region = box(0.5, 0.0, 0.0, 1.5, 1.0, 1.0);
+            (void)query.execute(request);
+        } catch (const std::invalid_argument&) {
+            threw = true;
+        }
+        require(threw, "a region outside the domain was accepted");
+        threw = false;
+        try {
+            request.region = box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0);
+            request.field.value = 5;
+            (void)query.execute(request);
+        } catch (const std::invalid_argument&) {
+            threw = true;
+        }
+        require(threw, "an unknown field was accepted");
+        request.field.value = 0;
+        threw = false;
+        try {
+            request.dataset.value = 4;
+            (void)query.execute(request);
+        } catch (const std::invalid_argument&) {
+            threw = true;
+        }
+        require(threw, "a foreign dataset id was accepted");
+        request.dataset.value = 3;
+        amrvis::StopSource stop;
+        stop.request_stop();
+        threw = false;
+        try {
+            (void)query.execute(request, stop.get_token());
+        } catch (const amrvis::ReadCancelled&) {
+            threw = true;
+        }
+        require(threw, "a cancelled sample did not throw ReadCancelled");
+    }
+
+    // --- two levels: composition ------------------------------------------
+    {
+        amrvis::PlotfileDataset dataset(
+            twoLevelRoot, amrvis::DatasetId{5}, 1024 * 1024);
+        amrvis::VolumeQuery query(dataset);
+        amrvis::VolumeSampleRequest request;
+        request.dataset.value = 5;
+        request.field.value = 0;
+        request.region = box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0);
+        request.maximumVoxels = 4096;
+
+        // Finest available up to level 1: an 8^3 grid, 2.0 under the fine
+        // block (level-1 cells 2..5 on every axis), 1.0 elsewhere.
+        request.maximumLevel = 1;
+        const auto composite = query.execute(request);
+        require(composite.grid.dims == (std::array<int, 3>{8, 8, 8})
+                && composite.grid.coveredVoxels == 512
+                && composite.grid.maximumLevel == 1
+                && composite.metrics.candidateBlocks == 2
+                && composite.metrics.blocksRead == 2,
+            "the two-level composite has the wrong shape or reads");
+        for (int k = 0; k < 8; ++k) {
+            for (int j = 0; j < 8; ++j) {
+                for (int i = 0; i < 8; ++i) {
+                    const bool fine = i >= 2 && i <= 5 && j >= 2 && j <= 5
+                        && k >= 2 && k <= 5;
+                    require(composite.grid.values[voxel(composite.grid, i, j, k)]
+                            == (fine ? 2.0F : 1.0F),
+                        "the fine level did not overwrite exactly its own cells");
+                }
+            }
+        }
+        // ExactLevel 1: only the fine block; the rest uncovered (NaN).
+        request.composition = amrvis::CompositionPolicy::ExactLevel;
+        const auto exact = query.execute(request);
+        require(exact.grid.dims == (std::array<int, 3>{8, 8, 8})
+                && exact.grid.coveredVoxels == 64
+                && exact.metrics.candidateBlocks == 1,
+            "ExactLevel did not restrict the sample to the fine level");
+        for (int k = 0; k < 8; ++k) {
+            for (int j = 0; j < 8; ++j) {
+                for (int i = 0; i < 8; ++i) {
+                    const bool fine = i >= 2 && i <= 5 && j >= 2 && j <= 5
+                        && k >= 2 && k <= 5;
+                    const auto value = exact.grid.values[voxel(exact.grid, i, j, k)];
+                    require(fine ? value == 2.0F : std::isnan(value),
+                        "ExactLevel left the wrong voxels covered");
+                }
+            }
+        }
+        // Maximum level 0: the coarse grid alone, 4^3 of 1.0.
+        request.composition = amrvis::CompositionPolicy::FinestAvailable;
+        request.maximumLevel = 0;
+        const auto coarseOnly = query.execute(request);
+        require(coarseOnly.grid.dims == (std::array<int, 3>{4, 4, 4})
+                && coarseOnly.grid.coveredVoxels == 64
+                && coarseOnly.grid.maximumLevel == 0
+                && coarseOnly.metrics.candidateBlocks == 1,
+            "a coarser maximum level still read the fine block");
+        for (const auto value : coarseOnly.grid.values) {
+            require(value == 1.0F, "the coarse-only grid is not uniformly coarse");
+        }
+        // A budget below the fine resolution: 2^3 with centres at 0.25 and
+        // 0.75. The fine block spans [0.25, 0.75): the centre 0.25 is its
+        // first cell (fine cell 2) and reads 2.0, while 0.75 is the coarse
+        // cell past its edge and reads 1.0 -- fine still overwrites coarse
+        // at whatever pitch the budget allows, and only where it exists.
+        request.maximumLevel = 1;
+        request.maximumVoxels = 8;
+        const auto budgeted = query.execute(request);
+        require(budgeted.grid.dims == (std::array<int, 3>{2, 2, 2})
+                && budgeted.grid.coveredVoxels == 8,
+            "the budgeted composite has the wrong shape");
+        for (int k = 0; k < 2; ++k) {
+            for (int j = 0; j < 2; ++j) {
+                for (int i = 0; i < 2; ++i) {
+                    const bool fine = i == 0 && j == 0 && k == 0;
+                    require(budgeted.grid.values[voxel(budgeted.grid, i, j, k)]
+                            == (fine ? 2.0F : 1.0F),
+                        "a budgeted voxel did not read the level under its centre");
+                }
+            }
+        }
+    }
+
+    std::error_code removeError;
+    std::filesystem::remove_all(scratch, removeError);
+    return 0;
+}


### PR DESCRIPTION
The AMR levels are painted coarse to fine into a voxel grid sized by the finest requested level's native cells and a voxel budget, each block pinned only while its cells are copied into the voxels whose centres they contain -- the same finest-available composition a slice resolves per sample, without pinning every block of every level at once. NaN marks voxels no level covers. volumeGridDims is pure so a server can bound a request with it.