### PR TITLE
give sessions renderVolume, with a cached local implementation and a pipeline

### DIFF
--- a/include/amrexplorer/core/Statistics.hpp
+++ b/include/amrexplorer/core/Statistics.hpp
@@ -4,6 +4,7 @@
 #include <amrexplorer/core/Request.hpp>
 
 #include <optional>
+#include <utility>
 
 namespace amrvis {
 
@@ -16,5 +17,19 @@ struct ValueRange {
 [[nodiscard]] std::optional<ValueRange> metadataValueRange(
     const DatasetMetadata& metadata, FieldId field,
     std::optional<int> level = std::nullopt);
+
+// Widens a degenerate (minimum == maximum) range just enough to have positive
+// extent, leaving anything else alone. The padding is *relative* to the value:
+// a uniform plane of 1e-7 must not be padded to a range straddling zero, which
+// is what an absolute floor did, and which silently disqualified the plane from
+// logarithmic display. A strictly positive constant under a logarithmic range
+// is widened multiplicatively so it stays positive.
+//
+// One definition, because there were three: two in SliceRangeResolver and one
+// in DisplayCoordinator, and only two of them knew about logarithmic ranges.
+// It lives in core because the data layer resolves a volume's visible range
+// with it too.
+[[nodiscard]] std::pair<double, double> paddedIfDegenerate(
+    double minimum, double maximum, bool logarithmic) noexcept;
 
 } // namespace amrvis

--- a/include/amrexplorer/data/DatasetSession.hpp
+++ b/include/amrexplorer/data/DatasetSession.hpp
@@ -5,6 +5,7 @@
 #include <amrexplorer/core/Request.hpp>
 #include <amrexplorer/core/Statistics.hpp>
 #include <amrexplorer/core/StopToken.hpp>
+#include <amrexplorer/core/Volume.hpp>
 #include <amrexplorer/data/DatasetPage.hpp>
 #include <amrexplorer/data/ViewData.hpp>
 #include <amrexplorer/io/ParticleReader.hpp>
@@ -12,6 +13,7 @@
 
 #include <cstdint>
 #include <optional>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -60,6 +62,27 @@ public:
     [[nodiscard]] virtual ParticleSample requestParticleSample(
         const std::string& species, double fraction, std::uint64_t seed,
         StopToken cancellation = {}) = 0;
+
+    // Direct volume rendering of a 3-D field (core/Volume.hpp): the session
+    // samples the field into a bounded grid, caches it, and ray-casts it to a
+    // viewport-sized frame -- locally, or on the server for a remote session,
+    // which never receives the sampled field. Not every session can: a
+    // standalone FAB, a 2-D dataset, or a peer speaking an older protocol
+    // cannot, and supportsVolumeRendering says so before a request is built.
+    // The defaults keep every other implementation (and every test fake)
+    // untouched.
+    [[nodiscard]] virtual bool supportsVolumeRendering() const noexcept
+    {
+        return false;
+    }
+    [[nodiscard]] virtual VolumeFrame renderVolume(
+        const VolumeRenderRequest& request, StopToken cancellation = {})
+    {
+        static_cast<void>(request);
+        static_cast<void>(cancellation);
+        throw std::runtime_error(
+            "volume rendering is not supported by this session");
+    }
 
     [[nodiscard]] virtual CacheMetrics cacheMetrics() const = 0;
     [[nodiscard]] virtual bool setCacheBudget(std::uint64_t bytes) = 0;

--- a/include/amrexplorer/data/LocalDatasetSession.hpp
+++ b/include/amrexplorer/data/LocalDatasetSession.hpp
@@ -38,6 +38,17 @@ struct VolumeGridKeyHash {
     [[nodiscard]] std::size_t operator()(const VolumeGridKey& key) const noexcept;
 };
 
+// The range a volume's colours span when a request leaves it to the renderer
+// (the "Visible" range), resolved from the sampled grid: its finite extrema,
+// padded if degenerate, logarithmic only when every finite value allows it,
+// and a neutral range when the grid holds none. Declared here rather than
+// kept file-local because the remote session has to answer it the same way,
+// and because the rule -- which has to agree with the slice path's
+// resolveRange -- is worth pinning on its own. Scans the grid, so it throws
+// ReadCancelled when the token stops.
+[[nodiscard]] VolumeRange visibleVolumeRange(
+    const VolumeGrid& grid, bool logarithmic, StopToken cancellation = {});
+
 class LocalDatasetSession final : public DatasetSession {
 public:
     // The file version comes from the dataset's own metadata read; nothing
@@ -77,7 +88,9 @@ public:
     [[nodiscard]] VolumeFrame renderVolume(const VolumeRenderRequest& request,
         StopToken cancellation = {}) override;
     // The sampled-grid cache's budget; grids larger than it are rendered
-    // uncached. Returns false for a zero budget.
+    // uncached. Returns whether the cache fits the new budget, which a zero
+    // budget does (every unpinned grid is evicted and nothing is resident);
+    // it is false only while a pinned grid still exceeds it.
     [[nodiscard]] bool setVolumeGridCacheBudget(std::uint64_t bytes);
 
     [[nodiscard]] CacheMetrics cacheMetrics() const override;

--- a/include/amrexplorer/data/LocalDatasetSession.hpp
+++ b/include/amrexplorer/data/LocalDatasetSession.hpp
@@ -1,9 +1,13 @@
 #pragma once
 
+#include <amrexplorer/cache/ByteLruCache.hpp>
 #include <amrexplorer/data/DatasetSession.hpp>
 
+#include <array>
+#include <cstddef>
 #include <cstdint>
 #include <filesystem>
+#include <functional>
 #include <map>
 #include <memory>
 #include <mutex>
@@ -12,6 +16,27 @@
 namespace amrvis {
 
 class PlotfileDataset;
+
+// The sampled volume grids a local session keeps between renders (rotating
+// the camera re-casts a cached grid instead of re-reading the plotfile),
+// keyed by everything the sample depends on. The default budget holds four
+// grids of the default voxel budget.
+inline constexpr std::uint64_t defaultVolumeGridCacheBytes
+    = 256ULL * 1024ULL * 1024ULL;
+
+struct VolumeGridKey {
+    FieldId field;
+    int component = 0;
+    int maximumLevel = 0;
+    CompositionPolicy composition = CompositionPolicy::FinestAvailable;
+    RealBox region;
+    std::array<int, 3> dims{0, 0, 0};
+    friend bool operator==(const VolumeGridKey&, const VolumeGridKey&) = default;
+};
+
+struct VolumeGridKeyHash {
+    [[nodiscard]] std::size_t operator()(const VolumeGridKey& key) const noexcept;
+};
 
 class LocalDatasetSession final : public DatasetSession {
 public:
@@ -47,6 +72,14 @@ public:
         const std::string& species, double fraction, std::uint64_t seed,
         std::size_t maximumPoints, StopToken cancellation = {});
 
+    // A 3-D plotfile with physical geometry can be volume-rendered.
+    [[nodiscard]] bool supportsVolumeRendering() const noexcept override;
+    [[nodiscard]] VolumeFrame renderVolume(const VolumeRenderRequest& request,
+        StopToken cancellation = {}) override;
+    // The sampled-grid cache's budget; grids larger than it are rendered
+    // uncached. Returns false for a zero budget.
+    [[nodiscard]] bool setVolumeGridCacheBudget(std::uint64_t bytes);
+
     [[nodiscard]] CacheMetrics cacheMetrics() const override;
     [[nodiscard]] bool setCacheBudget(std::uint64_t bytes) override;
     void clearUnpinnedCache() override;
@@ -68,6 +101,8 @@ private:
     // finite values", which costs the same scan to discover. Cancelled scans
     // record nothing.
     std::map<std::uint32_t, std::optional<ValueRange>> m_fabRanges;
+    ByteLruCache<VolumeGridKey, VolumeGrid, VolumeGridKeyHash> m_volumeGrids{
+        defaultVolumeGridCacheBytes};
 };
 
 } // namespace amrvis

--- a/include/amrexplorer/data/LocalDatasetSession.hpp
+++ b/include/amrexplorer/data/LocalDatasetSession.hpp
@@ -93,6 +93,11 @@ public:
     // it is false only while a pinned grid still exceeds it.
     [[nodiscard]] bool setVolumeGridCacheBudget(std::uint64_t bytes);
 
+    // The sampled-grid pool on its own. cacheMetrics() reports the block
+    // pool, because CacheMetrics carries one budget and one hit rate and the
+    // remote snapshot asserts that budget is the one setCacheBudget was
+    // given; until it can carry both, this is how the grid pool is observed.
+    [[nodiscard]] CacheMetrics volumeGridCacheMetrics() const;
     [[nodiscard]] CacheMetrics cacheMetrics() const override;
     [[nodiscard]] bool setCacheBudget(std::uint64_t bytes) override;
     void clearUnpinnedCache() override;
@@ -116,6 +121,13 @@ private:
     std::map<std::uint32_t, std::optional<ValueRange>> m_fabRanges;
     ByteLruCache<VolumeGridKey, VolumeGrid, VolumeGridKeyHash> m_volumeGrids{
         defaultVolumeGridCacheBytes};
+    // The last Visible range and what it was resolved from. Resolving it
+    // walks every voxel, so a camera rotation -- which reuses the cached grid
+    // and asks the same question of it -- would otherwise rescan the whole
+    // grid before each cast. One entry is enough: the interactive case is the
+    // same key and mapping frame after frame.
+    std::optional<std::pair<VolumeGridKey, bool>> m_visibleRangeFor;
+    VolumeRange m_visibleRange;
 };
 
 } // namespace amrvis

--- a/include/amrexplorer/data/LocalDatasetSession.hpp
+++ b/include/amrexplorer/data/LocalDatasetSession.hpp
@@ -19,10 +19,7 @@ class PlotfileDataset;
 
 // The sampled volume grids a local session keeps between renders (rotating
 // the camera re-casts a cached grid instead of re-reading the plotfile),
-// keyed by everything the sample depends on. The default budget holds four
-// grids of the default voxel budget.
-inline constexpr std::uint64_t defaultVolumeGridCacheBytes
-    = 256ULL * 1024ULL * 1024ULL;
+// keyed by everything the sample depends on.
 
 struct VolumeGridKey {
     FieldId field;
@@ -119,8 +116,12 @@ private:
     // finite values", which costs the same scan to discover. Cancelled scans
     // record nothing.
     std::map<std::uint32_t, std::optional<ValueRange>> m_fabRanges;
-    ByteLruCache<VolumeGridKey, VolumeGrid, VolumeGridKeyHash> m_volumeGrids{
-        defaultVolumeGridCacheBytes};
+    // Seeded by the constructor from the budget the dataset was opened with,
+    // and kept in step by setCacheBudget. It starts empty rather than on a
+    // default of its own: a constant here would be overwritten before the
+    // cache was ever used, and would only mislead a reader about the budget
+    // that actually applies.
+    ByteLruCache<VolumeGridKey, VolumeGrid, VolumeGridKeyHash> m_volumeGrids{0};
     // The last Visible range and what it was resolved from. Resolving it
     // walks every voxel, so a camera rotation -- which reuses the cached grid
     // and asks the same question of it -- would otherwise rescan the whole

--- a/include/amrexplorer/data/SessionValidation.hpp
+++ b/include/amrexplorer/data/SessionValidation.hpp
@@ -16,6 +16,8 @@ void validateSessionRangeRequest(
 void validateSessionParticleRequest(const DatasetMetadata& metadata,
     const std::vector<ParticleSpeciesMetadata>& species,
     const std::string& name, double fraction);
+void validateSessionVolumeRequest(const DatasetMetadata& metadata,
+    DatasetId dataset, const VolumeRenderRequest& request);
 
 // Results, checked against the catalog they claim to describe. A local session
 // produces its results with our own query code and needs none of this; a remote
@@ -31,5 +33,9 @@ void validateSessionDatasetPageResult(const DatasetMetadata& metadata,
 void validateSessionParticleSampleResult(
     const std::vector<ParticleSpeciesMetadata>& species,
     const std::string& requested, const ParticleSample& sample);
+// A rendered frame: exactly the requested size, a range the request allows,
+// and sampling metrics the dataset and the request's budget could produce.
+void validateSessionVolumeResult(const DatasetMetadata& metadata,
+    const VolumeRenderRequest& request, const VolumeFrame& frame);
 
 } // namespace amrvis

--- a/include/amrexplorer/pipeline/SliceRangeResolver.hpp
+++ b/include/amrexplorer/pipeline/SliceRangeResolver.hpp
@@ -29,17 +29,8 @@ struct ResolvedRange {
     bool logarithmic;
 };
 
-// Widens a degenerate (minimum == maximum) range just enough to have positive
-// extent, leaving anything else alone. The padding is *relative* to the value:
-// a uniform plane of 1e-7 must not be padded to a range straddling zero, which
-// is what an absolute floor did, and which silently disqualified the plane from
-// logarithmic display. A strictly positive constant under a logarithmic range
-// is widened multiplicatively so it stays positive.
-//
-// One definition, because there were three: two in SliceRangeResolver and one
-// in DisplayCoordinator, and only two of them knew about logarithmic ranges.
-[[nodiscard]] std::pair<double, double> paddedIfDegenerate(
-    double minimum, double maximum, bool logarithmic) noexcept;
+// paddedIfDegenerate, once declared here, now lives in core/Statistics.hpp
+// (included above) so the data layer can pad a volume's visible range too.
 
 // Finite extrema of a plane, padded so minimum < maximum; nullopt when the
 // plane has no finite valid samples.

--- a/include/amrexplorer/pipeline/VolumePipeline.hpp
+++ b/include/amrexplorer/pipeline/VolumePipeline.hpp
@@ -58,6 +58,12 @@ struct OpacityRamp {
 // would be coloured, and its colour bar labelled, by a range no part of the
 // volume it drew came from. The slice path avoids this by resolving inside
 // its own retry loop.
+//
+// It follows a fallback the *session* made too, not only one the loop drove:
+// a remote server that renders coarser under its own cache pressure reports
+// the level it used, and the render is then repeated for that level so the
+// range belongs to the pixels. That costs an extra render on a path that
+// only runs under cache pressure.
 struct VolumeRangeChoice {
     RangeMode mode = RangeMode::Visible;
     std::optional<std::pair<double, double>> userRange;

--- a/include/amrexplorer/pipeline/VolumePipeline.hpp
+++ b/include/amrexplorer/pipeline/VolumePipeline.hpp
@@ -24,7 +24,9 @@ namespace amrvis {
 // [0, 1] of the range) that ramps linearly from transparent at the low
 // threshold to maximumOpacity at the high one -- or, with usePaletteAlpha
 // and a palette that carries an alpha ramp, the palette's own per-slot
-// opacity, windowed and scaled the same way.
+// opacity, windowed and scaled the same way. A window too narrow to hold
+// an entry (the thresholds may be equal) selects the one nearest it, at
+// full opacity.
 struct OpacityRamp {
     double lowThreshold = 0.0;
     double highThreshold = 1.0;

--- a/include/amrexplorer/pipeline/VolumePipeline.hpp
+++ b/include/amrexplorer/pipeline/VolumePipeline.hpp
@@ -74,7 +74,17 @@ inline constexpr std::uint64_t volumeResponseOverheadBytes = 4096;
     std::optional<std::uint32_t> maximumResponseBytes);
 
 struct VolumeDisplayResult {
-    VolumeRenderRequest request;   // as rendered, after any fallback
+    // As rendered, after any fallback -- its maximumLevel is the level the
+    // pixels came from, not the one asked for.
+    //
+    // Which means it is NOT the request to hand validateSessionVolumeResult.
+    // That validator checks a peer's frame against the request that was sent
+    // it, and derives the finest allowed level from request.maximumLevel; a
+    // frame reporting a fallback from 2 to 0 paired with this request (level
+    // 0) fails its `from > highest` test, because from is 2. The two carry
+    // the same name and mean different things: the validator wants the
+    // original, this is the outcome.
+    VolumeRenderRequest request;
     VolumeFrame frame;
 };
 

--- a/include/amrexplorer/pipeline/VolumePipeline.hpp
+++ b/include/amrexplorer/pipeline/VolumePipeline.hpp
@@ -51,6 +51,19 @@ struct OpacityRamp {
     const std::optional<std::pair<double, double>>& userRange,
     bool logarithmic, StopToken cancellation = {});
 
+// How the range is resolved, for the fallback path below. Passing this
+// rather than a pre-resolved request.range is what keeps a File or Level
+// range following the level a cache-pressure fallback actually rendered:
+// level 2's statistics are not level 0's, and a frame resolved once up front
+// would be coloured, and its colour bar labelled, by a range no part of the
+// volume it drew came from. The slice path avoids this by resolving inside
+// its own retry loop.
+struct VolumeRangeChoice {
+    RangeMode mode = RangeMode::Visible;
+    std::optional<std::pair<double, double>> userRange;
+    bool logarithmic = false;
+};
+
 // The bytes a rendered frame of this size costs on the wire, and the size
 // shrunk (uniformly, aspect kept) until that fits the session's response
 // budget; unchanged for a local session.
@@ -69,6 +82,15 @@ struct VolumeDisplayResult {
 // CacheBudgetExceeded from the block cache lowers the composite level and
 // retries (finest-available only), reporting the fallback in the frame; an
 // exact level or level 0 that cannot fit throws an actionable message.
+//
+// The second form re-resolves the range for every attempt and is the one to
+// use for a File or Level range; the first takes request.range as final and
+// is only correct for a range that does not depend on the level (a User
+// range, or none -- Visible is resolved by the renderer from the grid it
+// actually sampled, so it follows a fallback on its own).
+[[nodiscard]] VolumeDisplayResult executeVolumeRenderWithFallback(
+    const std::shared_ptr<DatasetSession>& dataset, VolumeRenderRequest request,
+    const VolumeRangeChoice& range, StopToken cancellation = {});
 [[nodiscard]] VolumeDisplayResult executeVolumeRenderWithFallback(
     const std::shared_ptr<DatasetSession>& dataset, VolumeRenderRequest request,
     StopToken cancellation = {});

--- a/include/amrexplorer/pipeline/VolumePipeline.hpp
+++ b/include/amrexplorer/pipeline/VolumePipeline.hpp
@@ -1,0 +1,74 @@
+#pragma once
+
+#include <amrexplorer/core/StopToken.hpp>
+#include <amrexplorer/core/Volume.hpp>
+#include <amrexplorer/data/DatasetSession.hpp>
+#include <amrexplorer/pipeline/SliceRangeResolver.hpp>
+#include <amrexplorer/render2d/Palette.hpp>
+
+#include <array>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <utility>
+
+namespace amrvis {
+
+// The GUI's side of volume rendering, the analogue of SlicePipeline: it
+// turns the palette and the opacity controls into the request's transfer
+// function, resolves the range the same way a slice would, keeps a remote
+// frame under the negotiated size, and retries a render that overran the
+// block cache at a coarser level. Qt-free.
+
+// The opacity controls: a window over the colour range (in normalised
+// [0, 1] of the range) that ramps linearly from transparent at the low
+// threshold to maximumOpacity at the high one -- or, with usePaletteAlpha
+// and a palette that carries an alpha ramp, the palette's own per-slot
+// opacity, windowed and scaled the same way.
+struct OpacityRamp {
+    double lowThreshold = 0.0;
+    double highThreshold = 1.0;
+    double maximumOpacity = 1.0;
+    bool usePaletteAlpha = false;
+    friend bool operator==(const OpacityRamp&, const OpacityRamp&) = default;
+};
+
+// One entry per palette data slot (Palette::colorSlots), so a value maps to
+// the same colour the slices and the colour bar show for it.
+[[nodiscard]] VolumeTransferFunction makeVolumeTransferFunction(
+    const Palette& palette, const OpacityRamp& ramp);
+
+// The range for the request: File/Level statistics or the User range,
+// padded if degenerate and downgraded from logarithmic when the range is
+// not strictly positive (as resolveDisplayRange does); nullopt for the
+// Visible mode, which the renderer resolves from the sampled grid itself
+// (a remote session's grid never leaves the server).
+[[nodiscard]] std::optional<VolumeRange> resolveVolumeRange(
+    const std::shared_ptr<DatasetSession>& dataset, FieldId field,
+    int maximumLevel, CompositionPolicy composition, RangeMode rangeMode,
+    const std::optional<std::pair<double, double>>& userRange,
+    bool logarithmic, StopToken cancellation = {});
+
+// The bytes a rendered frame of this size costs on the wire, and the size
+// shrunk (uniformly, aspect kept) until that fits the session's response
+// budget; unchanged for a local session.
+inline constexpr std::uint64_t volumeResponseOverheadBytes = 4096;
+[[nodiscard]] std::uint64_t volumeResponseBytes(std::array<int, 2> outputSize);
+[[nodiscard]] std::array<int, 2> frameBudgetBoundedVolumeSize(
+    std::array<int, 2> outputSize,
+    std::optional<std::uint32_t> maximumResponseBytes);
+
+struct VolumeDisplayResult {
+    VolumeRenderRequest request;   // as rendered, after any fallback
+    VolumeFrame frame;
+};
+
+// renderVolume with the slice pipeline's cache-pressure fallback: a
+// CacheBudgetExceeded from the block cache lowers the composite level and
+// retries (finest-available only), reporting the fallback in the frame; an
+// exact level or level 0 that cannot fit throws an actionable message.
+[[nodiscard]] VolumeDisplayResult executeVolumeRenderWithFallback(
+    const std::shared_ptr<DatasetSession>& dataset, VolumeRenderRequest request,
+    StopToken cancellation = {});
+
+} // namespace amrvis

--- a/include/amrexplorer/pipeline/VolumePipeline.hpp
+++ b/include/amrexplorer/pipeline/VolumePipeline.hpp
@@ -51,19 +51,26 @@ struct OpacityRamp {
     const std::optional<std::pair<double, double>>& userRange,
     bool logarithmic, StopToken cancellation = {});
 
-// How the range is resolved, for the fallback path below. Passing this
-// rather than a pre-resolved request.range is what keeps a File or Level
-// range following the level a cache-pressure fallback actually rendered:
-// level 2's statistics are not level 0's, and a frame resolved once up front
-// would be coloured, and its colour bar labelled, by a range no part of the
-// volume it drew came from. The slice path avoids this by resolving inside
-// its own retry loop.
+// How the range is resolved, for the fallback path below, which resolves it
+// afresh for whatever level each attempt is about to render.
 //
-// It follows a fallback the *session* made too, not only one the loop drove:
-// a remote server that renders coarser under its own cache pressure reports
-// the level it used, and the render is then repeated for that level so the
-// range belongs to the pixels. That costs an extra render on a path that
-// only runs under cache pressure.
+// This matters for one mode: RangeMode::Level, whose statistics are read per
+// level. Level 2's are not level 0's, so a range resolved once up front
+// would colour a fallen-back frame, and label its colour bar, with numbers no
+// part of the volume it drew came from. The slice path avoids the same trap
+// by resolving inside its own retry loop.
+//
+// The other modes do not move with the level and are never worth a repeat:
+// File asks metadataValueRange for the whole file and ignores the level
+// entirely, User is the caller's own pair, and Visible is resolved by the
+// renderer from the grid it actually sampled, so it follows a fallback on its
+// own.
+//
+// A fallback the *session* made counts as well as one the loop drove: a
+// remote server that renders coarser under its own cache pressure reports the
+// level it used, and that level is always carried into the result. For a
+// Level range the render is then repeated for it, so the range belongs to the
+// pixels -- an extra render, on a path that only runs under cache pressure.
 struct VolumeRangeChoice {
     RangeMode mode = RangeMode::Visible;
     std::optional<std::pair<double, double>> userRange;
@@ -99,11 +106,10 @@ struct VolumeDisplayResult {
 // retries (finest-available only), reporting the fallback in the frame; an
 // exact level or level 0 that cannot fit throws an actionable message.
 //
-// The second form re-resolves the range for every attempt and is the one to
-// use for a File or Level range; the first takes request.range as final and
-// is only correct for a range that does not depend on the level (a User
-// range, or none -- Visible is resolved by the renderer from the grid it
-// actually sampled, so it follows a fallback on its own).
+// The overload taking a VolumeRangeChoice resolves the range for each attempt
+// and is the one to use for a Level range. The overload without one takes
+// request.range as final, which is correct for every other mode -- see
+// VolumeRangeChoice above for why none of them moves with the level.
 [[nodiscard]] VolumeDisplayResult executeVolumeRenderWithFallback(
     const std::shared_ptr<DatasetSession>& dataset, VolumeRenderRequest request,
     const VolumeRangeChoice& range, StopToken cancellation = {});

--- a/src/core/Statistics.cpp
+++ b/src/core/Statistics.cpp
@@ -47,4 +47,39 @@ std::optional<ValueRange> metadataValueRange(
     return ValueRange{minimum, maximum};
 }
 
+std::pair<double, double> paddedIfDegenerate(
+    double minimum, double maximum, bool logarithmic) noexcept
+{
+    if (minimum != maximum) {
+        return {minimum, maximum};
+    }
+    if (logarithmic && minimum > 0.0) {
+        return {minimum / (1.0 + 1.0e-6), maximum * (1.0 + 1.0e-6)};
+    }
+    // Relative to the value, not an absolute floor. The old
+    // max(abs(minimum), 1.0) * 1e-6 padded a uniform plane of 1e-7 by 1e-6 --
+    // ten times the value itself, straddling zero, which then disqualified the
+    // plane from logarithmic display. A constant of 5.0 meanwhile stayed
+    // logarithmic, so the same control behaved differently on data that
+    // differed only in scale.
+    //
+    // The floor is the smallest padding that can still separate the two
+    // endpoints in double precision near this magnitude: one ulp is far too
+    // small to survive later arithmetic, so a relative 1e-6 is used with the
+    // smallest normal as a backstop.
+    //
+    // Zero has no magnitude to be relative to, and the backstop is the wrong
+    // answer there: a uniform plane of zeros -- an ordinary case, not a
+    // pathological one -- would get a range of +/-2.2e-308, which is what the
+    // color bar and the seeded User-range spin boxes then display. Fall back to
+    // the relative constant as an absolute, which is what this returned before
+    // the padding became relative.
+    constexpr auto relative = 1.0e-6;
+    const auto magnitude = std::abs(minimum);
+    const auto padding = magnitude > 0.0
+        ? std::max(magnitude * relative, std::numeric_limits<double>::min())
+        : relative;
+    return {minimum - padding, maximum + padding};
+}
+
 } // namespace amrvis

--- a/src/data/CMakeLists.txt
+++ b/src/data/CMakeLists.txt
@@ -17,6 +17,7 @@ target_link_libraries(amrexplorer_data
         amrexplorer::core
         amrexplorer::io
         amrexplorer::query
+        amrexplorer::render3d
     PRIVATE amrexplorer::warnings
 )
 target_compile_features(amrexplorer_data PUBLIC cxx_std_20)

--- a/src/data/LocalDatasetSession.cpp
+++ b/src/data/LocalDatasetSession.cpp
@@ -343,12 +343,14 @@ VolumeFrame LocalDatasetSession::renderVolume(
         try {
             handle = m_volumeGrids.insertAndPin(key, owned, bytes);
             grid = handle.value();
-            // A racing thread may have inserted this key first, in which case
-            // insertAndPin returns its grid and ours is discarded. The frame
-            // then describes a sample whose result nothing used, so it is
-            // reported as the cache hit it actually was.
+            // A racing thread may have inserted this key first, in which
+            // case insertAndPin returns its grid and ours is discarded. The
+            // grid rendered did come from the cache, so say so -- but the
+            // sampling and the payload reads above genuinely happened and
+            // cost what they cost, so those stay. Zeroing them would make the
+            // diagnostics understate the work the process actually did, which
+            // is the opposite error.
             if (grid != owned) {
-                metrics = VolumeRenderMetrics{};
                 metrics.gridFromCache = true;
             }
         } catch (const CacheBudgetExceeded&) {

--- a/src/data/LocalDatasetSession.cpp
+++ b/src/data/LocalDatasetSession.cpp
@@ -47,34 +47,36 @@ std::optional<ValueRange> compositeMetadataRange(const DatasetMetadata& metadata
     return ValueRange{minimum, maximum};
 }
 
-// The range a volume's colours span when the request leaves it to the
-// renderer (the "Visible" range): the sampled grid's finite extrema, padded
-// if degenerate, logarithmic only when the data allows it, and a neutral
-// range for a grid with no finite values -- resolveRange's rules for a
-// plane, applied to a grid.
-VolumeRange visibleVolumeRange(const VolumeGrid& grid, bool logarithmic)
+} // namespace
+
+VolumeRange visibleVolumeRange(const VolumeGrid& grid, bool logarithmic,
+    StopToken cancellation)
 {
-    if (logarithmic) {
-        if (const auto extrema = volumeGridRange(grid, true)) {
-            const auto [minimum, maximum]
-                = paddedIfDegenerate(extrema->first, extrema->second, true);
-            if (minimum < maximum && minimum > 0.0) {
-                return {minimum, maximum, true};
-            }
-        } else if (grid.coveredVoxels == 0) {
-            return {1.0, 10.0, true};
-        }
-    }
-    const auto extrema = volumeGridRange(grid, false);
+    // One scan, and over every finite value rather than the positive ones.
+    // Asking volumeGridRange for the positive extrema first would answer
+    // "logarithmic is fine" for any field that merely *contains* positive
+    // values, and every negative voxel would then map to nothing and vanish.
+    // The slice path decides it the other way round -- finiteRange keeps
+    // every finite value and a non-positive minimum makes resolveRange fall
+    // back to linear -- and the two views of one field have to agree.
+    const auto extrema = volumeGridRange(grid, false, cancellation);
     if (!extrema) {
-        return {0.0, 1.0, false};
+        // Nothing finite to show. A logarithmic request still wants a
+        // logarithmic axis, so the neutral range keeps the mapping.
+        return logarithmic ? VolumeRange{1.0, 10.0, true}
+                           : VolumeRange{0.0, 1.0, false};
+    }
+    if (logarithmic && extrema->first > 0.0) {
+        const auto [minimum, maximum]
+            = paddedIfDegenerate(extrema->first, extrema->second, true);
+        if (minimum > 0.0 && minimum < maximum) {
+            return {minimum, maximum, true};
+        }
     }
     const auto [minimum, maximum]
         = paddedIfDegenerate(extrema->first, extrema->second, false);
     return {minimum, maximum, false};
 }
-
-} // namespace
 
 std::size_t VolumeGridKeyHash::operator()(const VolumeGridKey& key) const noexcept
 {
@@ -285,11 +287,15 @@ VolumeFrame LocalDatasetSession::renderVolume(
     const VolumeRenderRequest& request, StopToken cancellation)
 {
     const auto dataset = requireDataset();
-    validateSessionVolumeRequest(m_metadata, m_id, request);
+    // Before the request is measured against the catalog: a dataset without
+    // physical geometry has index-space sample bounds, so a request checked
+    // first would fail on some incidental mismatch instead of saying that
+    // this dataset cannot be volume-rendered at all.
     if (!supportsVolumeRendering()) {
         throw std::invalid_argument(
             "volume rendering requires a 3-D plotfile with physical geometry");
     }
+    validateSessionVolumeRequest(m_metadata, m_id, request);
     const auto maximumLevel = std::min(request.maximumLevel, m_metadata.finestLevel);
     const VolumeGridKey key{request.field, request.component, maximumLevel,
         request.composition, request.region,
@@ -343,7 +349,8 @@ VolumeFrame LocalDatasetSession::renderVolume(
     settings.domain = datasetSampleBounds(m_metadata);
     settings.outputSize = request.outputSize;
     settings.range = request.range
-        ? *request.range : visibleVolumeRange(*grid, request.logarithmic);
+        ? *request.range
+        : visibleVolumeRange(*grid, request.logarithmic, cancellation);
     settings.transfer = request.transfer;
     settings.samplesPerVoxel = request.samplesPerVoxel;
     auto frame = raycastVolume(*grid, settings, cancellation);
@@ -363,12 +370,28 @@ bool LocalDatasetSession::setVolumeGridCacheBudget(std::uint64_t bytes)
 
 CacheMetrics LocalDatasetSession::cacheMetrics() const
 {
+    // The block cache only. The sampled-grid cache is a second pool with its
+    // own hit rate and its own budget, and CacheMetrics has one of each --
+    // summing them would report a budget nobody set (the remote snapshot
+    // asserts the number it was given) and a hit rate over two caches that
+    // measure different things. What setCacheBudget below does guarantee is
+    // that neither pool exceeds the configured budget; reporting both needs
+    // a metrics shape that can hold two, which is a change of its own.
     return requireDataset()->cacheMetrics();
 }
 
 bool LocalDatasetSession::setCacheBudget(std::uint64_t bytes)
 {
-    return requireDataset()->setCacheBudget(bytes);
+    // Both caches, each bounded by `bytes`: they hold different things (read
+    // blocks and sampled grids) and neither should starve for the other, so
+    // this is one budget applied twice rather than one budget split. Without
+    // it AMREXPLORER_CACHE_SIZE_MB bounded only the block cache and a session
+    // could hold the whole grid budget on top of it, unaccounted. It also
+    // overrides an earlier setVolumeGridCacheBudget, which is the point: the
+    // global setting is the one a user reaches for.
+    const auto blocks = requireDataset()->setCacheBudget(bytes);
+    const auto grids = m_volumeGrids.setBudget(bytes);
+    return blocks && grids;
 }
 
 void LocalDatasetSession::clearUnpinnedCache()
@@ -381,7 +404,15 @@ void LocalDatasetSession::close() noexcept
 {
     std::scoped_lock lock(m_mutex);
     m_dataset.reset();
-    m_volumeGrids.clearUnpinned();
+    // clearUnpinned collects the doomed entries in a vector, so it allocates
+    // -- and the memory pressure that would make that throw is exactly when
+    // a cache gets cleared. Letting it escape a noexcept close would
+    // terminate the process during shutdown; dropping the grids is
+    // best-effort, and the cache dies with the session either way.
+    try {
+        m_volumeGrids.clearUnpinned();
+    } catch (...) {
+    }
 }
 
 std::shared_ptr<PlotfileDataset> LocalDatasetSession::requireDataset() const

--- a/src/data/LocalDatasetSession.cpp
+++ b/src/data/LocalDatasetSession.cpp
@@ -110,6 +110,13 @@ LocalDatasetSession::LocalDatasetSession(
     if (!m_dataset) {
         throw std::invalid_argument("local dataset session requires a dataset");
     }
+    // The grid cache starts on the same budget the dataset was opened with,
+    // not on its own default. setCacheBudget keeps the two in step afterwards,
+    // but the normal local and server open paths only construct a session --
+    // they never call it -- so without this a session opened with a small
+    // AMREXPLORER_CACHE_SIZE_MB still held up to the 256 MiB grid default.
+    static_cast<void>(
+        m_volumeGrids.setBudget(m_dataset->cacheMetrics().budgetBytes));
 }
 
 LocalDatasetSession::LocalDatasetSession(const std::filesystem::path& path,
@@ -296,7 +303,11 @@ VolumeFrame LocalDatasetSession::renderVolume(
             "volume rendering requires a 3-D plotfile with physical geometry");
     }
     validateSessionVolumeRequest(m_metadata, m_id, request);
-    const auto maximumLevel = std::min(request.maximumLevel, m_metadata.finestLevel);
+    // No clamp against finestLevel: validateSessionVolumeRequest above
+    // refuses a level past it, so a clamp here could only ever be a no-op --
+    // and reading like one that might fire invites the assumption that the
+    // key and the sampler can see a different level than the validator did.
+    const auto maximumLevel = request.maximumLevel;
     const VolumeGridKey key{request.field, request.component, maximumLevel,
         request.composition, request.region,
         volumeGridDims(m_metadata, request.region, maximumLevel,
@@ -314,15 +325,11 @@ VolumeFrame LocalDatasetSession::renderVolume(
         grid = handle.value();
     } else {
         const auto started = std::chrono::steady_clock::now();
-        VolumeSampleRequest sample;
-        sample.dataset = request.dataset;
-        sample.field = request.field;
-        sample.component = request.component;
-        sample.maximumLevel = maximumLevel;
-        sample.composition = request.composition;
-        sample.region = request.region;
-        sample.maximumVoxels = request.maximumVoxels;
-        auto sampled = VolumeQuery(*dataset).execute(sample, cancellation);
+        // Through the shared helper, so the fields the validator checked are
+        // the fields the sampler gets. Hand-copying them means a field added
+        // to VolumeSampleRequest is validated and then silently dropped here.
+        auto sampled = VolumeQuery(*dataset).execute(
+            volumeSampleRequestOf(request), cancellation);
         metrics.sampleMicroseconds = static_cast<std::uint64_t>(
             std::chrono::duration_cast<std::chrono::microseconds>(
                 std::chrono::steady_clock::now() - started).count());
@@ -336,6 +343,14 @@ VolumeFrame LocalDatasetSession::renderVolume(
         try {
             handle = m_volumeGrids.insertAndPin(key, owned, bytes);
             grid = handle.value();
+            // A racing thread may have inserted this key first, in which case
+            // insertAndPin returns its grid and ours is discarded. The frame
+            // then describes a sample whose result nothing used, so it is
+            // reported as the cache hit it actually was.
+            if (grid != owned) {
+                metrics = VolumeRenderMetrics{};
+                metrics.gridFromCache = true;
+            }
         } catch (const CacheBudgetExceeded&) {
             // Too big for the grid cache: render it anyway, uncached. (The
             // block cache's own budget failures come out of the sample above
@@ -348,9 +363,21 @@ VolumeFrame LocalDatasetSession::renderVolume(
     settings.camera = request.camera;
     settings.domain = datasetSampleBounds(m_metadata);
     settings.outputSize = request.outputSize;
-    settings.range = request.range
-        ? *request.range
-        : visibleVolumeRange(*grid, request.logarithmic, cancellation);
+    if (request.range) {
+        settings.range = *request.range;
+    } else {
+        // Memoized against the grid's own cache key: the answer depends only
+        // on the grid and the requested mapping, both of which the key and
+        // the flag already pin.
+        const std::scoped_lock lock(m_mutex);
+        const auto want = std::pair{key, request.logarithmic};
+        if (m_visibleRangeFor != want) {
+            m_visibleRange
+                = visibleVolumeRange(*grid, request.logarithmic, cancellation);
+            m_visibleRangeFor = want;
+        }
+        settings.range = m_visibleRange;
+    }
     settings.transfer = request.transfer;
     settings.samplesPerVoxel = request.samplesPerVoxel;
     auto frame = raycastVolume(*grid, settings, cancellation);
@@ -366,6 +393,11 @@ VolumeFrame LocalDatasetSession::renderVolume(
 bool LocalDatasetSession::setVolumeGridCacheBudget(std::uint64_t bytes)
 {
     return m_volumeGrids.setBudget(bytes);
+}
+
+CacheMetrics LocalDatasetSession::volumeGridCacheMetrics() const
+{
+    return m_volumeGrids.metrics();
 }
 
 CacheMetrics LocalDatasetSession::cacheMetrics() const

--- a/src/data/LocalDatasetSession.cpp
+++ b/src/data/LocalDatasetSession.cpp
@@ -371,14 +371,30 @@ VolumeFrame LocalDatasetSession::renderVolume(
         // Memoized against the grid's own cache key: the answer depends only
         // on the grid and the requested mapping, both of which the key and
         // the flag already pin.
-        const std::scoped_lock lock(m_mutex);
+        //
+        // The scan itself runs outside the lock. m_mutex is the session's
+        // general one -- requireDataset takes it, so every other entry point
+        // does -- and holding it across a walk of up to 134 million voxels
+        // would stall a slice request, a cacheMetrics poll, or close() for
+        // the whole scan. Two threads racing here both compute the same
+        // answer from the same grid, so publishing last-writer-wins costs
+        // nothing but a duplicated scan in a case that needs two misses on
+        // one key at once.
         const auto want = std::pair{key, request.logarithmic};
-        if (m_visibleRangeFor != want) {
-            m_visibleRange
-                = visibleVolumeRange(*grid, request.logarithmic, cancellation);
+        std::optional<VolumeRange> memo;
+        {
+            const std::scoped_lock lock(m_mutex);
+            if (m_visibleRangeFor == want) {
+                memo = m_visibleRange;
+            }
+        }
+        if (!memo) {
+            memo = visibleVolumeRange(*grid, request.logarithmic, cancellation);
+            const std::scoped_lock lock(m_mutex);
+            m_visibleRange = *memo;
             m_visibleRangeFor = want;
         }
-        settings.range = m_visibleRange;
+        settings.range = *memo;
     }
     settings.transfer = request.transfer;
     settings.samplesPerVoxel = request.samplesPerVoxel;

--- a/src/data/LocalDatasetSession.cpp
+++ b/src/data/LocalDatasetSession.cpp
@@ -5,9 +5,13 @@
 #include <amrexplorer/io/PlotfileDataset.hpp>
 #include <amrexplorer/query/LineQuery.hpp>
 #include <amrexplorer/query/SliceQuery.hpp>
+#include <amrexplorer/query/VolumeQuery.hpp>
+#include <amrexplorer/render3d/VolumeRaycaster.hpp>
 
 #include <algorithm>
+#include <chrono>
 #include <cmath>
+#include <functional>
 #include <limits>
 #include <stdexcept>
 #include <type_traits>
@@ -43,7 +47,51 @@ std::optional<ValueRange> compositeMetadataRange(const DatasetMetadata& metadata
     return ValueRange{minimum, maximum};
 }
 
+// The range a volume's colours span when the request leaves it to the
+// renderer (the "Visible" range): the sampled grid's finite extrema, padded
+// if degenerate, logarithmic only when the data allows it, and a neutral
+// range for a grid with no finite values -- resolveRange's rules for a
+// plane, applied to a grid.
+VolumeRange visibleVolumeRange(const VolumeGrid& grid, bool logarithmic)
+{
+    if (logarithmic) {
+        if (const auto extrema = volumeGridRange(grid, true)) {
+            const auto [minimum, maximum]
+                = paddedIfDegenerate(extrema->first, extrema->second, true);
+            if (minimum < maximum && minimum > 0.0) {
+                return {minimum, maximum, true};
+            }
+        } else if (grid.coveredVoxels == 0) {
+            return {1.0, 10.0, true};
+        }
+    }
+    const auto extrema = volumeGridRange(grid, false);
+    if (!extrema) {
+        return {0.0, 1.0, false};
+    }
+    const auto [minimum, maximum]
+        = paddedIfDegenerate(extrema->first, extrema->second, false);
+    return {minimum, maximum, false};
+}
+
 } // namespace
+
+std::size_t VolumeGridKeyHash::operator()(const VolumeGridKey& key) const noexcept
+{
+    std::size_t seed = std::hash<std::uint32_t>{}(key.field.value);
+    const auto combine = [&seed](std::size_t value) {
+        seed ^= value + 0x9e3779b9U + (seed << 6U) + (seed >> 2U);
+    };
+    combine(std::hash<int>{}(key.component));
+    combine(std::hash<int>{}(key.maximumLevel));
+    combine(std::hash<int>{}(static_cast<int>(key.composition)));
+    for (std::size_t axis = 0; axis < 3; ++axis) {
+        combine(std::hash<double>{}(key.region.lower[axis]));
+        combine(std::hash<double>{}(key.region.upper[axis]));
+        combine(std::hash<int>{}(key.dims[axis]));
+    }
+    return seed;
+}
 
 LocalDatasetSession::LocalDatasetSession(
     std::shared_ptr<PlotfileDataset> dataset)
@@ -227,6 +275,92 @@ ParticleSample LocalDatasetSession::requestParticleSample(
         species, fraction, seed, cancellation, maximumPoints);
 }
 
+bool LocalDatasetSession::supportsVolumeRendering() const noexcept
+{
+    return m_metadata.dimension == 3 && !m_metadata.isFab
+        && m_metadata.hasPhysicalGeometry;
+}
+
+VolumeFrame LocalDatasetSession::renderVolume(
+    const VolumeRenderRequest& request, StopToken cancellation)
+{
+    const auto dataset = requireDataset();
+    validateSessionVolumeRequest(m_metadata, m_id, request);
+    if (!supportsVolumeRendering()) {
+        throw std::invalid_argument(
+            "volume rendering requires a 3-D plotfile with physical geometry");
+    }
+    const auto maximumLevel = std::min(request.maximumLevel, m_metadata.finestLevel);
+    const VolumeGridKey key{request.field, request.component, maximumLevel,
+        request.composition, request.region,
+        volumeGridDims(m_metadata, request.region, maximumLevel,
+            request.maximumVoxels)};
+
+    // The grid: from the cache when the same sample was rendered before
+    // (a camera change re-casts it), else sampled now and cached -- unless
+    // it is larger than the whole grid budget, in which case it is rendered
+    // from the local copy and forgotten.
+    VolumeRenderMetrics metrics;
+    auto handle = m_volumeGrids.findAndPin(key);
+    std::shared_ptr<const VolumeGrid> grid;
+    if (handle) {
+        metrics.gridFromCache = true;
+        grid = handle.value();
+    } else {
+        const auto started = std::chrono::steady_clock::now();
+        VolumeSampleRequest sample;
+        sample.dataset = request.dataset;
+        sample.field = request.field;
+        sample.component = request.component;
+        sample.maximumLevel = maximumLevel;
+        sample.composition = request.composition;
+        sample.region = request.region;
+        sample.maximumVoxels = request.maximumVoxels;
+        auto sampled = VolumeQuery(*dataset).execute(sample, cancellation);
+        metrics.sampleMilliseconds = static_cast<std::uint64_t>(
+            std::chrono::duration_cast<std::chrono::milliseconds>(
+                std::chrono::steady_clock::now() - started).count());
+        metrics.candidateBlocks = sampled.metrics.candidateBlocks;
+        metrics.blocksRead = sampled.metrics.blocksRead;
+        metrics.cacheHits = sampled.metrics.cacheHits;
+        metrics.payloadBytesRead = sampled.metrics.payloadBytesRead;
+        const auto bytes = static_cast<std::uint64_t>(sampled.grid.values.size())
+            * sizeof(float);
+        auto owned = std::make_shared<const VolumeGrid>(std::move(sampled.grid));
+        try {
+            handle = m_volumeGrids.insertAndPin(key, owned, bytes);
+            grid = handle.value();
+        } catch (const CacheBudgetExceeded&) {
+            // Too big for the grid cache: render it anyway, uncached. (The
+            // block cache's own budget failures come out of the sample above
+            // and propagate, so the caller can fall back to a coarser level.)
+            grid = std::move(owned);
+        }
+    }
+
+    RaycastSettings settings;
+    settings.camera = request.camera;
+    settings.domain = datasetSampleBounds(m_metadata);
+    settings.outputSize = request.outputSize;
+    settings.range = request.range
+        ? *request.range : visibleVolumeRange(*grid, request.logarithmic);
+    settings.transfer = request.transfer;
+    settings.samplesPerVoxel = request.samplesPerVoxel;
+    auto frame = raycastVolume(*grid, settings, cancellation);
+    const auto renderMilliseconds = frame.metrics.renderMilliseconds;
+    frame.metrics = metrics;
+    frame.metrics.renderMilliseconds = renderMilliseconds;
+    frame.metrics.gridDims = grid->dims;
+    frame.metrics.coveredVoxels = grid->coveredVoxels;
+    frame.metrics.sampledMaximumLevel = grid->maximumLevel;
+    return frame;
+}
+
+bool LocalDatasetSession::setVolumeGridCacheBudget(std::uint64_t bytes)
+{
+    return m_volumeGrids.setBudget(bytes);
+}
+
 CacheMetrics LocalDatasetSession::cacheMetrics() const
 {
     return requireDataset()->cacheMetrics();
@@ -240,12 +374,14 @@ bool LocalDatasetSession::setCacheBudget(std::uint64_t bytes)
 void LocalDatasetSession::clearUnpinnedCache()
 {
     requireDataset()->clearUnpinnedCache();
+    m_volumeGrids.clearUnpinned();
 }
 
 void LocalDatasetSession::close() noexcept
 {
     std::scoped_lock lock(m_mutex);
     m_dataset.reset();
+    m_volumeGrids.clearUnpinned();
 }
 
 std::shared_ptr<PlotfileDataset> LocalDatasetSession::requireDataset() const

--- a/src/data/LocalDatasetSession.cpp
+++ b/src/data/LocalDatasetSession.cpp
@@ -317,8 +317,8 @@ VolumeFrame LocalDatasetSession::renderVolume(
         sample.region = request.region;
         sample.maximumVoxels = request.maximumVoxels;
         auto sampled = VolumeQuery(*dataset).execute(sample, cancellation);
-        metrics.sampleMilliseconds = static_cast<std::uint64_t>(
-            std::chrono::duration_cast<std::chrono::milliseconds>(
+        metrics.sampleMicroseconds = static_cast<std::uint64_t>(
+            std::chrono::duration_cast<std::chrono::microseconds>(
                 std::chrono::steady_clock::now() - started).count());
         metrics.candidateBlocks = sampled.metrics.candidateBlocks;
         metrics.blocksRead = sampled.metrics.blocksRead;
@@ -347,9 +347,9 @@ VolumeFrame LocalDatasetSession::renderVolume(
     settings.transfer = request.transfer;
     settings.samplesPerVoxel = request.samplesPerVoxel;
     auto frame = raycastVolume(*grid, settings, cancellation);
-    const auto renderMilliseconds = frame.metrics.renderMilliseconds;
+    const auto renderMicroseconds = frame.metrics.renderMicroseconds;
     frame.metrics = metrics;
-    frame.metrics.renderMilliseconds = renderMilliseconds;
+    frame.metrics.renderMicroseconds = renderMicroseconds;
     frame.metrics.gridDims = grid->dims;
     frame.metrics.coveredVoxels = grid->coveredVoxels;
     frame.metrics.sampledMaximumLevel = grid->maximumLevel;

--- a/src/data/SessionValidation.cpp
+++ b/src/data/SessionValidation.cpp
@@ -212,6 +212,92 @@ void validateSessionParticleRequest(const DatasetMetadata& metadata,
     }
 }
 
+void validateSessionVolumeRequest(const DatasetMetadata& metadata,
+    DatasetId dataset, const VolumeRenderRequest& request)
+{
+    if (request.dataset != dataset) {
+        throw std::invalid_argument("volume request uses the wrong dataset");
+    }
+    requireFieldAndLevel(metadata, request.field, request.maximumLevel, "volume");
+    requireComponent(metadata, request.field, request.component, "volume");
+    const auto errors = validateVolumeRenderRequest(request, metadata.dimension);
+    if (!errors.empty()) {
+        throw std::invalid_argument(errors.front());
+    }
+    // The region must lie within the domain, with a hair of tolerance for a
+    // region computed from the domain itself.
+    const auto domain = datasetSampleBounds(metadata);
+    for (std::size_t axis = 0; axis < 3; ++axis) {
+        const auto tolerance = 1.0e-9 * (domain.upper[axis] - domain.lower[axis]);
+        if (request.region.lower[axis] < domain.lower[axis] - tolerance
+            || request.region.upper[axis] > domain.upper[axis] + tolerance) {
+            throw std::invalid_argument("volume region lies outside the dataset");
+        }
+    }
+}
+
+void validateSessionVolumeResult(const DatasetMetadata& metadata,
+    const VolumeRenderRequest& request, const VolumeFrame& frame)
+{
+    if (frame.width != request.outputSize[0]
+        || frame.height != request.outputSize[1]) {
+        throw std::invalid_argument(
+            "volume frame is not the requested size");
+    }
+    if (frame.pixels.size() != static_cast<std::size_t>(frame.width)
+            * static_cast<std::size_t>(frame.height)) {
+        throw std::invalid_argument(
+            "volume frame pixel storage does not match its size");
+    }
+    const auto& used = frame.usedRange;
+    if (!std::isfinite(used.minimum) || !std::isfinite(used.maximum)
+        || !(used.minimum < used.maximum)
+        || (used.logarithmic && !(used.minimum > 0.0))) {
+        throw std::invalid_argument("volume frame reports an unusable range");
+    }
+    if (request.range && !(used == *request.range)) {
+        throw std::invalid_argument(
+            "volume frame did not use the requested range");
+    }
+    if (!request.range && used.logarithmic && !request.logarithmic) {
+        throw std::invalid_argument(
+            "volume frame used a logarithmic range that was not requested");
+    }
+    const auto& metrics = frame.metrics;
+    std::uint64_t voxels = 1;
+    for (const auto extent : metrics.gridDims) {
+        if (extent < 1) {
+            throw std::invalid_argument(
+                "volume frame reports an empty sampled grid");
+        }
+        voxels *= static_cast<std::uint64_t>(extent);
+    }
+    if (voxels > request.maximumVoxels) {
+        throw std::invalid_argument(
+            "volume frame reports a grid over the requested voxel budget");
+    }
+    if (metrics.coveredVoxels > voxels) {
+        throw std::invalid_argument(
+            "volume frame reports more covered voxels than the grid holds");
+    }
+    const auto highest = std::min(request.maximumLevel, metadata.finestLevel);
+    if (metrics.sampledMaximumLevel < 0
+        || metrics.sampledMaximumLevel > highest) {
+        throw std::invalid_argument(
+            "volume frame reports a sampled level the request did not allow");
+    }
+    const auto from = frame.cacheFallbackFromLevel;
+    const auto to = frame.cacheFallbackToLevel;
+    if ((from < 0) != (to < 0)) {
+        throw std::invalid_argument(
+            "volume frame reports a half-specified cache fallback");
+    }
+    if (from >= 0 && (from > highest || to < 0 || to >= from)) {
+        throw std::invalid_argument(
+            "volume frame reports an impossible cache fallback");
+    }
+}
+
 void validateSessionViewResult(const DatasetMetadata& metadata,
     const ViewDataRequest& request, const ViewDataResult& result)
 {

--- a/src/data/SessionValidation.cpp
+++ b/src/data/SessionValidation.cpp
@@ -224,16 +224,14 @@ void validateSessionVolumeRequest(const DatasetMetadata& metadata,
     if (!errors.empty()) {
         throw std::invalid_argument(errors.front());
     }
-    // The region must lie within the domain, with a hair of tolerance for a
-    // region computed from the domain itself.
-    const auto domain = datasetSampleBounds(metadata);
-    for (std::size_t axis = 0; axis < 3; ++axis) {
-        const auto tolerance = 1.0e-9 * (domain.upper[axis] - domain.lower[axis]);
-        if (request.region.lower[axis] < domain.lower[axis] - tolerance
-            || request.region.upper[axis] > domain.upper[axis] + tolerance) {
-            throw std::invalid_argument("volume region lies outside the dataset");
-        }
-    }
+    // No containment test. VolumeQuery states that "a region reaching past
+    // the domain is not refused. The grid already says 'no data here' with
+    // NaN", and validateSessionViewRequest does not refuse one either -- so
+    // refusing here would throw away a rubber-band selection that renders
+    // perfectly well as a slice, and the relative tolerance it needed
+    // collapsed to zero on an axis whose domain extent is degenerate.
+    // validateVolumeRenderRequest above already bounds the region's own
+    // shape, and volumeGridDims bounds the grid it turns into.
 }
 
 void validateSessionVolumeResult(const DatasetMetadata& metadata,
@@ -264,14 +262,16 @@ void validateSessionVolumeResult(const DatasetMetadata& metadata,
             "volume frame used a logarithmic range that was not requested");
     }
     const auto& metrics = frame.metrics;
-    std::uint64_t voxels = 1;
     for (const auto extent : metrics.gridDims) {
         if (extent < 1) {
             throw std::invalid_argument(
                 "volume frame reports an empty sampled grid");
         }
-        voxels *= static_cast<std::uint64_t>(extent);
     }
+    // Saturating, not a plain product: this validates a peer's numbers, and
+    // dims whose product wraps 64 bits (say {2^22, 2^21, 2^21}) would come
+    // out as zero and pass both the budget and the coverage test below.
+    const auto voxels = volumeVoxelCount(metrics.gridDims);
     if (voxels > request.maximumVoxels) {
         throw std::invalid_argument(
             "volume frame reports a grid over the requested voxel budget");

--- a/src/data/SessionValidation.cpp
+++ b/src/data/SessionValidation.cpp
@@ -292,7 +292,14 @@ void validateSessionVolumeResult(const DatasetMetadata& metadata,
         throw std::invalid_argument(
             "volume frame reports a half-specified cache fallback");
     }
-    if (from >= 0 && (from > highest || to < 0 || to >= from)) {
+    // No `to < 0` here: the half-specified test above already threw for
+    // exactly that pair, so from >= 0 implies to >= 0 by this point.
+    if (from >= 0
+        && (from > highest || to >= from || metrics.sampledMaximumLevel > to)) {
+        // The last clause: a frame that says it fell back to `to` was
+        // rendered with maximumLevel == to, so nothing finer than `to` can
+        // have put a value in its grid. A peer claiming otherwise is
+        // describing a render that cannot have happened.
         throw std::invalid_argument(
             "volume frame reports an impossible cache fallback");
     }

--- a/src/pipeline/CMakeLists.txt
+++ b/src/pipeline/CMakeLists.txt
@@ -3,6 +3,7 @@ add_library(amrexplorer_pipeline
     ParticleProjection.cpp
     SlicePipeline.cpp
     SliceRangeResolver.cpp
+    VolumePipeline.cpp
 )
 add_library(amrexplorer::pipeline ALIAS amrexplorer_pipeline)
 

--- a/src/pipeline/SliceRangeResolver.cpp
+++ b/src/pipeline/SliceRangeResolver.cpp
@@ -15,41 +15,6 @@ public:
 
 } // namespace
 
-std::pair<double, double> paddedIfDegenerate(
-    double minimum, double maximum, bool logarithmic) noexcept
-{
-    if (minimum != maximum) {
-        return {minimum, maximum};
-    }
-    if (logarithmic && minimum > 0.0) {
-        return {minimum / (1.0 + 1.0e-6), maximum * (1.0 + 1.0e-6)};
-    }
-    // Relative to the value, not an absolute floor. The old
-    // max(abs(minimum), 1.0) * 1e-6 padded a uniform plane of 1e-7 by 1e-6 --
-    // ten times the value itself, straddling zero, which then disqualified the
-    // plane from logarithmic display. A constant of 5.0 meanwhile stayed
-    // logarithmic, so the same control behaved differently on data that
-    // differed only in scale.
-    //
-    // The floor is the smallest padding that can still separate the two
-    // endpoints in double precision near this magnitude: one ulp is far too
-    // small to survive later arithmetic, so a relative 1e-6 is used with the
-    // smallest normal as a backstop.
-    //
-    // Zero has no magnitude to be relative to, and the backstop is the wrong
-    // answer there: a uniform plane of zeros -- an ordinary case, not a
-    // pathological one -- would get a range of +/-2.2e-308, which is what the
-    // color bar and the seeded User-range spin boxes then display. Fall back to
-    // the relative constant as an absolute, which is what this returned before
-    // the padding became relative.
-    constexpr auto relative = 1.0e-6;
-    const auto magnitude = std::abs(minimum);
-    const auto padding = magnitude > 0.0
-        ? std::max(magnitude * relative, std::numeric_limits<double>::min())
-        : relative;
-    return {minimum - padding, maximum + padding};
-}
-
 std::optional<std::pair<double, double>> finiteRange(
     const ScalarPlane& plane, bool logarithmic)
 {

--- a/src/pipeline/VolumePipeline.cpp
+++ b/src/pipeline/VolumePipeline.cpp
@@ -219,6 +219,11 @@ VolumeDisplayResult renderWithFallback(
         request.outputSize, dataset->maximumResponseBytes());
     int fallbackFrom = -1;
     int fallbackTo = -1;
+    // Whether the range moves with the level. Visible does not need a repeat
+    // (the renderer resolves it from the grid it sampled, so it already
+    // follows), and neither does User; File and Level are read per level.
+    const bool levelDependentRange = choice
+        && (choice->mode == RangeMode::File || choice->mode == RangeMode::Level);
     for (;;) {
         try {
             if (choice) {
@@ -230,27 +235,35 @@ VolumeDisplayResult renderWithFallback(
                     choice->userRange, choice->logarithmic, cancellation);
             }
             auto frame = dataset->renderVolume(request, cancellation);
-            if (fallbackFrom >= 0) {
-                // Only when this loop drove one. The frame arrives carrying
-                // whatever fallback the session itself made -- a remote
-                // server under its own cache pressure reports one -- and
-                // stamping -1 over it would hide from the user that their
-                // volume was rendered coarser than they asked. When both
-                // happened, the span runs from where this loop started to
-                // the coarsest level actually used.
-                const auto sessionTo = frame.cacheFallbackToLevel;
-                frame.cacheFallbackFromLevel = fallbackFrom;
-                frame.cacheFallbackToLevel = sessionTo >= 0
-                    ? std::min(sessionTo, fallbackTo) : fallbackTo;
+            // A fallback the session made inside this attempt counts the same
+            // as one this loop drove. A remote server under its own cache
+            // pressure renders coarser and says so, and the range that was
+            // resolved a few lines above belongs to the level we asked for,
+            // not the one it used -- level 1's statistics are not level 0's.
+            // So the level is taken from the frame and, when the range
+            // depends on it, the render is repeated for the level that
+            // actually happened. Each repeat is strictly coarser, so this
+            // walks down to level 0 at worst.
+            const auto sessionTo = frame.cacheFallbackToLevel;
+            if (sessionTo >= 0 && sessionTo < request.maximumLevel) {
+                if (fallbackFrom < 0) {
+                    fallbackFrom = frame.cacheFallbackFromLevel >= 0
+                        ? frame.cacheFallbackFromLevel : request.maximumLevel;
+                }
+                fallbackTo = sessionTo;
+                request.maximumLevel = sessionTo;
+                if (levelDependentRange) {
+                    continue;
+                }
             }
-            // VolumeDisplayResult::request is documented as the request "as
-            // rendered, after any fallback", and the session may have fallen
-            // back inside an attempt this loop never retried -- a remote
-            // server under its own cache pressure does exactly that. Without
-            // this the caller's own state stays at the level it asked for
-            // while the pixels came from a coarser one.
-            if (frame.cacheFallbackToLevel >= 0) {
-                request.maximumLevel = frame.cacheFallbackToLevel;
+            if (fallbackFrom >= 0) {
+                // The span runs from where the first fallback started to the
+                // coarsest level anything actually rendered at.
+                frame.cacheFallbackFromLevel = fallbackFrom;
+                frame.cacheFallbackToLevel = fallbackTo;
+                // VolumeDisplayResult::request is documented as the request
+                // "as rendered, after any fallback".
+                request.maximumLevel = fallbackTo;
             }
             return {request, std::move(frame)};
         } catch (const CacheBudgetExceeded&) {

--- a/src/pipeline/VolumePipeline.cpp
+++ b/src/pipeline/VolumePipeline.cpp
@@ -1,0 +1,170 @@
+#include <amrexplorer/pipeline/VolumePipeline.hpp>
+
+#include <amrexplorer/cache/ByteLruCache.hpp>
+#include <amrexplorer/core/Statistics.hpp>
+#include <amrexplorer/pipeline/SlicePipeline.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <stdexcept>
+#include <string>
+#include <tuple>
+
+namespace amrvis {
+
+VolumeTransferFunction makeVolumeTransferFunction(
+    const Palette& palette, const OpacityRamp& ramp)
+{
+    VolumeTransferFunction transfer;
+    constexpr int entryCount = Palette::colorSlots;
+    transfer.colors.reserve(static_cast<std::size_t>(entryCount));
+    transfer.opacities.reserve(static_cast<std::size_t>(entryCount));
+    const auto low = std::clamp(ramp.lowThreshold, 0.0, 1.0);
+    const auto high = std::clamp(ramp.highThreshold, 0.0, 1.0);
+    const auto maximum = std::clamp(ramp.maximumOpacity, 0.0, 1.0);
+    const bool paletteAlpha = ramp.usePaletteAlpha && palette.hasAlphaRamp();
+    for (int entry = 0; entry < entryCount; ++entry) {
+        const auto slot = Palette::paletteStart + entry;
+        transfer.colors.push_back(palette.slotArgb(slot) & 0x00FFFFFFU);
+        const auto t = static_cast<double>(entry) / static_cast<double>(entryCount - 1);
+        double opacity = 0.0;
+        if (t >= low && t <= high) {
+            if (paletteAlpha) {
+                opacity = palette.opacity(slot);
+            } else if (high > low) {
+                opacity = (t - low) / (high - low);
+            } else {
+                opacity = 1.0;   // a zero-width window is a step
+            }
+        }
+        transfer.opacities.push_back(
+            static_cast<float>(std::clamp(opacity * maximum, 0.0, 1.0)));
+    }
+    return transfer;
+}
+
+std::optional<VolumeRange> resolveVolumeRange(
+    const std::shared_ptr<DatasetSession>& dataset, FieldId field,
+    int maximumLevel, CompositionPolicy composition, RangeMode rangeMode,
+    const std::optional<std::pair<double, double>>& userRange,
+    bool logarithmic, StopToken cancellation)
+{
+    std::optional<std::pair<double, double>> selected;
+    if (rangeMode == RangeMode::User) {
+        selected = userRange;
+    } else if (rangeMode == RangeMode::File || rangeMode == RangeMode::Level) {
+        if (rangeMode == RangeMode::File) {
+            selected = fabDataRange(dataset, field, cancellation);
+        }
+        if (!selected) {
+            const auto statistics = dataset->requestRange(RangeRequest{
+                .field = field,
+                .maximumLevel = maximumLevel,
+                .composition = composition,
+                .scope = rangeMode == RangeMode::File
+                    ? RangeScope::File : RangeScope::Level}, cancellation);
+            if (statistics) {
+                selected = std::pair{statistics->minimum, statistics->maximum};
+            }
+        }
+    }
+    if (!selected) {
+        return std::nullopt;   // Visible, or statistics unavailable: the renderer decides
+    }
+    auto [minimum, maximum]
+        = paddedIfDegenerate(selected->first, selected->second, logarithmic);
+    if (!(minimum < maximum)) {
+        throw std::runtime_error("user scalar range must have positive extent");
+    }
+    if (logarithmic && minimum > 0.0) {
+        return VolumeRange{minimum, maximum, true};
+    }
+    if (logarithmic) {
+        // Not viable in log: linear, re-padded without the log rule.
+        std::tie(minimum, maximum)
+            = paddedIfDegenerate(selected->first, selected->second, false);
+    }
+    return VolumeRange{minimum, maximum, false};
+}
+
+std::uint64_t volumeResponseBytes(std::array<int, 2> outputSize)
+{
+    return static_cast<std::uint64_t>(std::max(0, outputSize[0]))
+        * static_cast<std::uint64_t>(std::max(0, outputSize[1]))
+        * sizeof(std::uint32_t) + volumeResponseOverheadBytes;
+}
+
+std::array<int, 2> frameBudgetBoundedVolumeSize(
+    std::array<int, 2> outputSize,
+    std::optional<std::uint32_t> maximumResponseBytes)
+{
+    if (!maximumResponseBytes) {
+        return outputSize;
+    }
+    const auto budget = static_cast<std::uint64_t>(*maximumResponseBytes);
+    if (budget <= volumeResponseOverheadBytes + sizeof(std::uint32_t)) {
+        return {1, 1};
+    }
+    const auto maximumPixels = (budget - volumeResponseOverheadBytes)
+        / sizeof(std::uint32_t);
+    auto bounded = outputSize;
+    const auto pixels = static_cast<std::uint64_t>(std::max(1, bounded[0]))
+        * static_cast<std::uint64_t>(std::max(1, bounded[1]));
+    if (pixels <= maximumPixels) {
+        return bounded;
+    }
+    const auto scale = std::sqrt(static_cast<double>(maximumPixels)
+        / static_cast<double>(pixels));
+    bounded = {std::max(1, static_cast<int>(std::floor(bounded[0] * scale))),
+        std::max(1, static_cast<int>(std::floor(bounded[1] * scale)))};
+    while (static_cast<std::uint64_t>(bounded[0])
+            * static_cast<std::uint64_t>(bounded[1]) > maximumPixels) {
+        auto& larger = bounded[0] >= bounded[1] ? bounded[0] : bounded[1];
+        if (larger <= 1) {
+            break;
+        }
+        --larger;
+    }
+    return bounded;
+}
+
+VolumeDisplayResult executeVolumeRenderWithFallback(
+    const std::shared_ptr<DatasetSession>& dataset, VolumeRenderRequest request,
+    StopToken cancellation)
+{
+    request.outputSize = frameBudgetBoundedVolumeSize(
+        request.outputSize, dataset->maximumResponseBytes());
+    int fallbackFrom = -1;
+    int fallbackTo = -1;
+    for (;;) {
+        try {
+            auto frame = dataset->renderVolume(request, cancellation);
+            frame.cacheFallbackFromLevel = fallbackFrom;
+            frame.cacheFallbackToLevel = fallbackTo;
+            return {request, std::move(frame)};
+        } catch (const CacheBudgetExceeded&) {
+            const auto budget = cacheBudgetDescription(
+                dataset->cacheMetrics().budgetBytes);
+            if (request.composition != CompositionPolicy::FinestAvailable) {
+                throw std::runtime_error(
+                    "The selected volume level cannot fit in the " + budget
+                    + " cache. Choose a lower level or increase "
+                      "AMREXPLORER_CACHE_SIZE_MB.");
+            }
+            if (request.maximumLevel == 0) {
+                throw std::runtime_error(
+                    "The volume cannot fit in the " + budget
+                    + " cache, even at level 0. Try a smaller plotfile or "
+                      "increase AMREXPLORER_CACHE_SIZE_MB.");
+            }
+            dataset->clearUnpinnedCache();
+            if (fallbackFrom < 0) {
+                fallbackFrom = request.maximumLevel;
+            }
+            fallbackTo = --request.maximumLevel;
+        }
+    }
+}
+
+} // namespace amrvis

--- a/src/pipeline/VolumePipeline.cpp
+++ b/src/pipeline/VolumePipeline.cpp
@@ -250,7 +250,10 @@ VolumeDisplayResult renderWithFallback(
         try {
             if (choice) {
                 // Per attempt, not once: request.maximumLevel is what the
-                // loop lowers, and a File or Level range is a property of it.
+                // loop lowers, and a Level range is read per level. The other
+                // modes resolve to the same range every time round, which
+                // costs a statistics lookup and nothing else -- only the
+                // repeat below is worth gating on the mode.
                 request.logarithmic = choice->logarithmic;
                 request.range = resolveVolumeRange(dataset, request.field,
                     request.maximumLevel, request.composition, choice->mode,

--- a/src/pipeline/VolumePipeline.cpp
+++ b/src/pipeline/VolumePipeline.cpp
@@ -2,6 +2,7 @@
 
 #include <amrexplorer/cache/ByteLruCache.hpp>
 #include <amrexplorer/core/Statistics.hpp>
+#include <amrexplorer/core/ValueMapping.hpp>
 #include <amrexplorer/pipeline/SlicePipeline.hpp>
 
 #include <algorithm>
@@ -131,15 +132,27 @@ std::optional<VolumeRange> resolveVolumeRange(
         throw std::runtime_error(
             std::string(source) + " scalar range must be finite with a finite span");
     }
+    VolumeRange resolved{minimum, maximum, false};
     if (logarithmic && minimum > 0.0) {
-        return VolumeRange{minimum, maximum, true};
-    }
-    if (logarithmic) {
+        resolved = VolumeRange{minimum, maximum, true};
+    } else if (logarithmic) {
         // Not viable in log: linear, re-padded without the log rule.
-        std::tie(minimum, maximum)
+        std::tie(resolved.minimum, resolved.maximum)
             = paddedIfDegenerate(selected->first, selected->second, false);
     }
-    return VolumeRange{minimum, maximum, false};
+    // The last thing the renderers do with a range is resolveValueRange, so
+    // one it cannot resolve is this function's error to report. Ordering and
+    // finiteness are already checked above; what is left is a logarithmic
+    // range whose two bounds share a logarithm -- adjacent doubles up at
+    // 1e300 do -- which has no span to spread the entries over and which
+    // validateVolumeRenderRequest would otherwise refuse from inside the
+    // render, as an invalid_argument rather than a named range error.
+    if (!resolveValueRange(
+            resolved.minimum, resolved.maximum, resolved.logarithmic)) {
+        throw std::runtime_error(std::string(source)
+            + " scalar range is too narrow to map: its bounds share a logarithm");
+    }
+    return resolved;
 }
 
 std::uint64_t volumeResponseBytes(std::array<int, 2> outputSize)
@@ -158,12 +171,20 @@ std::array<int, 2> frameBudgetBoundedVolumeSize(
     }
     const auto budget = static_cast<std::uint64_t>(*maximumResponseBytes);
     // Refused, not silently bounded to {1, 1}: a budget that cannot hold one
-    // pixel would produce a request the far side rejects anyway, and saying
-    // so here names the real problem instead of failing later as an
-    // oversized frame.
+    // pixel would produce a request the far side rejects anyway. The slice
+    // path returns {1, 1} for its own hopeless budget and gets away with it
+    // because its overhead is 512 bytes, so a one-pixel slice still fits
+    // inside a small budget; a one-pixel volume frame costs 4100 and does
+    // not. A runtime_error with the numbers in it, because this is the same
+    // kind of "your configuration cannot do this" message the cache-pressure
+    // refusals below carry, and it reaches the user the same way.
     if (budget < volumeResponseBytes({1, 1})) {
-        throw std::invalid_argument(
-            "the negotiated response budget cannot hold a single volume pixel");
+        throw std::runtime_error("The negotiated response budget of "
+            + std::to_string(budget) + " bytes cannot hold a single volume "
+            "pixel; volume rendering needs at least "
+            + std::to_string(volumeResponseBytes({1, 1}))
+            + " bytes per frame. Raise the frame-bytes limit or render "
+              "slices instead.");
     }
     const auto maximumPixels = (budget - volumeResponseOverheadBytes)
         / sizeof(std::uint32_t);

--- a/src/pipeline/VolumePipeline.cpp
+++ b/src/pipeline/VolumePipeline.cpp
@@ -24,18 +24,34 @@ VolumeTransferFunction makeVolumeTransferFunction(
     const auto high = std::clamp(ramp.highThreshold, 0.0, 1.0);
     const auto maximum = std::clamp(ramp.maximumOpacity, 0.0, 1.0);
     const bool paletteAlpha = ramp.usePaletteAlpha && palette.hasAlphaRamp();
+    // The window in entries: those whose position entry / (n - 1) lies in
+    // [low, high], ramping over that span so the top entry inside always
+    // reaches the maximum. A window narrower than the entry pitch (the
+    // coupled sliders make low == high reachable) would select nothing and
+    // render a blank volume; it selects the entry nearest its centre
+    // instead, fully opaque -- a thin shell at that value.
+    const auto last = static_cast<double>(entryCount - 1);
+    constexpr double slack = 1.0e-9;
+    int lowEntry = static_cast<int>(std::ceil(low * last - slack));
+    int highEntry = static_cast<int>(std::floor(high * last + slack));
+    if (highEntry < lowEntry) {
+        lowEntry = std::clamp(
+            static_cast<int>(std::lround(0.5 * (low + high) * last)), 0,
+            entryCount - 1);
+        highEntry = lowEntry;
+    }
     for (int entry = 0; entry < entryCount; ++entry) {
         const auto slot = Palette::paletteStart + entry;
         transfer.colors.push_back(palette.slotArgb(slot) & 0x00FFFFFFU);
-        const auto t = static_cast<double>(entry) / static_cast<double>(entryCount - 1);
         double opacity = 0.0;
-        if (t >= low && t <= high) {
+        if (entry >= lowEntry && entry <= highEntry) {
             if (paletteAlpha) {
                 opacity = palette.opacity(slot);
-            } else if (high > low) {
-                opacity = (t - low) / (high - low);
+            } else if (highEntry > lowEntry) {
+                opacity = static_cast<double>(entry - lowEntry)
+                    / static_cast<double>(highEntry - lowEntry);
             } else {
-                opacity = 1.0;   // a zero-width window is a step
+                opacity = 1.0;
             }
         }
         transfer.opacities.push_back(

--- a/src/pipeline/VolumePipeline.cpp
+++ b/src/pipeline/VolumePipeline.cpp
@@ -222,6 +222,15 @@ VolumeDisplayResult renderWithFallback(
                 frame.cacheFallbackToLevel = sessionTo >= 0
                     ? std::min(sessionTo, fallbackTo) : fallbackTo;
             }
+            // VolumeDisplayResult::request is documented as the request "as
+            // rendered, after any fallback", and the session may have fallen
+            // back inside an attempt this loop never retried -- a remote
+            // server under its own cache pressure does exactly that. Without
+            // this the caller's own state stays at the level it asked for
+            // while the pixels came from a coarser one.
+            if (frame.cacheFallbackToLevel >= 0) {
+                request.maximumLevel = frame.cacheFallbackToLevel;
+            }
             return {request, std::move(frame)};
         } catch (const CacheBudgetExceeded&) {
             const auto budget = cacheBudgetDescription(

--- a/src/pipeline/VolumePipeline.cpp
+++ b/src/pipeline/VolumePipeline.cpp
@@ -29,6 +29,16 @@ VolumeTransferFunction makeVolumeTransferFunction(
         throw std::invalid_argument(
             "opacity ramp thresholds and maximum must be finite");
     }
+    // An inverted window is refused rather than treated as the sub-pitch
+    // case. The two are indistinguishable once the entries are computed --
+    // both land in the highEntry < lowEntry branch -- so a caller that wired
+    // its two sliders the wrong way round would get one opaque shell at the
+    // midpoint and a picture that looks deliberate, with 60% of the range
+    // silently discarded and nothing to tell them.
+    if (ramp.lowThreshold > ramp.highThreshold) {
+        throw std::invalid_argument(
+            "the opacity ramp's low threshold is above its high threshold");
+    }
     const auto low = std::clamp(ramp.lowThreshold, 0.0, 1.0);
     const auto high = std::clamp(ramp.highThreshold, 0.0, 1.0);
     const auto maximum = std::clamp(ramp.maximumOpacity, 0.0, 1.0);
@@ -87,25 +97,39 @@ std::optional<VolumeRange> resolveVolumeRange(
         // No fabDataRange fallback here, unlike the slice path: a FAB has no
         // volume to render (supportsVolumeRendering requires !isFab), so the
         // call would return nullopt for every dataset that can reach this.
-        {
-            const auto statistics = dataset->requestRange(RangeRequest{
-                .field = field,
+        const auto statistics = dataset->requestRange(
+            RangeRequest{.field = field,
                 .maximumLevel = maximumLevel,
                 .composition = composition,
-                .scope = rangeMode == RangeMode::File
-                    ? RangeScope::File : RangeScope::Level}, cancellation);
-            if (statistics) {
-                selected = std::pair{statistics->minimum, statistics->maximum};
-            }
+                .scope = rangeMode == RangeMode::File ? RangeScope::File
+                                                      : RangeScope::Level},
+            cancellation);
+        if (statistics) {
+            selected = std::pair{statistics->minimum, statistics->maximum};
         }
     }
     if (!selected) {
         return std::nullopt;   // Visible, or statistics unavailable: the renderer decides
     }
+    // Named for where it came from: saying "user" for a range read out of
+    // level statistics sends the reader to a control that is not the cause.
+    const auto* source = rangeMode == RangeMode::User ? "user"
+        : rangeMode == RangeMode::File ? "file" : "level";
     auto [minimum, maximum]
         = paddedIfDegenerate(selected->first, selected->second, logarithmic);
     if (!(minimum < maximum)) {
-        throw std::runtime_error("user scalar range must have positive extent");
+        throw std::runtime_error(
+            std::string(source) + " scalar range must have positive extent");
+    }
+    // Checked here rather than left to the renderer: this function decides
+    // the range, so a range the renderer must refuse -- a span so wide it is
+    // infinite, which validateVolumeRenderRequest rejects -- is this
+    // function's error to report, not an invalid_argument out of the middle
+    // of a render.
+    if (!std::isfinite(minimum) || !std::isfinite(maximum)
+        || !std::isfinite(maximum - minimum)) {
+        throw std::runtime_error(
+            std::string(source) + " scalar range must be finite with a finite span");
     }
     if (logarithmic && minimum > 0.0) {
         return VolumeRange{minimum, maximum, true};
@@ -164,9 +188,11 @@ std::array<int, 2> frameBudgetBoundedVolumeSize(
     return bounded;
 }
 
-VolumeDisplayResult executeVolumeRenderWithFallback(
+namespace {
+
+VolumeDisplayResult renderWithFallback(
     const std::shared_ptr<DatasetSession>& dataset, VolumeRenderRequest request,
-    StopToken cancellation)
+    const std::optional<VolumeRangeChoice>& choice, StopToken cancellation)
 {
     request.outputSize = frameBudgetBoundedVolumeSize(
         request.outputSize, dataset->maximumResponseBytes());
@@ -174,6 +200,14 @@ VolumeDisplayResult executeVolumeRenderWithFallback(
     int fallbackTo = -1;
     for (;;) {
         try {
+            if (choice) {
+                // Per attempt, not once: request.maximumLevel is what the
+                // loop lowers, and a File or Level range is a property of it.
+                request.logarithmic = choice->logarithmic;
+                request.range = resolveVolumeRange(dataset, request.field,
+                    request.maximumLevel, request.composition, choice->mode,
+                    choice->userRange, choice->logarithmic, cancellation);
+            }
             auto frame = dataset->renderVolume(request, cancellation);
             if (fallbackFrom >= 0) {
                 // Only when this loop drove one. The frame arrives carrying
@@ -211,6 +245,23 @@ VolumeDisplayResult executeVolumeRenderWithFallback(
             fallbackTo = --request.maximumLevel;
         }
     }
+}
+
+} // namespace
+
+VolumeDisplayResult executeVolumeRenderWithFallback(
+    const std::shared_ptr<DatasetSession>& dataset, VolumeRenderRequest request,
+    const VolumeRangeChoice& range, StopToken cancellation)
+{
+    return renderWithFallback(dataset, std::move(request), range, cancellation);
+}
+
+VolumeDisplayResult executeVolumeRenderWithFallback(
+    const std::shared_ptr<DatasetSession>& dataset, VolumeRenderRequest request,
+    StopToken cancellation)
+{
+    return renderWithFallback(
+        dataset, std::move(request), std::nullopt, cancellation);
 }
 
 } // namespace amrvis

--- a/src/pipeline/VolumePipeline.cpp
+++ b/src/pipeline/VolumePipeline.cpp
@@ -20,6 +20,15 @@ VolumeTransferFunction makeVolumeTransferFunction(
     constexpr int entryCount = Palette::colorSlots;
     transfer.colors.reserve(static_cast<std::size_t>(entryCount));
     transfer.opacities.reserve(static_cast<std::size_t>(entryCount));
+    // Refused rather than clamped: std::clamp returns a NaN unchanged (it
+    // compares, and every comparison against a NaN is false), and the casts
+    // to int below are undefined for one. A control that is not a number is
+    // a caller error, not a value to guess at.
+    if (!std::isfinite(ramp.lowThreshold) || !std::isfinite(ramp.highThreshold)
+        || !std::isfinite(ramp.maximumOpacity)) {
+        throw std::invalid_argument(
+            "opacity ramp thresholds and maximum must be finite");
+    }
     const auto low = std::clamp(ramp.lowThreshold, 0.0, 1.0);
     const auto high = std::clamp(ramp.highThreshold, 0.0, 1.0);
     const auto maximum = std::clamp(ramp.maximumOpacity, 0.0, 1.0);
@@ -45,13 +54,18 @@ VolumeTransferFunction makeVolumeTransferFunction(
         transfer.colors.push_back(palette.slotArgb(slot) & 0x00FFFFFFU);
         double opacity = 0.0;
         if (entry >= lowEntry && entry <= highEntry) {
-            if (paletteAlpha) {
+            if (highEntry == lowEntry) {
+                // The sub-pitch window, whatever the alpha source. Taking the
+                // palette's stored alpha here would make the single selected
+                // entry as faint as that slot happens to be -- 5% on a typical
+                // ramp -- so the "thin shell at that value" the header
+                // promises would be the only visible entry and invisible.
+                opacity = 1.0;
+            } else if (paletteAlpha) {
                 opacity = palette.opacity(slot);
-            } else if (highEntry > lowEntry) {
+            } else {
                 opacity = static_cast<double>(entry - lowEntry)
                     / static_cast<double>(highEntry - lowEntry);
-            } else {
-                opacity = 1.0;
             }
         }
         transfer.opacities.push_back(
@@ -70,10 +84,10 @@ std::optional<VolumeRange> resolveVolumeRange(
     if (rangeMode == RangeMode::User) {
         selected = userRange;
     } else if (rangeMode == RangeMode::File || rangeMode == RangeMode::Level) {
-        if (rangeMode == RangeMode::File) {
-            selected = fabDataRange(dataset, field, cancellation);
-        }
-        if (!selected) {
+        // No fabDataRange fallback here, unlike the slice path: a FAB has no
+        // volume to render (supportsVolumeRendering requires !isFab), so the
+        // call would return nullopt for every dataset that can reach this.
+        {
             const auto statistics = dataset->requestRange(RangeRequest{
                 .field = field,
                 .maximumLevel = maximumLevel,
@@ -119,8 +133,13 @@ std::array<int, 2> frameBudgetBoundedVolumeSize(
         return outputSize;
     }
     const auto budget = static_cast<std::uint64_t>(*maximumResponseBytes);
-    if (budget <= volumeResponseOverheadBytes + sizeof(std::uint32_t)) {
-        return {1, 1};
+    // Refused, not silently bounded to {1, 1}: a budget that cannot hold one
+    // pixel would produce a request the far side rejects anyway, and saying
+    // so here names the real problem instead of failing later as an
+    // oversized frame.
+    if (budget < volumeResponseBytes({1, 1})) {
+        throw std::invalid_argument(
+            "the negotiated response budget cannot hold a single volume pixel");
     }
     const auto maximumPixels = (budget - volumeResponseOverheadBytes)
         / sizeof(std::uint32_t);
@@ -156,8 +175,19 @@ VolumeDisplayResult executeVolumeRenderWithFallback(
     for (;;) {
         try {
             auto frame = dataset->renderVolume(request, cancellation);
-            frame.cacheFallbackFromLevel = fallbackFrom;
-            frame.cacheFallbackToLevel = fallbackTo;
+            if (fallbackFrom >= 0) {
+                // Only when this loop drove one. The frame arrives carrying
+                // whatever fallback the session itself made -- a remote
+                // server under its own cache pressure reports one -- and
+                // stamping -1 over it would hide from the user that their
+                // volume was rendered coarser than they asked. When both
+                // happened, the span runs from where this loop started to
+                // the coarsest level actually used.
+                const auto sessionTo = frame.cacheFallbackToLevel;
+                frame.cacheFallbackFromLevel = fallbackFrom;
+                frame.cacheFallbackToLevel = sessionTo >= 0
+                    ? std::min(sessionTo, fallbackTo) : fallbackTo;
+            }
             return {request, std::move(frame)};
         } catch (const CacheBudgetExceeded&) {
             const auto budget = cacheBudgetDescription(

--- a/src/pipeline/VolumePipeline.cpp
+++ b/src/pipeline/VolumePipeline.cpp
@@ -219,11 +219,33 @@ VolumeDisplayResult renderWithFallback(
         request.outputSize, dataset->maximumResponseBytes());
     int fallbackFrom = -1;
     int fallbackTo = -1;
-    // Whether the range moves with the level. Visible does not need a repeat
-    // (the renderer resolves it from the grid it sampled, so it already
-    // follows), and neither does User; File and Level are read per level.
-    const bool levelDependentRange = choice
-        && (choice->mode == RangeMode::File || choice->mode == RangeMode::Level);
+    // Whether the range moves with the level, i.e. whether a fallback makes
+    // the resolved range wrong and the render worth repeating. Only Level
+    // does: Visible is resolved by the renderer from the grid it sampled, so
+    // it follows on its own; User does not depend on the level at all; and
+    // RangeScope::File asks metadataValueRange for the whole file
+    // (LocalDatasetSession.cpp passes std::nullopt for the level), so it
+    // returns the same bounds whatever the fallback did. Repeating for File
+    // would cost a second render, and a second round trip to a server, to
+    // arrive at the range it already had.
+    const bool levelDependentRange = choice && choice->mode == RangeMode::Level;
+
+    // Work done by an attempt whose frame is then discarded. The sampling and
+    // the payload reads happened and cost what they cost; the repeat runs
+    // against the grid the discarded attempt just cached, so it reports none
+    // of it, and the caller would be told a render that read the plotfile
+    // read nothing. Structural fields come from the attempt that produced the
+    // pixels; only the counters and the timers accumulate.
+    VolumeRenderMetrics carried;
+    const auto addWork = [](VolumeRenderMetrics& into,
+                             const VolumeRenderMetrics& from) {
+        into.sampleMicroseconds += from.sampleMicroseconds;
+        into.renderMicroseconds += from.renderMicroseconds;
+        into.candidateBlocks += from.candidateBlocks;
+        into.blocksRead += from.blocksRead;
+        into.cacheHits += from.cacheHits;
+        into.payloadBytesRead += from.payloadBytesRead;
+    };
     for (;;) {
         try {
             if (choice) {
@@ -253,9 +275,11 @@ VolumeDisplayResult renderWithFallback(
                 fallbackTo = sessionTo;
                 request.maximumLevel = sessionTo;
                 if (levelDependentRange) {
+                    addWork(carried, frame.metrics);
                     continue;
                 }
             }
+            addWork(frame.metrics, carried);
             if (fallbackFrom >= 0) {
                 // The span runs from where the first fallback started to the
                 // coarsest level anything actually rendered at.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -402,6 +402,10 @@ add_executable(test_volume_query integration/test_volume_query.cpp)
 target_link_libraries(test_volume_query PRIVATE amrexplorer::query amrexplorer::warnings)
 add_test(NAME volume_query COMMAND test_volume_query)
 
+add_executable(test_volume_pipeline integration/test_volume_pipeline.cpp)
+target_link_libraries(test_volume_pipeline PRIVATE amrexplorer::pipeline amrexplorer::warnings)
+add_test(NAME volume_pipeline COMMAND test_volume_pipeline)
+
 add_executable(test_spherical_display integration/test_spherical_display.cpp)
 target_link_libraries(
     test_spherical_display

--- a/tests/integration/test_volume_pipeline.cpp
+++ b/tests/integration/test_volume_pipeline.cpp
@@ -19,6 +19,7 @@
 #include <iostream>
 #include <memory>
 #include <span>
+#include <stdexcept>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -206,9 +207,24 @@ int main()
                 && shrunk[1] >= 298
                 && amrvis::volumeResponseBytes(shrunk) <= quarter,
             "an oversized frame was not shrunk to fit, aspect kept");
-        require(amrvis::frameBudgetBoundedVolumeSize({800, 600}, 100U)
+        // A budget too small for one pixel is refused rather than bounded to
+        // {1, 1}: volumeResponseBytes({1, 1}) exceeds it, so the request that
+        // came back would be rejected on arrival anyway, and the refusal here
+        // names the budget instead of failing later as an oversized frame.
+        bool refused = false;
+        try {
+            static_cast<void>(
+                amrvis::frameBudgetBoundedVolumeSize({800, 600}, 100U));
+        } catch (const std::invalid_argument&) {
+            refused = true;
+        }
+        require(refused, "a hopeless budget did not refuse");
+        // The smallest budget that does fit one pixel still yields one pixel.
+        const auto minimum = static_cast<std::uint32_t>(
+            amrvis::volumeResponseBytes({1, 1}));
+        require(amrvis::frameBudgetBoundedVolumeSize({800, 600}, minimum)
                 == (std::array<int, 2>{1, 1}),
-            "a hopeless budget did not collapse to one pixel");
+            "the smallest workable budget did not collapse to one pixel");
     }
 
     const auto unique = std::chrono::steady_clock::now().time_since_epoch().count();

--- a/tests/integration/test_volume_pipeline.cpp
+++ b/tests/integration/test_volume_pipeline.cpp
@@ -120,6 +120,102 @@ std::size_t litPixels(const amrvis::VolumeFrame& frame)
     return lit;
 }
 
+// A session that renders locally but reports a fallback of its own, the way
+// a remote server under its own cache pressure does. Everything but
+// renderVolume delegates; LocalDatasetSession is final, so this wraps rather
+// than derives.
+class FallbackReportingSession final : public amrvis::DatasetSession {
+public:
+    explicit FallbackReportingSession(
+        std::shared_ptr<amrvis::LocalDatasetSession> inner)
+        : m_inner(std::move(inner))
+    {
+    }
+
+    [[nodiscard]] amrvis::DatasetId id() const noexcept override
+    {
+        return m_inner->id();
+    }
+    [[nodiscard]] const amrvis::DatasetMetadata& metadata() const noexcept override
+    {
+        return m_inner->metadata();
+    }
+    [[nodiscard]] const amrvis::MetadataReadMetrics&
+    metadataReadMetrics() const noexcept override
+    {
+        return m_inner->metadataReadMetrics();
+    }
+    [[nodiscard]] const std::string& fileVersion() const noexcept override
+    {
+        return m_inner->fileVersion();
+    }
+    [[nodiscard]] const std::vector<amrvis::ParticleSpeciesMetadata>&
+    particleSpecies() const noexcept override
+    {
+        return m_inner->particleSpecies();
+    }
+    [[nodiscard]] amrvis::ViewDataResult requestView(
+        const amrvis::ViewDataRequest& request,
+        amrvis::StopToken cancellation = {}) override
+    {
+        return m_inner->requestView(request, cancellation);
+    }
+    [[nodiscard]] amrvis::DatasetPage requestDatasetPage(
+        const amrvis::DatasetPageRequest& request,
+        amrvis::StopToken cancellation = {}) override
+    {
+        return m_inner->requestDatasetPage(request, cancellation);
+    }
+    [[nodiscard]] std::optional<amrvis::ValueRange> requestRange(
+        const amrvis::RangeRequest& request,
+        amrvis::StopToken cancellation = {}) override
+    {
+        return m_inner->requestRange(request, cancellation);
+    }
+    [[nodiscard]] bool rangeAvailable(
+        const amrvis::RangeRequest& request) const noexcept override
+    {
+        return m_inner->rangeAvailable(request);
+    }
+    [[nodiscard]] amrvis::ParticleSample requestParticleSample(
+        const std::string& species, double fraction, std::uint64_t seed,
+        amrvis::StopToken cancellation = {}) override
+    {
+        return m_inner->requestParticleSample(
+            species, fraction, seed, cancellation);
+    }
+    [[nodiscard]] bool supportsVolumeRendering() const noexcept override
+    {
+        return m_inner->supportsVolumeRendering();
+    }
+    // The one that matters: render at one level coarser than asked and say
+    // so, without ever throwing CacheBudgetExceeded at the pipeline.
+    [[nodiscard]] amrvis::VolumeFrame renderVolume(
+        const amrvis::VolumeRenderRequest& request,
+        amrvis::StopToken cancellation = {}) override
+    {
+        auto coarser = request;
+        coarser.maximumLevel = std::max(0, request.maximumLevel - 1);
+        auto frame = m_inner->renderVolume(coarser, cancellation);
+        frame.cacheFallbackFromLevel = request.maximumLevel;
+        frame.cacheFallbackToLevel = coarser.maximumLevel;
+        return frame;
+    }
+    [[nodiscard]] amrvis::CacheMetrics cacheMetrics() const override
+    {
+        return m_inner->cacheMetrics();
+    }
+    [[nodiscard]] bool setCacheBudget(std::uint64_t bytes) override
+    {
+        return m_inner->setCacheBudget(bytes);
+    }
+    void clearUnpinnedCache() override { m_inner->clearUnpinnedCache(); }
+    void close() noexcept override { m_inner->close(); }
+
+private:
+    std::shared_ptr<amrvis::LocalDatasetSession> m_inner;
+};
+
 } // namespace
 
 int main()
@@ -442,6 +538,23 @@ int main()
             require(followed.request.maximumLevel == 0
                     && followed.frame.usedRange.maximum < 1.5,
                 "the range did not follow the fallback to level 0");
+        }
+        // A session that falls back inside an attempt the client never
+        // retried: the result's request must describe what was rendered, not
+        // what was asked for, or the caller's state stays finer than the
+        // pixels it got.
+        {
+            auto reporting = std::make_shared<FallbackReportingSession>(session);
+            std::shared_ptr<amrvis::DatasetSession> wrapped = reporting;
+            auto asked = request;
+            asked.maximumLevel = 1;
+            const auto served
+                = amrvis::executeVolumeRenderWithFallback(wrapped, asked);
+            require(served.frame.cacheFallbackFromLevel == 1
+                    && served.frame.cacheFallbackToLevel == 0,
+                "the session's own fallback was not reported");
+            require(served.request.maximumLevel == 0,
+                "the result's request did not follow the session's fallback");
         }
         auto exact = request;
         exact.composition = amrvis::CompositionPolicy::ExactLevel;

--- a/tests/integration/test_volume_pipeline.cpp
+++ b/tests/integration/test_volume_pipeline.cpp
@@ -17,6 +17,7 @@
 #include <filesystem>
 #include <fstream>
 #include <iostream>
+#include <limits>
 #include <memory>
 #include <span>
 #include <stdexcept>
@@ -307,14 +308,19 @@ int main()
         // {1, 1}: volumeResponseBytes({1, 1}) exceeds it, so the request that
         // came back would be rejected on arrival anyway, and the refusal here
         // names the budget instead of failing later as an oversized frame.
-        bool refused = false;
+        std::string refusal;
         try {
             static_cast<void>(
                 amrvis::frameBudgetBoundedVolumeSize({800, 600}, 100U));
-        } catch (const std::invalid_argument&) {
-            refused = true;
+        } catch (const std::runtime_error& error) {
+            refusal = error.what();
         }
-        require(refused, "a hopeless budget did not refuse");
+        // Actionable, and carrying both numbers: this escapes to the user the
+        // way the cache-pressure refusals do, and a bare "invalid argument"
+        // would tell them nothing about a budget they can raise.
+        require(refusal.find("100") != std::string::npos
+                && refusal.find("4100") != std::string::npos,
+            "a hopeless budget did not refuse with the numbers");
         // An inverted window is refused rather than silently collapsing to a
         // shell at the midpoint, which is what the sub-pitch branch would do
         // with it and is indistinguishable from a deliberate thin shell.
@@ -380,6 +386,23 @@ int main()
             std::pair{2.0, 2.0}, false);
         require(degenerate && degenerate->minimum < 2.0 && degenerate->maximum > 2.0,
             "a degenerate User range was not padded");
+        {
+            const auto huge = 1.0e300;
+            std::string narrow;
+            try {
+                static_cast<void>(amrvis::resolveVolumeRange(dataset, field, 1,
+                    amrvis::CompositionPolicy::FinestAvailable,
+                    amrvis::RangeMode::User,
+                    std::pair{huge, std::nextafter(huge,
+                        std::numeric_limits<double>::infinity())},
+                    true));
+            } catch (const std::runtime_error& error) {
+                narrow = error.what();
+            }
+            require(narrow.find("user") != std::string::npos
+                    && narrow.find("logarithm") != std::string::npos,
+                "a logarithmic range too narrow to map was handed to the renderer");
+        }
         require(!amrvis::resolveVolumeRange(dataset, field, 1,
                     amrvis::CompositionPolicy::FinestAvailable,
                     amrvis::RangeMode::Visible, std::nullopt, false)

--- a/tests/integration/test_volume_pipeline.cpp
+++ b/tests/integration/test_volume_pipeline.cpp
@@ -219,6 +219,24 @@ int main()
             refused = true;
         }
         require(refused, "a hopeless budget did not refuse");
+        // An inverted window is refused rather than silently collapsing to a
+        // shell at the midpoint, which is what the sub-pitch branch would do
+        // with it and is indistinguishable from a deliberate thin shell.
+        const auto ramps = syntheticPalette(false);
+        const auto refusesRamp = [&ramps](const amrvis::OpacityRamp& ramp) {
+            try {
+                static_cast<void>(
+                    amrvis::makeVolumeTransferFunction(ramps, ramp));
+            } catch (const std::invalid_argument&) {
+                return true;
+            }
+            return false;
+        };
+        require(refusesRamp({0.8, 0.2, 1.0, false}),
+            "an inverted opacity window was accepted");
+        require(refusesRamp({std::nan(""), 1.0, 1.0, false})
+                && refusesRamp({0.0, 1.0, std::nan(""), false}),
+            "a non-finite opacity control was accepted");
         // The smallest budget that does fit one pixel still yields one pixel.
         const auto minimum = static_cast<std::uint32_t>(
             amrvis::volumeResponseBytes({1, 1}));
@@ -341,6 +359,19 @@ int main()
                 && coarseResolved.frame.metrics.sampledMaximumLevel == 0
                 && !coarseResolved.frame.metrics.gridFromCache,
             "a coarser level did not resolve its own Visible range");
+        // The budget a session was constructed with bounds the grid pool
+        // too, not just the block pool. Nothing on the normal open paths
+        // calls setCacheBudget, so a session built with a small budget would
+        // otherwise keep the 256 MiB grid default.
+        {
+            auto small = std::make_shared<amrvis::LocalDatasetSession>(
+                root, amrvis::DatasetId{9}, 4096);
+            require(small->volumeGridCacheMetrics().budgetBytes == 4096,
+                "the constructed budget did not reach the grid cache");
+            require(small->setCacheBudget(8192)
+                    && small->volumeGridCacheMetrics().budgetBytes == 8192,
+                "setCacheBudget did not keep the grid cache in step");
+        }
         // A grid larger than the grid cache still renders, uncached.
         require(session->setVolumeGridCacheBudget(1024),
             "the grid cache budget could not be lowered");
@@ -392,6 +423,26 @@ int main()
                 && fallen.frame.metrics.gridDims == (std::array<int, 3>{4, 4, 4})
                 && litPixels(fallen.frame) > 0,
             "the render did not fall back to the level that fits");
+        // The range follows the fallback when it is resolved per attempt:
+        // level 1's statistics span [1, 2], level 0's are the coarse 1.0
+        // alone, so a Level range resolved once up front would colour a
+        // level-0 render with level-1's numbers.
+        {
+            const auto levelWide = amrvis::resolveVolumeRange(dataset,
+                request.field, 1, request.composition, amrvis::RangeMode::Level,
+                std::nullopt, false);
+            require(levelWide && levelWide->maximum > 1.5,
+                "the level-1 range is not the wider one");
+            auto tracking = request;
+            tracking.range.reset();
+            const auto followed = amrvis::executeVolumeRenderWithFallback(
+                dataset, tracking,
+                amrvis::VolumeRangeChoice{amrvis::RangeMode::Level,
+                    std::nullopt, false});
+            require(followed.request.maximumLevel == 0
+                    && followed.frame.usedRange.maximum < 1.5,
+                "the range did not follow the fallback to level 0");
+        }
         auto exact = request;
         exact.composition = amrvis::CompositionPolicy::ExactLevel;
         bool threw = false;

--- a/tests/integration/test_volume_pipeline.cpp
+++ b/tests/integration/test_volume_pipeline.cpp
@@ -578,6 +578,21 @@ int main()
                 "the session's own fallback was not reported");
             require(served.request.maximumLevel == 0,
                 "the result's request did not follow the session's fallback");
+            // And a Level range follows it too: level 1's statistics span
+            // [1, 2], level 0's are the coarse 1.0 alone. Resolving once
+            // before the call would map level-0 pixels with level-1's range.
+            auto tracked = asked;
+            tracked.range.reset();
+            const auto followed = amrvis::executeVolumeRenderWithFallback(
+                wrapped, tracked,
+                amrvis::VolumeRangeChoice{amrvis::RangeMode::Level,
+                    std::nullopt, false});
+            require(followed.request.maximumLevel == 0
+                    && followed.frame.cacheFallbackFromLevel == 1
+                    && followed.frame.cacheFallbackToLevel == 0,
+                "the session's fallback was not reported after the repeat");
+            require(followed.frame.usedRange.maximum < 1.5,
+                "a Level range did not follow the session's own fallback");
         }
         auto exact = request;
         exact.composition = amrvis::CompositionPolicy::ExactLevel;

--- a/tests/integration/test_volume_pipeline.cpp
+++ b/tests/integration/test_volume_pipeline.cpp
@@ -1,0 +1,372 @@
+// The volume pipeline over a real local session: the transfer function
+// built from a palette and the opacity controls, the range resolution, the
+// frame-budget bound, and executeVolumeRenderWithFallback end to end --
+// a frame with coverage, the grid cache serving the second render, a
+// closed session refusing, and the cache-pressure fallback to a coarser
+// level over a two-level fixture whose fine block outsizes the block cache.
+
+#include <amrexplorer/pipeline/VolumePipeline.hpp>
+
+#include <amrexplorer/data/LocalDatasetSession.hpp>
+
+#include <array>
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <span>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace {
+
+constexpr std::string_view realDescriptor =
+    "((8, (64 11 52 0 1 12 0 1023)),(8, (8 7 6 5 4 3 2 1)))";
+
+void require(bool condition, const char* message)
+{
+    if (!condition) {
+        std::cerr << "FAILED: " << message << '\n';
+        std::exit(1);
+    }
+}
+
+void writeText(const std::filesystem::path& path, const std::string& text)
+{
+    std::ofstream output(path, std::ios::binary);
+    require(static_cast<bool>(output), "could not create fixture text");
+    output << text;
+}
+
+void writeFab(const std::filesystem::path& path, std::string_view box,
+    std::span<const double> values)
+{
+    std::ofstream output(path, std::ios::binary);
+    require(static_cast<bool>(output), "could not create fixture FAB");
+    output << "FAB " << realDescriptor << box << " 1\n";
+    output.write(reinterpret_cast<const char*>(values.data()),
+        static_cast<std::streamsize>(values.size() * sizeof(double)));
+}
+
+// Two levels over [0,1]^3: coarse 4^3 = 1.0 (one 512-byte block), fine 8^3
+// = 2.0 over the whole domain (one 4 KiB block). Block statistics: the
+// coarse block [1, 1], the fine block [2, 2], so the File range is [1, 2].
+std::filesystem::path writeTwoLevelFixture(const std::filesystem::path& root)
+{
+    std::filesystem::create_directories(root / "Level_0");
+    std::filesystem::create_directories(root / "Level_1");
+    writeText(root / "Header",
+        "HyperCLaw-V1.1\n"
+        "1\nphi\n"
+        "3\n0.0\n1\n"
+        "0.0 0.0 0.0\n1.0 1.0 1.0\n2\n"
+        "((0,0,0) (3,3,3) (0,0,0))\n"
+        "((0,0,0) (7,7,7) (0,0,0))\n"
+        "0 0\n"
+        "0.25 0.25 0.25\n0.125 0.125 0.125\n"
+        "0\n0\n"
+        "0 1 0.0\n0\n"
+        "0.0 1.0\n0.0 1.0\n0.0 1.0\n"
+        "Level_0/Cell\n"
+        "1 1 0.0\n0\n"
+        "0.0 1.0\n0.0 1.0\n0.0 1.0\n"
+        "Level_1/Cell\n");
+    writeText(root / "Level_0" / "Cell_H",
+        "1\n1\n1\n0\n"
+        "(1 0\n((0,0,0) (3,3,3) (0,0,0))\n)\n"
+        "1\nFabOnDisk: Cell_D_00000 0\n\n"
+        "1,1\n1.0,\n\n1,1\n1.0,\n\n");
+    writeText(root / "Level_1" / "Cell_H",
+        "1\n1\n1\n0\n"
+        "(1 0\n((0,0,0) (7,7,7) (0,0,0))\n)\n"
+        "1\nFabOnDisk: Cell_D_00000 0\n\n"
+        "1,1\n2.0,\n\n1,1\n2.0,\n\n");
+    std::array<double, 64> coarse{};
+    std::array<double, 512> fine{};
+    coarse.fill(1.0);
+    fine.fill(2.0);
+    writeFab(root / "Level_0" / "Cell_D_00000", "((0,0,0) (3,3,3) (0,0,0))",
+        coarse);
+    writeFab(root / "Level_1" / "Cell_D_00000", "((0,0,0) (7,7,7) (0,0,0))",
+        fine);
+    return root;
+}
+
+amrvis::Palette syntheticPalette(bool withAlpha)
+{
+    std::array<amrvis::Palette::Rgb, amrvis::Palette::slotCount> slots{};
+    std::array<std::uint8_t, amrvis::Palette::slotCount> alpha{};
+    for (int index = 0; index < amrvis::Palette::slotCount; ++index) {
+        const auto i = static_cast<std::size_t>(index);
+        slots[i] = {static_cast<std::uint8_t>(index),
+            static_cast<std::uint8_t>(255 - index), 7};
+        alpha[i] = static_cast<std::uint8_t>(index % 3 == 0 ? 100 : 20);
+    }
+    return withAlpha ? amrvis::Palette(slots, alpha) : amrvis::Palette(slots);
+}
+
+std::size_t litPixels(const amrvis::VolumeFrame& frame)
+{
+    std::size_t lit = 0;
+    for (const auto pixel : frame.pixels) {
+        lit += (pixel >> 24U) != 0U;
+    }
+    return lit;
+}
+
+} // namespace
+
+int main()
+{
+    // --- the transfer function -------------------------------------------
+    {
+        const auto palette = syntheticPalette(false);
+        const auto plain = amrvis::makeVolumeTransferFunction(palette, {});
+        require(plain.colors.size() == 253 && plain.opacities.size() == 253,
+            "the transfer function does not have one entry per data slot");
+        for (int entry = 0; entry < 253; ++entry) {
+            const auto i = static_cast<std::size_t>(entry);
+            require(plain.colors[i]
+                    == (palette.slotArgb(amrvis::Palette::paletteStart + entry)
+                        & 0x00FFFFFFU),
+                "an entry's colour is not its palette slot");
+            const auto expected = static_cast<float>(entry / 252.0);
+            require(std::abs(plain.opacities[i] - expected) <= 1.0e-6F,
+                "the default ramp is not linear over the whole range");
+        }
+        // A window: transparent outside [0.25, 0.75], ramping inside to the
+        // maximum opacity at the top.
+        amrvis::OpacityRamp windowed{0.25, 0.75, 0.5, false};
+        const auto window = amrvis::makeVolumeTransferFunction(palette, windowed);
+        require(window.opacities[0] == 0.0F && window.opacities[252] == 0.0F
+                && window.opacities[50] == 0.0F,
+            "the window did not clear the entries outside the thresholds");
+        require(std::abs(window.opacities[189] - 0.5F) <= 1.0e-5F,   // t = 0.75
+            "the window's top is not the maximum opacity");
+        require(std::abs(window.opacities[126] - 0.25F) <= 2.0e-3F,   // t = 0.5
+            "the window's midpoint is not half the maximum opacity");
+        // The palette's alpha ramp, when asked for and present; the plain
+        // ramp when the palette has none.
+        amrvis::OpacityRamp fromPalette{0.0, 1.0, 1.0, true};
+        const auto alphaPalette = syntheticPalette(true);
+        const auto withAlpha = amrvis::makeVolumeTransferFunction(alphaPalette, fromPalette);
+        require(withAlpha.opacities[0] == 1.0F   // slot 3: 3 % 3 == 0 -> 100 %
+                && std::abs(withAlpha.opacities[1] - 0.2F) <= 1.0e-6F,
+            "the palette alpha ramp was not used");
+        const auto withoutAlpha = amrvis::makeVolumeTransferFunction(palette, fromPalette);
+        require(withoutAlpha.opacities == plain.opacities,
+            "a palette without a ramp did not fall back to the linear ramp");
+        // Every transfer function the builder makes validates.
+        require(amrvis::validateVolumeTransferFunction(withAlpha).empty()
+                && amrvis::validateVolumeTransferFunction(window).empty(),
+            "the builder produced an invalid transfer function");
+    }
+
+    // --- the frame-budget bound -------------------------------------------
+    {
+        require(amrvis::frameBudgetBoundedVolumeSize({800, 600}, std::nullopt)
+                == (std::array<int, 2>{800, 600}),
+            "a local session's frame was bounded");
+        const auto plenty = static_cast<std::uint32_t>(
+            amrvis::volumeResponseBytes({800, 600}));
+        require(amrvis::frameBudgetBoundedVolumeSize({800, 600}, plenty)
+                == (std::array<int, 2>{800, 600}),
+            "a frame that exactly fits was shrunk");
+        const auto quarter = static_cast<std::uint32_t>(
+            amrvis::volumeResponseBytes({400, 300}));
+        const auto shrunk = amrvis::frameBudgetBoundedVolumeSize({800, 600}, quarter);
+        require(shrunk[0] <= 400 && shrunk[1] <= 300 && shrunk[0] >= 398
+                && shrunk[1] >= 298
+                && amrvis::volumeResponseBytes(shrunk) <= quarter,
+            "an oversized frame was not shrunk to fit, aspect kept");
+        require(amrvis::frameBudgetBoundedVolumeSize({800, 600}, 100U)
+                == (std::array<int, 2>{1, 1}),
+            "a hopeless budget did not collapse to one pixel");
+    }
+
+    const auto unique = std::chrono::steady_clock::now().time_since_epoch().count();
+    const auto scratch = std::filesystem::temp_directory_path()
+        / ("amrexplorer-volume-pipeline-" + std::to_string(unique));
+    const auto root = writeTwoLevelFixture(scratch / "two-level");
+
+    // --- range resolution and rendering over a local session ------------
+    {
+        auto session = std::make_shared<amrvis::LocalDatasetSession>(
+            root, amrvis::DatasetId{4}, 1024 * 1024);
+        require(session->supportsVolumeRendering(),
+            "a 3-D plotfile session does not support volume rendering");
+        std::shared_ptr<amrvis::DatasetSession> dataset = session;
+        const amrvis::FieldId field{0};
+
+        // File statistics: [1, 2]; Level 1 (finest available) also [1, 2];
+        // User range as given, padded when degenerate; log downgrades on a
+        // non-positive range; Visible leaves it to the renderer.
+        const auto file = amrvis::resolveVolumeRange(dataset, field, 1,
+            amrvis::CompositionPolicy::FinestAvailable, amrvis::RangeMode::File,
+            std::nullopt, false);
+        require(file && file->minimum == 1.0 && file->maximum == 2.0
+                && !file->logarithmic,
+            "the File range is not the metadata's");
+        const auto logFile = amrvis::resolveVolumeRange(dataset, field, 1,
+            amrvis::CompositionPolicy::FinestAvailable, amrvis::RangeMode::File,
+            std::nullopt, true);
+        require(logFile && logFile->logarithmic && logFile->minimum == 1.0,
+            "a positive File range did not stay logarithmic");
+        const auto user = amrvis::resolveVolumeRange(dataset, field, 1,
+            amrvis::CompositionPolicy::FinestAvailable, amrvis::RangeMode::User,
+            std::pair{-3.0, 5.0}, true);
+        require(user && !user->logarithmic && user->minimum == -3.0
+                && user->maximum == 5.0,
+            "a non-positive User range did not fall back to linear");
+        const auto degenerate = amrvis::resolveVolumeRange(dataset, field, 1,
+            amrvis::CompositionPolicy::FinestAvailable, amrvis::RangeMode::User,
+            std::pair{2.0, 2.0}, false);
+        require(degenerate && degenerate->minimum < 2.0 && degenerate->maximum > 2.0,
+            "a degenerate User range was not padded");
+        require(!amrvis::resolveVolumeRange(dataset, field, 1,
+                    amrvis::CompositionPolicy::FinestAvailable,
+                    amrvis::RangeMode::Visible, std::nullopt, false)
+                    .has_value(),
+            "the Visible range was resolved on the client");
+
+        // Render: an oblique view of a domain that is 2.0 in its fine
+        // block and 1.0 in the coarse remainder, opaque above the middle.
+        amrvis::VolumeRenderRequest request;
+        request.dataset = amrvis::DatasetId{4};
+        request.field = field;
+        request.maximumLevel = 1;
+        request.region = amrvis::datasetSampleBounds(session->metadata());
+        request.camera = {0.6, 0.4, 1.0};
+        request.outputSize = {64, 48};
+        request.range = amrvis::VolumeRange{1.0, 2.0, false};
+        request.transfer = amrvis::makeVolumeTransferFunction(
+            amrvis::builtinPalette(amrvis::BuiltinPalette::Rainbow),
+            amrvis::OpacityRamp{0.5, 1.0, 1.0, false});
+        request.maximumVoxels = 4096;
+        const auto first = amrvis::executeVolumeRenderWithFallback(dataset, request);
+        require(first.frame.width == 64 && first.frame.height == 48
+                && litPixels(first.frame) > 0
+                && first.frame.usedRange == *request.range
+                && first.frame.metrics.gridDims == (std::array<int, 3>{8, 8, 8})
+                && first.frame.metrics.coveredVoxels == 512
+                && first.frame.metrics.sampledMaximumLevel == 1
+                && !first.frame.metrics.gridFromCache
+                && first.frame.metrics.blocksRead == 2
+                && first.frame.cacheFallbackFromLevel == -1
+                && first.request.maximumLevel == 1,
+            "the first render did not sample and draw the fixture");
+        // Everything is at least the middle of the range: the whole domain
+        // silhouette is lit; the pixel at the frame centre is inside it.
+        require((first.frame.pixels[static_cast<std::size_t>(24 * 64 + 32)] >> 24U) > 0,
+            "the domain centre pixel is not lit");
+        // The second render of the same sample comes from the grid cache and
+        // draws the same picture.
+        const auto second = amrvis::executeVolumeRenderWithFallback(dataset, request);
+        require(second.frame.metrics.gridFromCache
+                && second.frame.metrics.blocksRead == 0
+                && second.frame.pixels == first.frame.pixels,
+            "the second render did not reuse the cached grid");
+        // Visible range: resolved by the renderer from the sampled grid and
+        // reported back. The fine level covers the whole domain, so the grid
+        // is uniformly 2.0 and the range is that value, padded either side.
+        auto visible = request;
+        visible.range.reset();
+        const auto resolved = amrvis::executeVolumeRenderWithFallback(dataset, visible);
+        require(resolved.frame.usedRange.minimum < 2.0
+                && resolved.frame.usedRange.maximum > 2.0
+                && resolved.frame.usedRange.maximum - resolved.frame.usedRange.minimum
+                    < 1.0e-4
+                && !resolved.frame.usedRange.logarithmic
+                && resolved.frame.metrics.gridFromCache,
+            "the Visible range was not resolved from the sampled grid");
+        visible.logarithmic = true;
+        const auto resolvedLog = amrvis::executeVolumeRenderWithFallback(dataset, visible);
+        require(resolvedLog.frame.usedRange.logarithmic
+                && resolvedLog.frame.usedRange.minimum > 0.0
+                && resolvedLog.frame.usedRange.minimum < 2.0
+                && resolvedLog.frame.usedRange.maximum > 2.0,
+            "a positive Visible range did not go logarithmic when asked");
+        // A Visible render at level 0 sees only the coarse 1.0.
+        auto coarseVisible = visible;
+        coarseVisible.logarithmic = false;
+        coarseVisible.maximumLevel = 0;
+        const auto coarseResolved
+            = amrvis::executeVolumeRenderWithFallback(dataset, coarseVisible);
+        require(coarseResolved.frame.usedRange.minimum < 1.0
+                && coarseResolved.frame.usedRange.maximum > 1.0
+                && coarseResolved.frame.usedRange.maximum < 1.001
+                && coarseResolved.frame.metrics.sampledMaximumLevel == 0
+                && !coarseResolved.frame.metrics.gridFromCache,
+            "a coarser level did not resolve its own Visible range");
+        // A grid larger than the grid cache still renders, uncached.
+        require(session->setVolumeGridCacheBudget(1024),
+            "the grid cache budget could not be lowered");
+        session->clearUnpinnedCache();
+        const auto uncached = amrvis::executeVolumeRenderWithFallback(dataset, request);
+        require(!uncached.frame.metrics.gridFromCache
+                && uncached.frame.pixels == first.frame.pixels,
+            "an over-budget grid was not rendered uncached");
+        const auto uncachedAgain = amrvis::executeVolumeRenderWithFallback(dataset, request);
+        require(!uncachedAgain.frame.metrics.gridFromCache,
+            "an over-budget grid was cached anyway");
+        // A closed session refuses.
+        session->close();
+        bool threw = false;
+        try {
+            (void)amrvis::executeVolumeRenderWithFallback(dataset, request);
+        } catch (const std::runtime_error&) {
+            threw = true;
+        }
+        require(threw, "a closed session rendered a volume");
+    }
+
+    // --- cache-pressure fallback -----------------------------------------
+    // A block cache too small for the 4 KiB fine block but large enough for
+    // the 512-byte coarse one: the finest-available render falls back from
+    // level 1 to level 0 and says so; an exact-level request fails with an
+    // actionable message.
+    {
+        auto session = std::make_shared<amrvis::LocalDatasetSession>(
+            root, amrvis::DatasetId{6}, 2048);
+        std::shared_ptr<amrvis::DatasetSession> dataset = session;
+        amrvis::VolumeRenderRequest request;
+        request.dataset = amrvis::DatasetId{6};
+        request.field = amrvis::FieldId{0};
+        request.maximumLevel = 1;
+        request.region = amrvis::datasetSampleBounds(session->metadata());
+        request.camera = amrvis::orthoPresetXY;
+        request.outputSize = {32, 32};
+        // Range [0, 1]: the coarse 1.0 maps to the opaque top entry.
+        request.range = amrvis::VolumeRange{0.0, 1.0, false};
+        request.transfer.colors = {0x0U, 0xFFFFFFU};
+        request.transfer.opacities = {0.0F, 1.0F};
+        request.maximumVoxels = 4096;
+        const auto fallen = amrvis::executeVolumeRenderWithFallback(dataset, request);
+        require(fallen.frame.cacheFallbackFromLevel == 1
+                && fallen.frame.cacheFallbackToLevel == 0
+                && fallen.request.maximumLevel == 0
+                && fallen.frame.metrics.sampledMaximumLevel == 0
+                && fallen.frame.metrics.gridDims == (std::array<int, 3>{4, 4, 4})
+                && litPixels(fallen.frame) > 0,
+            "the render did not fall back to the level that fits");
+        auto exact = request;
+        exact.composition = amrvis::CompositionPolicy::ExactLevel;
+        bool threw = false;
+        try {
+            (void)amrvis::executeVolumeRenderWithFallback(dataset, exact);
+        } catch (const std::runtime_error& error) {
+            threw = std::string(error.what()).find("Choose a lower level")
+                != std::string::npos;
+        }
+        require(threw, "an exact level that cannot fit did not fail actionably");
+    }
+
+    std::error_code removeError;
+    std::filesystem::remove_all(scratch, removeError);
+    return 0;
+}

--- a/tests/integration/test_volume_pipeline.cpp
+++ b/tests/integration/test_volume_pipeline.cpp
@@ -150,6 +150,28 @@ int main()
             "the window's top is not the maximum opacity");
         require(std::abs(window.opacities[126] - 0.25F) <= 2.0e-3F,   // t = 0.5
             "the window's midpoint is not half the maximum opacity");
+        // Equal thresholds (the coupled sliders allow them) and a window
+        // narrower than the entry pitch select the single nearest entry,
+        // opaque, rather than nothing: 0.3 * 252 = 75.6 -> entry 76.
+        for (const amrvis::OpacityRamp narrow :
+            {amrvis::OpacityRamp{0.3, 0.3, 1.0, false},
+                amrvis::OpacityRamp{0.299, 0.301, 1.0, false}}) {
+            const auto shell = amrvis::makeVolumeTransferFunction(palette, narrow);
+            for (int entry = 0; entry < 253; ++entry) {
+                const auto i = static_cast<std::size_t>(entry);
+                require(shell.opacities[i] == (entry == 76 ? 1.0F : 0.0F),
+                    "a sub-pitch window did not select the nearest entry alone");
+            }
+        }
+        // A window holding a few entries ramps over exactly those, the top
+        // one at the maximum: [0.30, 0.31] * 252 = [75.6, 78.12] -> 76..78.
+        const auto few = amrvis::makeVolumeTransferFunction(
+            palette, amrvis::OpacityRamp{0.30, 0.31, 0.8, false});
+        require(few.opacities[75] == 0.0F && few.opacities[76] == 0.0F
+                && std::abs(few.opacities[77] - 0.4F) <= 1.0e-6F
+                && std::abs(few.opacities[78] - 0.8F) <= 1.0e-6F
+                && few.opacities[79] == 0.0F,
+            "a few-entry window did not ramp over its entries to the maximum");
         // The palette's alpha ramp, when asked for and present; the plain
         // ramp when the palette has none.
         amrvis::OpacityRamp fromPalette{0.0, 1.0, 1.0, true};

--- a/tests/integration/test_volume_pipeline.cpp
+++ b/tests/integration/test_volume_pipeline.cpp
@@ -581,6 +581,10 @@ int main()
             // And a Level range follows it too: level 1's statistics span
             // [1, 2], level 0's are the coarse 1.0 alone. Resolving once
             // before the call would map level-0 pixels with level-1's range.
+            // From cold: the render above already cached this grid, so
+            // without clearing, no attempt reads anything and the assertion
+            // below would pass for the wrong reason.
+            session->clearUnpinnedCache();
             auto tracked = asked;
             tracked.range.reset();
             const auto followed = amrvis::executeVolumeRenderWithFallback(
@@ -593,6 +597,24 @@ int main()
                 "the session's fallback was not reported after the repeat");
             require(followed.frame.usedRange.maximum < 1.5,
                 "a Level range did not follow the session's own fallback");
+            // The repeat renders against the grid the discarded attempt
+            // cached, so it reads nothing itself. The work still happened,
+            // and a caller told this render read no blocks would be misled.
+            require(followed.frame.metrics.blocksRead > 0
+                    && followed.frame.metrics.candidateBlocks > 0,
+                "the discarded attempt's work was dropped from the metrics");
+            // A File range asks for the whole file's bounds whatever the
+            // level, so a fallback cannot make it wrong and it is not worth a
+            // second render. One render means the grid was still uncached.
+            session->clearUnpinnedCache();
+            auto byFile = asked;
+            byFile.range.reset();
+            const auto fileRange = amrvis::executeVolumeRenderWithFallback(
+                wrapped, byFile,
+                amrvis::VolumeRangeChoice{amrvis::RangeMode::File,
+                    std::nullopt, false});
+            require(!fileRange.frame.metrics.gridFromCache,
+                "a File range was repeated even though it ignores the level");
         }
         auto exact = request;
         exact.composition = amrvis::CompositionPolicy::ExactLevel;

--- a/tests/unit/test_session_validation.cpp
+++ b/tests/unit/test_session_validation.cpp
@@ -923,7 +923,15 @@ int main()
             requireRejectedWith([&] {
                 validateSessionVolumeResult(metadata, request, bad);
             }, "impossible cache fallback", "a non-descending fallback was accepted");
+            // A frame that fell back to level 0 cannot also report having
+            // sampled level 1: it was rendered with maximumLevel == 0, so
+            // nothing finer can have put a value in its grid.
             bad.cacheFallbackToLevel = 0;
+            requireRejectedWith([&] {
+                validateSessionVolumeResult(metadata, request, bad);
+            }, "impossible cache fallback",
+                "a sampled level finer than the fallback was accepted");
+            bad.metrics.sampledMaximumLevel = 0;
             requireAccepted([&] {
                 validateSessionVolumeResult(metadata, request, bad);
             }, "a fallback from level 1 to 0 was rejected");

--- a/tests/unit/test_session_validation.cpp
+++ b/tests/unit/test_session_validation.cpp
@@ -1,4 +1,5 @@
 #include <amrexplorer/core/Metadata.hpp>
+#include <amrexplorer/data/LocalDatasetSession.hpp>
 #include <amrexplorer/data/SessionValidation.hpp>
 
 #include <cmath>
@@ -824,11 +825,16 @@ int main()
             requireRejectedWith([&] {
                 validateSessionVolumeRequest(metadata, id, bad);
             }, "component", "a missing volume component was accepted");
+            // A volume region may reach past the domain, exactly as a view
+            // region may (see the walk above): VolumeQuery fills the part
+            // with no data with NaN and the renderer treats it as
+            // transparent, so refusing here would throw away a rubber-band
+            // selection that renders perfectly well as a slice.
             bad = request;
             bad.region.upper[2] = 4.5;
-            requireRejectedWith([&] {
+            requireAccepted([&] {
                 validateSessionVolumeRequest(metadata, id, bad);
-            }, "outside", "a volume region past the domain was accepted");
+            }, "a volume region past the domain was rejected");
             bad = request;
             bad.region.upper[2] = 4.0 + 1.0e-12;   // a rounding hair: fine
             requireAccepted([&] {
@@ -921,7 +927,72 @@ int main()
             requireAccepted([&] {
                 validateSessionVolumeResult(metadata, request, bad);
             }, "a fallback from level 1 to 0 was rejected");
+
+            // Dims whose product wraps 64 bits: unsaturated it comes out as
+            // zero, which is under every budget and holds every coverage
+            // count. This validates a peer's numbers, so it is the one place
+            // the wrap is reachable from outside.
+            bad = frame;
+            bad.metrics.gridDims = {4194304, 2097152, 2097152};
+            bad.metrics.coveredVoxels = 0;
+            requireRejectedWith([&] {
+                validateSessionVolumeResult(metadata, request, bad);
+            }, "voxel budget", "grid dims whose product wraps were accepted");
         }
+    }
+
+    // --- the Visible range rule, which the slice path has to agree with ---
+    {
+        const auto gridOf = [](std::vector<float> values) {
+            amrvis::VolumeGrid grid;
+            grid.dims = {static_cast<int>(values.size()), 1, 1};
+            grid.region.lower = {{0.0, 0.0, 0.0}};
+            grid.region.upper = {{1.0, 1.0, 1.0}};
+            grid.coveredVoxels = values.size();
+            grid.values = std::move(values);
+            return grid;
+        };
+        // Mixed signs with a logarithmic request: the negatives are part of
+        // the field, so the range spans them and the mapping falls back to
+        // linear -- what resolveRange does for the same data on a plane.
+        // Deciding from the positive values alone would answer "logarithmic
+        // over [2, 2]" and make every negative voxel vanish.
+        const auto mixed = amrvis::visibleVolumeRange(gridOf({-1.0F, 2.0F}), true);
+        require(!mixed.logarithmic && mixed.minimum <= -1.0
+                && mixed.maximum >= 2.0,
+            "a mixed-sign Visible range went logarithmic");
+        // Strictly positive: logarithmic is viable and is used.
+        const auto positive
+            = amrvis::visibleVolumeRange(gridOf({1.0F, 100.0F}), true);
+        require(positive.logarithmic && positive.minimum > 0.0
+                && positive.maximum >= 100.0,
+            "a positive Visible range did not go logarithmic");
+        // The same grid without the logarithmic request stays linear.
+        require(!amrvis::visibleVolumeRange(gridOf({1.0F, 100.0F}), false)
+                     .logarithmic,
+            "a linear Visible request came back logarithmic");
+        // Degenerate: padded either side rather than left empty.
+        const auto degenerate
+            = amrvis::visibleVolumeRange(gridOf({2.0F, 2.0F}), false);
+        require(degenerate.minimum < 2.0 && degenerate.maximum > 2.0,
+            "a degenerate Visible range was not padded");
+        // Nothing finite: a neutral range that keeps the requested mapping.
+        const auto quietNaN = std::numeric_limits<float>::quiet_NaN();
+        require(amrvis::visibleVolumeRange(gridOf({quietNaN}), true).logarithmic
+                && !amrvis::visibleVolumeRange(gridOf({quietNaN}), false)
+                        .logarithmic,
+            "an all-NaN grid did not fall back to a neutral range");
+        // The scan honours the token: it walks the whole grid otherwise.
+        amrvis::StopSource stop;
+        stop.request_stop();
+        bool cancelled = false;
+        try {
+            static_cast<void>(amrvis::visibleVolumeRange(
+                gridOf({1.0F, 2.0F}), false, stop.get_token()));
+        } catch (const amrvis::ReadCancelled&) {
+            cancelled = true;
+        }
+        require(cancelled, "a cancelled Visible range scan did not throw");
     }
     return 0;
 }

--- a/tests/unit/test_session_validation.cpp
+++ b/tests/unit/test_session_validation.cpp
@@ -783,5 +783,145 @@ int main()
                 species, "electrons", overfull);
         }, "a sample larger than its species was accepted");
     }
+
+    // Volume requests: the structural validator plus what the catalog knows
+    // (field, level, component, the region inside the domain), and frames:
+    // the requested size, a usable range that honours the request, and
+    // metrics the dataset and budget could have produced.
+    {
+        const auto metadata = dataset(3);
+        const DatasetId id{1};
+        VolumeRenderRequest request;
+        request.dataset = id;
+        request.field = FieldId{0};
+        request.maximumLevel = 1;
+        request.region = RealBox{Real3{{0.0, 0.0, 0.0}}, Real3{{4.0, 4.0, 4.0}}};
+        request.outputSize = {16, 12};
+        request.transfer.colors = {0x0U, 0xFFFFFFU};
+        request.transfer.opacities = {0.0F, 1.0F};
+        requireAccepted([&] {
+            validateSessionVolumeRequest(metadata, id, request);
+        }, "a well-formed volume request was rejected");
+        requireRejectedWith([&] {
+            validateSessionVolumeRequest(metadata, DatasetId{2}, request);
+        }, "wrong dataset", "a volume request for another dataset was accepted");
+        requireRejectedWith([&] {
+            validateSessionVolumeRequest(dataset(2), id, request);
+        }, "3-D", "a volume request over a 2-D dataset was accepted");
+        {
+            auto bad = request;
+            bad.field = FieldId{3};
+            requireRejectedWith([&] {
+                validateSessionVolumeRequest(metadata, id, bad);
+            }, "field", "an unknown volume field was accepted");
+            bad = request;
+            bad.maximumLevel = 2;
+            requireRejectedWith([&] {
+                validateSessionVolumeRequest(metadata, id, bad);
+            }, "level", "a volume level past the finest was accepted");
+            bad = request;
+            bad.component = 1;
+            requireRejectedWith([&] {
+                validateSessionVolumeRequest(metadata, id, bad);
+            }, "component", "a missing volume component was accepted");
+            bad = request;
+            bad.region.upper[2] = 4.5;
+            requireRejectedWith([&] {
+                validateSessionVolumeRequest(metadata, id, bad);
+            }, "outside", "a volume region past the domain was accepted");
+            bad = request;
+            bad.region.upper[2] = 4.0 + 1.0e-12;   // a rounding hair: fine
+            requireAccepted([&] {
+                validateSessionVolumeRequest(metadata, id, bad);
+            }, "a region a rounding hair past the domain was rejected");
+            bad = request;
+            bad.outputSize = {0, 12};
+            requireRejected([&] {
+                validateSessionVolumeRequest(metadata, id, bad);
+            }, "a structurally invalid volume request was accepted");
+        }
+
+        VolumeFrame frame;
+        frame.width = 16;
+        frame.height = 12;
+        frame.pixels.assign(16 * 12, 0U);
+        frame.usedRange = {0.0, 1.0, false};
+        frame.metrics.gridDims = {4, 4, 4};
+        frame.metrics.coveredVoxels = 64;
+        frame.metrics.sampledMaximumLevel = 1;
+        requireAccepted([&] {
+            validateSessionVolumeResult(metadata, request, frame);
+        }, "a well-formed volume frame was rejected");
+        {
+            auto bad = frame;
+            bad.width = 15;
+            requireRejectedWith([&] {
+                validateSessionVolumeResult(metadata, request, bad);
+            }, "requested size", "a frame of another size was accepted");
+            bad = frame;
+            bad.pixels.pop_back();
+            requireRejectedWith([&] {
+                validateSessionVolumeResult(metadata, request, bad);
+            }, "storage", "a frame with short pixel storage was accepted");
+            bad = frame;
+            bad.usedRange = {1.0, 1.0, false};
+            requireRejectedWith([&] {
+                validateSessionVolumeResult(metadata, request, bad);
+            }, "unusable range", "a frame with an empty range was accepted");
+            bad = frame;
+            bad.usedRange = {0.0, 1.0, true};
+            requireRejectedWith([&] {
+                validateSessionVolumeResult(metadata, request, bad);
+            }, "unusable range", "a non-positive logarithmic range was accepted");
+            bad = frame;
+            bad.usedRange = {0.5, 2.0, true};
+            requireRejectedWith([&] {
+                validateSessionVolumeResult(metadata, request, bad);
+            }, "not requested", "an unrequested logarithmic range was accepted");
+            auto ranged = request;
+            ranged.range = VolumeRange{0.25, 0.75, false};
+            requireRejectedWith([&] {
+                validateSessionVolumeResult(metadata, ranged, frame);
+            }, "requested range", "a frame ignoring the explicit range was accepted");
+            bad = frame;
+            bad.usedRange = *ranged.range;
+            requireAccepted([&] {
+                validateSessionVolumeResult(metadata, ranged, bad);
+            }, "a frame honouring the explicit range was rejected");
+            bad = frame;
+            bad.metrics.gridDims = {0, 4, 4};
+            requireRejectedWith([&] {
+                validateSessionVolumeResult(metadata, request, bad);
+            }, "empty sampled grid", "an empty grid was accepted");
+            auto small = request;
+            small.maximumVoxels = 32;
+            requireRejectedWith([&] {
+                validateSessionVolumeResult(metadata, small, frame);
+            }, "voxel budget", "a grid over the voxel budget was accepted");
+            bad = frame;
+            bad.metrics.coveredVoxels = 65;
+            requireRejectedWith([&] {
+                validateSessionVolumeResult(metadata, request, bad);
+            }, "covered voxels", "an over-covered grid was accepted");
+            bad = frame;
+            bad.metrics.sampledMaximumLevel = 2;
+            requireRejectedWith([&] {
+                validateSessionVolumeResult(metadata, request, bad);
+            }, "sampled level", "a sampled level past the request was accepted");
+            bad = frame;
+            bad.cacheFallbackFromLevel = 1;
+            requireRejectedWith([&] {
+                validateSessionVolumeResult(metadata, request, bad);
+            }, "half-specified", "a half-specified fallback was accepted");
+            bad.cacheFallbackToLevel = 1;
+            requireRejectedWith([&] {
+                validateSessionVolumeResult(metadata, request, bad);
+            }, "impossible cache fallback", "a non-descending fallback was accepted");
+            bad.cacheFallbackToLevel = 0;
+            requireAccepted([&] {
+                validateSessionVolumeResult(metadata, request, bad);
+            }, "a fallback from level 1 to 0 was rejected");
+        }
+    }
     return 0;
 }


### PR DESCRIPTION
DatasetSession gains supportsVolumeRendering and renderVolume (throwing defaults, so nothing else changes). LocalDatasetSession samples the field with VolumeQuery into a grid it caches by everything the sample depends on, resolves a "Visible" range from the grid when the request leaves the range open, and ray-casts; SessionValidation checks the request against the catalog and a returned frame against the request, for the remote session to come. VolumePipeline builds the transfer function from the palette and the opacity controls, resolves File/Level/User ranges the slice way, bounds a frame to the response budget, and retries an over-cache render at a coarser level. paddedIfDegenerate moves to core.