### PR TITLE
sample a 3-D field onto a bounded uniform grid (VolumeQuery)

### DIFF
--- a/include/amrexplorer/core/Volume.hpp
+++ b/include/amrexplorer/core/Volume.hpp
@@ -93,7 +93,8 @@ struct VolumeRenderRequest {
 
 // The field sampled onto a uniform grid over `region`: voxel (i, j, k) is
 // centred at lower + (i + 0.5) * pitch per axis, x fastest; NaN marks a voxel
-// no level covers (or a value no float can hold), which the renderer treats
+// no level covers, and one whose value is not a finite float -- non-finite in
+// the data, or past the range float can represent -- which the renderer treats
 // as transparent. A region reaching past the domain is allowed and comes
 // back NaN there, as the same region does on a slice.
 struct VolumeGrid {

--- a/include/amrexplorer/core/Volume.hpp
+++ b/include/amrexplorer/core/Volume.hpp
@@ -93,14 +93,23 @@ struct VolumeRenderRequest {
 
 // The field sampled onto a uniform grid over `region`: voxel (i, j, k) is
 // centred at lower + (i + 0.5) * pitch per axis, x fastest; NaN marks a voxel
-// no level covers (or a non-finite value), which the renderer treats as
-// transparent.
+// no level covers (or a value no float can hold), which the renderer treats
+// as transparent. A region reaching past the domain is allowed and comes
+// back NaN there, as the same region does on a slice.
 struct VolumeGrid {
     std::array<int, 3> dims{0, 0, 0};
     RealBox region;
     std::vector<float> values;
+    // Voxels holding a value the renderer can show, which is not quite the
+    // same as voxels a level covered: a covered voxel whose source data is
+    // itself NaN counts here as uncovered, because nothing downstream can
+    // tell the two apart from the grid alone. Separating them would cost a
+    // parallel coverage mask over the whole grid, and no reader branches on
+    // the difference.
     std::uint64_t coveredVoxels = 0;
-    int maximumLevel = 0;   // the finest level that contributed
+    // The finest level that put a showable value in the grid, or 0 when
+    // none did.
+    int maximumLevel = 0;
 };
 
 struct VolumeRenderMetrics {

--- a/include/amrexplorer/core/Volume.hpp
+++ b/include/amrexplorer/core/Volume.hpp
@@ -49,6 +49,21 @@ inline constexpr std::uint64_t defaultVolumeVoxelBudget
     = 256ULL * 256ULL * 256ULL;
 inline constexpr std::uint64_t maxVolumeVoxelBudget = 512ULL * 512ULL * 512ULL;
 
+// What the sampler needs: the sub-box to sample, the levels to compose, and
+// the budget bounding the grid. A field-for-field subset of the render
+// request below, so both validate against the same rules.
+struct VolumeSampleRequest {
+    DatasetId dataset;
+    FieldId field;
+    int component = 0;
+    int maximumLevel = 0;
+    CompositionPolicy composition = CompositionPolicy::FinestAvailable;
+    RealBox region;
+    std::uint64_t maximumVoxels = defaultVolumeVoxelBudget;
+    friend bool operator==(const VolumeSampleRequest&,
+        const VolumeSampleRequest&) = default;
+};
+
 struct VolumeRenderRequest {
     DatasetId dataset;
     FieldId field;
@@ -122,7 +137,14 @@ struct VolumeFrame {
 // dataset: every field bounded and finite. Empty when valid.
 [[nodiscard]] std::vector<std::string> validateVolumeTransferFunction(
     const VolumeTransferFunction& transfer);
+[[nodiscard]] std::vector<std::string> validateVolumeSampleRequest(
+    const VolumeSampleRequest& request, int datasetDimension);
 [[nodiscard]] std::vector<std::string> validateVolumeRenderRequest(
     const VolumeRenderRequest& request, int datasetDimension);
+
+// The sampling fields of a render request, so the one validator above and the
+// sampler itself see the same values.
+[[nodiscard]] VolumeSampleRequest volumeSampleRequestOf(
+    const VolumeRenderRequest& request);
 
 } // namespace amrvis

--- a/include/amrexplorer/query/VolumeQuery.hpp
+++ b/include/amrexplorer/query/VolumeQuery.hpp
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <amrexplorer/core/Metadata.hpp>
+#include <amrexplorer/core/Request.hpp>
+#include <amrexplorer/core/StopToken.hpp>
+#include <amrexplorer/core/Volume.hpp>
+#include <amrexplorer/io/PlotfileDataset.hpp>
+#include <amrexplorer/query/SliceQuery.hpp>
+
+#include <array>
+#include <cstdint>
+
+namespace amrvis {
+
+// Samples a 3-D field over a physical region onto a uniform grid, composing
+// the AMR levels the way a slice does (the finest participating level that
+// covers a voxel's centre wins), for the volume renderer to ray-cast. The
+// grid is bounded by a voxel budget: it is the finest requested level's
+// native cell counts over the region, scaled down uniformly when those
+// exceed the budget.
+struct VolumeSampleRequest {
+    DatasetId dataset;
+    FieldId field;
+    int component = 0;
+    int maximumLevel = 0;
+    CompositionPolicy composition = CompositionPolicy::FinestAvailable;
+    RealBox region;
+    std::uint64_t maximumVoxels = defaultVolumeVoxelBudget;
+};
+
+struct VolumeQueryResult {
+    VolumeGrid grid;
+    SliceQueryMetrics metrics;
+};
+
+// The grid dimensions a request resolves to: the native cell counts of
+// `maximumLevel` (clamped to the finest level) across `region`, each at
+// least one, scaled by cbrt(budget / product) and trimmed until the product
+// fits `maximumVoxels`. Pure, so the server can bound a request with it.
+[[nodiscard]] std::array<int, 3> volumeGridDims(const DatasetMetadata& metadata,
+    const RealBox& region, int maximumLevel, std::uint64_t maximumVoxels);
+
+class VolumeQuery {
+public:
+    explicit VolumeQuery(PlotfileDataset& dataset)
+        : m_dataset(dataset)
+    {
+    }
+
+    // Reads every block that intersects the region at each participating
+    // level -- coarse to fine, each pinned only while it is painted -- and
+    // writes each block's cells into the voxels whose centres they contain,
+    // so a finer level overwrites a coarser one. Voxels no level covers, and
+    // non-finite values, are NaN. Throws std::invalid_argument for a request
+    // this dataset cannot serve and ReadCancelled when the token stops.
+    [[nodiscard]] VolumeQueryResult execute(
+        const VolumeSampleRequest& request, StopToken cancellation = {});
+
+private:
+    PlotfileDataset& m_dataset;
+};
+
+} // namespace amrvis

--- a/include/amrexplorer/query/VolumeQuery.hpp
+++ b/include/amrexplorer/query/VolumeQuery.hpp
@@ -48,8 +48,9 @@ public:
     // Reads every block that holds a voxel centre at each participating
     // level -- coarse to fine, each pinned only while it is painted -- and
     // writes each block's cells into the voxels whose centres they contain,
-    // so a finer level overwrites a coarser one. Voxels no level covers, and
-    // values no float can hold, are NaN.
+    // so a finer level overwrites a coarser one. A voxel is NaN when no level
+    // covers it, and when the value there is not a finite float -- non-finite
+    // in the data, or past the range float can represent.
     //
     // Throws std::invalid_argument for a request this dataset cannot serve
     // and ReadCancelled when the token stops. Propagates what reading the

--- a/include/amrexplorer/query/VolumeQuery.hpp
+++ b/include/amrexplorer/query/VolumeQuery.hpp
@@ -18,16 +18,6 @@ namespace amrvis {
 // grid is bounded by a voxel budget: it is the finest requested level's
 // native cell counts over the region, scaled down uniformly when those
 // exceed the budget.
-struct VolumeSampleRequest {
-    DatasetId dataset;
-    FieldId field;
-    int component = 0;
-    int maximumLevel = 0;
-    CompositionPolicy composition = CompositionPolicy::FinestAvailable;
-    RealBox region;
-    std::uint64_t maximumVoxels = defaultVolumeVoxelBudget;
-};
-
 struct VolumeQueryResult {
     VolumeGrid grid;
     SliceQueryMetrics metrics;
@@ -36,7 +26,13 @@ struct VolumeQueryResult {
 // The grid dimensions a request resolves to: the native cell counts of
 // `maximumLevel` (clamped to the finest level) across `region`, each at
 // least one, scaled by cbrt(budget / product) and trimmed until the product
-// fits `maximumVoxels`. Pure, so the server can bound a request with it.
+// fits `maximumVoxels`. Axes the dataset does not have are one.
+//
+// Pure and total, so a server can bound a request before validating it: the
+// budget is clamped to [1, maxVolumeVoxelBudget], the level is clamped to
+// the finest, and a region that is empty, inverted or non-finite yields one
+// voxel on the offending axis rather than a garbage count. Every result
+// satisfies dims >= 1 and product(dims) <= maxVolumeVoxelBudget.
 [[nodiscard]] std::array<int, 3> volumeGridDims(const DatasetMetadata& metadata,
     const RealBox& region, int maximumLevel, std::uint64_t maximumVoxels);
 
@@ -47,12 +43,18 @@ public:
     {
     }
 
-    // Reads every block that intersects the region at each participating
+    // Reads every block that holds a voxel centre at each participating
     // level -- coarse to fine, each pinned only while it is painted -- and
     // writes each block's cells into the voxels whose centres they contain,
     // so a finer level overwrites a coarser one. Voxels no level covers, and
-    // non-finite values, are NaN. Throws std::invalid_argument for a request
-    // this dataset cannot serve and ReadCancelled when the token stops.
+    // values no float can hold, are NaN.
+    //
+    // Throws std::invalid_argument for a request this dataset cannot serve
+    // and ReadCancelled when the token stops. Propagates what reading the
+    // data throws: BlockReadError and CacheBudgetExceeded from the dataset
+    // (the pipeline's cache-pressure fallback keys on the latter),
+    // std::out_of_range from an index outside the level, and
+    // std::runtime_error or std::overflow_error from a malformed FAB.
     [[nodiscard]] VolumeQueryResult execute(
         const VolumeSampleRequest& request, StopToken cancellation = {});
 

--- a/include/amrexplorer/query/VolumeQuery.hpp
+++ b/include/amrexplorer/query/VolumeQuery.hpp
@@ -30,9 +30,11 @@ struct VolumeQueryResult {
 //
 // Pure and total, so a server can bound a request before validating it: the
 // budget is clamped to [1, maxVolumeVoxelBudget], the level is clamped to
-// the finest, and a region that is empty, inverted or non-finite yields one
-// voxel on the offending axis rather than a garbage count. Every result
-// satisfies dims >= 1 and product(dims) <= maxVolumeVoxelBudget.
+// the finest, a single axis is capped at 1e9 native cells (what the int
+// conversion holds, and the only cap applied before the scaling), and a
+// region that is empty, inverted or non-finite yields one voxel on the
+// offending axis rather than a garbage count. Every result satisfies
+// dims >= 1 and product(dims) <= maxVolumeVoxelBudget.
 [[nodiscard]] std::array<int, 3> volumeGridDims(const DatasetMetadata& metadata,
     const RealBox& region, int maximumLevel, std::uint64_t maximumVoxels);
 

--- a/include/amrexplorer/query/VolumeQuery.hpp
+++ b/include/amrexplorer/query/VolumeQuery.hpp
@@ -57,6 +57,14 @@ public:
     // (the pipeline's cache-pressure fallback keys on the latter),
     // std::out_of_range from an index outside the level, and
     // std::runtime_error or std::overflow_error from a malformed FAB.
+    //
+    // The out_of_range is the one a caller can provoke with a bad request:
+    // a region is allowed past the domain, but only until a voxel centre
+    // lands more than INT_MAX cells from the level's index origin, and past
+    // that the throw comes out of sampleIndex rather than as an
+    // invalid_argument. Refusing it up front would mean restoring the
+    // containment test this deliberately dropped, so a caller that must
+    // distinguish a bad request from an internal fault has to catch both.
     [[nodiscard]] VolumeQueryResult execute(
         const VolumeSampleRequest& request, StopToken cancellation = {});
 

--- a/include/amrexplorer/query/detail/BlockLookup.hpp
+++ b/include/amrexplorer/query/detail/BlockLookup.hpp
@@ -88,20 +88,24 @@ struct LoadedBlock {
             metadata, level, axis)};
 }
 
-// A sampled value narrowed to the grid's float storage. Converting a double
-// outside float's range is undefined, so the overflow is mapped explicitly
-// to the infinity every target we build for produces anyway.
+// The magnitude at which a double stops converting to a finite float: the
+// midpoint between float's largest finite value and 2^128. Not that largest
+// value itself -- a double above it but below this midpoint still rounds
+// down to it, and converting one is perfectly well defined. Only from the
+// midpoint up does the conversion overflow, and only there is it undefined.
+inline constexpr double floatOverflowThreshold = 0x1.ffffffp127;
+
+// A sampled value narrowed to the grid's float storage, mapping the overflow
+// that would otherwise be undefined to the infinity the hardware produces.
 [[nodiscard]] inline float narrowToFloat(double value)
 {
-    constexpr auto largest = static_cast<double>(
-        std::numeric_limits<float>::max());
     if (std::isnan(value)) {
         return std::numeric_limits<float>::quiet_NaN();
     }
-    if (value > largest) {
+    if (value >= floatOverflowThreshold) {
         return std::numeric_limits<float>::infinity();
     }
-    if (value < -largest) {
+    if (value <= -floatOverflowThreshold) {
         return -std::numeric_limits<float>::infinity();
     }
     return static_cast<float>(value);

--- a/include/amrexplorer/query/detail/BlockLookup.hpp
+++ b/include/amrexplorer/query/detail/BlockLookup.hpp
@@ -1,8 +1,9 @@
 #pragma once
 
 // Shared per-point block-lookup helpers for the query layer: the one
-// overflow-checked valueOffset, and the point->block grid the slice and line
-// queries both index their loaded blocks with.
+// overflow-checked valueOffset, the sample-position and index-range
+// conventions every query resolves points with, and the point->block grid
+// the slice and line queries both index their loaded blocks with.
 
 #include <amrexplorer/core/Geometry.hpp>
 #include <amrexplorer/core/Metadata.hpp>
@@ -10,6 +11,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cmath>
 #include <cstddef>
 #include <cstdint>
 #include <limits>
@@ -58,6 +60,51 @@ struct LoadedBlock {
 {
     (void) metadata;
     return sampleIndex(level, axis, position);
+}
+
+// The physical position of sample `index` of `count` evenly dividing
+// [lower, upper). The extent is divided last, so a slice pixel and a volume
+// voxel over the same region agree to the bit: pre-dividing into a step
+// rounds it down, which can put the two on opposite sides of a cell edge.
+[[nodiscard]] inline double sampleCentre(
+    double lower, double upper, int index, int count)
+{
+    return lower + (static_cast<double>(index) + 0.5) * (upper - lower)
+        / static_cast<double>(count);
+}
+
+// The inclusive index range on `axis` that the physical interval
+// [lower, upper) covers at `level`: the samples whose positions fall inside
+// it, the upper edge nudged inward so an interval ending on a cell boundary
+// does not claim the next cell. Every query plans its blocks with this, so
+// the half-open convention lives in one place.
+[[nodiscard]] inline std::pair<int, int> indexRangeOnAxis(double lower,
+    double upper, const DatasetMetadata& metadata, const LevelMetadata& level,
+    int axis)
+{
+    return {physicalToIndex(lower, metadata, level, axis),
+        physicalToIndex(
+            std::nextafter(upper, -std::numeric_limits<double>::infinity()),
+            metadata, level, axis)};
+}
+
+// A sampled value narrowed to the grid's float storage. Converting a double
+// outside float's range is undefined, so the overflow is mapped explicitly
+// to the infinity every target we build for produces anyway.
+[[nodiscard]] inline float narrowToFloat(double value)
+{
+    constexpr auto largest = static_cast<double>(
+        std::numeric_limits<float>::max());
+    if (std::isnan(value)) {
+        return std::numeric_limits<float>::quiet_NaN();
+    }
+    if (value > largest) {
+        return std::numeric_limits<float>::infinity();
+    }
+    if (value < -largest) {
+        return -std::numeric_limits<float>::infinity();
+    }
+    return static_cast<float>(value);
 }
 
 // Offset of `point` into a FAB's component-major values (first axis

--- a/include/amrexplorer/query/detail/BlockLookup.hpp
+++ b/include/amrexplorer/query/detail/BlockLookup.hpp
@@ -97,6 +97,12 @@ inline constexpr double floatOverflowThreshold = 0x1.ffffffp127;
 
 // A sampled value narrowed to the grid's float storage, mapping the overflow
 // that would otherwise be undefined to the infinity the hardware produces.
+//
+// The slice and line use this; the volume deliberately does not. They carry a
+// separate valid mask, so an infinity is still a sample they marked valid,
+// whereas the volume grid has only NaN to say "nothing here" and spends it on
+// values no float can hold. Do not unify the two without giving the grid a
+// coverage mask first.
 [[nodiscard]] inline float narrowToFloat(double value)
 {
     if (std::isnan(value)) {

--- a/src/core/Volume.cpp
+++ b/src/core/Volume.cpp
@@ -37,8 +37,21 @@ std::vector<std::string> validateVolumeTransferFunction(
     return errors;
 }
 
-std::vector<std::string> validateVolumeRenderRequest(
-    const VolumeRenderRequest& request, int datasetDimension)
+VolumeSampleRequest volumeSampleRequestOf(const VolumeRenderRequest& request)
+{
+    VolumeSampleRequest sample;
+    sample.dataset = request.dataset;
+    sample.field = request.field;
+    sample.component = request.component;
+    sample.maximumLevel = request.maximumLevel;
+    sample.composition = request.composition;
+    sample.region = request.region;
+    sample.maximumVoxels = request.maximumVoxels;
+    return sample;
+}
+
+std::vector<std::string> validateVolumeSampleRequest(
+    const VolumeSampleRequest& request, int datasetDimension)
 {
     std::vector<std::string> errors;
     if (request.dataset.value == 0) {
@@ -56,6 +69,18 @@ std::vector<std::string> validateVolumeRenderRequest(
     if (!request.region.valid(3)) {
         errors.emplace_back("region must have finite positive extent");
     }
+    if (request.maximumVoxels < 1
+        || request.maximumVoxels > maxVolumeVoxelBudget) {
+        errors.emplace_back("voxel budget is outside the supported range");
+    }
+    return errors;
+}
+
+std::vector<std::string> validateVolumeRenderRequest(
+    const VolumeRenderRequest& request, int datasetDimension)
+{
+    auto errors = validateVolumeSampleRequest(
+        volumeSampleRequestOf(request), datasetDimension);
     if (!std::isfinite(request.camera.azimuth)
         || !std::isfinite(request.camera.elevation)) {
         errors.emplace_back("camera angles must be finite");
@@ -88,10 +113,6 @@ std::vector<std::string> validateVolumeRenderRequest(
     if (request.samplesPerVoxel < 1
         || request.samplesPerVoxel > maxVolumeSamplesPerVoxel) {
         errors.emplace_back("samples per voxel must be within [1, 8]");
-    }
-    if (request.maximumVoxels < 1
-        || request.maximumVoxels > maxVolumeVoxelBudget) {
-        errors.emplace_back("voxel budget is outside the supported range");
     }
     return errors;
 }

--- a/src/core/Volume.cpp
+++ b/src/core/Volume.cpp
@@ -58,7 +58,9 @@ std::vector<std::string> validateVolumeSampleRequest(
         errors.emplace_back("dataset id must be nonzero");
     }
     if (datasetDimension != 3) {
-        errors.emplace_back("volume rendering requires a 3-D dataset");
+        // Both the sampler and the renderer validate through here, so the
+        // message names neither.
+        errors.emplace_back("volume operations require a 3-D dataset");
     }
     if (request.component < 0) {
         errors.emplace_back("component must be non-negative");

--- a/src/query/CMakeLists.txt
+++ b/src/query/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(amrexplorer_query LineQuery.cpp SliceQuery.cpp)
+add_library(amrexplorer_query LineQuery.cpp SliceQuery.cpp VolumeQuery.cpp)
 add_library(amrexplorer::query ALIAS amrexplorer_query)
 
 target_include_directories(amrexplorer_query

--- a/src/query/LineQuery.cpp
+++ b/src/query/LineQuery.cpp
@@ -18,6 +18,7 @@ using detail::IndexedBlocks;
 using detail::LoadedBlock;
 using detail::intersects;
 using detail::lookupBlockValue;
+using detail::narrowToFloat;
 using detail::physicalToIndex;
 
 // A covering cell hit during the line walk: which level won, the cell index,
@@ -169,7 +170,7 @@ LineQueryResult LineQuery::execute(
                     point)) {
                 cover.level = levelIndex;
                 cover.point = point;
-                cover.value = static_cast<float>(*value);
+                cover.value = narrowToFloat(*value);
                 return true;
             }
         }

--- a/src/query/SliceQuery.cpp
+++ b/src/query/SliceQuery.cpp
@@ -17,9 +17,12 @@ namespace {
 
 using detail::IndexedBlocks;
 using detail::LoadedBlock;
+using detail::indexRangeOnAxis;
 using detail::intersects;
 using detail::lookupBlockValue;
+using detail::narrowToFloat;
 using detail::physicalToIndex;
+using detail::sampleCentre;
 
 // The blocks of one level that intersect the planning region, with the point->
 // block index over them. Levels are processed finest first so the composed
@@ -39,12 +42,10 @@ IntBox requestIndexBox(const RealBox& region, const SliceRequest& request,
     auto result = level.domain;
     for (const auto axis : axes) {
         const auto i = static_cast<std::size_t>(axis);
-        result.lower[i] = physicalToIndex(
-            region.lower[i], metadata, level, axis);
-        result.upper[i] = physicalToIndex(
-            std::nextafter(region.upper[i],
-                -std::numeric_limits<double>::infinity()),
-            metadata, level, axis);
+        const auto [first, last] = indexRangeOnAxis(
+            region.lower[i], region.upper[i], metadata, level, axis);
+        result.lower[i] = first;
+        result.upper[i] = last;
     }
     if (metadata.dimension == 3) {
         const auto normal = static_cast<std::size_t>(request.normalDirection);
@@ -302,16 +303,12 @@ SliceQueryResult SliceQuery::execute(
                     * static_cast<std::size_t>(outputY);
 
             Real3 position;
-            position[xAxis] = request.visibleRegion.lower[xAxis]
-                + (static_cast<double>(outputX) + 0.5)
-                    * (request.visibleRegion.upper[xAxis]
-                        - request.visibleRegion.lower[xAxis])
-                    / static_cast<double>(request.outputSize[0]);
-            position[yAxis] = request.visibleRegion.lower[yAxis]
-                + (static_cast<double>(outputY) + 0.5)
-                    * (request.visibleRegion.upper[yAxis]
-                        - request.visibleRegion.lower[yAxis])
-                    / static_cast<double>(request.outputSize[1]);
+            position[xAxis] = sampleCentre(request.visibleRegion.lower[xAxis],
+                request.visibleRegion.upper[xAxis], outputX,
+                request.outputSize[0]);
+            position[yAxis] = sampleCentre(request.visibleRegion.lower[yAxis],
+                request.visibleRegion.upper[yAxis], outputY,
+                request.outputSize[1]);
             if (metadata.dimension == 3) {
                 position[static_cast<std::size_t>(request.normalDirection)] =
                     request.physicalPosition;
@@ -321,7 +318,7 @@ SliceQueryResult SliceQuery::execute(
             if (!sample) {
                 continue;
             }
-            result.plane.values[output] = static_cast<float>(sample->first);
+            result.plane.values[output] = narrowToFloat(sample->first);
             result.plane.valid[output] = 1;
             result.plane.sourceLevel[output] =
                 static_cast<std::int16_t>(sample->second);

--- a/src/query/VolumeQuery.cpp
+++ b/src/query/VolumeQuery.cpp
@@ -321,8 +321,12 @@ VolumeQueryResult VolumeQuery::execute(
                         cell[2] = cellK;
                         const auto value = fab.values[valueOffset(fab.box, cell, 3)];
                         // Range-checked before the cast, not after: converting
-                        // a double past the overflow threshold is undefined,
-                        // and the grid promises NaN for what it cannot hold.
+                        // a double past the overflow threshold is undefined.
+                        // The grid promises NaN for anything that is not a
+                        // finite float, which is both the non-finite values
+                        // and the ones past float's range -- an infinity
+                        // would survive the cast, but it is no more showable
+                        // than a voxel nothing covered.
                         const auto storable = std::isfinite(value)
                             && std::fabs(value) < floatOverflowThreshold;
                         row[static_cast<std::size_t>(i)]

--- a/src/query/VolumeQuery.cpp
+++ b/src/query/VolumeQuery.cpp
@@ -14,7 +14,6 @@ namespace amrvis {
 namespace {
 
 using detail::floatOverflowThreshold;
-using detail::indexRangeOnAxis;
 using detail::intersects;
 using detail::requireBlockPayload;
 using detail::sampleCentre;
@@ -44,22 +43,6 @@ double realProduct(const std::array<int, 3>& dims)
 {
     return static_cast<double>(dims[0]) * static_cast<double>(dims[1])
         * static_cast<double>(dims[2]);
-}
-
-// The index box `region` covers at `level`, on the same half-open convention
-// the slice and line planners use.
-IntBox regionIndexBox(const RealBox& region, const DatasetMetadata& metadata,
-    const LevelMetadata& level)
-{
-    auto result = level.domain;
-    for (int axis = 0; axis < 3; ++axis) {
-        const auto i = static_cast<std::size_t>(axis);
-        const auto [first, last] = indexRangeOnAxis(
-            region.lower[i], region.upper[i], metadata, level, axis);
-        result.lower[i] = first;
-        result.upper[i] = last;
-    }
-    return result;
 }
 
 } // namespace
@@ -180,7 +163,21 @@ VolumeQueryResult VolumeQuery::execute(
     auto contributingLevel = -1;
     for (int levelIndex = minimumLevel; levelIndex <= maximumLevel; ++levelIndex) {
         const auto& level = metadata.levels[static_cast<std::size_t>(levelIndex)];
-        const auto queryBox = regionIndexBox(request.region, metadata, level);
+        // Which blocks can hold a voxel centre, asked of the centres rather
+        // than of the region. Deriving it from the region means nudging its
+        // upper edge inward by one ulp, which is a fraction of a cell near
+        // the origin but more than a whole cell far from it -- and a block
+        // holding only the last voxel's cell would then never be a
+        // candidate at all, so no window would ever be computed for it.
+        // sampleIndex(voxelCentre(v)) is non-decreasing in v, so the first
+        // and last voxel bound every cell this grid can sample.
+        auto queryBox = level.domain;
+        for (std::size_t axis = 0; axis < 3; ++axis) {
+            const auto onAxis = static_cast<int>(axis);
+            queryBox.lower[axis] = sampleIndex(level, onAxis, voxelCentre(axis, 0));
+            queryBox.upper[axis] = sampleIndex(
+                level, onAxis, voxelCentre(axis, dims[axis] - 1));
+        }
         auto levelPainted = false;
         for (std::size_t reverse = level.blocks.size(); reverse > 0; --reverse) {
             if (cancellation.stop_requested()) {

--- a/src/query/VolumeQuery.cpp
+++ b/src/query/VolumeQuery.cpp
@@ -29,6 +29,8 @@ std::uint64_t product(const std::array<int, 3>& dims)
     std::uint64_t result = 1;
     for (const auto extent : dims) {
         const auto value = static_cast<std::uint64_t>(extent);
+        // Callers only ever pass positive dims, but the zero test guards the
+        // division below rather than the overflow, so it stays.
         if (value != 0 && result > limit / value) {
             return limit;
         }

--- a/src/query/VolumeQuery.cpp
+++ b/src/query/VolumeQuery.cpp
@@ -140,18 +140,11 @@ VolumeQueryResult VolumeQuery::execute(
     if (request.component != 0) {
         throw std::invalid_argument("the initial plotfile fields are scalar");
     }
-    // The region must lie within the domain (a hair of tolerance for a
-    // region computed from the domain itself).
-    const auto domain = datasetSampleBounds(metadata);
-    for (std::size_t axis = 0; axis < 3; ++axis) {
-        const auto tolerance = 1.0e-9
-            * (domain.upper[axis] - domain.lower[axis]);
-        if (request.region.lower[axis] < domain.lower[axis] - tolerance
-            || request.region.upper[axis] > domain.upper[axis] + tolerance) {
-            throw std::invalid_argument("volume region lies outside the dataset");
-        }
-    }
-
+    // A region reaching past the domain is not refused. The grid already
+    // says "no data here" with NaN, and a slice over the same region simply
+    // leaves those pixels uncovered, so refusing would fail a rubber-band
+    // selection the slice renders. The voxel budget bounds the grid whatever
+    // the region's size, so there is nothing to protect against here.
     const auto maximumLevel = std::min(request.maximumLevel, metadata.finestLevel);
     const auto minimumLevel = request.composition == CompositionPolicy::ExactLevel
         ? maximumLevel : 0;

--- a/src/query/VolumeQuery.cpp
+++ b/src/query/VolumeQuery.cpp
@@ -19,14 +19,34 @@ using detail::valueOffset;
 
 constexpr auto quietNaN = std::numeric_limits<float>::quiet_NaN();
 
+// Saturating: a level large enough to overflow the product would otherwise
+// wrap past the budget test in volumeGridDims and pass as if it fitted.
 std::uint64_t product(const std::array<int, 3>& dims)
 {
+    constexpr auto limit = std::numeric_limits<std::uint64_t>::max();
     std::uint64_t result = 1;
     for (const auto extent : dims) {
-        result *= static_cast<std::uint64_t>(extent);
+        const auto value = static_cast<std::uint64_t>(extent);
+        if (value != 0 && result > limit / value) {
+            return limit;
+        }
+        result *= value;
     }
     return result;
 }
+
+// The same product in double: no overflow, so the scaling below shrinks by
+// the true ratio even when the integer product has saturated.
+double realProduct(const std::array<int, 3>& dims)
+{
+    return static_cast<double>(dims[0]) * static_cast<double>(dims[1])
+        * static_cast<double>(dims[2]);
+}
+
+// The cell index a voxel centre falls in, when the centre lands outside the
+// block being painted. Out of band rather than -1: a level's index domain may
+// start below zero, and those cells are as paintable as any other.
+constexpr int noCell = std::numeric_limits<int>::min();
 
 // The index box `region` covers at `level`: the cells whose sample positions
 // fall inside it, the upper edge nudged inward so a region that ends on a
@@ -54,8 +74,9 @@ std::array<int, 3> volumeGridDims(const DatasetMetadata& metadata,
     }
     const auto& level = metadata.levels[static_cast<std::size_t>(
         std::clamp(maximumLevel, 0, metadata.finestLevel))];
-    // Native cell counts, kept far below any product overflow: a single axis
-    // never needs more voxels than the whole budget can hold.
+    // Native cell counts, capped per axis by the whole budget: a thin region
+    // may legitimately spend all of it on one axis. The product of three such
+    // axes can overflow, which is why product() saturates.
     const auto ceiling = static_cast<double>(
         std::max<std::uint64_t>(maximumVoxels, 1));
     std::array<int, 3> dims{};
@@ -68,7 +89,7 @@ std::array<int, 3> volumeGridDims(const DatasetMetadata& metadata,
     const auto budget = std::max<std::uint64_t>(maximumVoxels, 1);
     if (product(dims) > budget) {
         const auto scale = std::cbrt(static_cast<double>(budget)
-            / static_cast<double>(product(dims)));
+            / realProduct(dims));
         for (auto& extent : dims) {
             // The nudge keeps an exact ratio (64 -> 8 is exactly 1/2 per
             // axis) from flooring to the size below when cbrt lands a hair
@@ -182,8 +203,15 @@ VolumeQueryResult VolumeQuery::execute(
 
             // The voxels whose centres fall inside the block's cells: per
             // axis, the index range of centres within the block's physical
-            // bounds, and each centre's cell index (or -1 when the centre
-            // lands in a nodal box's half-cell halo outside the valid box).
+            // bounds, and each centre's cell index (or noCell when the centre
+            // lands outside the valid box).
+            //
+            // The range is inverted from the centre formula in floating point,
+            // so it can land a voxel off either end; it is widened by one per
+            // side and sampleIndex below decides, since that -- not the
+            // interval -- is what the composition is defined by. Too wide only
+            // costs a rejected candidate, while too narrow drops a voxel the
+            // block covers and no other block will paint.
             const auto bounds = sampleBounds(level, block.box, 3);
             std::array<int, 3> first{};
             std::array<int, 3> last{};
@@ -196,10 +224,10 @@ VolumeQueryResult VolumeQuery::execute(
                         -std::numeric_limits<double>::infinity())
                     - request.region.lower[axis]) / pitch[axis] - 0.5;
                 first[axis] = static_cast<int>(
-                    std::clamp(std::ceil(lower), 0.0,
+                    std::clamp(std::ceil(lower) - 1.0, 0.0,
                         static_cast<double>(dims[axis])));
                 last[axis] = static_cast<int>(
-                    std::clamp(std::floor(upper), -1.0,
+                    std::clamp(std::floor(upper) + 1.0, -1.0,
                         static_cast<double>(dims[axis] - 1)));
                 if (last[axis] < first[axis]) {
                     empty = true;
@@ -212,7 +240,7 @@ VolumeQueryResult VolumeQuery::execute(
                         voxelCentre(axis, voxel));
                     indices[static_cast<std::size_t>(voxel - first[axis])]
                         = cell >= block.box.lower[axis] && cell <= block.box.upper[axis]
-                        ? cell : -1;
+                        ? cell : noCell;
                 }
             }
             if (empty) {
@@ -225,19 +253,19 @@ VolumeQueryResult VolumeQuery::execute(
                     throw ReadCancelled();
                 }
                 const auto cellK = cellIndex[2][static_cast<std::size_t>(k - first[2])];
-                if (cellK < 0) {
+                if (cellK == noCell) {
                     continue;
                 }
                 for (int j = first[1]; j <= last[1]; ++j) {
                     const auto cellJ = cellIndex[1][static_cast<std::size_t>(j - first[1])];
-                    if (cellJ < 0) {
+                    if (cellJ == noCell) {
                         continue;
                     }
                     auto* row = grid.values.data() + slabStride * static_cast<std::size_t>(k)
                         + rowStride * static_cast<std::size_t>(j);
                     for (int i = first[0]; i <= last[0]; ++i) {
                         const auto cellI = cellIndex[0][static_cast<std::size_t>(i - first[0])];
-                        if (cellI < 0) {
+                        if (cellI == noCell) {
                             continue;
                         }
                         Int3 cell;
@@ -245,7 +273,12 @@ VolumeQueryResult VolumeQuery::execute(
                         cell[1] = cellJ;
                         cell[2] = cellK;
                         const auto value = fab.values[valueOffset(fab.box, cell, 3)];
+                        // Range-checked before the cast, not after: converting
+                        // a double beyond float's range is undefined, and the
+                        // grid promises NaN for every value it cannot hold.
                         row[static_cast<std::size_t>(i)] = std::isfinite(value)
+                                && std::fabs(value) <= static_cast<double>(
+                                    std::numeric_limits<float>::max())
                             ? static_cast<float>(value) : quietNaN;
                     }
                 }

--- a/src/query/VolumeQuery.cpp
+++ b/src/query/VolumeQuery.cpp
@@ -13,8 +13,10 @@
 namespace amrvis {
 namespace {
 
+using detail::indexRangeOnAxis;
 using detail::intersects;
 using detail::requireBlockPayload;
+using detail::sampleCentre;
 using detail::valueOffset;
 
 constexpr auto quietNaN = std::numeric_limits<float>::quiet_NaN();
@@ -48,18 +50,18 @@ double realProduct(const std::array<int, 3>& dims)
 // start below zero, and those cells are as paintable as any other.
 constexpr int noCell = std::numeric_limits<int>::min();
 
-// The index box `region` covers at `level`: the cells whose sample positions
-// fall inside it, the upper edge nudged inward so a region that ends on a
-// cell boundary does not claim the next cell (as the slice planner does).
-IntBox regionIndexBox(const RealBox& region, const LevelMetadata& level)
+// The index box `region` covers at `level`, on the same half-open convention
+// the slice and line planners use.
+IntBox regionIndexBox(const RealBox& region, const DatasetMetadata& metadata,
+    const LevelMetadata& level)
 {
     auto result = level.domain;
     for (int axis = 0; axis < 3; ++axis) {
         const auto i = static_cast<std::size_t>(axis);
-        result.lower[i] = sampleIndex(level, axis, region.lower[i]);
-        result.upper[i] = sampleIndex(level, axis,
-            std::nextafter(region.upper[i],
-                -std::numeric_limits<double>::infinity()));
+        const auto [first, last] = indexRangeOnAxis(
+            region.lower[i], region.upper[i], metadata, level, axis);
+        result.lower[i] = first;
+        result.upper[i] = last;
     }
     return result;
 }
@@ -74,26 +76,40 @@ std::array<int, 3> volumeGridDims(const DatasetMetadata& metadata,
     }
     const auto& level = metadata.levels[static_cast<std::size_t>(
         std::clamp(maximumLevel, 0, metadata.finestLevel))];
+    // Bounded here, not by the caller: a server sizes an inbound request with
+    // this before it has validated one, so an unchecked budget must not buy
+    // a grid larger than the sampler would ever allocate.
+    const auto budget = std::clamp<std::uint64_t>(
+        maximumVoxels, 1, maxVolumeVoxelBudget);
     // Native cell counts, capped per axis by the whole budget: a thin region
     // may legitimately spend all of it on one axis. The product of three such
     // axes can overflow, which is why product() saturates.
-    const auto ceiling = static_cast<double>(
-        std::max<std::uint64_t>(maximumVoxels, 1));
-    std::array<int, 3> dims{};
-    for (std::size_t axis = 0; axis < 3; ++axis) {
+    const auto ceiling = static_cast<double>(budget);
+    // Only the axes the dataset has: a 2-D level's third cellSize is the
+    // synthetic 1.0, which would invent a third dimension out of it.
+    const auto sampled = static_cast<std::size_t>(
+        std::clamp(metadata.dimension, 1, 3));
+    std::array<int, 3> dims{1, 1, 1};
+    for (std::size_t axis = 0; axis < sampled; ++axis) {
         const auto extent = region.upper[axis] - region.lower[axis];
         const auto cells = std::round(extent / level.cellSize[axis]);
-        dims[axis] = static_cast<int>(
-            std::clamp(cells, 1.0, std::min(ceiling, 1.0e9)));
+        // A non-finite region has no cell count to round to, and clamp cannot
+        // reject a NaN -- both of its comparisons are false -- so the cast
+        // would be undefined. One voxel is the honest answer.
+        dims[axis] = std::isfinite(cells)
+            ? static_cast<int>(
+                std::clamp(cells, 1.0, std::min(ceiling, 1.0e9)))
+            : 1;
     }
-    const auto budget = std::max<std::uint64_t>(maximumVoxels, 1);
     if (product(dims) > budget) {
         const auto scale = std::cbrt(static_cast<double>(budget)
             / realProduct(dims));
         for (auto& extent : dims) {
             // The nudge keeps an exact ratio (64 -> 8 is exactly 1/2 per
             // axis) from flooring to the size below when cbrt lands a hair
-            // under; the trim below repairs any overshoot it lets through.
+            // under. It is absolute, so it does nothing once an axis exceeds
+            // ~8.4e6 and an ulp is the larger of the two; the trim below is
+            // what keeps the result within budget either way.
             extent = std::max(1, static_cast<int>(
                 std::floor(static_cast<double>(extent) * scale + 1.0e-9)));
         }
@@ -113,8 +129,9 @@ VolumeQueryResult VolumeQuery::execute(
     const VolumeSampleRequest& request, StopToken cancellation)
 {
     const auto& metadata = m_dataset.metadata();
-    if (metadata.dimension != 3) {
-        throw std::invalid_argument("volume sampling requires a 3-D dataset");
+    const auto errors = validateVolumeSampleRequest(request, metadata.dimension);
+    if (!errors.empty()) {
+        throw std::invalid_argument(errors.front());
     }
     if (request.dataset != m_dataset.id()) {
         throw std::invalid_argument("volume request targets a different dataset");
@@ -124,15 +141,6 @@ VolumeQueryResult VolumeQuery::execute(
     }
     if (request.component != 0) {
         throw std::invalid_argument("the initial plotfile fields are scalar");
-    }
-    if (request.maximumLevel < 0) {
-        throw std::invalid_argument("maximum level must be non-negative");
-    }
-    if (!request.region.valid(3)) {
-        throw std::invalid_argument("volume region must have positive extent");
-    }
-    if (request.maximumVoxels < 1 || request.maximumVoxels > maxVolumeVoxelBudget) {
-        throw std::invalid_argument("voxel budget is outside the supported range");
     }
     // The region must lie within the domain (a hair of tolerance for a
     // region computed from the domain itself).
@@ -156,7 +164,6 @@ VolumeQueryResult VolumeQuery::execute(
     auto& grid = result.grid;
     grid.dims = dims;
     grid.region = request.region;
-    grid.maximumLevel = maximumLevel;
     grid.values.assign(static_cast<std::size_t>(product(dims)), quietNaN);
 
     std::array<double, 3> pitch{};
@@ -164,18 +171,29 @@ VolumeQueryResult VolumeQuery::execute(
         pitch[axis] = (request.region.upper[axis] - request.region.lower[axis])
             / static_cast<double>(dims[axis]);
     }
+    // The slice resolves its pixels with this too, so a voxel and a pixel
+    // over the same region land on the same cell rather than a rounding step
+    // apart. `pitch` only brackets the candidate range below.
     const auto voxelCentre = [&](std::size_t axis, int index) {
-        return request.region.lower[axis]
-            + (static_cast<double>(index) + 0.5) * pitch[axis];
+        return sampleCentre(request.region.lower[axis],
+            request.region.upper[axis], index, dims[axis]);
     };
 
     // Coarse to fine, so a finer level's cells overwrite the coarser ones
     // beneath them; within a level the grids run backwards, so on a
     // (malformed) overlap the lowest grid index wins, as the slice lookup's
     // first match does.
+    // Reused by every block: bounded by dims, so after the first block the
+    // resize is a no-op rather than three allocations per candidate.
+    std::array<std::vector<int>, 3> cellIndex;
+    // The finest level that put a value in the grid, which is what the field
+    // reports -- not the level that was asked for. Nothing painted means no
+    // level was finer than the coarsest that took part.
+    auto contributingLevel = minimumLevel;
     for (int levelIndex = minimumLevel; levelIndex <= maximumLevel; ++levelIndex) {
         const auto& level = metadata.levels[static_cast<std::size_t>(levelIndex)];
-        const auto queryBox = regionIndexBox(request.region, level);
+        const auto queryBox = regionIndexBox(request.region, metadata, level);
+        auto levelPainted = false;
         for (std::size_t reverse = level.blocks.size(); reverse > 0; --reverse) {
             if (cancellation.stop_requested()) {
                 throw ReadCancelled();
@@ -186,21 +204,12 @@ VolumeQueryResult VolumeQuery::execute(
                 continue;
             }
             ++result.metrics.candidateBlocks;
-            BlockRequest blockRequest;
-            blockRequest.dataset = request.dataset;
-            blockRequest.level = levelIndex;
-            blockRequest.gridIndex = static_cast<int>(gridIndex);
-            blockRequest.field = request.field;
-            auto access = m_dataset.requestBlock(blockRequest, cancellation);
-            if (access.cacheHit) {
-                ++result.metrics.cacheHits;
-            } else {
-                ++result.metrics.blocksRead;
-                result.metrics.payloadBytesRead += access.io.bytesRead;
-            }
-            const auto& fab = *access.handle;
-            requireBlockPayload(fab, block.box, 3);
 
+            // Which voxels this block can paint, settled before it is read:
+            // the range needs the box and the grid, not the payload, and on a
+            // budget-scaled grid most blocks of a fine level hold no voxel
+            // centre at all. Reading those would evict blocks that do.
+            //
             // The voxels whose centres fall inside the block's cells: per
             // axis, the index range of centres within the block's physical
             // bounds, and each centre's cell index (or noCell when the centre
@@ -215,8 +224,7 @@ VolumeQueryResult VolumeQuery::execute(
             const auto bounds = sampleBounds(level, block.box, 3);
             std::array<int, 3> first{};
             std::array<int, 3> last{};
-            std::array<std::vector<int>, 3> cellIndex;
-            bool empty = false;
+            auto empty = false;
             for (std::size_t axis = 0; axis < 3; ++axis) {
                 const auto lower = (bounds.lower[axis] - request.region.lower[axis])
                     / pitch[axis] - 0.5;
@@ -235,17 +243,44 @@ VolumeQueryResult VolumeQuery::execute(
                 }
                 auto& indices = cellIndex[axis];
                 indices.resize(static_cast<std::size_t>(last[axis] - first[axis] + 1));
+                auto any = false;
                 for (int voxel = first[axis]; voxel <= last[axis]; ++voxel) {
                     const auto cell = sampleIndex(level, static_cast<int>(axis),
                         voxelCentre(axis, voxel));
+                    const auto inside = cell >= block.box.lower[axis]
+                        && cell <= block.box.upper[axis];
                     indices[static_cast<std::size_t>(voxel - first[axis])]
-                        = cell >= block.box.lower[axis] && cell <= block.box.upper[axis]
-                        ? cell : noCell;
+                        = inside ? cell : noCell;
+                    any = any || inside;
+                }
+                // Widening the range costs a candidate per side, and on a
+                // coarse grid the whole widened range can miss the block. No
+                // index on an axis means no voxel to paint, so the read is
+                // skipped rather than charged and thrown away.
+                if (!any) {
+                    empty = true;
+                    break;
                 }
             }
             if (empty) {
                 continue;
             }
+
+            BlockRequest blockRequest;
+            blockRequest.dataset = request.dataset;
+            blockRequest.level = levelIndex;
+            blockRequest.gridIndex = static_cast<int>(gridIndex);
+            blockRequest.field = request.field;
+            auto access = m_dataset.requestBlock(blockRequest, cancellation);
+            if (access.cacheHit) {
+                ++result.metrics.cacheHits;
+            } else {
+                ++result.metrics.blocksRead;
+                result.metrics.payloadBytesRead += access.io.bytesRead;
+            }
+            const auto& fab = *access.handle;
+            requireBlockPayload(fab, block.box, 3);
+
             const auto rowStride = static_cast<std::size_t>(dims[0]);
             const auto slabStride = rowStride * static_cast<std::size_t>(dims[1]);
             for (int k = first[2]; k <= last[2]; ++k) {
@@ -280,11 +315,16 @@ VolumeQueryResult VolumeQuery::execute(
                                 && std::fabs(value) <= static_cast<double>(
                                     std::numeric_limits<float>::max())
                             ? static_cast<float>(value) : quietNaN;
+                        levelPainted = true;
                     }
                 }
             }
         }
+        if (levelPainted) {
+            contributingLevel = levelIndex;
+        }
     }
+    grid.maximumLevel = contributingLevel;
 
     grid.coveredVoxels = static_cast<std::uint64_t>(std::count_if(
         grid.values.begin(), grid.values.end(),

--- a/src/query/VolumeQuery.cpp
+++ b/src/query/VolumeQuery.cpp
@@ -46,11 +46,6 @@ double realProduct(const std::array<int, 3>& dims)
         * static_cast<double>(dims[2]);
 }
 
-// The cell index a voxel centre falls in, when the centre lands outside the
-// block being painted. Out of band rather than -1: a level's index domain may
-// start below zero, and those cells are as paintable as any other.
-constexpr int noCell = std::numeric_limits<int>::min();
-
 // The index box `region` covers at `level`, on the same half-open convention
 // the slice and line planners use.
 IntBox regionIndexBox(const RealBox& region, const DatasetMetadata& metadata,
@@ -82,10 +77,13 @@ std::array<int, 3> volumeGridDims(const DatasetMetadata& metadata,
     // a grid larger than the sampler would ever allocate.
     const auto budget = std::clamp<std::uint64_t>(
         maximumVoxels, 1, maxVolumeVoxelBudget);
-    // Native cell counts, capped per axis by the whole budget: a thin region
-    // may legitimately spend all of it on one axis. The product of three such
-    // axes can overflow, which is why product() saturates.
-    const auto ceiling = static_cast<double>(budget);
+    // Native cell counts, capped only where int stops holding them. Capping
+    // an axis at the budget first would be wrong: the cbrt below shrinks the
+    // whole grid by one ratio, so an axis already truncated to the budget
+    // gets shrunk a second time and a thin region ends up spending a
+    // fraction of what it was given. The product of three uncapped axes
+    // overflows, which is why product() saturates.
+    constexpr auto ceiling = 1.0e9;
     // Only the axes the dataset has: a 2-D level's third cellSize is the
     // synthetic 1.0, which would invent a third dimension out of it.
     const auto sampled = static_cast<std::size_t>(
@@ -98,8 +96,7 @@ std::array<int, 3> volumeGridDims(const DatasetMetadata& metadata,
         // reject a NaN -- both of its comparisons are false -- so the cast
         // would be undefined. One voxel is the honest answer.
         dims[axis] = std::isfinite(cells)
-            ? static_cast<int>(
-                std::clamp(cells, 1.0, std::min(ceiling, 1.0e9)))
+            ? static_cast<int>(std::clamp(cells, 1.0, ceiling))
             : 1;
     }
     if (product(dims) > budget) {
@@ -167,14 +164,10 @@ VolumeQueryResult VolumeQuery::execute(
     grid.region = request.region;
     grid.values.assign(static_cast<std::size_t>(product(dims)), quietNaN);
 
-    std::array<double, 3> pitch{};
-    for (std::size_t axis = 0; axis < 3; ++axis) {
-        pitch[axis] = (request.region.upper[axis] - request.region.lower[axis])
-            / static_cast<double>(dims[axis]);
-    }
     // The slice resolves its pixels with this too, so a voxel and a pixel
     // over the same region land on the same cell rather than a rounding step
-    // apart. `pitch` only brackets the candidate range below.
+    // apart. It is now the only encoding of the voxel geometry: the block
+    // windows below bisect on it instead of inverting it.
     const auto voxelCentre = [&](std::size_t axis, int index) {
         return sampleCentre(request.region.lower[axis],
             request.region.upper[axis], index, dims[axis]);
@@ -187,10 +180,11 @@ VolumeQueryResult VolumeQuery::execute(
     // Reused by every block: bounded by dims, so after the first block the
     // resize is a no-op rather than three allocations per candidate.
     std::array<std::vector<int>, 3> cellIndex;
-    // The finest level that put a value in the grid, which is what the field
-    // reports -- not the level that was asked for. Nothing painted means no
-    // level was finer than the coarsest that took part.
-    auto contributingLevel = minimumLevel;
+    // The finest level that put a showable value in the grid, which is what
+    // the field reports -- not the level that was asked for. Negative until
+    // one does, since an empty grid has no contributing level to name and
+    // must not claim the finest one merely because it was requested.
+    auto contributingLevel = -1;
     for (int levelIndex = minimumLevel; levelIndex <= maximumLevel; ++levelIndex) {
         const auto& level = metadata.levels[static_cast<std::size_t>(levelIndex)];
         const auto queryBox = regionIndexBox(request.region, metadata, level);
@@ -211,56 +205,55 @@ VolumeQueryResult VolumeQuery::execute(
             // budget-scaled grid most blocks of a fine level hold no voxel
             // centre at all. Reading those would evict blocks that do.
             //
-            // The voxels whose centres fall inside the block's cells: per
-            // axis, the index range of centres within the block's physical
-            // bounds, and each centre's cell index (or noCell when the centre
-            // lands outside the valid box).
-            //
-            // The range is inverted from the centre formula in floating point,
-            // so it can land a voxel off either end; it is widened by one per
-            // side and sampleIndex below decides, since that -- not the
-            // interval -- is what the composition is defined by. Too wide only
-            // costs a rejected candidate, while too narrow drops a voxel the
-            // block covers and no other block will paint.
-            const auto bounds = sampleBounds(level, block.box, 3);
+            // Searched, not inverted. Inverting the centre formula in
+            // floating point costs an error of ulp(coordinate)/pitch voxels:
+            // nothing near the origin, and tens of voxels for a finely
+            // resolved region far from it, which no fixed widening covers.
+            // sampleIndex(voxelCentre(v)) is non-decreasing in v, so the
+            // voxels landing in this block form a contiguous run whose ends
+            // can be bisected with the very predicate the composition is
+            // defined by -- exact at any distance from the origin, and every
+            // voxel in [first, last] is then known to be inside the block.
             std::array<int, 3> first{};
             std::array<int, 3> last{};
             auto empty = false;
             for (std::size_t axis = 0; axis < 3; ++axis) {
-                const auto lower = (bounds.lower[axis] - request.region.lower[axis])
-                    / pitch[axis] - 0.5;
-                const auto upper = (std::nextafter(bounds.upper[axis],
-                        -std::numeric_limits<double>::infinity())
-                    - request.region.lower[axis]) / pitch[axis] - 0.5;
-                first[axis] = static_cast<int>(
-                    std::clamp(std::ceil(lower) - 1.0, 0.0,
-                        static_cast<double>(dims[axis])));
-                last[axis] = static_cast<int>(
-                    std::clamp(std::floor(upper) + 1.0, -1.0,
-                        static_cast<double>(dims[axis] - 1)));
+                const auto cellAt = [&](int voxel) {
+                    return sampleIndex(level, static_cast<int>(axis),
+                        voxelCentre(axis, voxel));
+                };
+                // The first voxel whose cell has reached the block's lower
+                // edge, then the first past its upper edge.
+                auto low = 0;
+                auto high = dims[axis];
+                while (low < high) {
+                    const auto middle = low + (high - low) / 2;
+                    if (cellAt(middle) < block.box.lower[axis]) {
+                        low = middle + 1;
+                    } else {
+                        high = middle;
+                    }
+                }
+                first[axis] = low;
+                high = dims[axis];
+                while (low < high) {
+                    const auto middle = low + (high - low) / 2;
+                    if (cellAt(middle) <= block.box.upper[axis]) {
+                        low = middle + 1;
+                    } else {
+                        high = middle;
+                    }
+                }
+                last[axis] = low - 1;
                 if (last[axis] < first[axis]) {
                     empty = true;
                     break;
                 }
                 auto& indices = cellIndex[axis];
                 indices.resize(static_cast<std::size_t>(last[axis] - first[axis] + 1));
-                auto any = false;
                 for (int voxel = first[axis]; voxel <= last[axis]; ++voxel) {
-                    const auto cell = sampleIndex(level, static_cast<int>(axis),
-                        voxelCentre(axis, voxel));
-                    const auto inside = cell >= block.box.lower[axis]
-                        && cell <= block.box.upper[axis];
                     indices[static_cast<std::size_t>(voxel - first[axis])]
-                        = inside ? cell : noCell;
-                    any = any || inside;
-                }
-                // Widening the range costs a candidate per side, and on a
-                // coarse grid the whole widened range can miss the block. No
-                // index on an axis means no voxel to paint, so the read is
-                // skipped rather than charged and thrown away.
-                if (!any) {
-                    empty = true;
-                    break;
+                        = cellAt(voxel);
                 }
             }
             if (empty) {
@@ -285,25 +278,16 @@ VolumeQueryResult VolumeQuery::execute(
             const auto rowStride = static_cast<std::size_t>(dims[0]);
             const auto slabStride = rowStride * static_cast<std::size_t>(dims[1]);
             for (int k = first[2]; k <= last[2]; ++k) {
-                if ((k - first[2]) % 32 == 31 && cancellation.stop_requested()) {
+                if ((k - first[2]) % 32 == 0 && cancellation.stop_requested()) {
                     throw ReadCancelled();
                 }
                 const auto cellK = cellIndex[2][static_cast<std::size_t>(k - first[2])];
-                if (cellK == noCell) {
-                    continue;
-                }
                 for (int j = first[1]; j <= last[1]; ++j) {
                     const auto cellJ = cellIndex[1][static_cast<std::size_t>(j - first[1])];
-                    if (cellJ == noCell) {
-                        continue;
-                    }
                     auto* row = grid.values.data() + slabStride * static_cast<std::size_t>(k)
                         + rowStride * static_cast<std::size_t>(j);
                     for (int i = first[0]; i <= last[0]; ++i) {
                         const auto cellI = cellIndex[0][static_cast<std::size_t>(i - first[0])];
-                        if (cellI == noCell) {
-                            continue;
-                        }
                         Int3 cell;
                         cell[0] = cellI;
                         cell[1] = cellJ;
@@ -328,7 +312,7 @@ VolumeQueryResult VolumeQuery::execute(
             contributingLevel = levelIndex;
         }
     }
-    grid.maximumLevel = contributingLevel;
+    grid.maximumLevel = std::max(contributingLevel, 0);
 
     grid.coveredVoxels = static_cast<std::uint64_t>(std::count_if(
         grid.values.begin(), grid.values.end(),

--- a/src/query/VolumeQuery.cpp
+++ b/src/query/VolumeQuery.cpp
@@ -96,13 +96,48 @@ std::array<int, 3> volumeGridDims(const DatasetMetadata& metadata,
             extent = std::max(1, static_cast<int>(
                 std::floor(static_cast<double>(extent) * scale + 1.0e-9)));
         }
-        // Rounding can leave the product a hair over: trim the largest axis.
-        while (product(dims) > budget) {
-            auto& largest = *std::max_element(dims.begin(), dims.end());
-            if (largest <= 1) {
-                break;
+        // Whatever the scaling leaves over, taken off the tallest axes by
+        // water-filling: the highest cap the budget allows, then a voxel
+        // given back to each still-capped axis while it still fits.
+        //
+        // Lowering the tallest axis one voxel at a time lands in the same
+        // place, but a thin region arrives here hundreds of millions of
+        // voxels over -- the scaling floors its two short axes to one, so
+        // the product only falls to N^(2/3) * budget^(1/3) -- and walking
+        // that took the better part of a second inside a call a server makes
+        // before it has validated anything. The search is bounded by the
+        // bit width instead.
+        if (product(dims) > budget) {
+            const auto native = dims;
+            const auto cappedAt = [&native](int cap) {
+                std::array<int, 3> trial{};
+                for (std::size_t axis = 0; axis < 3; ++axis) {
+                    trial[axis] = std::min(native[axis], cap);
+                }
+                return trial;
+            };
+            auto low = 1;
+            auto high = *std::max_element(native.begin(), native.end());
+            while (low < high) {
+                const auto middle = low + (high - low + 1) / 2;
+                if (product(cappedAt(middle)) <= budget) {
+                    low = middle;
+                } else {
+                    high = middle - 1;
+                }
             }
-            --largest;
+            dims = cappedAt(low);
+            // The cap is uniform, so the budget usually has room left for a
+            // voxel or two above it. Only an axis the cap actually shortened
+            // may take one: the others are already at their native count.
+            for (std::size_t axis = 0; axis < 3; ++axis) {
+                if (native[axis] > low) {
+                    ++dims[axis];
+                    if (product(dims) > budget) {
+                        --dims[axis];
+                    }
+                }
+            }
         }
     }
     return dims;

--- a/src/query/VolumeQuery.cpp
+++ b/src/query/VolumeQuery.cpp
@@ -1,0 +1,262 @@
+#include <amrexplorer/query/VolumeQuery.hpp>
+#include <amrexplorer/query/detail/BlockLookup.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+namespace amrvis {
+namespace {
+
+using detail::intersects;
+using detail::requireBlockPayload;
+using detail::valueOffset;
+
+constexpr auto quietNaN = std::numeric_limits<float>::quiet_NaN();
+
+std::uint64_t product(const std::array<int, 3>& dims)
+{
+    std::uint64_t result = 1;
+    for (const auto extent : dims) {
+        result *= static_cast<std::uint64_t>(extent);
+    }
+    return result;
+}
+
+// The index box `region` covers at `level`: the cells whose sample positions
+// fall inside it, the upper edge nudged inward so a region that ends on a
+// cell boundary does not claim the next cell (as the slice planner does).
+IntBox regionIndexBox(const RealBox& region, const LevelMetadata& level)
+{
+    auto result = level.domain;
+    for (int axis = 0; axis < 3; ++axis) {
+        const auto i = static_cast<std::size_t>(axis);
+        result.lower[i] = sampleIndex(level, axis, region.lower[i]);
+        result.upper[i] = sampleIndex(level, axis,
+            std::nextafter(region.upper[i],
+                -std::numeric_limits<double>::infinity()));
+    }
+    return result;
+}
+
+} // namespace
+
+std::array<int, 3> volumeGridDims(const DatasetMetadata& metadata,
+    const RealBox& region, int maximumLevel, std::uint64_t maximumVoxels)
+{
+    if (metadata.levels.empty()) {
+        return {1, 1, 1};
+    }
+    const auto& level = metadata.levels[static_cast<std::size_t>(
+        std::clamp(maximumLevel, 0, metadata.finestLevel))];
+    // Native cell counts, kept far below any product overflow: a single axis
+    // never needs more voxels than the whole budget can hold.
+    const auto ceiling = static_cast<double>(
+        std::max<std::uint64_t>(maximumVoxels, 1));
+    std::array<int, 3> dims{};
+    for (std::size_t axis = 0; axis < 3; ++axis) {
+        const auto extent = region.upper[axis] - region.lower[axis];
+        const auto cells = std::round(extent / level.cellSize[axis]);
+        dims[axis] = static_cast<int>(
+            std::clamp(cells, 1.0, std::min(ceiling, 1.0e9)));
+    }
+    const auto budget = std::max<std::uint64_t>(maximumVoxels, 1);
+    if (product(dims) > budget) {
+        const auto scale = std::cbrt(static_cast<double>(budget)
+            / static_cast<double>(product(dims)));
+        for (auto& extent : dims) {
+            // The nudge keeps an exact ratio (64 -> 8 is exactly 1/2 per
+            // axis) from flooring to the size below when cbrt lands a hair
+            // under; the trim below repairs any overshoot it lets through.
+            extent = std::max(1, static_cast<int>(
+                std::floor(static_cast<double>(extent) * scale + 1.0e-9)));
+        }
+        // Rounding can leave the product a hair over: trim the largest axis.
+        while (product(dims) > budget) {
+            auto& largest = *std::max_element(dims.begin(), dims.end());
+            if (largest <= 1) {
+                break;
+            }
+            --largest;
+        }
+    }
+    return dims;
+}
+
+VolumeQueryResult VolumeQuery::execute(
+    const VolumeSampleRequest& request, StopToken cancellation)
+{
+    const auto& metadata = m_dataset.metadata();
+    if (metadata.dimension != 3) {
+        throw std::invalid_argument("volume sampling requires a 3-D dataset");
+    }
+    if (request.dataset != m_dataset.id()) {
+        throw std::invalid_argument("volume request targets a different dataset");
+    }
+    if (request.field.value >= metadata.fields.size()) {
+        throw std::invalid_argument("volume field is unavailable");
+    }
+    if (request.component != 0) {
+        throw std::invalid_argument("the initial plotfile fields are scalar");
+    }
+    if (request.maximumLevel < 0) {
+        throw std::invalid_argument("maximum level must be non-negative");
+    }
+    if (!request.region.valid(3)) {
+        throw std::invalid_argument("volume region must have positive extent");
+    }
+    if (request.maximumVoxels < 1 || request.maximumVoxels > maxVolumeVoxelBudget) {
+        throw std::invalid_argument("voxel budget is outside the supported range");
+    }
+    // The region must lie within the domain (a hair of tolerance for a
+    // region computed from the domain itself).
+    const auto domain = datasetSampleBounds(metadata);
+    for (std::size_t axis = 0; axis < 3; ++axis) {
+        const auto tolerance = 1.0e-9
+            * (domain.upper[axis] - domain.lower[axis]);
+        if (request.region.lower[axis] < domain.lower[axis] - tolerance
+            || request.region.upper[axis] > domain.upper[axis] + tolerance) {
+            throw std::invalid_argument("volume region lies outside the dataset");
+        }
+    }
+
+    const auto maximumLevel = std::min(request.maximumLevel, metadata.finestLevel);
+    const auto minimumLevel = request.composition == CompositionPolicy::ExactLevel
+        ? maximumLevel : 0;
+    const auto dims = volumeGridDims(
+        metadata, request.region, maximumLevel, request.maximumVoxels);
+
+    VolumeQueryResult result;
+    auto& grid = result.grid;
+    grid.dims = dims;
+    grid.region = request.region;
+    grid.maximumLevel = maximumLevel;
+    grid.values.assign(static_cast<std::size_t>(product(dims)), quietNaN);
+
+    std::array<double, 3> pitch{};
+    for (std::size_t axis = 0; axis < 3; ++axis) {
+        pitch[axis] = (request.region.upper[axis] - request.region.lower[axis])
+            / static_cast<double>(dims[axis]);
+    }
+    const auto voxelCentre = [&](std::size_t axis, int index) {
+        return request.region.lower[axis]
+            + (static_cast<double>(index) + 0.5) * pitch[axis];
+    };
+
+    // Coarse to fine, so a finer level's cells overwrite the coarser ones
+    // beneath them; within a level the grids run backwards, so on a
+    // (malformed) overlap the lowest grid index wins, as the slice lookup's
+    // first match does.
+    for (int levelIndex = minimumLevel; levelIndex <= maximumLevel; ++levelIndex) {
+        const auto& level = metadata.levels[static_cast<std::size_t>(levelIndex)];
+        const auto queryBox = regionIndexBox(request.region, level);
+        for (std::size_t reverse = level.blocks.size(); reverse > 0; --reverse) {
+            if (cancellation.stop_requested()) {
+                throw ReadCancelled();
+            }
+            const auto gridIndex = reverse - 1;
+            const auto& block = level.blocks[gridIndex];
+            if (!intersects(block.box, queryBox, 3)) {
+                continue;
+            }
+            ++result.metrics.candidateBlocks;
+            BlockRequest blockRequest;
+            blockRequest.dataset = request.dataset;
+            blockRequest.level = levelIndex;
+            blockRequest.gridIndex = static_cast<int>(gridIndex);
+            blockRequest.field = request.field;
+            auto access = m_dataset.requestBlock(blockRequest, cancellation);
+            if (access.cacheHit) {
+                ++result.metrics.cacheHits;
+            } else {
+                ++result.metrics.blocksRead;
+                result.metrics.payloadBytesRead += access.io.bytesRead;
+            }
+            const auto& fab = *access.handle;
+            requireBlockPayload(fab, block.box, 3);
+
+            // The voxels whose centres fall inside the block's cells: per
+            // axis, the index range of centres within the block's physical
+            // bounds, and each centre's cell index (or -1 when the centre
+            // lands in a nodal box's half-cell halo outside the valid box).
+            const auto bounds = sampleBounds(level, block.box, 3);
+            std::array<int, 3> first{};
+            std::array<int, 3> last{};
+            std::array<std::vector<int>, 3> cellIndex;
+            bool empty = false;
+            for (std::size_t axis = 0; axis < 3; ++axis) {
+                const auto lower = (bounds.lower[axis] - request.region.lower[axis])
+                    / pitch[axis] - 0.5;
+                const auto upper = (std::nextafter(bounds.upper[axis],
+                        -std::numeric_limits<double>::infinity())
+                    - request.region.lower[axis]) / pitch[axis] - 0.5;
+                first[axis] = static_cast<int>(
+                    std::clamp(std::ceil(lower), 0.0,
+                        static_cast<double>(dims[axis])));
+                last[axis] = static_cast<int>(
+                    std::clamp(std::floor(upper), -1.0,
+                        static_cast<double>(dims[axis] - 1)));
+                if (last[axis] < first[axis]) {
+                    empty = true;
+                    break;
+                }
+                auto& indices = cellIndex[axis];
+                indices.resize(static_cast<std::size_t>(last[axis] - first[axis] + 1));
+                for (int voxel = first[axis]; voxel <= last[axis]; ++voxel) {
+                    const auto cell = sampleIndex(level, static_cast<int>(axis),
+                        voxelCentre(axis, voxel));
+                    indices[static_cast<std::size_t>(voxel - first[axis])]
+                        = cell >= block.box.lower[axis] && cell <= block.box.upper[axis]
+                        ? cell : -1;
+                }
+            }
+            if (empty) {
+                continue;
+            }
+            const auto rowStride = static_cast<std::size_t>(dims[0]);
+            const auto slabStride = rowStride * static_cast<std::size_t>(dims[1]);
+            for (int k = first[2]; k <= last[2]; ++k) {
+                if ((k - first[2]) % 32 == 31 && cancellation.stop_requested()) {
+                    throw ReadCancelled();
+                }
+                const auto cellK = cellIndex[2][static_cast<std::size_t>(k - first[2])];
+                if (cellK < 0) {
+                    continue;
+                }
+                for (int j = first[1]; j <= last[1]; ++j) {
+                    const auto cellJ = cellIndex[1][static_cast<std::size_t>(j - first[1])];
+                    if (cellJ < 0) {
+                        continue;
+                    }
+                    auto* row = grid.values.data() + slabStride * static_cast<std::size_t>(k)
+                        + rowStride * static_cast<std::size_t>(j);
+                    for (int i = first[0]; i <= last[0]; ++i) {
+                        const auto cellI = cellIndex[0][static_cast<std::size_t>(i - first[0])];
+                        if (cellI < 0) {
+                            continue;
+                        }
+                        Int3 cell;
+                        cell[0] = cellI;
+                        cell[1] = cellJ;
+                        cell[2] = cellK;
+                        const auto value = fab.values[valueOffset(fab.box, cell, 3)];
+                        row[static_cast<std::size_t>(i)] = std::isfinite(value)
+                            ? static_cast<float>(value) : quietNaN;
+                    }
+                }
+            }
+        }
+    }
+
+    grid.coveredVoxels = static_cast<std::uint64_t>(std::count_if(
+        grid.values.begin(), grid.values.end(),
+        [](float value) { return !std::isnan(value); }));
+    return result;
+}
+
+} // namespace amrvis

--- a/src/query/VolumeQuery.cpp
+++ b/src/query/VolumeQuery.cpp
@@ -13,6 +13,7 @@
 namespace amrvis {
 namespace {
 
+using detail::floatOverflowThreshold;
 using detail::indexRangeOnAxis;
 using detail::intersects;
 using detail::requireBlockPayload;
@@ -309,13 +310,16 @@ VolumeQueryResult VolumeQuery::execute(
                         cell[2] = cellK;
                         const auto value = fab.values[valueOffset(fab.box, cell, 3)];
                         // Range-checked before the cast, not after: converting
-                        // a double beyond float's range is undefined, and the
-                        // grid promises NaN for every value it cannot hold.
-                        row[static_cast<std::size_t>(i)] = std::isfinite(value)
-                                && std::fabs(value) <= static_cast<double>(
-                                    std::numeric_limits<float>::max())
-                            ? static_cast<float>(value) : quietNaN;
-                        levelPainted = true;
+                        // a double past the overflow threshold is undefined,
+                        // and the grid promises NaN for what it cannot hold.
+                        const auto storable = std::isfinite(value)
+                            && std::fabs(value) < floatOverflowThreshold;
+                        row[static_cast<std::size_t>(i)]
+                            = storable ? static_cast<float>(value) : quietNaN;
+                        // A NaN is indistinguishable from an uncovered voxel,
+                        // so a level that wrote only those contributed
+                        // nothing the grid can show.
+                        levelPainted = levelPainted || storable;
                     }
                 }
             }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -394,6 +394,10 @@ add_executable(test_slice_query integration/test_slice_query.cpp)
 target_link_libraries(test_slice_query PRIVATE amrexplorer::query amrexplorer::warnings)
 add_test(NAME slice_query COMMAND test_slice_query)
 
+add_executable(test_volume_query integration/test_volume_query.cpp)
+target_link_libraries(test_volume_query PRIVATE amrexplorer::query amrexplorer::warnings)
+add_test(NAME volume_query COMMAND test_volume_query)
+
 add_executable(test_spherical_display integration/test_spherical_display.cpp)
 target_link_libraries(
     test_spherical_display

--- a/tests/integration/test_volume_query.cpp
+++ b/tests/integration/test_volume_query.cpp
@@ -1,0 +1,377 @@
+// VolumeQuery: the AMR hierarchy sampled onto a bounded uniform grid.
+// Synthesised plotfiles (as test_slice_query does): a single-level 4x4x4
+// analytic field q(i, j, k) = (i + j + k) / 9 pins exact values, the voxel
+// budget, sub-regions and the grid geometry; a two-level fixture pins the
+// composition (fine over coarse, ExactLevel, a coarser maximum level).
+
+#include <amrexplorer/query/VolumeQuery.hpp>
+
+#include <array>
+#include <chrono>
+#include <cmath>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <span>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace {
+
+constexpr std::string_view realDescriptor =
+    "((8, (64 11 52 0 1 12 0 1023)),(8, (8 7 6 5 4 3 2 1)))";
+
+void require(bool condition, const char* message)
+{
+    if (!condition) {
+        std::cerr << "FAILED: " << message << '\n';
+        std::exit(1);
+    }
+}
+
+void writeText(const std::filesystem::path& path, const std::string& text)
+{
+    std::ofstream output(path, std::ios::binary);
+    require(static_cast<bool>(output), "could not create fixture text");
+    output << text;
+}
+
+void writeFab(const std::filesystem::path& path, std::string_view box,
+    std::span<const double> values)
+{
+    std::ofstream output(path, std::ios::binary);
+    require(static_cast<bool>(output), "could not create fixture FAB");
+    output << "FAB " << realDescriptor << box << " 1\n";
+    output.write(reinterpret_cast<const char*>(values.data()),
+        static_cast<std::streamsize>(values.size() * sizeof(double)));
+}
+
+// The single-level analytic fixture: 4^3 cells over [0,1]^3, cell size 0.25.
+std::filesystem::path writeAnalyticFixture(const std::filesystem::path& root)
+{
+    std::filesystem::create_directories(root / "Level_0");
+    writeText(root / "Header",
+        "HyperCLaw-V1.1\n"
+        "1\nq\n"
+        "3\n0.0\n0\n"
+        "0.0 0.0 0.0\n1.0 1.0 1.0\n\n"
+        "((0,0,0) (3,3,3) (0,0,0))\n"
+        "0\n"
+        "0.25 0.25 0.25\n"
+        "0\n0\n"
+        "0 1 0.0\n0\n"
+        "0.0 1.0\n0.0 1.0\n0.0 1.0\n"
+        "Level_0/Cell\n");
+    writeText(root / "Level_0" / "Cell_H",
+        "1\n1\n1\n0\n"
+        "(1 0\n((0,0,0) (3,3,3) (0,0,0))\n)\n"
+        "1\nFabOnDisk: Cell_D_00000 0\n\n"
+        "1,1\n0.0,\n\n1,1\n1.0,\n\n");
+    std::vector<double> values;
+    for (int k = 0; k <= 3; ++k) {
+        for (int j = 0; j <= 3; ++j) {
+            for (int i = 0; i <= 3; ++i) {
+                values.push_back(static_cast<double>(i + j + k) / 9.0);
+            }
+        }
+    }
+    writeFab(root / "Level_0" / "Cell_D_00000", "((0,0,0) (3,3,3) (0,0,0))",
+        values);
+    return root;
+}
+
+// Two levels over [0,1]^3: coarse 4^3 = 1.0 everywhere, a fine 4^3 block
+// (level-1 indices 2..5, i.e. the central [0.25,0.75]^3) = 2.0.
+std::filesystem::path writeTwoLevelFixture(const std::filesystem::path& root)
+{
+    std::filesystem::create_directories(root / "Level_0");
+    std::filesystem::create_directories(root / "Level_1");
+    writeText(root / "Header",
+        "HyperCLaw-V1.1\n"
+        "1\nphi\n"
+        "3\n0.0\n1\n"
+        "0.0 0.0 0.0\n1.0 1.0 1.0\n2\n"
+        "((0,0,0) (3,3,3) (0,0,0))\n"
+        "((0,0,0) (7,7,7) (0,0,0))\n"
+        "0 0\n"
+        "0.25 0.25 0.25\n0.125 0.125 0.125\n"
+        "0\n0\n"
+        "0 1 0.0\n0\n"
+        "0.0 1.0\n0.0 1.0\n0.0 1.0\n"
+        "Level_0/Cell\n"
+        "1 1 0.0\n0\n"
+        "0.25 0.75\n0.25 0.75\n0.25 0.75\n"
+        "Level_1/Cell\n");
+    writeText(root / "Level_0" / "Cell_H",
+        "1\n1\n1\n0\n"
+        "(1 0\n((0,0,0) (3,3,3) (0,0,0))\n)\n"
+        "1\nFabOnDisk: Cell_D_00000 0\n\n"
+        "1,1\n1.0,\n\n1,1\n1.0,\n\n");
+    writeText(root / "Level_1" / "Cell_H",
+        "1\n1\n1\n0\n"
+        "(1 0\n((2,2,2) (5,5,5) (0,0,0))\n)\n"
+        "1\nFabOnDisk: Cell_D_00000 0\n\n"
+        "1,1\n2.0,\n\n1,1\n2.0,\n\n");
+    std::array<double, 64> coarse{};
+    std::array<double, 64> fine{};
+    coarse.fill(1.0);
+    fine.fill(2.0);
+    writeFab(root / "Level_0" / "Cell_D_00000", "((0,0,0) (3,3,3) (0,0,0))",
+        coarse);
+    writeFab(root / "Level_1" / "Cell_D_00000", "((2,2,2) (5,5,5) (0,0,0))",
+        fine);
+    return root;
+}
+
+std::size_t voxel(const amrvis::VolumeGrid& grid, int i, int j, int k)
+{
+    return static_cast<std::size_t>(i)
+        + static_cast<std::size_t>(grid.dims[0])
+            * (static_cast<std::size_t>(j)
+                + static_cast<std::size_t>(grid.dims[1]) * static_cast<std::size_t>(k));
+}
+
+amrvis::RealBox box(double x0, double y0, double z0, double x1, double y1,
+    double z1)
+{
+    amrvis::RealBox result;
+    result.lower = {{x0, y0, z0}};
+    result.upper = {{x1, y1, z1}};
+    return result;
+}
+
+} // namespace
+
+int main()
+{
+    const auto unique = std::chrono::steady_clock::now().time_since_epoch().count();
+    const auto scratch = std::filesystem::temp_directory_path()
+        / ("amrexplorer-volume-query-" + std::to_string(unique));
+    const auto analyticRoot = writeAnalyticFixture(scratch / "analytic");
+    const auto twoLevelRoot = writeTwoLevelFixture(scratch / "two-level");
+
+    // --- the analytic single-level field ---------------------------------
+    {
+        amrvis::PlotfileDataset dataset(
+            analyticRoot, amrvis::DatasetId{3}, 1024 * 1024);
+        amrvis::VolumeQuery query(dataset);
+        amrvis::VolumeSampleRequest request;
+        request.dataset.value = 3;
+        request.field.value = 0;
+        request.maximumLevel = 0;
+        request.region = box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0);
+
+        // Whole domain within budget: native 4x4x4, every voxel exact.
+        request.maximumVoxels = 64;
+        const auto native = query.execute(request);
+        require(native.grid.dims == (std::array<int, 3>{4, 4, 4}),
+            "the native grid is not one voxel per cell");
+        require(native.grid.values.size() == 64
+                && native.grid.coveredVoxels == 64
+                && native.grid.maximumLevel == 0
+                && native.grid.region == request.region,
+            "the native grid's shape or coverage is wrong");
+        require(native.metrics.candidateBlocks == 1
+                && native.metrics.blocksRead == 1
+                && native.metrics.cacheHits == 0,
+            "the single block was not read exactly once");
+        for (int k = 0; k < 4; ++k) {
+            for (int j = 0; j < 4; ++j) {
+                for (int i = 0; i < 4; ++i) {
+                    const auto expected
+                        = static_cast<float>(static_cast<double>(i + j + k) / 9.0);
+                    require(native.grid.values[voxel(native.grid, i, j, k)]
+                            == expected,
+                        "a native voxel does not carry its cell's value");
+                }
+            }
+        }
+        // A second execute hits the cache.
+        const auto again = query.execute(request);
+        require(again.metrics.cacheHits == 1 && again.metrics.blocksRead == 0
+                && again.grid.values == native.grid.values,
+            "the second sample did not come from the block cache");
+
+        // Over budget: 4^3 = 64 into a budget of 8 -> 2x2x2, each voxel the
+        // cell that contains its centre (0.25 -> cell 1, 0.75 -> cell 3).
+        request.maximumVoxels = 8;
+        const auto coarse = query.execute(request);
+        require(coarse.grid.dims == (std::array<int, 3>{2, 2, 2})
+                && coarse.grid.coveredVoxels == 8,
+            "the budget did not scale the grid down uniformly");
+        for (int k = 0; k < 2; ++k) {
+            for (int j = 0; j < 2; ++j) {
+                for (int i = 0; i < 2; ++i) {
+                    const auto cell = [](int index) { return index == 0 ? 1 : 3; };
+                    const auto expected = static_cast<float>(
+                        static_cast<double>(cell(i) + cell(j) + cell(k)) / 9.0);
+                    require(coarse.grid.values[voxel(coarse.grid, i, j, k)]
+                            == expected,
+                        "a downsampled voxel is not the cell under its centre");
+                }
+            }
+        }
+        // A budget of 1 collapses to a single voxel: the centre cell (2,2,2).
+        request.maximumVoxels = 1;
+        const auto single = query.execute(request);
+        require(single.grid.dims == (std::array<int, 3>{1, 1, 1})
+                && single.grid.values[0] == static_cast<float>(6.0 / 9.0),
+            "a one-voxel grid is not the centre cell");
+
+        // A sub-region: [0.5,1] x [0,1] x [0.25,0.75] at native pitch is
+        // 2 x 4 x 2 voxels over cells i=2..3, j=0..3, k=1..2.
+        request.maximumVoxels = 4096;
+        request.region = box(0.5, 0.0, 0.25, 1.0, 1.0, 0.75);
+        const auto sub = query.execute(request);
+        require(sub.grid.dims == (std::array<int, 3>{2, 4, 2})
+                && sub.grid.coveredVoxels == 16,
+            "the sub-region grid has the wrong shape");
+        for (int k = 0; k < 2; ++k) {
+            for (int j = 0; j < 4; ++j) {
+                for (int i = 0; i < 2; ++i) {
+                    const auto expected = static_cast<float>(
+                        static_cast<double>((i + 2) + j + (k + 1)) / 9.0);
+                    require(sub.grid.values[voxel(sub.grid, i, j, k)] == expected,
+                        "a sub-region voxel does not carry its cell's value");
+                }
+            }
+        }
+        // volumeGridDims agrees with what execute produced, and is pure.
+        require(amrvis::volumeGridDims(dataset.metadata(), request.region, 0, 4096)
+                    == sub.grid.dims
+                && amrvis::volumeGridDims(dataset.metadata(),
+                       box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0), 0, 8)
+                    == (std::array<int, 3>{2, 2, 2}),
+            "volumeGridDims disagrees with the sampled grid");
+
+        // Refusals: a region outside the domain, a bad field, a foreign
+        // dataset id, and a cancelled token.
+        bool threw = false;
+        try {
+            request.region = box(0.5, 0.0, 0.0, 1.5, 1.0, 1.0);
+            (void)query.execute(request);
+        } catch (const std::invalid_argument&) {
+            threw = true;
+        }
+        require(threw, "a region outside the domain was accepted");
+        threw = false;
+        try {
+            request.region = box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0);
+            request.field.value = 5;
+            (void)query.execute(request);
+        } catch (const std::invalid_argument&) {
+            threw = true;
+        }
+        require(threw, "an unknown field was accepted");
+        request.field.value = 0;
+        threw = false;
+        try {
+            request.dataset.value = 4;
+            (void)query.execute(request);
+        } catch (const std::invalid_argument&) {
+            threw = true;
+        }
+        require(threw, "a foreign dataset id was accepted");
+        request.dataset.value = 3;
+        amrvis::StopSource stop;
+        stop.request_stop();
+        threw = false;
+        try {
+            (void)query.execute(request, stop.get_token());
+        } catch (const amrvis::ReadCancelled&) {
+            threw = true;
+        }
+        require(threw, "a cancelled sample did not throw ReadCancelled");
+    }
+
+    // --- two levels: composition ------------------------------------------
+    {
+        amrvis::PlotfileDataset dataset(
+            twoLevelRoot, amrvis::DatasetId{5}, 1024 * 1024);
+        amrvis::VolumeQuery query(dataset);
+        amrvis::VolumeSampleRequest request;
+        request.dataset.value = 5;
+        request.field.value = 0;
+        request.region = box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0);
+        request.maximumVoxels = 4096;
+
+        // Finest available up to level 1: an 8^3 grid, 2.0 under the fine
+        // block (level-1 cells 2..5 on every axis), 1.0 elsewhere.
+        request.maximumLevel = 1;
+        const auto composite = query.execute(request);
+        require(composite.grid.dims == (std::array<int, 3>{8, 8, 8})
+                && composite.grid.coveredVoxels == 512
+                && composite.grid.maximumLevel == 1
+                && composite.metrics.candidateBlocks == 2
+                && composite.metrics.blocksRead == 2,
+            "the two-level composite has the wrong shape or reads");
+        for (int k = 0; k < 8; ++k) {
+            for (int j = 0; j < 8; ++j) {
+                for (int i = 0; i < 8; ++i) {
+                    const bool fine = i >= 2 && i <= 5 && j >= 2 && j <= 5
+                        && k >= 2 && k <= 5;
+                    require(composite.grid.values[voxel(composite.grid, i, j, k)]
+                            == (fine ? 2.0F : 1.0F),
+                        "the fine level did not overwrite exactly its own cells");
+                }
+            }
+        }
+        // ExactLevel 1: only the fine block; the rest uncovered (NaN).
+        request.composition = amrvis::CompositionPolicy::ExactLevel;
+        const auto exact = query.execute(request);
+        require(exact.grid.dims == (std::array<int, 3>{8, 8, 8})
+                && exact.grid.coveredVoxels == 64
+                && exact.metrics.candidateBlocks == 1,
+            "ExactLevel did not restrict the sample to the fine level");
+        for (int k = 0; k < 8; ++k) {
+            for (int j = 0; j < 8; ++j) {
+                for (int i = 0; i < 8; ++i) {
+                    const bool fine = i >= 2 && i <= 5 && j >= 2 && j <= 5
+                        && k >= 2 && k <= 5;
+                    const auto value = exact.grid.values[voxel(exact.grid, i, j, k)];
+                    require(fine ? value == 2.0F : std::isnan(value),
+                        "ExactLevel left the wrong voxels covered");
+                }
+            }
+        }
+        // Maximum level 0: the coarse grid alone, 4^3 of 1.0.
+        request.composition = amrvis::CompositionPolicy::FinestAvailable;
+        request.maximumLevel = 0;
+        const auto coarseOnly = query.execute(request);
+        require(coarseOnly.grid.dims == (std::array<int, 3>{4, 4, 4})
+                && coarseOnly.grid.coveredVoxels == 64
+                && coarseOnly.grid.maximumLevel == 0
+                && coarseOnly.metrics.candidateBlocks == 1,
+            "a coarser maximum level still read the fine block");
+        for (const auto value : coarseOnly.grid.values) {
+            require(value == 1.0F, "the coarse-only grid is not uniformly coarse");
+        }
+        // A budget below the fine resolution: 2^3 with centres at 0.25 and
+        // 0.75. The fine block spans [0.25, 0.75): the centre 0.25 is its
+        // first cell (fine cell 2) and reads 2.0, while 0.75 is the coarse
+        // cell past its edge and reads 1.0 -- fine still overwrites coarse
+        // at whatever pitch the budget allows, and only where it exists.
+        request.maximumLevel = 1;
+        request.maximumVoxels = 8;
+        const auto budgeted = query.execute(request);
+        require(budgeted.grid.dims == (std::array<int, 3>{2, 2, 2})
+                && budgeted.grid.coveredVoxels == 8,
+            "the budgeted composite has the wrong shape");
+        for (int k = 0; k < 2; ++k) {
+            for (int j = 0; j < 2; ++j) {
+                for (int i = 0; i < 2; ++i) {
+                    const bool fine = i == 0 && j == 0 && k == 0;
+                    require(budgeted.grid.values[voxel(budgeted.grid, i, j, k)]
+                            == (fine ? 2.0F : 1.0F),
+                        "a budgeted voxel did not read the level under its centre");
+                }
+            }
+        }
+    }
+
+    std::error_code removeError;
+    std::filesystem::remove_all(scratch, removeError);
+    return 0;
+}

--- a/tests/integration/test_volume_query.cpp
+++ b/tests/integration/test_volume_query.cpp
@@ -125,6 +125,79 @@ std::filesystem::path writeTwoLevelFixture(const std::filesystem::path& root)
     return root;
 }
 
+// Two blocks over 16 x 1 x 1 cells of dx = 0.1, split at i = 12: block 0
+// (x < 1.2) is 1.0, block 1 is 2.0. The seam is the point of the fixture --
+// 0.1 and 1.2 are not exact in binary, so a voxel centre that lands on the
+// boundary exposes any rounding the block window does.
+std::filesystem::path writeSeamFixture(const std::filesystem::path& root)
+{
+    std::filesystem::create_directories(root / "Level_0");
+    writeText(root / "Header",
+        "HyperCLaw-V1.1\n"
+        "1\nq\n"
+        "3\n0.0\n0\n"
+        "0.0 0.0 0.0\n1.6 0.1 0.1\n\n"
+        "((0,0,0) (15,0,0) (0,0,0))\n"
+        "0\n"
+        "0.1 0.1 0.1\n"
+        "0\n0\n"
+        "0 2 0.0\n0\n"
+        "0.0 1.2\n0.0 0.1\n0.0 0.1\n"
+        "1.2 1.6\n0.0 0.1\n0.0 0.1\n"
+        "Level_0/Cell\n");
+    writeText(root / "Level_0" / "Cell_H",
+        "1\n1\n1\n0\n"
+        "(2 0\n((0,0,0) (11,0,0) (0,0,0))\n((12,0,0) (15,0,0) (0,0,0))\n)\n"
+        "2\nFabOnDisk: Cell_D_00000 0\nFabOnDisk: Cell_D_00001 0\n\n"
+        "2,1\n1.0,\n2.0,\n\n2,1\n1.0,\n2.0,\n\n");
+    const std::vector<double> lower(12, 1.0);
+    const std::vector<double> upper(4, 2.0);
+    writeFab(root / "Level_0" / "Cell_D_00000", "((0,0,0) (11,0,0) (0,0,0))",
+        lower);
+    writeFab(root / "Level_0" / "Cell_D_00001", "((12,0,0) (15,0,0) (0,0,0))",
+        upper);
+    return root;
+}
+
+// 4^3 cells of dx = 0.25 whose index domain starts at -2, over [-0.5,0.5]^3.
+// Cell (i,j,k) holds i + 10*j + 100*k, so a voxel that silently fell back to
+// another cell is visible in the value. One cell carries 1e300, which no
+// float can hold.
+std::filesystem::path writeNegativeIndexFixture(const std::filesystem::path& root)
+{
+    std::filesystem::create_directories(root / "Level_0");
+    writeText(root / "Header",
+        "HyperCLaw-V1.1\n"
+        "1\nq\n"
+        "3\n0.0\n0\n"
+        "-0.5 -0.5 -0.5\n0.5 0.5 0.5\n\n"
+        "((-2,-2,-2) (1,1,1) (0,0,0))\n"
+        "0\n"
+        "0.25 0.25 0.25\n"
+        "0\n0\n"
+        "0 1 0.0\n0\n"
+        "-0.5 0.5\n-0.5 0.5\n-0.5 0.5\n"
+        "Level_0/Cell\n");
+    writeText(root / "Level_0" / "Cell_H",
+        "1\n1\n1\n0\n"
+        "(1 0\n((-2,-2,-2) (1,1,1) (0,0,0))\n)\n"
+        "1\nFabOnDisk: Cell_D_00000 0\n\n"
+        "1,1\n-222.0,\n\n1,1\n1e300,\n\n");
+    std::vector<double> values;
+    for (int k = -2; k <= 1; ++k) {
+        for (int j = -2; j <= 1; ++j) {
+            for (int i = -2; i <= 1; ++i) {
+                values.push_back(i == 1 && j == 1 && k == 1
+                    ? 1.0e300
+                    : static_cast<double>(i + 10 * j + 100 * k));
+            }
+        }
+    }
+    writeFab(root / "Level_0" / "Cell_D_00000", "((-2,-2,-2) (1,1,1) (0,0,0))",
+        values);
+    return root;
+}
+
 std::size_t voxel(const amrvis::VolumeGrid& grid, int i, int j, int k)
 {
     return static_cast<std::size_t>(i)
@@ -369,6 +442,109 @@ int main()
                 }
             }
         }
+    }
+
+    // --- a voxel centre on a block seam ----------------------------------
+    {
+        const auto seamRoot = writeSeamFixture(scratch / "seam");
+        amrvis::PlotfileDataset dataset(
+            seamRoot, amrvis::DatasetId{5}, 1024 * 1024);
+        amrvis::VolumeQuery query(dataset);
+        amrvis::VolumeSampleRequest request;
+        request.dataset.value = 5;
+        request.field.value = 0;
+        request.maximumLevel = 0;
+        request.region = box(0.0, 0.0, 0.0, 1.6, 0.1, 0.1);
+        request.maximumVoxels = 2;
+
+        // Voxel 1's centre is 1.5 * (1.6/2), which rounds to a hair above 1.2
+        // and so belongs to cell 12 -- the upper block's first cell. Inverting
+        // the centre formula puts it a hair outside that block's window, so a
+        // window that trusts its own arithmetic paints neither block here and
+        // leaves a hole in data that has none.
+        const auto grid = query.execute(request).grid;
+        require(grid.dims == (std::array<int, 3>{2, 1, 1}),
+            "the seam grid has the wrong shape");
+        require(grid.coveredVoxels == 2,
+            "a voxel on the block seam was left uncovered");
+        require(grid.values[0] == 1.0F && grid.values[1] == 2.0F,
+            "a seam voxel read the wrong block");
+    }
+
+    // --- a level whose index domain starts below zero ---------------------
+    {
+        const auto negativeRoot = writeNegativeIndexFixture(scratch / "negative");
+        amrvis::PlotfileDataset dataset(
+            negativeRoot, amrvis::DatasetId{6}, 1024 * 1024);
+        amrvis::VolumeQuery query(dataset);
+        amrvis::VolumeSampleRequest request;
+        request.dataset.value = 6;
+        request.field.value = 0;
+        request.maximumLevel = 0;
+        request.region = box(-0.5, -0.5, -0.5, 0.5, 0.5, 0.5);
+        request.maximumVoxels = 64;
+
+        // Negative cell indices are ordinary indices: all 64 voxels are
+        // covered, and each reads the cell its centre falls in rather than
+        // being mistaken for a miss.
+        const auto grid = query.execute(request).grid;
+        require(grid.dims == (std::array<int, 3>{4, 4, 4}),
+            "the negative-index grid has the wrong shape");
+        require(grid.coveredVoxels == 63,
+            "the negative-index grid covered the wrong number of voxels");
+        for (int k = 0; k < 4; ++k) {
+            for (int j = 0; j < 4; ++j) {
+                for (int i = 0; i < 4; ++i) {
+                    if (i == 3 && j == 3 && k == 3) {
+                        continue;
+                    }
+                    const auto expected = static_cast<float>(
+                        (i - 2) + 10 * (j - 2) + 100 * (k - 2));
+                    require(grid.values[voxel(grid, i, j, k)] == expected,
+                        "a voxel over a negative index read the wrong cell");
+                }
+            }
+        }
+
+        // 1e300 is finite as a double but has no float to round to, and the
+        // grid promises NaN for anything it cannot hold.
+        require(std::isnan(grid.values[voxel(grid, 3, 3, 3)]),
+            "a value outside float's range was not reported as uncovered");
+    }
+
+    // --- the budget holds for a level too large to multiply out -----------
+    {
+        // Each axis may spend the whole budget -- a thin region legitimately
+        // does -- so three of them can overflow the product that the budget
+        // test and the buffer size are both taken from.
+        amrvis::DatasetMetadata metadata;
+        metadata.dimension = 3;
+        metadata.finestLevel = 0;
+        metadata.physicalDomain = box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0);
+        amrvis::LevelMetadata level;
+        level.domain.lower = {{0, 0, 0}};
+        level.domain.upper = {{(1 << 27) - 1, (1 << 27) - 1, (1 << 27) - 1}};
+        level.cellSize = {{1.0 / (1 << 27), 1.0 / (1 << 27), 1.0 / (1 << 27)}};
+        metadata.levels.push_back(level);
+
+        const auto budget = static_cast<std::uint64_t>(
+            amrvis::maxVolumeVoxelBudget);
+        const auto dims = amrvis::volumeGridDims(
+            metadata, metadata.physicalDomain, 0, budget);
+        const auto product = static_cast<double>(dims[0])
+            * static_cast<double>(dims[1]) * static_cast<double>(dims[2]);
+        require(product <= static_cast<double>(budget),
+            "an oversized level was returned over the voxel budget");
+        // And it still spends the budget: shrinking by the true ratio keeps
+        // the cube a cube, where shrinking by the saturated one collapses it.
+        require(dims == (std::array<int, 3>{512, 512, 512}),
+            "an oversized level did not scale by its true ratio");
+
+        // A thin region still gets the whole budget on its one long axis.
+        const auto thin = amrvis::volumeGridDims(metadata,
+            box(0.0, 0.0, 0.0, 1.0, 1.0 / (1 << 27), 1.0 / (1 << 27)), 0, 64);
+        require(thin == (std::array<int, 3>{64, 1, 1}),
+            "a thin region did not spend its budget on the long axis");
     }
 
     std::error_code removeError;

--- a/tests/integration/test_volume_query.cpp
+++ b/tests/integration/test_volume_query.cpp
@@ -300,6 +300,43 @@ std::filesystem::path writeFarFromOriginFixture(const std::filesystem::path& roo
     return root;
 }
 
+// The far-from-origin domain again, at dx = 0.008 and split so the second
+// grid holds only cells 14 and 15. The planner's query box decides whether
+// that grid is ever looked at: nudging the region's upper edge inward by one
+// ulp -- close to two cells wide out here -- ends the box at cell 13 and
+// drops the grid entirely, so the voxels over it come back NaN and it is
+// never read. Two cells is the thinnest such grid that has a representable
+// physical extent at this distance.
+std::filesystem::path writeLastCellFixture(const std::filesystem::path& root)
+{
+    std::filesystem::create_directories(root / "Level_0");
+    writeText(root / "Header",
+        "HyperCLaw-V1.1\n"
+        "1\nq\n"
+        "3\n0.0\n0\n"
+        "1e14 0.0 0.0\n100000000000000.128 0.008 0.008\n\n"
+        "((0,0,0) (15,0,0) (0,0,0))\n"
+        "0\n"
+        "0.008 0.008 0.008\n"
+        "0\n0\n"
+        "0 2 0.0\n0\n"
+        "1e14 100000000000000.112\n0.0 0.008\n0.0 0.008\n"
+        "100000000000000.112 100000000000000.128\n0.0 0.008\n0.0 0.008\n"
+        "Level_0/Cell\n");
+    writeText(root / "Level_0" / "Cell_H",
+        "1\n1\n1\n0\n"
+        "(2 0\n((0,0,0) (13,0,0) (0,0,0))\n((14,0,0) (15,0,0) (0,0,0))\n)\n"
+        "2\nFabOnDisk: Cell_D_00000 0\nFabOnDisk: Cell_D_00001 0\n\n"
+        "2,1\n1.0,\n2.0,\n\n2,1\n1.0,\n2.0,\n\n");
+    const std::vector<double> body(14, 1.0);
+    const std::vector<double> tail(2, 2.0);
+    writeFab(root / "Level_0" / "Cell_D_00000", "((0,0,0) (13,0,0) (0,0,0))",
+        body);
+    writeFab(root / "Level_0" / "Cell_D_00001", "((14,0,0) (15,0,0) (0,0,0))",
+        tail);
+    return root;
+}
+
 // A 2 x 2 2-D plotfile, which the sampler must refuse rather than invent a
 // third axis for.
 std::filesystem::path writeTwoDimensionalFixture(const std::filesystem::path& root)
@@ -897,9 +934,9 @@ int main()
             "the cache-pressure budget was loose enough to pin both blocks");
 
         // A block holding no voxel centre is never read. At one voxel the
-        // only centre is x = 0.4, which is grid 1's first cell, so grid 0 is
-        // a candidate that costs nothing -- the point of settling the range
-        // before the read rather than after it.
+        // only centre is x = 0.4, which is grid 1's first cell; planning
+        // from the centres rather than the region puts grid 0 outside the
+        // query box entirely, so it is not even a candidate.
         amrvis::PlotfileDataset counted(
             pairRoot, amrvis::DatasetId{15}, 1024 * 1024);
         amrvis::VolumeQuery countedQuery(counted);
@@ -909,8 +946,8 @@ int main()
         require(coarse.grid.dims == (std::array<int, 3>{1, 1, 1})
                 && coarse.grid.values[0] == 2.0F,
             "the one-voxel grid read the wrong grid");
-        require(coarse.metrics.candidateBlocks == 2,
-            "both grids should have been candidates");
+        require(coarse.metrics.candidateBlocks == 1,
+            "a grid with no voxel centre in it was still a candidate");
         require(coarse.metrics.blocksRead == 1,
             "a grid with no voxel centre in it was read anyway");
     }
@@ -1109,6 +1146,43 @@ int main()
             require(grid.values[static_cast<std::size_t>(i)]
                     == (cell < 8 ? 1.0F : 2.0F),
                 "a far-from-origin voxel read the wrong grid");
+        }
+    }
+
+    // --- a grid holding only the last sampled cell ------------------------
+    {
+        // The last voxel's centre lands in cell 15, in a grid that starts at
+        // cell 14. Planning from the region instead of from the centres ends
+        // the query box at cell 13 -- the nudge is close to two cells wide
+        // out here -- so that grid is never even a candidate.
+        const auto lastRoot = writeLastCellFixture(scratch / "last-cell");
+        amrvis::PlotfileDataset dataset(
+            lastRoot, amrvis::DatasetId{19}, 1024 * 1024);
+        amrvis::VolumeQuery query(dataset);
+        amrvis::VolumeSampleRequest request;
+        request.dataset.value = 19;
+        request.field.value = 0;
+        request.maximumLevel = 0;
+        request.region = dataset.metadata().physicalDomain;
+        request.maximumVoxels = 16;
+
+        const auto result = query.execute(request);
+        const auto& grid = result.grid;
+        require(grid.dims == (std::array<int, 3>{16, 1, 1}),
+            "the last-cell grid has the wrong shape");
+        require(grid.coveredVoxels == 16,
+            "the voxel over the last cell was left uncovered");
+        require(result.metrics.candidateBlocks == 2,
+            "the grid holding the last cell was never a candidate");
+        const auto& level = dataset.metadata().levels[0];
+        for (int i = 0; i < 16; ++i) {
+            const auto centre = request.region.lower[0]
+                + (static_cast<double>(i) + 0.5)
+                    * (request.region.upper[0] - request.region.lower[0])
+                    / 16.0;
+            require(grid.values[static_cast<std::size_t>(i)]
+                    == (amrvis::sampleIndex(level, 0, centre) < 14 ? 1.0F : 2.0F),
+                "a voxel read the wrong grid near the last cell");
         }
     }
 

--- a/tests/integration/test_volume_query.cpp
+++ b/tests/integration/test_volume_query.cpp
@@ -866,12 +866,13 @@ int main()
 
         // This is the case where it is not: 4 x 4 x 1 native at budget 7
         // scales by cbrt(7/16) = 0.759 to 3 x 3 x 1, whose product is 9 --
-        // still over. Only the trim loop lands it, and it takes the first
-        // largest axis, so the answer is 2 x 3 x 1 rather than 3 x 2 x 1.
+        // still over. Only the water-fill lands it: a cap of 2 gives 4, and
+        // the voxel it then gives back goes to the first axis the cap
+        // shortened, so the answer is 3 x 2 x 1 and spends 6 of the 7.
         require(amrvis::volumeGridDims(
                     metadata, box(0.0, 0.0, 0.0, 1.0, 1.0, 0.25), 0, 7)
-                == (std::array<int, 3>{2, 3, 1}),
-            "the trim loop did not land an over-budget grid");
+                == (std::array<int, 3>{3, 2, 1}),
+            "the water-fill did not land an over-budget grid");
     }
 
     // --- one block pinned at a time --------------------------------------
@@ -1214,6 +1215,26 @@ int main()
         require(amrvis::volumeGridDims(metadata, metadata.physicalDomain, 0, 512)
                 == (std::array<int, 3>{512, 1, 1}),
             "a long thin region did not spend its voxel budget");
+
+        // And it does not walk there. A region reaching far past the domain
+        // arrives at the fitting step hundreds of millions of voxels over,
+        // because the scaling floors its two short axes to one; taking that
+        // off a voxel at a time cost the better part of a second in a call
+        // a server makes before it has validated anything. The budget here
+        // is the cap, so a per-voxel walk would be ~4e8 iterations.
+        metadata.physicalDomain = box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0);
+        metadata.levels[0].domain.upper = {{999, 999, 999}};
+        metadata.levels[0].cellSize = {{1.0e-3, 1.0e-3, 1.0e-3}};
+        const auto started = std::chrono::steady_clock::now();
+        const auto far = amrvis::volumeGridDims(metadata,
+            box(0.0, 0.0, 0.0, 1.0e6, 1.0e-3, 1.0e-3), 0,
+            amrvis::maxVolumeVoxelBudget);
+        const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::steady_clock::now() - started).count();
+        require(far == (std::array<int, 3>{134217728, 1, 1}),
+            "the far thin region did not fill its budget on the long axis");
+        require(elapsed < 100,
+            "sizing a far thin region took long enough to be a CPU sink");
     }
 
     std::error_code removeError;

--- a/tests/integration/test_volume_query.cpp
+++ b/tests/integration/test_volume_query.cpp
@@ -265,6 +265,41 @@ std::filesystem::path writePairFixture(const std::filesystem::path& root)
     return root;
 }
 
+// 16 x 1 x 1 cells of dx = 0.01 whose domain sits at x = 1e14, split into
+// two grids at cell 8. At that distance ulp is 0.015625 -- more than a cell
+// -- so a block window derived by inverting the voxel-centre formula is off
+// by whole voxels, beyond any fixed widening. The domain still spans ten
+// representable values, so the plotfile itself remains well formed.
+std::filesystem::path writeFarFromOriginFixture(const std::filesystem::path& root)
+{
+    std::filesystem::create_directories(root / "Level_0");
+    writeText(root / "Header",
+        "HyperCLaw-V1.1\n"
+        "1\nq\n"
+        "3\n0.0\n0\n"
+        "1e14 0.0 0.0\n100000000000000.16 0.01 0.01\n\n"
+        "((0,0,0) (15,0,0) (0,0,0))\n"
+        "0\n"
+        "0.01 0.01 0.01\n"
+        "0\n0\n"
+        "0 2 0.0\n0\n"
+        "1e14 100000000000000.08\n0.0 0.01\n0.0 0.01\n"
+        "100000000000000.08 100000000000000.16\n0.0 0.01\n0.0 0.01\n"
+        "Level_0/Cell\n");
+    writeText(root / "Level_0" / "Cell_H",
+        "1\n1\n1\n0\n"
+        "(2 0\n((0,0,0) (7,0,0) (0,0,0))\n((8,0,0) (15,0,0) (0,0,0))\n)\n"
+        "2\nFabOnDisk: Cell_D_00000 0\nFabOnDisk: Cell_D_00001 0\n\n"
+        "2,1\n1.0,\n2.0,\n\n2,1\n1.0,\n2.0,\n\n");
+    const std::vector<double> lower(8, 1.0);
+    const std::vector<double> upper(8, 2.0);
+    writeFab(root / "Level_0" / "Cell_D_00000", "((0,0,0) (7,0,0) (0,0,0))",
+        lower);
+    writeFab(root / "Level_0" / "Cell_D_00001", "((8,0,0) (15,0,0) (0,0,0))",
+        upper);
+    return root;
+}
+
 // A 2 x 2 2-D plotfile, which the sampler must refuse rather than invent a
 // third axis for.
 std::filesystem::path writeTwoDimensionalFixture(const std::filesystem::path& root)
@@ -915,6 +950,18 @@ int main()
         request.region = box(0.25, 0.25, 0.25, 0.75, 0.75, 0.75);
         require(query.execute(request).grid.maximumLevel == 1,
             "maximumLevel missed the level that contributed");
+
+        // ExactLevel over a corner level 1 does not cover: level 1 is the
+        // only participating level and it paints nothing, so the grid is
+        // empty and names no level. Reporting the requested level here would
+        // claim fine data for a grid that has none at all.
+        request.composition = amrvis::CompositionPolicy::ExactLevel;
+        request.region = box(0.0, 0.0, 0.0, 0.25, 0.25, 0.25);
+        const auto exactCorner = query.execute(request).grid;
+        require(exactCorner.coveredVoxels == 0,
+            "the corner is not covered at level 1");
+        require(exactCorner.maximumLevel == 0,
+            "an empty grid named a level that contributed nothing");
     }
 
     // --- a voxel and a slice pixel agree on the same point ----------------
@@ -1008,6 +1055,77 @@ int main()
         }
         require(grid.maximumLevel == 0,
             "a level that wrote only NaN was reported as contributing");
+    }
+
+    // --- a domain far from the coordinate origin ---------------------------
+    {
+        // ulp(1e14) is 0.015625, more than a whole cell of 0.01, so a
+        // window derived by inverting the centre formula lands voxels wrong
+        // and leaves holes in data that has none. Bisecting on sampleIndex
+        // is exact however far out the domain sits.
+        const auto farRoot = writeFarFromOriginFixture(scratch / "far");
+        amrvis::PlotfileDataset dataset(
+            farRoot, amrvis::DatasetId{18}, 1024 * 1024);
+        amrvis::VolumeQuery query(dataset);
+        amrvis::VolumeSampleRequest request;
+        request.dataset.value = 18;
+        request.field.value = 0;
+        request.maximumLevel = 0;
+        request.region = dataset.metadata().physicalDomain;
+        request.maximumVoxels = 16;
+
+        const auto grid = query.execute(request).grid;
+        require(grid.dims == (std::array<int, 3>{16, 1, 1}),
+            "the far-from-origin grid has the wrong shape");
+        // The point of the case: no voxel is dropped. At this distance
+        // several voxel centres quantise onto the same coordinate, so the
+        // voxel-to-cell map is not the identity -- which is exactly why the
+        // expected value is taken from sampleIndex rather than from i.
+        require(grid.coveredVoxels == 16,
+            "voxels were lost in a domain far from the origin");
+        const auto& level = dataset.metadata().levels[0];
+        for (int i = 0; i < 16; ++i) {
+            const auto centre = request.region.lower[0]
+                + (static_cast<double>(i) + 0.5)
+                    * (request.region.upper[0] - request.region.lower[0])
+                    / 16.0;
+            const auto cell = amrvis::sampleIndex(level, 0, centre);
+            require(cell >= 0 && cell <= 15,
+                "a far-from-origin voxel centre left the domain");
+            require(grid.values[static_cast<std::size_t>(i)]
+                    == (cell < 8 ? 1.0F : 2.0F),
+                "a far-from-origin voxel read the wrong grid");
+        }
+    }
+
+    // --- a thin region spends the budget it was given ---------------------
+    {
+        // Capping each axis at the budget before the cbrt shrinks an already
+        // truncated axis a second time, so a pencil-thin region ends up with
+        // a fraction of what it was allowed. The documented formula is the
+        // native counts scaled by cbrt(budget / product) and trimmed.
+        amrvis::DatasetMetadata metadata;
+        metadata.dimension = 3;
+        metadata.finestLevel = 0;
+        metadata.physicalDomain = box(0.0, 0.0, 0.0, 200.0, 3.0, 3.0);
+        amrvis::LevelMetadata level;
+        level.domain.lower = {{0, 0, 0}};
+        level.domain.upper = {{199, 2, 2}};
+        level.cellSize = {{1.0, 1.0, 1.0}};
+        metadata.levels.push_back(level);
+
+        // 200 x 3 x 3 native at budget 64: cbrt(64/1800) = 0.329 gives
+        // 65 x 1 x 1, which the trim lands at 64 x 1 x 1 -- the whole budget
+        // on the axis that has the cells for it.
+        require(amrvis::volumeGridDims(metadata, metadata.physicalDomain, 0, 64)
+                == (std::array<int, 3>{64, 1, 1}),
+            "a thin region did not spend its voxel budget");
+
+        metadata.physicalDomain = box(0.0, 0.0, 0.0, 10000.0, 2.0, 2.0);
+        metadata.levels[0].domain.upper = {{9999, 1, 1}};
+        require(amrvis::volumeGridDims(metadata, metadata.physicalDomain, 0, 512)
+                == (std::array<int, 3>{512, 1, 1}),
+            "a long thin region did not spend its voxel budget");
     }
 
     std::error_code removeError;

--- a/tests/integration/test_volume_query.cpp
+++ b/tests/integration/test_volume_query.cpp
@@ -304,6 +304,23 @@ bool rejects(amrvis::VolumeQuery& query,
     return false;
 }
 
+// The two-level fixture with the fine level holding 1e300, which no float
+// can store: level 1 covers those voxels but puts nothing showable in them.
+std::filesystem::path writeNanFineFixture(const std::filesystem::path& root)
+{
+    writeTwoLevelFixture(root);
+    writeText(root / "Level_1" / "Cell_H",
+        "1\n1\n1\n0\n"
+        "(1 0\n((2,2,2) (5,5,5) (0,0,0))\n)\n"
+        "1\nFabOnDisk: Cell_D_00000 0\n\n"
+        "1,1\n1e300,\n\n1,1\n1e300,\n\n");
+    std::array<double, 64> fine{};
+    fine.fill(1.0e300);
+    writeFab(root / "Level_1" / "Cell_D_00000", "((2,2,2) (5,5,5) (0,0,0))",
+        fine);
+    return root;
+}
+
 std::size_t voxel(const amrvis::VolumeGrid& grid, int i, int j, int k)
 {
     return static_cast<std::size_t>(i)
@@ -641,10 +658,9 @@ int main()
             * static_cast<double>(dims[1]) * static_cast<double>(dims[2]);
         require(product <= static_cast<double>(budget),
             "an oversized level was returned over the voxel budget");
-        // And it still spends the budget: shrinking by the true ratio keeps
-        // the cube a cube, where shrinking by the saturated one collapses it.
+        // And it still spends the budget.
         require(dims == (std::array<int, 3>{512, 512, 512}),
-            "an oversized level did not scale by its true ratio");
+            "an oversized level did not spend its budget");
 
         // A budget past the cap buys no more than the cap: a server sizes an
         // inbound request with this before it has validated the budget, so
@@ -654,6 +670,21 @@ int main()
                     std::numeric_limits<std::uint64_t>::max())
                 == (std::array<int, 3>{512, 512, 512}),
             "an unchecked budget was not clamped to the cap");
+
+        // A cube cannot tell the two ratios apart -- the trim loop drives
+        // any overshoot back to equal axes -- so the aspect is what shows
+        // that the scale came from the true product and not the saturated
+        // one. 2^27 x 2^26 x 2^25 keeps its 4:2:1 at cbrt(2^-51) = 2^-17;
+        // scaling by the saturated ratio instead overshoots to
+        // 26010 x 13005 x 6502 and the trim loop equalises it to a cube.
+        amrvis::DatasetMetadata skewed = metadata;
+        skewed.levels[0].domain.upper
+            = {{(1 << 27) - 1, (1 << 26) - 1, (1 << 25) - 1}};
+        skewed.levels[0].cellSize = {{1.0 / (1 << 27), 1.0 / (1 << 26),
+            1.0 / (1 << 25)}};
+        require(amrvis::volumeGridDims(skewed, skewed.physicalDomain, 0, budget)
+                == (std::array<int, 3>{1024, 512, 256}),
+            "an oversized level did not scale by its true ratio");
 
         // A thin region still gets the whole budget on its one long axis.
         const auto thin = amrvis::volumeGridDims(metadata,
@@ -741,18 +772,20 @@ int main()
                 "a malformed region produced a grid over budget");
         }
 
-        // A non-cubic region over budget: the cbrt scale alone leaves the
-        // product over, so the trim loop is what lands it. 4 x 4 x 4 native,
-        // budget 10 -> cbrt(10/64) = 0.54 -> 2 x 2 x 2 = 8.
+        // The cbrt scale alone is usually enough -- 4 x 4 x 4 at budget 10
+        // scales by 0.539 straight to 2 x 2 x 2 = 8, no trimming.
         require(amrvis::volumeGridDims(metadata, whole, 0, 10)
                 == (std::array<int, 3>{2, 2, 2}),
-            "an over-budget region was not trimmed to fit");
-        const auto slab = amrvis::volumeGridDims(
-            metadata, box(0.0, 0.0, 0.0, 1.0, 0.25, 0.25), 0, 3);
-        require(static_cast<std::uint64_t>(slab[0]) * static_cast<std::uint64_t>(slab[1])
-                    * static_cast<std::uint64_t>(slab[2])
-                <= 3,
-            "a non-cubic over-budget region was not trimmed to fit");
+            "an over-budget region was not scaled to fit");
+
+        // This is the case where it is not: 4 x 4 x 1 native at budget 7
+        // scales by cbrt(7/16) = 0.759 to 3 x 3 x 1, whose product is 9 --
+        // still over. Only the trim loop lands it, and it takes the first
+        // largest axis, so the answer is 2 x 3 x 1 rather than 3 x 2 x 1.
+        require(amrvis::volumeGridDims(
+                    metadata, box(0.0, 0.0, 0.0, 1.0, 1.0, 0.25), 0, 7)
+                == (std::array<int, 3>{2, 3, 1}),
+            "the trim loop did not land an over-budget grid");
     }
 
     // --- one block pinned at a time --------------------------------------
@@ -937,6 +970,44 @@ int main()
                 }
             }
         }
+    }
+
+    // --- a level that writes only NaN contributed nothing ------------------
+    {
+        // Level 1 holds 1e300 throughout, so every voxel it covers lands in
+        // the grid as NaN -- indistinguishable from a voxel no level
+        // covered. It overwrote level 0 without putting anything showable
+        // in its place, so the finest level that contributed is 0.
+        const auto lostRoot = writeNanFineFixture(scratch / "nan-fine");
+        amrvis::PlotfileDataset dataset(
+            lostRoot, amrvis::DatasetId{17}, 1024 * 1024);
+        amrvis::VolumeQuery query(dataset);
+        amrvis::VolumeSampleRequest request;
+        request.dataset.value = 17;
+        request.field.value = 0;
+        request.maximumLevel = 1;
+        request.region = box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0);
+        request.maximumVoxels = 64;
+        const auto grid = query.execute(request).grid;
+        require(grid.dims == (std::array<int, 3>{4, 4, 4}),
+            "the NaN-fine grid has the wrong shape");
+        // Voxel centres are 0.125, 0.375, 0.625, 0.875; the fine level spans
+        // [0.25, 0.75], so the middle two on each axis fall inside it.
+        require(grid.coveredVoxels == 64 - 8,
+            "the fine level's 1e300 cells were not reported as uncovered");
+        for (int k = 0; k < 4; ++k) {
+            for (int j = 0; j < 4; ++j) {
+                for (int i = 0; i < 4; ++i) {
+                    const auto inner = i >= 1 && i <= 2 && j >= 1 && j <= 2
+                        && k >= 1 && k <= 2;
+                    const auto value = grid.values[voxel(grid, i, j, k)];
+                    require(inner ? std::isnan(value) : value == 1.0F,
+                        "a voxel under the NaN-only fine level is wrong");
+                }
+            }
+        }
+        require(grid.maximumLevel == 0,
+            "a level that wrote only NaN was reported as contributing");
     }
 
     std::error_code removeError;

--- a/tests/integration/test_volume_query.cpp
+++ b/tests/integration/test_volume_query.cpp
@@ -757,12 +757,12 @@ int main()
                 == (std::array<int, 3>{512, 512, 512}),
             "an unchecked budget was not clamped to the cap");
 
-        // A cube cannot tell the two ratios apart -- the trim loop drives
+        // A cube cannot tell the two ratios apart -- the fitting step drives
         // any overshoot back to equal axes -- so the aspect is what shows
         // that the scale came from the true product and not the saturated
         // one. 2^27 x 2^26 x 2^25 keeps its 4:2:1 at cbrt(2^-51) = 2^-17;
         // scaling by the saturated ratio instead overshoots to
-        // 26010 x 13005 x 6502 and the trim loop equalises it to a cube.
+        // 26010 x 13005 x 6502 and the fitting step equalises it to a cube.
         amrvis::DatasetMetadata skewed = metadata;
         skewed.levels[0].domain.upper
             = {{(1 << 27) - 1, (1 << 26) - 1, (1 << 25) - 1}};
@@ -1204,7 +1204,7 @@ int main()
         metadata.levels.push_back(level);
 
         // 200 x 3 x 3 native at budget 64: cbrt(64/1800) = 0.329 gives
-        // 65 x 1 x 1, which the trim lands at 64 x 1 x 1 -- the whole budget
+        // 65 x 1 x 1, which the fitting step lands at 64 x 1 x 1 -- the budget
         // on the axis that has the cells for it.
         require(amrvis::volumeGridDims(metadata, metadata.physicalDomain, 0, 64)
                 == (std::array<int, 3>{64, 1, 1}),
@@ -1220,21 +1220,62 @@ int main()
         // arrives at the fitting step hundreds of millions of voxels over,
         // because the scaling floors its two short axes to one; taking that
         // off a voxel at a time cost the better part of a second in a call
-        // a server makes before it has validated anything. The budget here
-        // is the cap, so a per-voxel walk would be ~4e8 iterations.
+        // a server makes before it has validated anything.
+        //
+        // Timed over a thousand calls rather than one. A single call is well
+        // under a microsecond and the walk it guards against is ~440 ms, so
+        // the bound has a factor of a million of room on both sides and no
+        // one scheduler stall on a shared runner can trip it.
         metadata.physicalDomain = box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0);
         metadata.levels[0].domain.upper = {{999, 999, 999}};
         metadata.levels[0].cellSize = {{1.0e-3, 1.0e-3, 1.0e-3}};
+        const auto farRegion = box(0.0, 0.0, 0.0, 1.0e6, 1.0e-3, 1.0e-3);
+        auto far = std::array<int, 3>{0, 0, 0};
         const auto started = std::chrono::steady_clock::now();
-        const auto far = amrvis::volumeGridDims(metadata,
-            box(0.0, 0.0, 0.0, 1.0e6, 1.0e-3, 1.0e-3), 0,
-            amrvis::maxVolumeVoxelBudget);
+        for (int repeat = 0; repeat < 1000; ++repeat) {
+            far = amrvis::volumeGridDims(
+                metadata, farRegion, 0, amrvis::maxVolumeVoxelBudget);
+        }
         const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
             std::chrono::steady_clock::now() - started).count();
         require(far == (std::array<int, 3>{134217728, 1, 1}),
             "the far thin region did not fill its budget on the long axis");
-        require(elapsed < 100,
+        require(elapsed < 1000,
             "sizing a far thin region took long enough to be a CPU sink");
+
+        // The invariants over the whole fitting block, including the shapes
+        // where two axes each take a voxel back rather than one.
+        for (const auto& shape : {std::array<int, 3>{5, 5, 5},
+                 std::array<int, 3>{7, 5, 3}, std::array<int, 3>{9, 9, 2},
+                 std::array<int, 3>{31, 4, 4}, std::array<int, 3>{6, 6, 1},
+                 std::array<int, 3>{2, 2, 2}, std::array<int, 3>{17, 1, 1}}) {
+            amrvis::DatasetMetadata shaped;
+            shaped.dimension = 3;
+            shaped.finestLevel = 0;
+            shaped.physicalDomain = box(0.0, 0.0, 0.0,
+                static_cast<double>(shape[0]), static_cast<double>(shape[1]),
+                static_cast<double>(shape[2]));
+            amrvis::LevelMetadata shapedLevel;
+            shapedLevel.domain.lower = {{0, 0, 0}};
+            shapedLevel.domain.upper = {{shape[0] - 1, shape[1] - 1, shape[2] - 1}};
+            shapedLevel.cellSize = {{1.0, 1.0, 1.0}};
+            shaped.levels.push_back(shapedLevel);
+            for (std::uint64_t allowed = 1; allowed <= 200; ++allowed) {
+                const auto fitted = amrvis::volumeGridDims(
+                    shaped, shaped.physicalDomain, 0, allowed);
+                for (std::size_t axis = 0; axis < 3; ++axis) {
+                    require(fitted[axis] >= 1,
+                        "the fitting step produced an empty axis");
+                    require(fitted[axis] <= shape[axis],
+                        "the fitting step gave an axis more voxels than cells");
+                }
+                require(static_cast<std::uint64_t>(fitted[0])
+                            * static_cast<std::uint64_t>(fitted[1])
+                            * static_cast<std::uint64_t>(fitted[2])
+                        <= allowed,
+                    "the fitting step returned a grid over its budget");
+            }
+        }
     }
 
     std::error_code removeError;

--- a/tests/integration/test_volume_query.cpp
+++ b/tests/integration/test_volume_query.cpp
@@ -198,6 +198,112 @@ std::filesystem::path writeNegativeIndexFixture(const std::filesystem::path& roo
     return root;
 }
 
+// One level of 4 x 1 x 1 cells over [0,1] whose two grids overlap on cells
+// 1 and 2 -- malformed, but the composition has to resolve it the way the
+// slice's first match does, so the lowest grid index wins.
+std::filesystem::path writeOverlapFixture(const std::filesystem::path& root)
+{
+    std::filesystem::create_directories(root / "Level_0");
+    writeText(root / "Header",
+        "HyperCLaw-V1.1\n"
+        "1\nq\n"
+        "3\n0.0\n0\n"
+        "0.0 0.0 0.0\n1.0 0.25 0.25\n\n"
+        "((0,0,0) (3,0,0) (0,0,0))\n"
+        "0\n"
+        "0.25 0.25 0.25\n"
+        "0\n0\n"
+        "0 2 0.0\n0\n"
+        "0.0 0.75\n0.0 0.25\n0.0 0.25\n"
+        "0.25 1.0\n0.0 0.25\n0.0 0.25\n"
+        "Level_0/Cell\n");
+    writeText(root / "Level_0" / "Cell_H",
+        "1\n1\n1\n0\n"
+        "(2 0\n((0,0,0) (2,0,0) (0,0,0))\n((1,0,0) (3,0,0) (0,0,0))\n)\n"
+        "2\nFabOnDisk: Cell_D_00000 0\nFabOnDisk: Cell_D_00001 0\n\n"
+        "2,1\n1.0,\n2.0,\n\n2,1\n1.0,\n2.0,\n\n");
+    const std::vector<double> first(3, 1.0);
+    const std::vector<double> second(3, 2.0);
+    writeFab(root / "Level_0" / "Cell_D_00000", "((0,0,0) (2,0,0) (0,0,0))",
+        first);
+    writeFab(root / "Level_0" / "Cell_D_00001", "((1,0,0) (3,0,0) (0,0,0))",
+        second);
+    return root;
+}
+
+// 8 x 1 x 1 cells of dx = 0.1 split into two equal 4-cell grids, 1.0 then
+// 2.0. Equal on purpose: the cache charges a block its vector's capacity, so
+// only equal blocks let a test say "fits one of these but not both" without
+// knowing what that capacity came out as.
+std::filesystem::path writePairFixture(const std::filesystem::path& root)
+{
+    std::filesystem::create_directories(root / "Level_0");
+    writeText(root / "Header",
+        "HyperCLaw-V1.1\n"
+        "1\nq\n"
+        "3\n0.0\n0\n"
+        "0.0 0.0 0.0\n0.8 0.1 0.1\n\n"
+        "((0,0,0) (7,0,0) (0,0,0))\n"
+        "0\n"
+        "0.1 0.1 0.1\n"
+        "0\n0\n"
+        "0 2 0.0\n0\n"
+        "0.0 0.4\n0.0 0.1\n0.0 0.1\n"
+        "0.4 0.8\n0.0 0.1\n0.0 0.1\n"
+        "Level_0/Cell\n");
+    writeText(root / "Level_0" / "Cell_H",
+        "1\n1\n1\n0\n"
+        "(2 0\n((0,0,0) (3,0,0) (0,0,0))\n((4,0,0) (7,0,0) (0,0,0))\n)\n"
+        "2\nFabOnDisk: Cell_D_00000 0\nFabOnDisk: Cell_D_00001 0\n\n"
+        "2,1\n1.0,\n2.0,\n\n2,1\n1.0,\n2.0,\n\n");
+    const std::vector<double> first(4, 1.0);
+    const std::vector<double> second(4, 2.0);
+    writeFab(root / "Level_0" / "Cell_D_00000", "((0,0,0) (3,0,0) (0,0,0))",
+        first);
+    writeFab(root / "Level_0" / "Cell_D_00001", "((4,0,0) (7,0,0) (0,0,0))",
+        second);
+    return root;
+}
+
+// A 2 x 2 2-D plotfile, which the sampler must refuse rather than invent a
+// third axis for.
+std::filesystem::path writeTwoDimensionalFixture(const std::filesystem::path& root)
+{
+    std::filesystem::create_directories(root / "Level_0");
+    writeText(root / "Header",
+        "HyperCLaw-V1.1\n"
+        "1\nq\n"
+        "2\n0.0\n0\n"
+        "0.0 0.0\n1.0 1.0\n\n"
+        "((0,0) (1,1) (0,0))\n"
+        "0\n"
+        "0.5 0.5\n"
+        "0\n0\n"
+        "0 1 0.0\n0\n"
+        "0.0 1.0\n0.0 1.0\n"
+        "Level_0/Cell\n");
+    writeText(root / "Level_0" / "Cell_H",
+        "1\n1\n1\n0\n"
+        "(1 0\n((0,0) (1,1) (0,0))\n)\n"
+        "1\nFabOnDisk: Cell_D_00000 0\n\n"
+        "1,1\n0.0,\n\n1,1\n3.0,\n\n");
+    const std::vector<double> values{0.0, 1.0, 2.0, 3.0};
+    writeFab(root / "Level_0" / "Cell_D_00000", "((0,0) (1,1) (0,0))", values);
+    return root;
+}
+
+// True when execute refuses `request` outright.
+bool rejects(amrvis::VolumeQuery& query,
+    const amrvis::VolumeSampleRequest& request)
+{
+    try {
+        (void)query.execute(request);
+    } catch (const std::invalid_argument&) {
+        return true;
+    }
+    return false;
+}
+
 std::size_t voxel(const amrvis::VolumeGrid& grid, int i, int j, int k)
 {
     return static_cast<std::size_t>(i)
@@ -540,11 +646,297 @@ int main()
         require(dims == (std::array<int, 3>{512, 512, 512}),
             "an oversized level did not scale by its true ratio");
 
+        // A budget past the cap buys no more than the cap: a server sizes an
+        // inbound request with this before it has validated the budget, so
+        // an unchecked one must not be able to ask for a bigger grid than
+        // the sampler would ever allocate.
+        require(amrvis::volumeGridDims(metadata, metadata.physicalDomain, 0,
+                    std::numeric_limits<std::uint64_t>::max())
+                == (std::array<int, 3>{512, 512, 512}),
+            "an unchecked budget was not clamped to the cap");
+
         // A thin region still gets the whole budget on its one long axis.
         const auto thin = amrvis::volumeGridDims(metadata,
             box(0.0, 0.0, 0.0, 1.0, 1.0 / (1 << 27), 1.0 / (1 << 27)), 0, 64);
         require(thin == (std::array<int, 3>{64, 1, 1}),
             "a thin region did not spend its budget on the long axis");
+    }
+
+    // --- every refusal ----------------------------------------------------
+    {
+        amrvis::PlotfileDataset dataset(
+            analyticRoot, amrvis::DatasetId{7}, 1024 * 1024);
+        amrvis::VolumeQuery query(dataset);
+        amrvis::VolumeSampleRequest good;
+        good.dataset.value = 7;
+        good.field.value = 0;
+        good.maximumLevel = 0;
+        good.region = box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0);
+        good.maximumVoxels = 64;
+        require(!rejects(query, good), "a valid request was refused");
+
+        auto request = good;
+        request.maximumVoxels = 0;
+        require(rejects(query, request), "a zero voxel budget was accepted");
+        request.maximumVoxels = amrvis::maxVolumeVoxelBudget + 1;
+        require(rejects(query, request),
+            "a voxel budget past the cap was accepted");
+
+        request = good;
+        request.maximumLevel = -1;
+        require(rejects(query, request), "a negative maximum level was accepted");
+
+        request = good;
+        request.component = 1;
+        require(rejects(query, request), "a vector component was accepted");
+
+        request = good;
+        request.region = box(1.0, 0.0, 0.0, 0.0, 1.0, 1.0);
+        require(rejects(query, request), "an inverted region was accepted");
+
+        // A 2-D dataset has no volume to sample.
+        const auto flatRoot = writeTwoDimensionalFixture(scratch / "flat");
+        amrvis::PlotfileDataset flat(flatRoot, amrvis::DatasetId{8}, 1024 * 1024);
+        amrvis::VolumeQuery flatQuery(flat);
+        auto flatRequest = good;
+        flatRequest.dataset.value = 8;
+        require(rejects(flatQuery, flatRequest), "a 2-D dataset was accepted");
+
+        // And the pure sizer gives the third axis one voxel rather than
+        // measuring the region against the synthetic unit cell size a 2-D
+        // level carries: 4 / 1.0 would otherwise read as four voxels deep.
+        require(amrvis::volumeGridDims(flat.metadata(),
+                    box(0.0, 0.0, 0.0, 1.0, 1.0, 4.0), 0, 64)
+                == (std::array<int, 3>{2, 2, 1}),
+            "the pure sizer invented a third dimension for a 2-D dataset");
+    }
+
+    // --- volumeGridDims is total -----------------------------------------
+    {
+        amrvis::PlotfileDataset dataset(
+            analyticRoot, amrvis::DatasetId{9}, 1024 * 1024);
+        const auto& metadata = dataset.metadata();
+        const auto whole = box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0);
+
+        // A NaN axis has no cell count to round to, and clamp cannot reject
+        // it -- both of its comparisons are false -- so the conversion would
+        // be undefined. It costs that axis one voxel and leaves the others
+        // alone; converting the NaN instead poisons the whole product.
+        const auto nan = std::numeric_limits<double>::quiet_NaN();
+        require(amrvis::volumeGridDims(metadata,
+                    box(0.0, 0.0, 0.0, nan, 1.0, 1.0), 0, 64)
+                == (std::array<int, 3>{1, 4, 4}),
+            "a NaN on one axis was not confined to that axis");
+
+        for (const auto& bad : {box(0.0, 0.0, 0.0, nan, 1.0, 1.0),
+                 box(nan, nan, nan, nan, nan, nan),
+                 box(1.0, 1.0, 1.0, 0.0, 0.0, 0.0),
+                 box(0.0, 0.0, 0.0, 0.0, 0.0, 0.0)}) {
+            const auto dims = amrvis::volumeGridDims(metadata, bad, 0, 64);
+            require(dims[0] >= 1 && dims[1] >= 1 && dims[2] >= 1,
+                "a malformed region produced a degenerate grid");
+            require(static_cast<double>(dims[0]) * static_cast<double>(dims[1])
+                        * static_cast<double>(dims[2])
+                    <= 64.0,
+                "a malformed region produced a grid over budget");
+        }
+
+        // A non-cubic region over budget: the cbrt scale alone leaves the
+        // product over, so the trim loop is what lands it. 4 x 4 x 4 native,
+        // budget 10 -> cbrt(10/64) = 0.54 -> 2 x 2 x 2 = 8.
+        require(amrvis::volumeGridDims(metadata, whole, 0, 10)
+                == (std::array<int, 3>{2, 2, 2}),
+            "an over-budget region was not trimmed to fit");
+        const auto slab = amrvis::volumeGridDims(
+            metadata, box(0.0, 0.0, 0.0, 1.0, 0.25, 0.25), 0, 3);
+        require(static_cast<std::uint64_t>(slab[0]) * static_cast<std::uint64_t>(slab[1])
+                    * static_cast<std::uint64_t>(slab[2])
+                <= 3,
+            "a non-cubic over-budget region was not trimmed to fit");
+    }
+
+    // --- one block pinned at a time --------------------------------------
+    {
+        const auto pairRoot = writePairFixture(scratch / "pair");
+        amrvis::VolumeSampleRequest request;
+        request.field.value = 0;
+        request.maximumLevel = 0;
+        request.region = box(0.0, 0.0, 0.0, 0.8, 0.1, 0.1);
+        request.maximumVoxels = 8;
+
+        // What both blocks cost the cache, measured rather than assumed.
+        std::uint64_t bothBytes = 0;
+        {
+            amrvis::PlotfileDataset roomy(
+                pairRoot, amrvis::DatasetId{10}, 1024 * 1024);
+            amrvis::VolumeQuery query(roomy);
+            request.dataset.value = 10;
+            (void)query.execute(request);
+            bothBytes = roomy.cacheMetrics().residentBytes;
+        }
+        require(bothBytes > 0, "the pair fixture left nothing in the cache");
+
+        // Three quarters of that holds either block on its own but never
+        // both, so a query that pinned the level instead of one block at a
+        // time would throw CacheBudgetExceeded here. Painting block by block
+        // is what the design exists for; this is the test of it.
+        amrvis::PlotfileDataset tight(
+            pairRoot, amrvis::DatasetId{11}, bothBytes * 3 / 4);
+        amrvis::VolumeQuery query(tight);
+        request.dataset.value = 11;
+        const auto grid = query.execute(request).grid;
+        require(grid.dims == (std::array<int, 3>{8, 1, 1}),
+            "the cache-pressure grid has the wrong shape");
+        require(grid.coveredVoxels == 8,
+            "a block was lost under cache pressure");
+        for (std::size_t i = 0; i < 8; ++i) {
+            require(grid.values[i] == (i < 4 ? 1.0F : 2.0F),
+                "a voxel read the wrong block under cache pressure");
+        }
+
+        // And the budget really was too tight for two: holding both pins at
+        // once throws, so the query above passed by not doing that.
+        auto blockRequest = [&](int gridIndex) {
+            amrvis::BlockRequest block;
+            block.dataset = request.dataset;
+            block.level = 0;
+            block.gridIndex = gridIndex;
+            block.field = request.field;
+            return block;
+        };
+        auto threwOnPin = false;
+        try {
+            const auto pinned = tight.requestBlock(blockRequest(0));
+            const auto second = tight.requestBlock(blockRequest(1));
+        } catch (const amrvis::CacheBudgetExceeded&) {
+            threwOnPin = true;
+        }
+        require(threwOnPin,
+            "the cache-pressure budget was loose enough to pin both blocks");
+
+        // A block holding no voxel centre is never read. At one voxel the
+        // only centre is x = 0.4, which is grid 1's first cell, so grid 0 is
+        // a candidate that costs nothing -- the point of settling the range
+        // before the read rather than after it.
+        amrvis::PlotfileDataset counted(
+            pairRoot, amrvis::DatasetId{15}, 1024 * 1024);
+        amrvis::VolumeQuery countedQuery(counted);
+        request.dataset.value = 15;
+        request.maximumVoxels = 1;
+        const auto coarse = countedQuery.execute(request);
+        require(coarse.grid.dims == (std::array<int, 3>{1, 1, 1})
+                && coarse.grid.values[0] == 2.0F,
+            "the one-voxel grid read the wrong grid");
+        require(coarse.metrics.candidateBlocks == 2,
+            "both grids should have been candidates");
+        require(coarse.metrics.blocksRead == 1,
+            "a grid with no voxel centre in it was read anyway");
+    }
+
+    // --- overlapping grids resolve to the lowest index --------------------
+    {
+        const auto overlapRoot = writeOverlapFixture(scratch / "overlap");
+        amrvis::PlotfileDataset dataset(
+            overlapRoot, amrvis::DatasetId{12}, 1024 * 1024);
+        amrvis::VolumeQuery query(dataset);
+        amrvis::VolumeSampleRequest request;
+        request.dataset.value = 12;
+        request.field.value = 0;
+        request.maximumLevel = 0;
+        request.region = box(0.0, 0.0, 0.0, 1.0, 0.25, 0.25);
+        request.maximumVoxels = 4;
+
+        const auto grid = query.execute(request).grid;
+        require(grid.dims == (std::array<int, 3>{4, 1, 1}),
+            "the overlap grid has the wrong shape");
+        // Cells 1 and 2 are in both grids; grid 0 wins, as the slice's first
+        // match does. Cell 3 is only in grid 1.
+        const std::array<float, 4> expected{1.0F, 1.0F, 1.0F, 2.0F};
+        for (std::size_t i = 0; i < 4; ++i) {
+            require(grid.values[i] == expected[i],
+                "an overlapped voxel did not resolve to the lowest grid index");
+        }
+    }
+
+    // --- maximumLevel reports what contributed ----------------------------
+    {
+        amrvis::PlotfileDataset dataset(
+            twoLevelRoot, amrvis::DatasetId{13}, 1024 * 1024);
+        amrvis::VolumeQuery query(dataset);
+        amrvis::VolumeSampleRequest request;
+        request.dataset.value = 13;
+        request.field.value = 0;
+        request.maximumLevel = 1;
+        request.maximumVoxels = 64;
+
+        // Level 1 covers only the central [0.25,0.75]^3, so a corner region
+        // is level-0 data however fine a level was asked for.
+        request.region = box(0.0, 0.0, 0.0, 0.25, 0.25, 0.25);
+        const auto corner = query.execute(request).grid;
+        require(corner.coveredVoxels == corner.values.size(),
+            "the corner region was not fully covered");
+        require(corner.maximumLevel == 0,
+            "maximumLevel reported a level that did not contribute");
+
+        // The centre does reach level 1.
+        request.region = box(0.25, 0.25, 0.25, 0.75, 0.75, 0.75);
+        require(query.execute(request).grid.maximumLevel == 1,
+            "maximumLevel missed the level that contributed");
+    }
+
+    // --- a voxel and a slice pixel agree on the same point ----------------
+    {
+        // Both resolve a sample position over the same region, so a budgeted
+        // voxel centre must land in the cell the slice reads at that point --
+        // the composition the header promises is "the same as a slice".
+        //
+        // The seam fixture at 14 voxels is the case that tells the two
+        // formulas apart: voxel 10's centre is 1.1999999999999999556 when the
+        // extent is divided last and 1.2000000000000001776 when it is
+        // pre-divided into a step, which is cell 11 in grid 0 against cell 12
+        // in grid 1 -- a different value, not just a different index.
+        const auto agreementRoot = writeSeamFixture(scratch / "agreement");
+        amrvis::PlotfileDataset dataset(
+            agreementRoot, amrvis::DatasetId{16}, 1024 * 1024);
+        amrvis::VolumeQuery query(dataset);
+        amrvis::VolumeSampleRequest request;
+        request.dataset.value = 16;
+        request.field.value = 0;
+        request.maximumLevel = 0;
+        request.region = box(0.0, 0.0, 0.0, 1.6, 0.1, 0.1);
+        request.maximumVoxels = 14;
+        const auto grid = query.execute(request).grid;
+        require(grid.dims == (std::array<int, 3>{14, 1, 1}),
+            "the agreement grid has the wrong shape");
+
+        amrvis::SliceQuery slice(dataset);
+        amrvis::SliceRequest sliceRequest;
+        sliceRequest.dataset.value = 16;
+        sliceRequest.field.value = 0;
+        sliceRequest.maximumLevel = 0;
+        sliceRequest.normalDirection = 2;
+        sliceRequest.sampling = amrvis::SamplingPolicy::PiecewiseConstant;
+        sliceRequest.outputSize = {grid.dims[0], grid.dims[1]};
+        sliceRequest.visibleRegion = request.region;
+        sliceRequest.maximumLevel = 0;
+        for (int k = 0; k < grid.dims[2]; ++k) {
+            sliceRequest.physicalPosition = request.region.lower[2]
+                + (static_cast<double>(k) + 0.5)
+                    * (request.region.upper[2] - request.region.lower[2])
+                    / static_cast<double>(grid.dims[2]);
+            const auto plane = slice.execute(sliceRequest).plane;
+            for (int j = 0; j < grid.dims[1]; ++j) {
+                for (int i = 0; i < grid.dims[0]; ++i) {
+                    const auto pixel = static_cast<std::size_t>(i)
+                        + static_cast<std::size_t>(grid.dims[0])
+                            * static_cast<std::size_t>(j);
+                    require(plane.valid[pixel] != 0,
+                        "the slice left a pixel the volume covered");
+                    require(plane.values[pixel] == grid.values[voxel(grid, i, j, k)],
+                        "a voxel and the slice pixel over it disagree");
+                }
+            }
+        }
     }
 
     std::error_code removeError;

--- a/tests/integration/test_volume_query.cpp
+++ b/tests/integration/test_volume_query.cpp
@@ -477,17 +477,31 @@ int main()
                     == (std::array<int, 3>{2, 2, 2}),
             "volumeGridDims disagrees with the sampled grid");
 
-        // Refusals: a region outside the domain, a bad field, a foreign
-        // dataset id, and a cancelled token.
-        bool threw = false;
-        try {
-            request.region = box(0.5, 0.0, 0.0, 1.5, 1.0, 1.0);
-            (void)query.execute(request);
-        } catch (const std::invalid_argument&) {
-            threw = true;
+        // A region reaching past the domain is sampled, not refused: the
+        // half that has data is painted and the half that does not comes
+        // back NaN, which is what a slice over the same region does. Region
+        // x spans [0.5, 1.5] at pitch 0.25, so the centres are 0.625, 0.875,
+        // 1.125 and 1.375 -- the first two in cells 2 and 3, the last two
+        // past the domain's cell 3.
+        request.region = box(0.5, 0.0, 0.0, 1.5, 1.0, 1.0);
+        request.maximumVoxels = 64;
+        const auto overhang = query.execute(request).grid;
+        require(overhang.dims == (std::array<int, 3>{4, 4, 4}),
+            "the overhanging grid has the wrong shape");
+        require(overhang.coveredVoxels == 32,
+            "an overhanging region did not cover exactly its inside half");
+        for (int k = 0; k < 4; ++k) {
+            for (int j = 0; j < 4; ++j) {
+                for (int i = 0; i < 4; ++i) {
+                    const auto value = overhang.values[voxel(overhang, i, j, k)];
+                    require(i < 2 ? !std::isnan(value) : std::isnan(value),
+                        "an overhanging voxel is on the wrong side of the edge");
+                }
+            }
         }
-        require(threw, "a region outside the domain was accepted");
-        threw = false;
+
+        // Refusals: a bad field, a foreign dataset id, and a cancelled token.
+        bool threw = false;
         try {
             request.region = box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0);
             request.field.value = 5;

--- a/tests/unit/test_block_lookup.cpp
+++ b/tests/unit/test_block_lookup.cpp
@@ -1,9 +1,11 @@
 #include <amrexplorer/query/detail/BlockLookup.hpp>
 
 #include <array>
+#include <cmath>
 #include <cstdint>
 #include <cstdlib>
 #include <iostream>
+#include <limits>
 #include <memory>
 #include <stdexcept>
 #include <utility>
@@ -532,6 +534,39 @@ int main()
         // And an inverted FAB header box, which cannot contain the catalog box.
         rejects("an inverted FAB header box was accepted",
             {second, pin(4, box2d(5, 1, 4, 0), {0.0})}, true);
+    }
+
+    // --- narrowToFloat overflows where the conversion does, not sooner ---
+    {
+        // A double above float's largest finite value still rounds down to
+        // it until the midpoint with 2^128; only from there does converting
+        // it overflow. Thresholding at the largest value instead would send
+        // that whole band to infinity, which is not what converting gives.
+        using amrvis::detail::floatOverflowThreshold;
+        using amrvis::detail::narrowToFloat;
+        constexpr auto largest = std::numeric_limits<float>::max();
+        constexpr auto largestAsDouble = static_cast<double>(largest);
+        require(largestAsDouble < floatOverflowThreshold,
+            "the overflow threshold is not above FLT_MAX");
+        for (const auto value : {largestAsDouble,
+                 std::nextafter(largestAsDouble, floatOverflowThreshold),
+                 std::nextafter(floatOverflowThreshold, 0.0)}) {
+            require(narrowToFloat(value) == largest,
+                "a double that rounds to FLT_MAX was reported as infinite");
+            require(narrowToFloat(-value) == -largest,
+                "a double that rounds to -FLT_MAX was reported as infinite");
+        }
+        require(std::isinf(narrowToFloat(floatOverflowThreshold))
+                && narrowToFloat(floatOverflowThreshold) > 0.0F,
+            "a double at the overflow threshold was not +infinity");
+        require(std::isinf(narrowToFloat(-floatOverflowThreshold))
+                && narrowToFloat(-floatOverflowThreshold) < 0.0F,
+            "a double at the negative threshold was not -infinity");
+        require(std::isnan(narrowToFloat(
+                    std::numeric_limits<double>::quiet_NaN())),
+            "a NaN did not survive narrowing");
+        require(narrowToFloat(1.5) == 1.5F && narrowToFloat(0.0) == 0.0F,
+            "an ordinary value did not narrow to itself");
     }
 
     std::cout << "block lookup tests passed\n";


### PR DESCRIPTION
The AMR levels are painted coarse to fine into a voxel grid sized by the finest requested level's native cells and a voxel budget, each block pinned only while its cells are copied into the voxels whose centres they contain -- the same finest-available composition a slice resolves per sample, without pinning every block of every level at once. NaN marks voxels no level covers. volumeGridDims is pure so a server can bound a request with it.