### PR TITLE
add the Volume Rendering window and its controller

### DIFF
--- a/include/amrexplorer/core/OrthoProjection.hpp
+++ b/include/amrexplorer/core/OrthoProjection.hpp
@@ -41,6 +41,19 @@ inline constexpr double orthoViewportMargin = 12.0;
 [[nodiscard]] ViewportFrame viewportFrame(
     int width, int height, double margin = orthoViewportMargin) noexcept;
 
+// The scale at which an image rendered for `rendered` at `renderedZoom` has to
+// be drawn, about the viewport centre, into `frame` at `zoom` for the two
+// projections to agree.
+//
+// Both project about their own centre at scale * zoom, so the image's pixels
+// already carry the zoom it was rendered at: the ratio of the frame scales
+// alone lines up a frame rendered at another *size* (a half-size draft) but
+// not one rendered at another *magnification*, and a wheel notch would then
+// slide the image out of the wireframe drawn over it. Returns 1 when either
+// magnification is not positive.
+[[nodiscard]] double backdropScale(const ViewportFrame& frame, double zoom,
+    const ViewportFrame& rendered, double renderedZoom) noexcept;
+
 // A point projected into the viewport: pixel x (right), pixel y (down), and
 // its depth along the view axis in normalised units, increasing toward the
 // viewer.

--- a/src/core/OrthoProjection.cpp
+++ b/src/core/OrthoProjection.cpp
@@ -83,6 +83,17 @@ ViewportFrame viewportFrame(int width, int height, double margin) noexcept
     return frame;
 }
 
+double backdropScale(const ViewportFrame& frame, double zoom,
+    const ViewportFrame& rendered, double renderedZoom) noexcept
+{
+    const auto pixels = frame.scale * zoom;
+    const auto renderedPixels = rendered.scale * renderedZoom;
+    if (!(pixels > 0.0) || !(renderedPixels > 0.0)) {
+        return 1.0;
+    }
+    return pixels / renderedPixels;
+}
+
 ProjectedPoint projectPoint(const OrthoCamera& camera,
     const ViewportFrame& frame, const RealBox& domain,
     const Real3& point) noexcept

--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -58,6 +58,10 @@ add_executable(amrexplorer_qt
     Theme.hpp
     UserGuideDialog.cpp
     UserGuideDialog.hpp
+    VolumeController.cpp
+    VolumeController.hpp
+    VolumeWindow.cpp
+    VolumeWindow.hpp
     main.cpp
     ${CMAKE_SOURCE_DIR}/resources/amrexplorer.qrc
     ${CMAKE_SOURCE_DIR}/resources/user-guide.qrc
@@ -82,6 +86,7 @@ if(AMREXPLORER_BUILD_TESTS)
         SmokeHarnessRange.cpp
         SmokeHarnessRemote.cpp
         SmokeHarnessSequence.cpp
+        SmokeHarnessVolume.cpp
         SmokeHarnessZoom.cpp)
     target_compile_definitions(amrexplorer_qt PRIVATE AMREXPLORER_QT_TEST_ACCESS)
 endif()
@@ -110,6 +115,7 @@ target_link_libraries(amrexplorer_qt
         amrexplorer::io
         amrexplorer::query
         amrexplorer::render2d
+        amrexplorer::render3d
         amrexplorer::pipeline
         amrexplorer::warnings
         Qt6::Concurrent

--- a/src/qt/IsoWidget.cpp
+++ b/src/qt/IsoWidget.cpp
@@ -118,10 +118,12 @@ void IsoWidget::paintEvent(QPaintEvent* event)
 
     const auto frame = viewportFrame(width(), height());
     if (!m_backdrop.isNull()) {
-        // The frame's own projection frame, so its centre lands on ours and
-        // its pixels are scaled by the ratio of the projection scales.
+        // The frame's own projection frame, so its centre lands on ours, and
+        // both magnifications, so a zoom the frame was not rendered at is
+        // corrected instead of sliding the image out of its own box.
         const auto rendered = viewportFrame(m_backdrop.width(), m_backdrop.height());
-        const auto ratio = frame.scale / rendered.scale;
+        const auto ratio = backdropScale(
+            frame, m_camera.zoom, rendered, m_backdropCamera.zoom);
         const QRectF target(frame.centerX - 0.5 * ratio * m_backdrop.width(),
             frame.centerY - 0.5 * ratio * m_backdrop.height(),
             ratio * m_backdrop.width(), ratio * m_backdrop.height());
@@ -380,9 +382,10 @@ void IsoWidget::setViewAngles(double azimuth, double elevation)
     emit interactionEnded();
 }
 
-void IsoWidget::setBackdropImage(QImage image)
+void IsoWidget::setBackdropImage(QImage image, const OrthoCamera& camera)
 {
     m_backdrop = std::move(image);
+    m_backdropCamera = camera;
     update();
 }
 

--- a/src/qt/IsoWidget.cpp
+++ b/src/qt/IsoWidget.cpp
@@ -16,6 +16,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
+#include <utility>
 
 namespace amrvis::qt {
 namespace {
@@ -116,13 +117,28 @@ void IsoWidget::paintEvent(QPaintEvent* event)
     painter.setRenderHint(QPainter::Antialiasing, true);
 
     const auto frame = viewportFrame(width(), height());
-    for (const auto& level : m_levels) {
-        const QPen pen(levelOutlineColor(level.level), 1);
-        for (const auto& box : level.boxes) {
-            drawBox(painter, frame, physicalBox(level, box), pen);
+    if (!m_backdrop.isNull()) {
+        // The frame's own projection frame, so its centre lands on ours and
+        // its pixels are scaled by the ratio of the projection scales.
+        const auto rendered = viewportFrame(m_backdrop.width(), m_backdrop.height());
+        const auto ratio = frame.scale / rendered.scale;
+        const QRectF target(frame.centerX - 0.5 * ratio * m_backdrop.width(),
+            frame.centerY - 0.5 * ratio * m_backdrop.height(),
+            ratio * m_backdrop.width(), ratio * m_backdrop.height());
+        painter.setRenderHint(QPainter::SmoothPixmapTransform, true);
+        painter.drawImage(target, m_backdrop);
+    }
+    if (m_levelBoxesVisible) {
+        for (const auto& level : m_levels) {
+            const QPen pen(levelOutlineColor(level.level), 1);
+            for (const auto& box : level.boxes) {
+                drawBox(painter, frame, physicalBox(level, box), pen);
+            }
         }
     }
-    drawBox(painter, frame, m_domain, QPen(Qt::white, 1));
+    if (m_domainOutlineVisible) {
+        drawBox(painter, frame, m_domain, QPen(Qt::white, 1));
+    }
     // Translucent slice planes overlay the wireframe so the user can see where
     // the XY/XZ/YZ slices sit in the domain.
     if (m_slicePlanesVisible) {
@@ -357,6 +373,24 @@ void IsoWidget::setViewAngles(double azimuth, double elevation)
     m_camera.elevation = elevation;
     update();
     emit cameraChanged();
+}
+
+void IsoWidget::setBackdropImage(QImage image)
+{
+    m_backdrop = std::move(image);
+    update();
+}
+
+void IsoWidget::setLevelBoxesVisible(bool visible)
+{
+    m_levelBoxesVisible = visible;
+    update();
+}
+
+void IsoWidget::setDomainOutlineVisible(bool visible)
+{
+    m_domainOutlineVisible = visible;
+    update();
 }
 
 void IsoWidget::setCamera(const OrthoCamera& camera)

--- a/src/qt/IsoWidget.cpp
+++ b/src/qt/IsoWidget.cpp
@@ -372,7 +372,12 @@ void IsoWidget::setViewAngles(double azimuth, double elevation)
     m_camera.azimuth = azimuth;
     m_camera.elevation = elevation;
     update();
+    // Both, in this order: the camera moved, and the move is already over. A
+    // preset has no mouse release to end it, so without the second signal a
+    // consumer that drafts during interaction would draft this and only reach
+    // full quality when its own settle timer fired.
     emit cameraChanged();
+    emit interactionEnded();
 }
 
 void IsoWidget::setBackdropImage(QImage image)

--- a/src/qt/IsoWidget.cpp
+++ b/src/qt/IsoWidget.cpp
@@ -407,6 +407,7 @@ void IsoWidget::resizeEvent(QResizeEvent* event)
 {
     QWidget::resizeEvent(event);
     layoutButtons();
+    emit viewResized();
 }
 
 void IsoWidget::layoutButtons()

--- a/src/qt/IsoWidget.hpp
+++ b/src/qt/IsoWidget.hpp
@@ -55,7 +55,6 @@ public:
     // draft while the camera moves) still lines up with the wireframe drawn
     // over it. A null image draws nothing -- the main window's quadrant.
     void setBackdropImage(QImage image);
-    [[nodiscard]] bool hasBackdropImage() const noexcept { return !m_backdrop.isNull(); }
     // Overlay toggles for the volume view; the quadrant keeps both on.
     void setLevelBoxesVisible(bool visible);
     void setDomainOutlineVisible(bool visible);
@@ -63,6 +62,9 @@ public:
 signals:
     void cameraChanged();
     void interactionEnded();
+    // The viewport changed size, so a backdrop rendered for the old one is
+    // now being stretched: whoever renders it wants to render it again.
+    void viewResized();
 
 protected:
     void paintEvent(QPaintEvent* event) override;

--- a/src/qt/IsoWidget.hpp
+++ b/src/qt/IsoWidget.hpp
@@ -48,13 +48,16 @@ public:
     [[nodiscard]] const OrthoCamera& camera() const noexcept { return m_camera; }
     void setCamera(const OrthoCamera& camera);
 
-    // A rendered volume frame drawn under the wireframe: a premultiplied
-    // image produced with this widget's camera at some viewport size. It is
-    // drawn about the viewport centre at the ratio of the two viewports'
-    // projection scales, so a frame rendered at another size (a half-size
-    // draft while the camera moves) still lines up with the wireframe drawn
-    // over it. A null image draws nothing -- the main window's quadrant.
-    void setBackdropImage(QImage image);
+    // A rendered volume frame drawn under the wireframe, with the camera it
+    // was rendered with: a premultiplied image produced at some viewport size
+    // and some zoom. It is drawn about the viewport centre at backdropScale of
+    // the two, so a frame rendered at another size (a half-size draft while
+    // the camera moves) or another zoom (a wheel notch not yet re-rendered)
+    // still lines up with the wireframe drawn over it -- the orientation
+    // cannot be corrected that way, so a rotation still shows a stale frame
+    // until the next one lands. A null image draws nothing -- the main
+    // window's quadrant.
+    void setBackdropImage(QImage image, const OrthoCamera& camera);
     // Overlay toggles for the volume view; the quadrant keeps both on.
     void setLevelBoxesVisible(bool visible);
     void setDomainOutlineVisible(bool visible);
@@ -103,6 +106,7 @@ private:
     bool m_levelBoxesVisible = true;
     bool m_domainOutlineVisible = true;
     QImage m_backdrop;
+    OrthoCamera m_backdropCamera;
     const Palette* m_palette = nullptr;
     bool m_hasGeometry = false;
 

--- a/src/qt/IsoWidget.hpp
+++ b/src/qt/IsoWidget.hpp
@@ -4,6 +4,7 @@
 #include <amrexplorer/core/OrthoProjection.hpp>
 
 #include <QColor>
+#include <QImage>
 #include <QPoint>
 #include <QWidget>
 
@@ -47,6 +48,18 @@ public:
     [[nodiscard]] const OrthoCamera& camera() const noexcept { return m_camera; }
     void setCamera(const OrthoCamera& camera);
 
+    // A rendered volume frame drawn under the wireframe: a premultiplied
+    // image produced with this widget's camera at some viewport size. It is
+    // drawn about the viewport centre at the ratio of the two viewports'
+    // projection scales, so a frame rendered at another size (a half-size
+    // draft while the camera moves) still lines up with the wireframe drawn
+    // over it. A null image draws nothing -- the main window's quadrant.
+    void setBackdropImage(QImage image);
+    [[nodiscard]] bool hasBackdropImage() const noexcept { return !m_backdrop.isNull(); }
+    // Overlay toggles for the volume view; the quadrant keeps both on.
+    void setLevelBoxesVisible(bool visible);
+    void setDomainOutlineVisible(bool visible);
+
 signals:
     void cameraChanged();
     void interactionEnded();
@@ -85,6 +98,9 @@ private:
     std::vector<LevelBoxes> m_levels;
     std::array<double, 3> m_slicePositions{0.0, 0.0, 0.0};
     bool m_slicePlanesVisible = false;
+    bool m_levelBoxesVisible = true;
+    bool m_domainOutlineVisible = true;
+    QImage m_backdrop;
     const Palette* m_palette = nullptr;
     bool m_hasGeometry = false;
 

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -484,8 +484,11 @@ MainWindow::MainWindow(QWidget* parent)
                     m_fieldSelector->currentText()};
             },
             [this] {
+                // The live session, as every other decodeLevelData caller
+                // does: m_openMetadata is the open-time snapshot and lags it
+                // for the whole of each sequence frame's install.
                 return decodeLevelData(m_levelSelector->currentData().toInt(),
-                    m_openMetadata ? m_openMetadata->finestLevel : 0);
+                    m_dataset ? m_dataset->metadata().finestLevel : 0);
             },
             [this] { return m_range->selection(); },
             [this]() -> const Palette& { return m_paletteController->palette(); },

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -225,6 +225,7 @@ MainWindow::MainWindow(QWidget* parent)
             m_pendingRangeStore.reset();
             updateRangeModeAvailability();
             scheduleSliceRequest();
+            m_volumeController->refresh();
         });
     connect(m_levelSelector, qOverload<int>(&QComboBox::currentIndexChanged),
         this, [this](int) {
@@ -232,16 +233,24 @@ MainWindow::MainWindow(QWidget* parent)
             m_pendingRangeStore.reset();  // see the field selector above
             updateRangeModeAvailability();
             scheduleSliceRequest();
+            m_volumeController->refresh();
         });
     connect(m_range, &RangeController::modeChanged, this, [this] {
         m_pendingRangeStore.reset();  // see the field selector above
         updateRangeModeAvailability();
         scheduleSliceRequest();
+        m_volumeController->refresh();
     });
     connect(m_range, &RangeController::userRangeChanged, this,
-        [this] { scheduleSliceRequest(); });
+        [this] {
+            scheduleSliceRequest();
+            m_volumeController->refresh();
+        });
     connect(m_range, &RangeController::logarithmicChanged, this,
-        [this] { scheduleSliceRequest(); });
+        [this] {
+            scheduleSliceRequest();
+            m_volumeController->refresh();
+        });
     connect(m_range, &RangeController::statusMessage, this,
         [this](const QString& message, int timeoutMs) {
             statusBar()->showMessage(message, timeoutMs);
@@ -388,6 +397,7 @@ MainWindow::MainWindow(QWidget* parent)
             m_initialStopSource.request_stop();
             m_linePlotStopSource.request_stop();
             m_particleController->cancel();
+            m_volumeController->cancel();
             m_pendingAllViews = false;
             m_pendingViews.clear();
             m_sliceDebounce->stop();
@@ -457,6 +467,48 @@ MainWindow::MainWindow(QWidget* parent)
         this, [this] { m_diagnosticsModel->noteStaleResult(); });
     connect(m_particleController, &ParticleController::loadFinished, this,
         [this] { updateDiagnostics(); });
+
+    // The volume view: its window, camera, opacity controls and render
+    // scheduling live in the controller; this window supplies what a render
+    // is built from (the dataset, the field, level, range and palette in
+    // effect, the slice positions) and folds its bookkeeping into the
+    // diagnostics.
+    m_volumeController = new VolumeController(
+        VolumeController::Hooks{
+            [this] { return m_dataset; },
+            [this]() -> std::optional<std::pair<FieldId, QString>> {
+                if (!m_dataset || m_fieldSelector->currentIndex() < 0) {
+                    return std::nullopt;
+                }
+                return std::pair{FieldId{m_fieldSelector->currentData().toUInt()},
+                    m_fieldSelector->currentText()};
+            },
+            [this] {
+                return decodeLevelData(m_levelSelector->currentData().toInt(),
+                    m_openMetadata ? m_openMetadata->finestLevel : 0);
+            },
+            [this] { return m_range->selection(); },
+            [this]() -> const Palette& { return m_paletteController->palette(); },
+            [this] { return m_slicePosition3d; },
+            [this] { return m_slicePlanesAction->isChecked(); },
+            [this] { return m_closing; },
+        },
+        this);
+    connect(m_volumeController, &VolumeController::renderActivityChanged, this,
+        [this](int delta) {
+            m_diagnosticsModel->adjustActivity(delta);
+            updateDiagnostics();
+        });
+    connect(m_volumeController, &VolumeController::renderFailed, this,
+        [this](const QString& message) { reportBackgroundError(message); });
+    connect(m_volumeController, &VolumeController::statusMessage, this,
+        [this](const QString& message, int timeoutMs) {
+            statusBar()->showMessage(message, timeoutMs);
+        });
+    connect(m_volumeController, &VolumeController::staleResultDropped, this,
+        [this] { m_diagnosticsModel->noteStaleResult(); });
+    connect(m_volumeController, &VolumeController::frameDisplayed, this,
+        [this] { emit volumeFrameDisplayed(); });
     connect(m_sequenceController, &SequenceController::frameDisplayed,
         this, [this](int index) {
             m_animationPanel->setSequenceFrame(index);
@@ -1072,7 +1124,10 @@ void MainWindow::createMenus()
     m_slicePlanesAction->setCheckable(true);
     m_slicePlanesAction->setEnabled(false);
     connect(m_slicePlanesAction, &QAction::toggled, this,
-        [this](bool visible) { m_isoWidget->setSlicePlanesVisible(visible); });
+        [this](bool visible) {
+            m_isoWidget->setSlicePlanesVisible(visible);
+            m_volumeController->slicePlanesVisibilityChanged();
+        });
 
     m_contoursAction = new QAction(tr("&Contours..."), this);
     m_contoursAction->setObjectName(QStringLiteral("contoursAction"));
@@ -1101,6 +1156,7 @@ void MainWindow::createMenus()
     viewMenu->addMenu(m_levelMenu);
     viewMenu->addAction(m_boxesAction);
     viewMenu->addAction(m_slicePlanesAction);
+    viewMenu->addAction(m_volumeController->createAction(this));
     viewMenu->addMenu(paletteMenu);
     viewMenu->addSeparator();
     viewMenu->addMenu(m_sphericalMenu);
@@ -1292,6 +1348,7 @@ void MainWindow::refreshPaletteDisplay()
     updateOverlays();
     updateCrosshairs();
     m_isoWidget->update();
+    m_volumeController->refresh();
 }
 
 void MainWindow::showContoursDialog()

--- a/src/qt/MainWindow.hpp
+++ b/src/qt/MainWindow.hpp
@@ -690,6 +690,10 @@ private:
     // separator, so the separator never dangles when no dataset is loaded.
     void setSlicePositionControlsVisible(bool visible);
     void setSlicePosition(int axis, double value);
+    // Pushes m_slicePosition3d to everything that draws the planes: the iso
+    // quadrant and, when it is open, the volume window. Every writer of
+    // m_slicePosition3d goes through here, so the two cannot drift.
+    void publishSlicePositions();
     [[nodiscard]] int sliceIndexLevel() const;
     // Visible-range mode in 3-D: recompute the min/max from all three panels'
     // planes so the single color bar maps them consistently. The heavy part

--- a/src/qt/MainWindow.hpp
+++ b/src/qt/MainWindow.hpp
@@ -691,8 +691,10 @@ private:
     void setSlicePositionControlsVisible(bool visible);
     void setSlicePosition(int axis, double value);
     // Pushes m_slicePosition3d to everything that draws the planes: the iso
-    // quadrant and, when it is open, the volume window. Every writer of
-    // m_slicePosition3d goes through here, so the two cannot drift.
+    // quadrant and, when it is open, the volume window. Every writer that
+    // publishes the positions goes through here; requestInitialSlice sets
+    // them and relies on configureSliceControls to publish, and the ForTest
+    // setter is test-only.
     void publishSlicePositions();
     [[nodiscard]] int sliceIndexLevel() const;
     // Visible-range mode in 3-D: recompute the min/max from all three panels'

--- a/src/qt/MainWindow.hpp
+++ b/src/qt/MainWindow.hpp
@@ -81,6 +81,7 @@ class ParticleController;
 class RangeController;
 class RemoteSessionController;
 class SequenceController;
+class VolumeController;
 struct PlaneMapping;
 class UserGuideDialog;
 
@@ -233,6 +234,12 @@ public:
     // per cell -- rather than in physical units. The two differ only when
     // the cells are not square (see remote-fit-anisotropic-cells).
     [[nodiscard]] bool activeViewRasterHasCellAspectForTest() const;
+    // Test-only: the Volume Rendering window -- open it as the View menu
+    // action does, whether it is open, and what fraction of the last frame's
+    // pixels the ray caster lit (alpha > 0); zero before any frame.
+    void showVolumeWindowForTest();
+    [[nodiscard]] bool volumeWindowOpenForTest() const;
+    [[nodiscard]] double volumeFrameAlphaCoverageForTest() const;
     [[nodiscard]] bool fabStateClearedForTest() const;
     // Test-only: how many failures have been reported non-modally. The FAB
     // rollback smoke tests assert on this so a passing run proves the failure
@@ -398,6 +405,9 @@ signals:
     // smoke test drives frame stepping off it.
     void sequenceFrameDisplayed(int index);
     void sequenceFrameFailed();
+    // Emitted when the Volume Rendering window has drawn a frame; the volume
+    // smoke tests wait on it.
+    void volumeFrameDisplayed();
     // Emitted when the FFmpeg encoding phase begins (frames rendered, encoder
     // workers about to run); the export-quit smoke test quits on it to exercise
     // bounded encoder cancellation.
@@ -904,6 +914,7 @@ private:
     // Owns the particle selection, samples, sample load, dialog, action and
     // progress indicator; the host draws its samples into the views.
     ParticleController* m_particleController = nullptr;
+    VolumeController* m_volumeController = nullptr;
     std::filesystem::path m_datasetPath;
     // Owns the ssh session and the connection every remote open goes
     // through, and the Open Remote dialogs and browser; asks this window to

--- a/src/qt/MainWindowDataset.cpp
+++ b/src/qt/MainWindowDataset.cpp
@@ -46,6 +46,7 @@ void MainWindow::cancelInFlight()
     m_sequenceController->cancelActiveWork();
     m_linePlotStopSource.request_stop();
     m_particleController->cancel();
+    m_volumeController->cancel();
     m_view2d.stopSource.request_stop();
     for (auto& state : m_planeViews) {
         state.stopSource.request_stop();
@@ -683,6 +684,7 @@ void MainWindow::openDatasetImpl(const std::filesystem::path& path,
     m_initialStopSource.request_stop();
     m_linePlotStopSource.request_stop();
     m_particleController->cancel();
+    m_volumeController->cancel();
     m_pendingAllViews = false;
     m_pendingViews.clear();
     m_sliceDebounce->stop();
@@ -710,6 +712,8 @@ void MainWindow::openDatasetImpl(const std::filesystem::path& path,
     }
     // The dataset window shows this dataset's raw values; drop it too.
     closeDatasetWindow();
+    // And the volume window, which rendered this dataset's field.
+    m_volumeController->reset();
     if (m_contoursDialog != nullptr) {
         auto* dialog = m_contoursDialog;
         m_contoursDialog = nullptr;
@@ -908,6 +912,7 @@ void MainWindow::requestInitialSlice(
     m_initialStopSource.request_stop();
     m_linePlotStopSource.request_stop();
     m_particleController->cancel();
+    m_volumeController->cancel();
     m_initialStopSource = StopSource{};
     const auto cancellation = m_initialStopSource.get_token();
     // The initial open uses default slice state: field 0, finest available,
@@ -978,6 +983,7 @@ void MainWindow::requestInitialSlice(
                     }
                     m_particleController->configureForDataset(
                         restoredSpec.has_value());
+                    m_volumeController->configureForDataset();
                     configureSliceControls();
                     if (restoredSpec) {
                         const QSignalBlocker fieldBlocker(m_fieldSelector);

--- a/src/qt/MainWindowInteraction.cpp
+++ b/src/qt/MainWindowInteraction.cpp
@@ -1533,6 +1533,7 @@ void MainWindow::closeEvent(QCloseEvent* event)
         linePlotWindow->close();
     }
     closeDatasetWindow();
+    m_volumeController->reset();
     if (m_contoursDialog != nullptr) {
         auto* dialog = m_contoursDialog;
         m_contoursDialog = nullptr;

--- a/src/qt/MainWindowInternal.hpp
+++ b/src/qt/MainWindowInternal.hpp
@@ -13,6 +13,7 @@
 #include "FabNavigator.hpp"
 #include "PaletteController.hpp"
 #include "ParticleController.hpp"
+#include "VolumeController.hpp"
 #include "RangeController.hpp"
 #include "SequenceController.hpp"
 #include "AnimationPanel.hpp"

--- a/src/qt/MainWindowSlice.cpp
+++ b/src/qt/MainWindowSlice.cpp
@@ -75,10 +75,16 @@ void MainWindow::configureSliceControls()
     configureSlicePositionControls();
     if (isThreeDimensional) {
         m_isoWidget->setGeometry(metadata);
-        m_isoWidget->setSlicePositions(m_slicePosition3d[0], m_slicePosition3d[1],
-            m_slicePosition3d[2]);
+        publishSlicePositions();
     }
     ensureVectorFieldDefaults();
+}
+
+void MainWindow::publishSlicePositions()
+{
+    m_isoWidget->setSlicePositions(m_slicePosition3d[0], m_slicePosition3d[1],
+        m_slicePosition3d[2]);
+    m_volumeController->slicePositionsChanged();
 }
 
 void MainWindow::setSlicePositionControlsVisible(bool visible)
@@ -155,9 +161,7 @@ void MainWindow::setSlicePosition(int axis, double value)
                 m_dataset->metadata(), level, axis, position));
         }
     }
-    m_isoWidget->setSlicePositions(m_slicePosition3d[0], m_slicePosition3d[1],
-        m_slicePosition3d[2]);
-    m_volumeController->slicePositionsChanged();
+    publishSlicePositions();
     // The cached full-domain Visible range is now stale — and so is any
     // pending deferred store, whose union was computed from pre-move planes.
     m_displayCoordinator.invalidateRangeCache();
@@ -1596,8 +1600,7 @@ void MainWindow::configureSequenceControls(bool defaultPositions)
                     std::nextafter(domain.upper[axis], domain.lower[axis]));
         }
         m_isoWidget->setGeometry(metadata);
-        m_isoWidget->setSlicePositions(m_slicePosition3d[0], m_slicePosition3d[1],
-            m_slicePosition3d[2]);
+        publishSlicePositions();
     }
     m_stack->setCurrentIndex(isThreeDimensional ? 1 : 0);
     m_animationPanel->setSweepVisible(isThreeDimensional);

--- a/src/qt/MainWindowSlice.cpp
+++ b/src/qt/MainWindowSlice.cpp
@@ -433,6 +433,12 @@ void MainWindow::requestSlice(PlaneViewState& state, bool rasterDirty)
                             configureSlicePositionControls();
                             updateRangeModeAvailability();
                             syncMenuChecks();
+                            // The combo moved behind a signal blocker, so the
+                            // volume window is not told by the usual
+                            // currentIndexChanged: without this its frame and
+                            // its "level N" label keep the level the slices
+                            // just fell back from.
+                            m_volumeController->refresh();
                         }
                         statusBar()->showMessage(cacheFallbackMessage(
                             *dataset, fallbackFromLevel, fallbackToLevel));

--- a/src/qt/MainWindowSlice.cpp
+++ b/src/qt/MainWindowSlice.cpp
@@ -157,6 +157,7 @@ void MainWindow::setSlicePosition(int axis, double value)
     }
     m_isoWidget->setSlicePositions(m_slicePosition3d[0], m_slicePosition3d[1],
         m_slicePosition3d[2]);
+    m_volumeController->slicePositionsChanged();
     // The cached full-domain Visible range is now stale — and so is any
     // pending deferred store, whose union was computed from pre-move planes.
     m_displayCoordinator.invalidateRangeCache();
@@ -1511,6 +1512,7 @@ void MainWindow::displayFrameResult(InitialSliceResult& result,
     m_dataset = result.dataset;
     m_particleController->setSamples(std::move(result.particles));
     m_particleController->configureForDataset(true);
+    m_volumeController->configureForDataset();
     const auto& metadata = m_dataset->metadata();
     m_viewDimension = metadata.dimension;
 

--- a/src/qt/MainWindowTestAccess.cpp
+++ b/src/qt/MainWindowTestAccess.cpp
@@ -294,6 +294,29 @@ bool MainWindow::activeViewRasterHasCellAspectForTest() const
     return std::abs(actual - expected) <= 0.02 * expected;
 }
 
+void MainWindow::showVolumeWindowForTest()
+{
+    m_volumeController->showWindow(this);
+}
+
+bool MainWindow::volumeWindowOpenForTest() const
+{
+    return m_volumeController->windowOpen();
+}
+
+double MainWindow::volumeFrameAlphaCoverageForTest() const
+{
+    const auto& frame = m_volumeController->lastFrame();
+    if (frame.pixels.empty()) {
+        return 0.0;
+    }
+    std::size_t lit = 0;
+    for (const auto pixel : frame.pixels) {
+        lit += (pixel >> 24U) != 0U;
+    }
+    return static_cast<double>(lit) / static_cast<double>(frame.pixels.size());
+}
+
 bool MainWindow::fabStateClearedForTest() const
 {
     return m_fabNavigator->cleared()

--- a/src/qt/SmokeHarness.cpp
+++ b/src/qt/SmokeHarness.cpp
@@ -1,8 +1,14 @@
 #include "SmokeHarnessInternal.hpp"
 
+#include "MainWindow.hpp"
+
+#include <QString>
+
+#include <amrexplorer/remote/Connection.hpp>
 #include <amrexplorer/remote/Server.hpp>
 
 #include <initializer_list>
+#include <memory>
 #include <optional>
 
 // The offscreen smoke-test harnesses, moved out of main() as they were and
@@ -13,6 +19,18 @@
 // (AMREXPLORER_BUILD_TESTS), and the release binary carries neither.
 
 namespace amrvis::qt::smoke {
+
+void attachSmokeServer(amrvis::qt::MainWindow& window,
+    const std::shared_ptr<amrvis::remote::Server>& server)
+{
+    window.useRemoteConnection(
+        std::make_shared<amrvis::remote::Connection>("127.0.0.1",
+            server->port(),
+            amrvis::remote::ConnectionOptions{
+                .clientName = "AMReXplorer Qt smoke",
+                .sessionToken = server->token()}),
+        QStringLiteral("127.0.0.1:%1").arg(server->port()));
+}
 
 Outcome dispatch(Context& context)
 {

--- a/src/qt/SmokeHarness.cpp
+++ b/src/qt/SmokeHarness.cpp
@@ -25,7 +25,8 @@ Outcome dispatch(Context& context)
              &dispatchRange,
              &dispatchZoom,
              &dispatchFab,
-             &dispatchSequence
+             &dispatchSequence,
+             &dispatchVolume
          }) {
         if (auto outcome = themed(context); outcome.handled) {
             return outcome;

--- a/src/qt/SmokeHarnessInternal.hpp
+++ b/src/qt/SmokeHarnessInternal.hpp
@@ -8,31 +8,26 @@
 
 #include "SmokeHarness.hpp"
 
-#include "MainWindow.hpp"
-
-#include <QString>
-
-#include <amrexplorer/remote/Connection.hpp>
-#include <amrexplorer/remote/Server.hpp>
-
 #include <memory>
+
+namespace amrvis::qt {
+class MainWindow;
+}
+
+namespace amrvis::remote {
+class Server;
+}
 
 namespace amrvis::qt::smoke {
 
 // The smoke tests speak to an in-process loopback server; the handshake
 // against it takes milliseconds, so it runs right here on the GUI thread.
-// Shared, so the client name and the options cannot drift between themes.
-inline void attachSmokeServer(amrvis::qt::MainWindow& window,
-    const std::shared_ptr<amrvis::remote::Server>& server)
-{
-    window.useRemoteConnection(
-        std::make_shared<amrvis::remote::Connection>("127.0.0.1",
-            server->port(),
-            amrvis::remote::ConnectionOptions{
-                .clientName = "AMReXplorer Qt smoke",
-                .sessionToken = server->token()}),
-        QStringLiteral("127.0.0.1:%1").arg(server->port()));
-}
+// Shared, so the client name and the options cannot drift between themes --
+// declared here and defined in SmokeHarness.cpp, so the two themes that need
+// a server do not put MainWindow and the transport headers in front of the
+// six that do not.
+void attachSmokeServer(amrvis::qt::MainWindow& window,
+    const std::shared_ptr<amrvis::remote::Server>& server);
 
 // SmokeHarnessRemote.cpp
 Outcome dispatchRemote(Context& context);

--- a/src/qt/SmokeHarnessInternal.hpp
+++ b/src/qt/SmokeHarnessInternal.hpp
@@ -22,5 +22,7 @@ Outcome dispatchZoom(Context& context);
 Outcome dispatchFab(Context& context);
 // SmokeHarnessSequence.cpp
 Outcome dispatchSequence(Context& context);
+// SmokeHarnessVolume.cpp
+Outcome dispatchVolume(Context& context);
 
 } // namespace amrvis::qt::smoke

--- a/src/qt/SmokeHarnessInternal.hpp
+++ b/src/qt/SmokeHarnessInternal.hpp
@@ -8,7 +8,31 @@
 
 #include "SmokeHarness.hpp"
 
+#include "MainWindow.hpp"
+
+#include <QString>
+
+#include <amrexplorer/remote/Connection.hpp>
+#include <amrexplorer/remote/Server.hpp>
+
+#include <memory>
+
 namespace amrvis::qt::smoke {
+
+// The smoke tests speak to an in-process loopback server; the handshake
+// against it takes milliseconds, so it runs right here on the GUI thread.
+// Shared, so the client name and the options cannot drift between themes.
+inline void attachSmokeServer(amrvis::qt::MainWindow& window,
+    const std::shared_ptr<amrvis::remote::Server>& server)
+{
+    window.useRemoteConnection(
+        std::make_shared<amrvis::remote::Connection>("127.0.0.1",
+            server->port(),
+            amrvis::remote::ConnectionOptions{
+                .clientName = "AMReXplorer Qt smoke",
+                .sessionToken = server->token()}),
+        QStringLiteral("127.0.0.1:%1").arg(server->port()));
+}
 
 // SmokeHarnessRemote.cpp
 Outcome dispatchRemote(Context& context);

--- a/src/qt/SmokeHarnessRemote.cpp
+++ b/src/qt/SmokeHarnessRemote.cpp
@@ -32,20 +32,6 @@ namespace amrvis::qt::smoke {
 
 namespace {
 
-// The smoke tests speak to an in-process loopback server; the handshake
-// against it takes milliseconds, so it runs right here on the GUI thread.
-void attachSmokeServer(amrvis::qt::MainWindow& window,
-    const std::shared_ptr<amrvis::remote::Server>& server)
-{
-    window.useRemoteConnection(
-        std::make_shared<amrvis::remote::Connection>("127.0.0.1",
-            server->port(),
-            amrvis::remote::ConnectionOptions{
-                .clientName = "AMReXplorer Qt smoke",
-                .sessionToken = server->token()}),
-        QStringLiteral("127.0.0.1:%1").arg(server->port()));
-}
-
 // What one view shows, for a local-versus-remote comparison: the physical
 // window the probe reports, the viewport pixels, and the raster size.
 struct ViewCapture {

--- a/src/qt/SmokeHarnessVolume.cpp
+++ b/src/qt/SmokeHarnessVolume.cpp
@@ -4,7 +4,6 @@
 
 #include <QTimer>
 
-#include <amrexplorer/remote/Connection.hpp>
 #include <amrexplorer/remote/Server.hpp>
 
 #include <filesystem>

--- a/src/qt/SmokeHarnessVolume.cpp
+++ b/src/qt/SmokeHarnessVolume.cpp
@@ -25,18 +25,6 @@ namespace amrvis::qt::smoke {
 
 namespace {
 
-void attachSmokeServer(amrvis::qt::MainWindow& window,
-    const std::shared_ptr<amrvis::remote::Server>& server)
-{
-    window.useRemoteConnection(
-        std::make_shared<amrvis::remote::Connection>("127.0.0.1",
-            server->port(),
-            amrvis::remote::ConnectionOptions{
-                .clientName = "AMReXplorer Qt smoke",
-                .sessionToken = server->token()}),
-        QStringLiteral("127.0.0.1:%1").arg(server->port()));
-}
-
 // Arms the volume checks on `window`: open the window once the initial
 // slices are in, then exit 0 on the first displayed frame with coverage,
 // 1 on one without, 2 on a failed load, 3 if no frame arrives in time.

--- a/src/qt/SmokeHarnessVolume.cpp
+++ b/src/qt/SmokeHarnessVolume.cpp
@@ -1,0 +1,103 @@
+#include "SmokeHarnessInternal.hpp"
+
+#include "MainWindow.hpp"
+
+#include <QTimer>
+
+#include <amrexplorer/remote/Connection.hpp>
+#include <amrexplorer/remote/Server.hpp>
+
+#include <filesystem>
+#include <memory>
+#include <string>
+#include <string_view>
+
+// Volume: the Volume Rendering window over a 3-D plotfile, opened locally
+// and over an in-process server. Each waits for the initial slices, opens
+// the window through the same path as the View menu action, and requires
+// the first frame the controller displays to have lit some pixels -- the
+// ray caster ran end to end, locally or on the server, and the frame came
+// back through the session, the pipeline and the window. Coverage, not
+// pixels: the exact picture depends on the viewport the platform gives an
+// offscreen window.
+
+namespace amrvis::qt::smoke {
+
+namespace {
+
+void attachSmokeServer(amrvis::qt::MainWindow& window,
+    const std::shared_ptr<amrvis::remote::Server>& server)
+{
+    window.useRemoteConnection(
+        std::make_shared<amrvis::remote::Connection>("127.0.0.1",
+            server->port(),
+            amrvis::remote::ConnectionOptions{
+                .clientName = "AMReXplorer Qt smoke",
+                .sessionToken = server->token()}),
+        QStringLiteral("127.0.0.1:%1").arg(server->port()));
+}
+
+// Arms the volume checks on `window`: open the window once the initial
+// slices are in, then exit 0 on the first displayed frame with coverage,
+// 1 on one without, 2 on a failed load, 3 if no frame arrives in time.
+void armVolumeChecks(amrvis::qt::MainWindow& window, QApplication& application)
+{
+    QObject::connect(&window, &amrvis::qt::MainWindow::initialSliceFinished,
+        &application, [&window, &application](bool success) {
+            if (!success) {
+                application.exit(2);
+                return;
+            }
+            window.showVolumeWindowForTest();
+            if (!window.volumeWindowOpenForTest()) {
+                qCritical("the volume window did not open");
+                application.exit(1);
+                return;
+            }
+        });
+    QObject::connect(&window, &amrvis::qt::MainWindow::volumeFrameDisplayed,
+        &application, [&window, &application] {
+            const auto coverage = window.volumeFrameAlphaCoverageForTest();
+            if (!(coverage > 0.0)) {
+                qCritical("the volume frame lit no pixels");
+                application.exit(1);
+                return;
+            }
+            application.exit(0);
+        });
+    QTimer::singleShot(30000, &application, [&application] { application.exit(3); });
+}
+
+} // namespace
+
+Outcome dispatchVolume(Context& context)
+{
+    auto& application = context.application;
+    auto& window = context.window;
+    const int argc = context.argc;
+    char** argv = context.argv;
+    auto& smokeServer = context.server;
+    auto& smokeServerThread = context.serverThread;
+
+    if (argc == 3 && std::string_view(argv[1]) == "--volume-smoke-test") {
+        const std::filesystem::path path(argv[2]);
+        armVolumeChecks(window, application);
+        QTimer::singleShot(0, &window, [&window, path] { window.openDataset(path); });
+    } else if (argc == 3
+        && std::string_view(argv[1]) == "--remote-volume-smoke-test") {
+        smokeServer = std::make_shared<amrvis::remote::Server>();
+        smokeServerThread.emplace(
+            [server = smokeServer] { server->run(); });
+        armVolumeChecks(window, application);
+        QTimer::singleShot(0, &window,
+            [&window, path = std::string(argv[2]), server = smokeServer] {
+                attachSmokeServer(window, server);
+                window.openRemoteDataset(path);
+            });
+    } else {
+        return {false, std::nullopt};
+    }
+    return {true, std::nullopt};
+}
+
+} // namespace amrvis::qt::smoke

--- a/src/qt/VolumeController.cpp
+++ b/src/qt/VolumeController.cpp
@@ -294,7 +294,8 @@ void VolumeController::startRender()
     const int height = std::max(1, m_interacting ? viewSize.height() / 2 : viewSize.height());
     request.outputSize = {std::min(width, maxVolumeOutputDimension),
         std::min(height, maxVolumeOutputDimension)};
-    request.logarithmic = rangeSelection.logarithmic;
+    // No request.logarithmic here: the choice built below carries it, and
+    // the pipeline sets it from there before each attempt's range resolve.
     request.transfer = makeVolumeTransferFunction(
         m_hooks.palette ? m_hooks.palette() : builtinPalette(BuiltinPalette::Rainbow),
         m_window->ramp());

--- a/src/qt/VolumeController.cpp
+++ b/src/qt/VolumeController.cpp
@@ -188,6 +188,7 @@ void VolumeController::configureForDataset()
     cancel();
     pushGeometry();
     m_window->clearFrame();
+    m_frameShown = false;
     scheduleRender();
 }
 
@@ -264,6 +265,9 @@ void VolumeController::startRender()
     const auto dataset = m_hooks.dataset ? m_hooks.dataset() : nullptr;
     const auto field = m_hooks.field ? m_hooks.field() : std::nullopt;
     if (!dataset || !dataset->supportsVolumeRendering() || !field) {
+        // Nothing to render after all: the label must not outlive the
+        // intention to render that put it up.
+        m_window->showRendering(false);
         return;
     }
     const auto& metadata = dataset->metadata();
@@ -310,7 +314,7 @@ void VolumeController::startRender()
     const auto fieldName = field->second;
     auto* watcher = new QFutureWatcher<VolumeDisplayResult>(this);
     connect(watcher, &QFutureWatcher<VolumeDisplayResult>::finished, this,
-        [this, watcher, generation, cancellation, dataset, fieldName] {
+        [this, watcher, generation, cancellation, fieldName] {
             emit renderActivityChanged(-1);
             m_inFlight = false;
             if (m_hooks.isShuttingDown && m_hooks.isShuttingDown()) {
@@ -345,17 +349,18 @@ void VolumeController::startRender()
                     emit staleResultDropped();
                 }
             }
-            // Not gated on the generation: a superseded result still means
-            // this render stopped, and if nothing is in flight now the label
-            // has to come down or it stays up forever.
-            if (m_window && !m_inFlight) {
-                m_window->showRendering(false);
-            }
             watcher->deleteLater();
-            // A change that arrived while this ran: render it now.
+            // A change that arrived while this ran is rendered now, and the
+            // label stays up for it -- taking it down here would flicker it
+            // off and on again on every coalesced rerun of a drag. Otherwise
+            // it comes down whatever this result was: a superseded render has
+            // still stopped, and gating that on the generation left the label
+            // up forever after a cancel.
             if (m_rerun && m_window) {
                 m_rerun = false;
                 scheduleRender();
+            } else if (m_window) {
+                m_window->showRendering(false);
             }
         });
     // The choice, not a range resolved once here: under cache pressure the
@@ -365,7 +370,8 @@ void VolumeController::startRender()
     const VolumeRangeChoice rangeChoice{rangeSelection.mode,
         rangeSelection.userRange, rangeSelection.logarithmic};
     watcher->setFuture(QtConcurrent::run(
-        [dataset, request, rangeChoice, cancellation]() mutable {
+        [dataset, request = std::move(request), rangeChoice,
+            cancellation]() mutable {
             return executeVolumeRenderWithFallback(dataset, std::move(request),
                 rangeChoice, cancellation);
         }));

--- a/src/qt/VolumeController.cpp
+++ b/src/qt/VolumeController.cpp
@@ -3,7 +3,6 @@
 #include "QtErrorText.hpp"
 #include "VolumeWindow.hpp"
 
-#include <amrexplorer/cache/ByteLruCache.hpp>
 #include <amrexplorer/core/Metadata.hpp>
 
 #include <QAction>
@@ -23,8 +22,10 @@ VolumeController::VolumeController(Hooks hooks, QObject* parent)
 {
     // Several changes in one event-loop turn (a range mode and its user
     // range, a palette and its reversal, sliders dragged) collapse into one
-    // render; a moving camera keeps rearming it, so the draft frames come
-    // at most every debounce interval.
+    // render. A throttle, not a debounce: scheduleRender leaves an already
+    // running timer alone, so a continuous drag -- which emits faster than
+    // this interval -- gets a draft every interval instead of rearming the
+    // timer forever and rendering nothing until the mouse stops.
     m_debounce = new QTimer(this);
     m_debounce->setSingleShot(true);
     m_debounce->setInterval(40);
@@ -65,8 +66,7 @@ void VolumeController::refreshActionEnabled()
 {
     const auto dataset = m_hooks.dataset ? m_hooks.dataset() : nullptr;
     if (m_action) {
-        m_action->setEnabled(
-            dataset && dataset->supportsVolumeRendering() && !m_suspended);
+        m_action->setEnabled(dataset && dataset->supportsVolumeRendering());
     }
 }
 
@@ -87,18 +87,39 @@ void VolumeController::showWindow(QWidget* parent)
     auto* window = new VolumeWindow(parent);
     window->setWindowFlag(Qt::Window, true);
     m_window = window;
-    connect(window, &VolumeWindow::cameraChanged, this, [this] {
+    m_frameShown = false;
+    // A camera move, a resize and a dragged opacity slider all arrive far
+    // faster than a full render finishes, so they share one path: draft
+    // frames while it continues, a full frame once it has been still for the
+    // settle interval. A drag also ends explicitly, on the mouse release.
+    const auto beginInteraction = [this] {
         m_interacting = true;
         m_settle->start();
         scheduleRender();
+    };
+    connect(window, &VolumeWindow::cameraChanged, this, beginInteraction);
+    connect(window, &VolumeWindow::rampChanged, this, beginInteraction);
+    connect(window, &VolumeWindow::viewResized, this, [this, beginInteraction] {
+        // Until the first frame is up nothing is being stretched: these are
+        // the window's own opening layout passes, and drafting them would
+        // open on a half-size frame instead of the view-sized one.
+        if (!m_frameShown) {
+            scheduleRender();
+            return;
+        }
+        beginInteraction();
     });
     connect(window, &VolumeWindow::interactionEnded, this, [this] {
         m_settle->stop();
         m_interacting = false;
         scheduleRender();
     });
-    connect(window, &VolumeWindow::rampChanged, this, [this] { scheduleRender(); });
-    connect(window, &VolumeWindow::qualityChanged, this, [this] { scheduleRender(); });
+    // The quality combo is a single discrete choice: render it in full.
+    connect(window, &VolumeWindow::qualityChanged, this, [this] {
+        m_settle->stop();
+        m_interacting = false;
+        scheduleRender();
+    });
     connect(window, &QObject::destroyed, this, [this] {
         // A close cancels the render in flight; its result would go nowhere.
         ++m_generation;
@@ -108,6 +129,7 @@ void VolumeController::showWindow(QWidget* parent)
         m_debounce->stop();
         m_settle->stop();
         m_interacting = false;
+        m_frameShown = false;
     });
     pushGeometry();
     window->show();
@@ -161,6 +183,9 @@ void VolumeController::configureForDataset()
         closeWindow();
         return;
     }
+    // Before the new geometry goes in: a frame still in flight was rendered
+    // for the outgoing dataset and must not be displayed against this one.
+    cancel();
     pushGeometry();
     m_window->clearFrame();
     scheduleRender();
@@ -209,6 +234,12 @@ void VolumeController::cancel()
     m_stopSource = StopSource{};
     m_rerun = false;
     m_debounce->stop();
+    // The settle timer too, and the interaction it stands for: left armed, it
+    // fires after the cancellation and schedules a render of whatever dataset
+    // is published by then -- the outgoing frame's, under the incoming one's
+    // geometry.
+    m_settle->stop();
+    m_interacting = false;
 }
 
 void VolumeController::scheduleRender()
@@ -220,7 +251,9 @@ void VolumeController::scheduleRender()
         m_rerun = true;
         return;
     }
-    m_debounce->start();
+    if (!m_debounce->isActive()) {
+        m_debounce->start();
+    }
 }
 
 void VolumeController::startRender()
@@ -250,8 +283,9 @@ void VolumeController::startRender()
     request.composition = level.composition;
     request.region = datasetSampleBounds(metadata);
     request.camera = m_window->camera();
-    // A moving camera gets a half-size, single-sample draft; the settled
-    // camera the full frame at the view's size.
+    // Mid-interaction (a moving camera, a resize, a dragged slider) gets a
+    // half-size, single-sample draft; a settled view the full frame at the
+    // view's size.
     const int width = std::max(1, m_interacting ? viewSize.width() / 2 : viewSize.width());
     const int height = std::max(1, m_interacting ? viewSize.height() / 2 : viewSize.height());
     request.outputSize = {std::min(width, maxVolumeOutputDimension),
@@ -271,9 +305,12 @@ void VolumeController::startRender()
     m_window->showRendering(true);
     emit renderActivityChanged(1);
 
+    // The name the request was built from: read again at display time it
+    // would label these pixels with whatever field the combo shows by then.
+    const auto fieldName = field->second;
     auto* watcher = new QFutureWatcher<VolumeDisplayResult>(this);
     connect(watcher, &QFutureWatcher<VolumeDisplayResult>::finished, this,
-        [this, watcher, generation, cancellation, dataset] {
+        [this, watcher, generation, cancellation, dataset, fieldName] {
             emit renderActivityChanged(-1);
             m_inFlight = false;
             if (m_hooks.isShuttingDown && m_hooks.isShuttingDown()) {
@@ -284,22 +321,22 @@ void VolumeController::startRender()
             try {
                 auto result = watcher->future().takeResult();
                 if (current) {
-                    m_lastFrame = result.frame;
-                    m_window->showFrame(m_lastFrame, describe(result));
-                    if (result.frame.cacheFallbackFromLevel >= 0) {
+                    auto status = describe(result, fieldName);
+                    m_lastFrame = std::move(result.frame);
+                    m_window->showFrame(m_lastFrame, status);
+                    if (m_lastFrame.cacheFallbackFromLevel >= 0) {
                         emit statusMessage(
                             tr("Volume: the finest level exceeded the cache; "
                                "showing levels 0 through %1 instead of 0 through %2.")
-                                .arg(result.frame.cacheFallbackToLevel)
-                                .arg(result.frame.cacheFallbackFromLevel),
+                                .arg(m_lastFrame.cacheFallbackToLevel)
+                                .arg(m_lastFrame.cacheFallbackFromLevel),
                             5000);
                     }
+                    m_frameShown = true;
                     emit frameDisplayed();
                 } else {
                     emit staleResultDropped();
                 }
-            } catch (const ReadCancelled&) {
-                emit staleResultDropped();
             } catch (const std::exception& error) {
                 if (current && !cancellation.stop_requested()) {
                     emit renderFailed(
@@ -308,33 +345,39 @@ void VolumeController::startRender()
                     emit staleResultDropped();
                 }
             }
-            if (m_window && generation == m_generation) {
+            // Not gated on the generation: a superseded result still means
+            // this render stopped, and if nothing is in flight now the label
+            // has to come down or it stays up forever.
+            if (m_window && !m_inFlight) {
                 m_window->showRendering(false);
             }
             watcher->deleteLater();
             // A change that arrived while this ran: render it now.
             if (m_rerun && m_window) {
                 m_rerun = false;
-                m_debounce->start();
+                scheduleRender();
             }
         });
+    // The choice, not a range resolved once here: under cache pressure the
+    // pipeline lowers the level, and a Level range read at the level asked
+    // for would colour and label pixels no part of that level produced. The
+    // overload taking it re-resolves per attempt (VolumePipeline.hpp).
+    const VolumeRangeChoice rangeChoice{rangeSelection.mode,
+        rangeSelection.userRange, rangeSelection.logarithmic};
     watcher->setFuture(QtConcurrent::run(
-        [dataset, request, rangeSelection, cancellation]() mutable {
-            request.range = resolveVolumeRange(dataset, request.field,
-                request.maximumLevel, request.composition, rangeSelection.mode,
-                rangeSelection.userRange, rangeSelection.logarithmic, cancellation);
+        [dataset, request, rangeChoice, cancellation]() mutable {
             return executeVolumeRenderWithFallback(dataset, std::move(request),
-                cancellation);
+                rangeChoice, cancellation);
         }));
 }
 
-QString VolumeController::describe(const VolumeDisplayResult& result) const
+QString VolumeController::describe(
+    const VolumeDisplayResult& result, const QString& fieldName) const
 {
-    const auto field = m_hooks.field ? m_hooks.field() : std::nullopt;
     const auto& frame = result.frame;
     const auto& range = frame.usedRange;
     return tr("%1  level %2  range [%3, %4]%5\ngrid %6 x %7 x %8 (%9)  %10 ms")
-        .arg(field ? field->second : QString())
+        .arg(fieldName)
         .arg(result.request.maximumLevel)
         .arg(range.minimum)
         .arg(range.maximum)
@@ -343,7 +386,12 @@ QString VolumeController::describe(const VolumeDisplayResult& result) const
         .arg(frame.metrics.gridDims[1])
         .arg(frame.metrics.gridDims[2])
         .arg(frame.metrics.gridFromCache ? tr("cached") : tr("sampled"))
-        .arg(frame.metrics.renderMilliseconds + frame.metrics.sampleMilliseconds);
+        // The metrics are microseconds (Volume.hpp says why); one decimal
+        // place so a sub-millisecond render reads as fast rather than as 0.
+        .arg(static_cast<double>(frame.metrics.renderMicroseconds
+                 + frame.metrics.sampleMicroseconds)
+                / 1000.0,
+            0, 'f', 1);
 }
 
 } // namespace amrvis::qt

--- a/src/qt/VolumeController.cpp
+++ b/src/qt/VolumeController.cpp
@@ -85,7 +85,6 @@ void VolumeController::showWindow(QWidget* parent)
     // the main window without being modal). Deleted on close; the pointer
     // is a QPointer so a close from the title bar clears it.
     auto* window = new VolumeWindow(parent);
-    window->setWindowFlag(Qt::Window, true);
     m_window = window;
     m_frameShown = false;
     // A camera move, a resize and a dragged opacity slider all arrive far
@@ -100,6 +99,16 @@ void VolumeController::showWindow(QWidget* parent)
     connect(window, &VolumeWindow::cameraChanged, this, beginInteraction);
     connect(window, &VolumeWindow::rampChanged, this, beginInteraction);
     connect(window, &VolumeWindow::viewResized, this, [this, beginInteraction] {
+        if (!m_window) {
+            return;
+        }
+        // Same size: this is the dock relaying itself out, which showFrame and
+        // the "Rendering..." label can both cause, not the user resizing. The
+        // frame in the view still matches the view, so rendering again would
+        // be a loop fed by its own output.
+        if (m_window->viewSize() == m_lastRenderViewSize) {
+            return;
+        }
         // Until the first frame is up nothing is being stretched: these are
         // the window's own opening layout passes, and drafting them would
         // open on a half-size frame instead of the view-sized one.
@@ -109,28 +118,21 @@ void VolumeController::showWindow(QWidget* parent)
         }
         beginInteraction();
     });
-    connect(window, &VolumeWindow::interactionEnded, this, [this] {
+    // The counterpart: a change that is already complete -- a drag's release,
+    // the quality combo, the alpha checkbox -- renders in full at once.
+    const auto endInteraction = [this] {
         m_settle->stop();
         m_interacting = false;
         scheduleRender();
-    });
-    // The quality combo is a single discrete choice: render it in full.
-    connect(window, &VolumeWindow::qualityChanged, this, [this] {
-        m_settle->stop();
-        m_interacting = false;
-        scheduleRender();
-    });
-    connect(window, &QObject::destroyed, this, [this] {
-        // A close cancels the render in flight; its result would go nowhere.
-        ++m_generation;
-        m_stopSource.request_stop();
-        m_stopSource = StopSource{};
-        m_rerun = false;
-        m_debounce->stop();
-        m_settle->stop();
-        m_interacting = false;
-        m_frameShown = false;
-    });
+    };
+    connect(window, &VolumeWindow::interactionEnded, this, endInteraction);
+    connect(window, &VolumeWindow::qualityChanged, this, endInteraction);
+    connect(window, &VolumeWindow::paletteAlphaChanged, this, endInteraction);
+    // A close from the title bar: closeWindow drops this connection before
+    // closing, so reaching here means the user closed the window and nothing
+    // else has handled it.
+    m_windowDestroyed = connect(window, &QObject::destroyed, this,
+        [this] { forgetWindow(); });
     pushGeometry();
     window->show();
     window->raise();
@@ -143,8 +145,22 @@ void VolumeController::closeWindow()
     if (m_window) {
         auto* window = m_window.data();
         m_window = nullptr;
+        // Here, not in the window's destroyed handler: WA_DeleteOnClose only
+        // defers the delete, so that handler runs a turn later. Until it does,
+        // the render in flight still matches m_generation -- and a window
+        // opened in between would be handed the closed window's frame, then
+        // have its own scheduled render disarmed by the late handler.
+        QObject::disconnect(m_windowDestroyed);
+        forgetWindow();
         window->close();
     }
+}
+
+void VolumeController::forgetWindow()
+{
+    cancel();
+    m_frameShown = false;
+    m_lastRenderViewSize = QSize{};
 }
 
 bool VolumeController::windowOpen() const noexcept
@@ -161,13 +177,18 @@ void VolumeController::pushGeometry()
     if (dataset) {
         m_window->setDatasetGeometry(dataset->metadata());
     }
-    if (m_hooks.palette) {
+    pushPalette();
+    slicePositionsChanged();
+    slicePlanesVisibilityChanged();
+}
+
+void VolumeController::pushPalette()
+{
+    if (m_window && m_hooks.palette) {
         const auto& palette = m_hooks.palette();
         m_window->setColorPalette(&palette);
         m_window->setPaletteHasAlpha(palette.hasAlphaRamp());
     }
-    slicePositionsChanged();
-    slicePlanesVisibilityChanged();
 }
 
 void VolumeController::configureForDataset()
@@ -188,7 +209,11 @@ void VolumeController::configureForDataset()
     cancel();
     pushGeometry();
     m_window->clearFrame();
+    // The frame just cleared belonged to the outgoing dataset; lastFrame()
+    // would otherwise keep reporting it as this one's.
+    m_lastFrame = VolumeFrame{};
     m_frameShown = false;
+    m_lastRenderViewSize = QSize{};
     scheduleRender();
 }
 
@@ -197,11 +222,7 @@ void VolumeController::refresh()
     if (!m_window) {
         return;
     }
-    if (m_hooks.palette) {
-        const auto& palette = m_hooks.palette();
-        m_window->setColorPalette(&palette);
-        m_window->setPaletteHasAlpha(palette.hasAlphaRamp());
-    }
+    pushPalette();
     scheduleRender();
 }
 
@@ -277,6 +298,7 @@ void VolumeController::startRender()
         ? m_hooks.rangeSelection() : RangeController::Selection{};
     const auto quality = m_window->quality();
     const auto viewSize = m_window->viewSize();
+    m_lastRenderViewSize = viewSize;
 
     // The request, less its range: that is resolved on the worker, since
     // File/Level statistics may be a round trip away on a remote session.

--- a/src/qt/VolumeController.cpp
+++ b/src/qt/VolumeController.cpp
@@ -161,6 +161,10 @@ void VolumeController::forgetWindow()
     cancel();
     m_frameShown = false;
     m_lastRenderViewSize = QSize{};
+    // The frame belonged to the window that is going away: keeping it holds a
+    // whole pixel buffer for the life of the process and leaves lastFrame()
+    // describing a window that no longer exists.
+    m_lastFrame = VolumeFrame{};
 }
 
 bool VolumeController::windowOpen() const noexcept
@@ -195,6 +199,9 @@ void VolumeController::configureForDataset()
 {
     refreshActionEnabled();
     if (!m_window) {
+        // No window to reconfigure, but the frame still described the dataset
+        // being replaced.
+        m_lastFrame = VolumeFrame{};
         return;
     }
     const auto dataset = m_hooks.dataset ? m_hooks.dataset() : nullptr;
@@ -243,7 +250,8 @@ void VolumeController::slicePlanesVisibilityChanged()
 
 void VolumeController::reset()
 {
-    cancel();
+    // closeWindow cancels and drops the frame through forgetWindow; cancelling
+    // here as well would bump the generation twice for one teardown.
     closeWindow();
     m_lastFrame = VolumeFrame{};
     refreshActionEnabled();
@@ -350,7 +358,8 @@ void VolumeController::startRender()
                 if (current) {
                     auto status = describe(result, fieldName);
                     m_lastFrame = std::move(result.frame);
-                    m_window->showFrame(m_lastFrame, status);
+                    m_window->showFrame(
+                        m_lastFrame, result.request.camera, status);
                     if (m_lastFrame.cacheFallbackFromLevel >= 0) {
                         emit statusMessage(
                             tr("Volume: the finest level exceeded the cache; "
@@ -366,8 +375,14 @@ void VolumeController::startRender()
                 }
             } catch (const std::exception& error) {
                 if (current && !cancellation.stop_requested()) {
-                    emit renderFailed(
-                        tr("Cannot render the volume: %1").arg(exceptionMessage(error)));
+                    const auto message = tr("Cannot render the volume: %1")
+                        .arg(exceptionMessage(error));
+                    // Into the window as well as out to the host: this window
+                    // is raised over the main window, whose status bar and
+                    // Diagnostics dock are where renderFailed lands, so on its
+                    // own the view would simply stop changing.
+                    m_window->showFailure(message);
+                    emit renderFailed(message);
                 } else {
                     emit staleResultDropped();
                 }

--- a/src/qt/VolumeController.cpp
+++ b/src/qt/VolumeController.cpp
@@ -1,0 +1,349 @@
+#include "VolumeController.hpp"
+
+#include "QtErrorText.hpp"
+#include "VolumeWindow.hpp"
+
+#include <amrexplorer/cache/ByteLruCache.hpp>
+#include <amrexplorer/core/Metadata.hpp>
+
+#include <QAction>
+#include <QFutureWatcher>
+#include <QTimer>
+#include <QtConcurrent/QtConcurrent>
+
+#include <algorithm>
+#include <exception>
+#include <utility>
+
+namespace amrvis::qt {
+
+VolumeController::VolumeController(Hooks hooks, QObject* parent)
+    : QObject(parent)
+    , m_hooks(std::move(hooks))
+{
+    // Several changes in one event-loop turn (a range mode and its user
+    // range, a palette and its reversal, sliders dragged) collapse into one
+    // render; a moving camera keeps rearming it, so the draft frames come
+    // at most every debounce interval.
+    m_debounce = new QTimer(this);
+    m_debounce->setSingleShot(true);
+    m_debounce->setInterval(40);
+    connect(m_debounce, &QTimer::timeout, this, [this] { startRender(); });
+    // A wheel zoom has no "release": the camera counts as settled once it
+    // has been still for this long, and the settled camera gets a full frame.
+    m_settle = new QTimer(this);
+    m_settle->setSingleShot(true);
+    m_settle->setInterval(250);
+    connect(m_settle, &QTimer::timeout, this, [this] {
+        if (m_interacting) {
+            m_interacting = false;
+            scheduleRender();
+        }
+    });
+}
+
+VolumeController::~VolumeController()
+{
+    m_stopSource.request_stop();
+    closeWindow();
+}
+
+QAction* VolumeController::createAction(QObject* parent)
+{
+    auto* action = new QAction(tr("&Volume Rendering..."), parent);
+    action->setObjectName(QStringLiteral("volumeRenderingAction"));
+    action->setToolTip(tr("Ray-cast the 3-D field in its own window"));
+    m_action = action;
+    refreshActionEnabled();
+    connect(action, &QAction::triggered, this, [this] {
+        showWindow(qobject_cast<QWidget*>(this->parent()));
+    });
+    return action;
+}
+
+void VolumeController::refreshActionEnabled()
+{
+    const auto dataset = m_hooks.dataset ? m_hooks.dataset() : nullptr;
+    if (m_action) {
+        m_action->setEnabled(
+            dataset && dataset->supportsVolumeRendering() && !m_suspended);
+    }
+}
+
+void VolumeController::showWindow(QWidget* parent)
+{
+    if (m_window) {
+        m_window->raise();
+        m_window->activateWindow();
+        return;
+    }
+    const auto dataset = m_hooks.dataset ? m_hooks.dataset() : nullptr;
+    if (!dataset || !dataset->supportsVolumeRendering()) {
+        return;
+    }
+    // A top-level window (parented for placement only, so it stays above
+    // the main window without being modal). Deleted on close; the pointer
+    // is a QPointer so a close from the title bar clears it.
+    auto* window = new VolumeWindow(parent);
+    window->setWindowFlag(Qt::Window, true);
+    m_window = window;
+    connect(window, &VolumeWindow::cameraChanged, this, [this] {
+        m_interacting = true;
+        m_settle->start();
+        scheduleRender();
+    });
+    connect(window, &VolumeWindow::interactionEnded, this, [this] {
+        m_settle->stop();
+        m_interacting = false;
+        scheduleRender();
+    });
+    connect(window, &VolumeWindow::rampChanged, this, [this] { scheduleRender(); });
+    connect(window, &VolumeWindow::qualityChanged, this, [this] { scheduleRender(); });
+    connect(window, &QObject::destroyed, this, [this] {
+        // A close cancels the render in flight; its result would go nowhere.
+        ++m_generation;
+        m_stopSource.request_stop();
+        m_stopSource = StopSource{};
+        m_rerun = false;
+        m_debounce->stop();
+        m_settle->stop();
+        m_interacting = false;
+    });
+    pushGeometry();
+    window->show();
+    window->raise();
+    window->activateWindow();
+    scheduleRender();
+}
+
+void VolumeController::closeWindow()
+{
+    if (m_window) {
+        auto* window = m_window.data();
+        m_window = nullptr;
+        window->close();
+    }
+}
+
+bool VolumeController::windowOpen() const noexcept
+{
+    return !m_window.isNull();
+}
+
+void VolumeController::pushGeometry()
+{
+    if (!m_window) {
+        return;
+    }
+    const auto dataset = m_hooks.dataset ? m_hooks.dataset() : nullptr;
+    if (dataset) {
+        m_window->setDatasetGeometry(dataset->metadata());
+    }
+    if (m_hooks.palette) {
+        const auto& palette = m_hooks.palette();
+        m_window->setColorPalette(&palette);
+        m_window->setPaletteHasAlpha(palette.hasAlphaRamp());
+    }
+    slicePositionsChanged();
+    slicePlanesVisibilityChanged();
+}
+
+void VolumeController::configureForDataset()
+{
+    refreshActionEnabled();
+    if (!m_window) {
+        return;
+    }
+    const auto dataset = m_hooks.dataset ? m_hooks.dataset() : nullptr;
+    if (!dataset || !dataset->supportsVolumeRendering()) {
+        // The new dataset cannot be volume-rendered: the window shows nothing
+        // of it, so it closes as the dataset window does.
+        closeWindow();
+        return;
+    }
+    pushGeometry();
+    m_window->clearFrame();
+    scheduleRender();
+}
+
+void VolumeController::refresh()
+{
+    if (!m_window) {
+        return;
+    }
+    if (m_hooks.palette) {
+        const auto& palette = m_hooks.palette();
+        m_window->setColorPalette(&palette);
+        m_window->setPaletteHasAlpha(palette.hasAlphaRamp());
+    }
+    scheduleRender();
+}
+
+void VolumeController::slicePositionsChanged()
+{
+    if (m_window && m_hooks.slicePositions) {
+        const auto positions = m_hooks.slicePositions();
+        m_window->setSlicePositions(positions[0], positions[1], positions[2]);
+    }
+}
+
+void VolumeController::slicePlanesVisibilityChanged()
+{
+    if (m_window && m_hooks.slicePlanesVisible) {
+        m_window->setSlicePlanesVisible(m_hooks.slicePlanesVisible());
+    }
+}
+
+void VolumeController::reset()
+{
+    cancel();
+    closeWindow();
+    m_lastFrame = VolumeFrame{};
+    refreshActionEnabled();
+}
+
+void VolumeController::cancel()
+{
+    ++m_generation;
+    m_stopSource.request_stop();
+    m_stopSource = StopSource{};
+    m_rerun = false;
+    m_debounce->stop();
+}
+
+void VolumeController::scheduleRender()
+{
+    if (!m_window) {
+        return;
+    }
+    if (m_inFlight) {
+        m_rerun = true;
+        return;
+    }
+    m_debounce->start();
+}
+
+void VolumeController::startRender()
+{
+    if (!m_window || m_inFlight) {
+        return;
+    }
+    const auto dataset = m_hooks.dataset ? m_hooks.dataset() : nullptr;
+    const auto field = m_hooks.field ? m_hooks.field() : std::nullopt;
+    if (!dataset || !dataset->supportsVolumeRendering() || !field) {
+        return;
+    }
+    const auto& metadata = dataset->metadata();
+    const auto level = m_hooks.levelSelection
+        ? m_hooks.levelSelection() : LevelSelection{};
+    const auto rangeSelection = m_hooks.rangeSelection
+        ? m_hooks.rangeSelection() : RangeController::Selection{};
+    const auto quality = m_window->quality();
+    const auto viewSize = m_window->viewSize();
+
+    // The request, less its range: that is resolved on the worker, since
+    // File/Level statistics may be a round trip away on a remote session.
+    VolumeRenderRequest request;
+    request.dataset = dataset->id();
+    request.field = field->first;
+    request.maximumLevel = std::clamp(level.maximumLevel, 0, metadata.finestLevel);
+    request.composition = level.composition;
+    request.region = datasetSampleBounds(metadata);
+    request.camera = m_window->camera();
+    // A moving camera gets a half-size, single-sample draft; the settled
+    // camera the full frame at the view's size.
+    const int width = std::max(1, m_interacting ? viewSize.width() / 2 : viewSize.width());
+    const int height = std::max(1, m_interacting ? viewSize.height() / 2 : viewSize.height());
+    request.outputSize = {std::min(width, maxVolumeOutputDimension),
+        std::min(height, maxVolumeOutputDimension)};
+    request.logarithmic = rangeSelection.logarithmic;
+    request.transfer = makeVolumeTransferFunction(
+        m_hooks.palette ? m_hooks.palette() : builtinPalette(BuiltinPalette::Rainbow),
+        m_window->ramp());
+    request.samplesPerVoxel = m_interacting ? 1 : quality.samplesPerVoxel;
+    request.maximumVoxels = quality.maximumVoxels;
+
+    const auto generation = ++m_generation;
+    m_stopSource = StopSource{};
+    const auto cancellation = m_stopSource.get_token();
+    m_inFlight = true;
+    m_rerun = false;
+    m_window->showRendering(true);
+    emit renderActivityChanged(1);
+
+    auto* watcher = new QFutureWatcher<VolumeDisplayResult>(this);
+    connect(watcher, &QFutureWatcher<VolumeDisplayResult>::finished, this,
+        [this, watcher, generation, cancellation, dataset] {
+            emit renderActivityChanged(-1);
+            m_inFlight = false;
+            if (m_hooks.isShuttingDown && m_hooks.isShuttingDown()) {
+                watcher->deleteLater();
+                return;
+            }
+            const bool current = generation == m_generation && m_window;
+            try {
+                auto result = watcher->future().takeResult();
+                if (current) {
+                    m_lastFrame = result.frame;
+                    m_window->showFrame(m_lastFrame, describe(result));
+                    if (result.frame.cacheFallbackFromLevel >= 0) {
+                        emit statusMessage(
+                            tr("Volume: the finest level exceeded the cache; "
+                               "showing levels 0 through %1 instead of 0 through %2.")
+                                .arg(result.frame.cacheFallbackToLevel)
+                                .arg(result.frame.cacheFallbackFromLevel),
+                            5000);
+                    }
+                    emit frameDisplayed();
+                } else {
+                    emit staleResultDropped();
+                }
+            } catch (const ReadCancelled&) {
+                emit staleResultDropped();
+            } catch (const std::exception& error) {
+                if (current && !cancellation.stop_requested()) {
+                    emit renderFailed(
+                        tr("Cannot render the volume: %1").arg(exceptionMessage(error)));
+                } else {
+                    emit staleResultDropped();
+                }
+            }
+            if (m_window && generation == m_generation) {
+                m_window->showRendering(false);
+            }
+            watcher->deleteLater();
+            // A change that arrived while this ran: render it now.
+            if (m_rerun && m_window) {
+                m_rerun = false;
+                m_debounce->start();
+            }
+        });
+    watcher->setFuture(QtConcurrent::run(
+        [dataset, request, rangeSelection, level, cancellation]() mutable {
+            request.range = resolveVolumeRange(dataset, request.field,
+                request.maximumLevel, request.composition, rangeSelection.mode,
+                rangeSelection.userRange, rangeSelection.logarithmic, cancellation);
+            return executeVolumeRenderWithFallback(dataset, std::move(request),
+                cancellation);
+        }));
+}
+
+QString VolumeController::describe(const VolumeDisplayResult& result) const
+{
+    const auto field = m_hooks.field ? m_hooks.field() : std::nullopt;
+    const auto& frame = result.frame;
+    const auto& range = frame.usedRange;
+    return tr("%1  level %2  range [%3, %4]%5\ngrid %6 x %7 x %8 (%9)  %10 ms")
+        .arg(field ? field->second : QString())
+        .arg(result.request.maximumLevel)
+        .arg(range.minimum)
+        .arg(range.maximum)
+        .arg(range.logarithmic ? tr(" log") : QString())
+        .arg(frame.metrics.gridDims[0])
+        .arg(frame.metrics.gridDims[1])
+        .arg(frame.metrics.gridDims[2])
+        .arg(frame.metrics.gridFromCache ? tr("cached") : tr("sampled"))
+        .arg(frame.metrics.renderMilliseconds + frame.metrics.sampleMilliseconds);
+}
+
+} // namespace amrvis::qt

--- a/src/qt/VolumeController.cpp
+++ b/src/qt/VolumeController.cpp
@@ -319,7 +319,7 @@ void VolumeController::startRender()
             }
         });
     watcher->setFuture(QtConcurrent::run(
-        [dataset, request, rangeSelection, level, cancellation]() mutable {
+        [dataset, request, rangeSelection, cancellation]() mutable {
             request.range = resolveVolumeRange(dataset, request.field,
                 request.maximumLevel, request.composition, rangeSelection.mode,
                 rangeSelection.userRange, rangeSelection.logarithmic, cancellation);

--- a/src/qt/VolumeController.hpp
+++ b/src/qt/VolumeController.hpp
@@ -1,0 +1,125 @@
+#pragma once
+
+#include "RangeController.hpp"
+
+#include <amrexplorer/core/Request.hpp>
+#include <amrexplorer/core/StopToken.hpp>
+#include <amrexplorer/data/DatasetSession.hpp>
+#include <amrexplorer/pipeline/SlicePipeline.hpp>
+#include <amrexplorer/pipeline/VolumePipeline.hpp>
+#include <amrexplorer/render2d/Palette.hpp>
+
+#include <QObject>
+#include <QPointer>
+#include <QString>
+
+#include <array>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <utility>
+
+class QAction;
+class QTimer;
+class QWidget;
+
+namespace amrvis::qt {
+
+class VolumeWindow;
+
+// The volume view's state machine, extracted from MainWindow the way the
+// other collaborators are: it owns the Volume Rendering... action and the
+// Volume window, decides when a render is due -- a camera move, a changed
+// field, level, range, palette or opacity control -- builds each request
+// from what the host tells it (through Hooks) and the window's controls,
+// runs it on a worker through the session (locally or on the server), and
+// pushes the frame back into the window. One render is in flight at a time;
+// a change during one is remembered and rendered after it. While the camera
+// is moving the frames are half-size, one-sample drafts; the settled camera
+// gets a full frame. Late results (a superseded generation, a closed
+// window, a shutting-down host) are dropped, never displayed.
+class VolumeController final : public QObject {
+    Q_OBJECT
+
+public:
+    struct Hooks {
+        // The open dataset, or null.
+        std::function<std::shared_ptr<DatasetSession>()> dataset;
+        // The selected field and its display name, or nullopt with none.
+        std::function<std::optional<std::pair<FieldId, QString>>()> field;
+        // The level combo's selection.
+        std::function<LevelSelection()> levelSelection;
+        // The range controls' selection.
+        std::function<RangeController::Selection()> rangeSelection;
+        // The palette in effect (colours; alpha ramp when the file had one).
+        std::function<const Palette&()> palette;
+        // The three slice positions and whether the planes are shown.
+        std::function<std::array<double, 3>()> slicePositions;
+        std::function<bool()> slicePlanesVisible;
+        // True once application shutdown began: late results are dropped
+        // without touching the GUI.
+        std::function<bool()> isShuttingDown;
+    };
+
+    VolumeController(Hooks hooks, QObject* parent = nullptr);
+    ~VolumeController() override;
+
+    // The View menu's action: opens the window; enabled while the dataset
+    // can be volume-rendered (a 3-D plotfile, and for a remote one a server
+    // speaking protocol 1.2) and the host has not suspended it. Owned by
+    // `parent`.
+    QAction* createAction(QObject* parent);
+    // The window (one at a time), parented to `parent` for placement only.
+    void showWindow(QWidget* parent);
+    void closeWindow();
+    [[nodiscard]] bool windowOpen() const noexcept;
+
+    // Host notifications. configureForDataset: a dataset opened or a sequence
+    // frame arrived -- the geometry is pushed and, with the window open, a
+    // frame rendered with the same camera. refresh: field, level, range, log
+    // or palette changed. slicePositionsChanged / slicePlanesVisibilityChanged:
+    // overlay-only, no render. reset: the dataset is going away -- cancel,
+    // close the window, disable the action. cancel: in-flight work is
+    // abandoned (a frame switch, shutdown); the window stays.
+    void configureForDataset();
+    void refresh();
+    void slicePositionsChanged();
+    void slicePlanesVisibilityChanged();
+    void reset();
+    void cancel();
+
+    // The last frame displayed (empty until one is), for tests.
+    [[nodiscard]] const VolumeFrame& lastFrame() const noexcept { return m_lastFrame; }
+    [[nodiscard]] bool renderInFlight() const noexcept { return m_inFlight; }
+
+signals:
+    // A render started (+1) or ended (-1), for the host's activity count.
+    void renderActivityChanged(int delta);
+    void renderFailed(const QString& message);
+    void statusMessage(const QString& message, int timeoutMs);
+    void staleResultDropped();
+    void frameDisplayed();
+
+private:
+    void refreshActionEnabled();
+    void scheduleRender();
+    void startRender();
+    void pushGeometry();
+    [[nodiscard]] QString describe(const VolumeDisplayResult& result) const;
+
+    Hooks m_hooks;
+    QPointer<QAction> m_action;
+    QPointer<VolumeWindow> m_window;
+    QTimer* m_debounce = nullptr;
+    QTimer* m_settle = nullptr;
+    StopSource m_stopSource;
+    std::uint64_t m_generation = 0;
+    bool m_inFlight = false;
+    bool m_rerun = false;
+    bool m_interacting = false;
+    bool m_suspended = false;
+    VolumeFrame m_lastFrame;
+};
+
+} // namespace amrvis::qt

--- a/src/qt/VolumeController.hpp
+++ b/src/qt/VolumeController.hpp
@@ -36,8 +36,9 @@ class VolumeWindow;
 // runs it on a worker through the session (locally or on the server), and
 // pushes the frame back into the window. One render is in flight at a time;
 // a change during one is remembered and rendered after it. While the camera
-// is moving the frames are half-size, one-sample drafts; the settled camera
-// gets a full frame. Late results (a superseded generation, a closed
+// is moving, the view is being resized or an opacity slider is being dragged,
+// the frames are half-size, one-sample drafts; once that settles, a full
+// frame. Late results (a superseded generation, a closed
 // window, a shutting-down host) are dropped, never displayed.
 class VolumeController final : public QObject {
     Q_OBJECT
@@ -67,8 +68,7 @@ public:
 
     // The View menu's action: opens the window; enabled while the dataset
     // can be volume-rendered (a 3-D plotfile, and for a remote one a server
-    // speaking protocol 1.2) and the host has not suspended it. Owned by
-    // `parent`.
+    // speaking protocol 1.2). Owned by `parent`.
     QAction* createAction(QObject* parent);
     // The window (one at a time), parented to `parent` for placement only.
     void showWindow(QWidget* parent);
@@ -106,7 +106,8 @@ private:
     void scheduleRender();
     void startRender();
     void pushGeometry();
-    [[nodiscard]] QString describe(const VolumeDisplayResult& result) const;
+    [[nodiscard]] QString describe(
+        const VolumeDisplayResult& result, const QString& fieldName) const;
 
     Hooks m_hooks;
     QPointer<QAction> m_action;
@@ -118,7 +119,9 @@ private:
     bool m_inFlight = false;
     bool m_rerun = false;
     bool m_interacting = false;
-    bool m_suspended = false;
+    // Whether the open window has shown a frame yet: only then is a resize
+    // stretching something, and only then is it worth a draft.
+    bool m_frameShown = false;
     VolumeFrame m_lastFrame;
 };
 

--- a/src/qt/VolumeController.hpp
+++ b/src/qt/VolumeController.hpp
@@ -9,8 +9,10 @@
 #include <amrexplorer/pipeline/VolumePipeline.hpp>
 #include <amrexplorer/render2d/Palette.hpp>
 
+#include <QMetaObject>
 #include <QObject>
 #include <QPointer>
+#include <QSize>
 #include <QString>
 
 #include <array>
@@ -106,6 +108,10 @@ private:
     void scheduleRender();
     void startRender();
     void pushGeometry();
+    void pushPalette();
+    // The window is going away, closed here or by the user: abandon the render
+    // in flight and forget that a frame was ever shown in it.
+    void forgetWindow();
     [[nodiscard]] QString describe(
         const VolumeDisplayResult& result, const QString& fieldName) const;
 
@@ -114,6 +120,13 @@ private:
     QPointer<VolumeWindow> m_window;
     QTimer* m_debounce = nullptr;
     QTimer* m_settle = nullptr;
+    // Kept so closeWindow can drop the window's destroyed handler: that runs a
+    // turn later, when m_window may already be a newly opened window.
+    QMetaObject::Connection m_windowDestroyed;
+    // The view size the last render was built for. A resize to the same size
+    // is layout churn, not a resize, and rendering for it would be a loop fed
+    // by its own output (showFrame writes a label in the same dock).
+    QSize m_lastRenderViewSize;
     StopSource m_stopSource;
     std::uint64_t m_generation = 0;
     bool m_inFlight = false;

--- a/src/qt/VolumeWindow.cpp
+++ b/src/qt/VolumeWindow.cpp
@@ -7,6 +7,7 @@
 #include <QDockWidget>
 #include <QFormLayout>
 #include <QLabel>
+#include <QSignalBlocker>
 #include <QSlider>
 #include <QHBoxLayout>
 #include <QVBoxLayout>
@@ -158,6 +159,15 @@ void VolumeWindow::setColorPalette(const Palette* palette)
 void VolumeWindow::setPaletteHasAlpha(bool hasAlpha)
 {
     m_paletteAlpha->setEnabled(hasAlpha);
+    if (!hasAlpha && m_paletteAlpha->isChecked()) {
+        // ramp() ands in isEnabled(), so the render already ignores a ticked
+        // box on a palette with no ramp -- but the box would sit there ticked,
+        // claiming an opacity source that is not in use, and re-arm itself the
+        // moment any palette with a ramp is selected. Silently: the palette
+        // change that caused this is already scheduling a render.
+        const QSignalBlocker blocker(m_paletteAlpha);
+        m_paletteAlpha->setChecked(false);
+    }
     m_paletteAlpha->setToolTip(hasAlpha
         ? tr("Take each colour's opacity from the palette's alpha ramp "
              "instead of the linear window above.")
@@ -165,20 +175,29 @@ void VolumeWindow::setPaletteHasAlpha(bool hasAlpha)
              "with one to enable this."));
 }
 
-void VolumeWindow::showFrame(const VolumeFrame& frame, const QString& status)
+void VolumeWindow::showFrame(const VolumeFrame& frame,
+    const OrthoCamera& camera, const QString& status)
 {
     // Premultiplied ARGB, row 0 at the top: exactly the frame's layout, so
     // the image wraps the pixels and copies them once.
     const QImage wrapped(reinterpret_cast<const uchar*>(frame.pixels.data()),
         frame.width, frame.height, frame.width * static_cast<int>(sizeof(std::uint32_t)),
         QImage::Format_ARGB32_Premultiplied);
-    m_view->setBackdropImage(wrapped.copy());
+    m_view->setBackdropImage(wrapped.copy(), camera);
     m_status->setText(status);
+}
+
+void VolumeWindow::showFailure(const QString& message)
+{
+    // The frame stays: it is the last thing that did render, and replacing it
+    // with nothing would lose the view. The status says why it is not moving,
+    // which the main window's status bar cannot do from behind this window.
+    m_status->setText(message);
 }
 
 void VolumeWindow::clearFrame()
 {
-    m_view->setBackdropImage(QImage());
+    m_view->setBackdropImage(QImage(), OrthoCamera{});
     m_status->clear();
 }
 

--- a/src/qt/VolumeWindow.cpp
+++ b/src/qt/VolumeWindow.cpp
@@ -8,10 +8,9 @@
 #include <QFormLayout>
 #include <QLabel>
 #include <QSlider>
+#include <QHBoxLayout>
 #include <QVBoxLayout>
 #include <QWidget>
-
-#include <algorithm>
 
 namespace amrvis::qt {
 
@@ -126,7 +125,8 @@ void VolumeWindow::buildControls()
         updateLabels();
         emit rampChanged();
     });
-    connect(m_paletteAlpha, &QCheckBox::toggled, this, [this] { emit rampChanged(); });
+    connect(m_paletteAlpha, &QCheckBox::toggled, this,
+        [this] { emit paletteAlphaChanged(); });
     connect(m_qualityCombo, qOverload<int>(&QComboBox::currentIndexChanged), this,
         [this](int) { emit qualityChanged(); });
     connect(m_boxesCheck, &QCheckBox::toggled, this,
@@ -200,6 +200,12 @@ QSize VolumeWindow::viewSize() const
 
 OpacityRamp VolumeWindow::ramp() const
 {
+    // Every field comes from a slider in [0, 100], and buildControls keeps
+    // low <= high by pushing the other along. makeVolumeTransferFunction
+    // throws on a non-finite or inverted window, so anything that lets these
+    // controls produce one -- a text entry, a restored setting -- has to
+    // resolve it here rather than hand it to the render.
+
     OpacityRamp ramp;
     ramp.lowThreshold = m_lowSlider->value() / 100.0;
     ramp.highThreshold = m_highSlider->value() / 100.0;

--- a/src/qt/VolumeWindow.cpp
+++ b/src/qt/VolumeWindow.cpp
@@ -28,6 +28,8 @@ VolumeWindow::VolumeWindow(QWidget* parent)
         [this] { emit cameraChanged(); });
     connect(m_view, &IsoWidget::interactionEnded, this,
         [this] { emit interactionEnded(); });
+    connect(m_view, &IsoWidget::viewResized, this,
+        [this] { emit viewResized(); });
     buildControls();
 }
 
@@ -184,11 +186,6 @@ void VolumeWindow::showRendering(bool rendering)
 {
     m_rendering->setText(rendering ? tr("Rendering…") : QString());
     m_rendering->setVisible(rendering);
-}
-
-void VolumeWindow::showStatus(const QString& status)
-{
-    m_status->setText(status);
 }
 
 const OrthoCamera& VolumeWindow::camera() const noexcept

--- a/src/qt/VolumeWindow.cpp
+++ b/src/qt/VolumeWindow.cpp
@@ -1,0 +1,226 @@
+#include "VolumeWindow.hpp"
+
+#include "IsoWidget.hpp"
+
+#include <QCheckBox>
+#include <QComboBox>
+#include <QDockWidget>
+#include <QFormLayout>
+#include <QLabel>
+#include <QSlider>
+#include <QVBoxLayout>
+#include <QWidget>
+
+#include <algorithm>
+
+namespace amrvis::qt {
+
+VolumeWindow::VolumeWindow(QWidget* parent)
+    : QMainWindow(parent)
+{
+    setWindowTitle(tr("Volume Rendering"));
+    setAttribute(Qt::WA_DeleteOnClose);
+    resize(760, 620);
+    m_view = new IsoWidget(this);
+    m_view->setMinimumSize(320, 240);
+    setCentralWidget(m_view);
+    connect(m_view, &IsoWidget::cameraChanged, this,
+        [this] { emit cameraChanged(); });
+    connect(m_view, &IsoWidget::interactionEnded, this,
+        [this] { emit interactionEnded(); });
+    buildControls();
+}
+
+void VolumeWindow::buildControls()
+{
+    auto* dock = new QDockWidget(tr("Volume"), this);
+    dock->setObjectName(QStringLiteral("volumeControlsDock"));
+    dock->setFeatures(QDockWidget::DockWidgetMovable
+        | QDockWidget::DockWidgetFloatable);
+    auto* panel = new QWidget(dock);
+    auto* layout = new QVBoxLayout(panel);
+    auto* form = new QFormLayout;
+    form->setFieldGrowthPolicy(QFormLayout::AllNonFixedFieldsGrow);
+
+    // The opacity window over the colour range: transparent below "from",
+    // ramping to the maximum at "to"; the labels read the slider positions.
+    const auto makeSlider = [panel](int initial) {
+        auto* slider = new QSlider(Qt::Horizontal, panel);
+        slider->setRange(0, 100);
+        slider->setValue(initial);
+        return slider;
+    };
+    m_lowSlider = makeSlider(0);
+    m_highSlider = makeSlider(100);
+    m_maximumSlider = makeSlider(100);
+    m_lowLabel = new QLabel(panel);
+    m_highLabel = new QLabel(panel);
+    m_maximumLabel = new QLabel(panel);
+    const auto rampRow = [panel](QSlider* slider, QLabel* label) {
+        auto* row = new QWidget(panel);
+        auto* rowLayout = new QHBoxLayout(row);
+        rowLayout->setContentsMargins(0, 0, 0, 0);
+        rowLayout->addWidget(slider, 1);
+        label->setMinimumWidth(36);
+        rowLayout->addWidget(label);
+        return row;
+    };
+    form->addRow(tr("Opacity from:"), rampRow(m_lowSlider, m_lowLabel));
+    form->addRow(tr("Opacity to:"), rampRow(m_highSlider, m_highLabel));
+    form->addRow(tr("Maximum opacity:"), rampRow(m_maximumSlider, m_maximumLabel));
+    m_paletteAlpha = new QCheckBox(tr("Use palette alpha ramp"), panel);
+    m_paletteAlpha->setToolTip(tr("Take each colour's opacity from the palette's "
+                                  "alpha ramp (legacy .pal files carry one) "
+                                  "instead of the linear window above."));
+    form->addRow(QString(), m_paletteAlpha);
+    m_qualityCombo = new QComboBox(panel);
+    m_qualityCombo->addItem(tr("Draft"), 0);
+    m_qualityCombo->addItem(tr("Normal"), 1);
+    m_qualityCombo->addItem(tr("High"), 2);
+    m_qualityCombo->setCurrentIndex(1);
+    form->addRow(tr("Quality:"), m_qualityCombo);
+    m_boxesCheck = new QCheckBox(tr("Grid boxes"), panel);
+    m_boxesCheck->setChecked(true);
+    m_outlineCheck = new QCheckBox(tr("Domain outline"), panel);
+    m_outlineCheck->setChecked(true);
+    form->addRow(QString(), m_boxesCheck);
+    form->addRow(QString(), m_outlineCheck);
+    layout->addLayout(form);
+    m_rendering = new QLabel(panel);
+    m_rendering->setVisible(false);
+    layout->addWidget(m_rendering);
+    m_status = new QLabel(panel);
+    m_status->setWordWrap(true);
+    m_status->setTextInteractionFlags(Qt::TextSelectableByMouse);
+    layout->addWidget(m_status);
+    layout->addStretch(1);
+    dock->setWidget(panel);
+    addDockWidget(Qt::RightDockWidgetArea, dock);
+
+    const auto updateLabels = [this] {
+        m_lowLabel->setText(QStringLiteral("%1%").arg(m_lowSlider->value()));
+        m_highLabel->setText(QStringLiteral("%1%").arg(m_highSlider->value()));
+        m_maximumLabel->setText(
+            QStringLiteral("%1%").arg(m_maximumSlider->value()));
+    };
+    updateLabels();
+    // The window is kept ordered: dragging one threshold past the other
+    // pushes the other along.
+    connect(m_lowSlider, &QSlider::valueChanged, this, [this, updateLabels](int value) {
+        if (m_highSlider->value() < value) {
+            m_highSlider->setValue(value);
+        }
+        updateLabels();
+        emit rampChanged();
+    });
+    connect(m_highSlider, &QSlider::valueChanged, this, [this, updateLabels](int value) {
+        if (m_lowSlider->value() > value) {
+            m_lowSlider->setValue(value);
+        }
+        updateLabels();
+        emit rampChanged();
+    });
+    connect(m_maximumSlider, &QSlider::valueChanged, this, [this, updateLabels] {
+        updateLabels();
+        emit rampChanged();
+    });
+    connect(m_paletteAlpha, &QCheckBox::toggled, this, [this] { emit rampChanged(); });
+    connect(m_qualityCombo, qOverload<int>(&QComboBox::currentIndexChanged), this,
+        [this](int) { emit qualityChanged(); });
+    connect(m_boxesCheck, &QCheckBox::toggled, this,
+        [this](bool checked) { m_view->setLevelBoxesVisible(checked); });
+    connect(m_outlineCheck, &QCheckBox::toggled, this,
+        [this](bool checked) { m_view->setDomainOutlineVisible(checked); });
+}
+
+void VolumeWindow::setDatasetGeometry(const DatasetMetadata& metadata)
+{
+    m_view->setGeometry(metadata);
+}
+
+void VolumeWindow::setSlicePositions(double x, double y, double z)
+{
+    m_view->setSlicePositions(x, y, z);
+}
+
+void VolumeWindow::setSlicePlanesVisible(bool visible)
+{
+    m_view->setSlicePlanesVisible(visible);
+}
+
+void VolumeWindow::setColorPalette(const Palette* palette)
+{
+    m_view->setColorPalette(palette);
+}
+
+void VolumeWindow::setPaletteHasAlpha(bool hasAlpha)
+{
+    m_paletteAlpha->setEnabled(hasAlpha);
+    m_paletteAlpha->setToolTip(hasAlpha
+        ? tr("Take each colour's opacity from the palette's alpha ramp "
+             "instead of the linear window above.")
+        : tr("This palette carries no alpha ramp; load a legacy .pal file "
+             "with one to enable this."));
+}
+
+void VolumeWindow::showFrame(const VolumeFrame& frame, const QString& status)
+{
+    // Premultiplied ARGB, row 0 at the top: exactly the frame's layout, so
+    // the image wraps the pixels and copies them once.
+    const QImage wrapped(reinterpret_cast<const uchar*>(frame.pixels.data()),
+        frame.width, frame.height, frame.width * static_cast<int>(sizeof(std::uint32_t)),
+        QImage::Format_ARGB32_Premultiplied);
+    m_view->setBackdropImage(wrapped.copy());
+    m_status->setText(status);
+}
+
+void VolumeWindow::clearFrame()
+{
+    m_view->setBackdropImage(QImage());
+    m_status->clear();
+}
+
+void VolumeWindow::showRendering(bool rendering)
+{
+    m_rendering->setText(rendering ? tr("Rendering…") : QString());
+    m_rendering->setVisible(rendering);
+}
+
+void VolumeWindow::showStatus(const QString& status)
+{
+    m_status->setText(status);
+}
+
+const OrthoCamera& VolumeWindow::camera() const noexcept
+{
+    return m_view->camera();
+}
+
+QSize VolumeWindow::viewSize() const
+{
+    return m_view->size();
+}
+
+OpacityRamp VolumeWindow::ramp() const
+{
+    OpacityRamp ramp;
+    ramp.lowThreshold = m_lowSlider->value() / 100.0;
+    ramp.highThreshold = m_highSlider->value() / 100.0;
+    ramp.maximumOpacity = m_maximumSlider->value() / 100.0;
+    ramp.usePaletteAlpha = m_paletteAlpha->isEnabled() && m_paletteAlpha->isChecked();
+    return ramp;
+}
+
+VolumeWindow::Quality VolumeWindow::quality() const
+{
+    switch (m_qualityCombo->currentData().toInt()) {
+    case 0:
+        return {1, 128ULL * 128ULL * 128ULL};
+    case 2:
+        return {4, 384ULL * 384ULL * 384ULL};
+    default:
+        return {2, defaultVolumeVoxelBudget};
+    }
+}
+
+} // namespace amrvis::qt

--- a/src/qt/VolumeWindow.hpp
+++ b/src/qt/VolumeWindow.hpp
@@ -68,7 +68,11 @@ signals:
     // changed size, so the frame drawn in it is being stretched.
     void cameraChanged();
     void interactionEnded();
+    // rampChanged is the sliders, which arrive continuously while dragged;
+    // paletteAlphaChanged is the checkbox, one discrete choice like the
+    // quality combo.
     void rampChanged();
+    void paletteAlphaChanged();
     void qualityChanged();
     void viewResized();
 

--- a/src/qt/VolumeWindow.hpp
+++ b/src/qt/VolumeWindow.hpp
@@ -51,9 +51,13 @@ public:
     // Enables the "use palette alpha" control (the palette carries a ramp).
     void setPaletteHasAlpha(bool hasAlpha);
 
-    // The frame to draw, with a line of status text; and whether a render is
-    // in flight (shown in the status).
-    void showFrame(const VolumeFrame& frame, const QString& status);
+    // The frame to draw, the camera it was rendered with (so a camera moved
+    // since can be corrected for), and a line of status text; and whether a
+    // render is in flight (shown in the status). showFailure replaces the
+    // status with a render's error, leaving the last good frame on screen.
+    void showFrame(const VolumeFrame& frame, const OrthoCamera& camera,
+        const QString& status);
+    void showFailure(const QString& message);
     void clearFrame();
     void showRendering(bool rendering);
 

--- a/src/qt/VolumeWindow.hpp
+++ b/src/qt/VolumeWindow.hpp
@@ -1,0 +1,93 @@
+#pragma once
+
+#include <amrexplorer/core/Metadata.hpp>
+#include <amrexplorer/core/OrthoProjection.hpp>
+#include <amrexplorer/core/Volume.hpp>
+#include <amrexplorer/pipeline/VolumePipeline.hpp>
+
+#include <QMainWindow>
+#include <QSize>
+#include <QString>
+
+#include <cstdint>
+
+class QCheckBox;
+class QComboBox;
+class QLabel;
+class QSlider;
+
+namespace amrvis {
+class Palette;
+}
+
+namespace amrvis::qt {
+
+class IsoWidget;
+
+// The Volume Rendering window: an IsoWidget in the middle -- the same
+// orthographic view as the main window's iso quadrant, drag to rotate, wheel
+// to zoom, XY/XZ/YZ presets, the domain wireframe, the grid boxes and the
+// slice planes -- with the rendered volume drawn under the wireframe, and a
+// dock of controls: the opacity ramp (a window over the colour range and a
+// maximum opacity, or the palette's own alpha ramp), the render quality, and
+// the overlay toggles. The window holds no data logic: VolumeController
+// decides when to render and pushes each frame here.
+class VolumeWindow final : public QMainWindow {
+    Q_OBJECT
+
+public:
+    struct Quality {
+        int samplesPerVoxel = 2;
+        std::uint64_t maximumVoxels = defaultVolumeVoxelBudget;
+    };
+
+    explicit VolumeWindow(QWidget* parent = nullptr);
+
+    // Geometry and overlays, pushed by the host as its own change.
+    void setDatasetGeometry(const DatasetMetadata& metadata);
+    void setSlicePositions(double x, double y, double z);
+    void setSlicePlanesVisible(bool visible);
+    void setColorPalette(const Palette* palette);
+    // Enables the "use palette alpha" control (the palette carries a ramp).
+    void setPaletteHasAlpha(bool hasAlpha);
+
+    // The frame to draw, with a line of status text; and whether a render is
+    // in flight (shown in the status).
+    void showFrame(const VolumeFrame& frame, const QString& status);
+    void clearFrame();
+    void showRendering(bool rendering);
+    void showStatus(const QString& status);
+
+    [[nodiscard]] const OrthoCamera& camera() const noexcept;
+    [[nodiscard]] QSize viewSize() const;
+    [[nodiscard]] OpacityRamp ramp() const;
+    [[nodiscard]] Quality quality() const;
+    [[nodiscard]] IsoWidget& view() noexcept { return *m_view; }
+
+signals:
+    // The user moved the camera (drag or wheel) / finished a drag; changed
+    // the opacity controls; changed the quality.
+    void cameraChanged();
+    void interactionEnded();
+    void rampChanged();
+    void qualityChanged();
+
+private:
+    void buildControls();
+
+    IsoWidget* m_view = nullptr;
+    QSlider* m_lowSlider = nullptr;
+    QSlider* m_highSlider = nullptr;
+    QSlider* m_maximumSlider = nullptr;
+    QCheckBox* m_paletteAlpha = nullptr;
+    QComboBox* m_qualityCombo = nullptr;
+    QCheckBox* m_boxesCheck = nullptr;
+    QCheckBox* m_outlineCheck = nullptr;
+    QLabel* m_lowLabel = nullptr;
+    QLabel* m_highLabel = nullptr;
+    QLabel* m_maximumLabel = nullptr;
+    QLabel* m_status = nullptr;
+    QLabel* m_rendering = nullptr;
+};
+
+} // namespace amrvis::qt

--- a/src/qt/VolumeWindow.hpp
+++ b/src/qt/VolumeWindow.hpp
@@ -56,21 +56,21 @@ public:
     void showFrame(const VolumeFrame& frame, const QString& status);
     void clearFrame();
     void showRendering(bool rendering);
-    void showStatus(const QString& status);
 
     [[nodiscard]] const OrthoCamera& camera() const noexcept;
     [[nodiscard]] QSize viewSize() const;
     [[nodiscard]] OpacityRamp ramp() const;
     [[nodiscard]] Quality quality() const;
-    [[nodiscard]] IsoWidget& view() noexcept { return *m_view; }
 
 signals:
     // The user moved the camera (drag or wheel) / finished a drag; changed
-    // the opacity controls; changed the quality.
+    // the opacity controls; changed the quality. viewResized: the viewport
+    // changed size, so the frame drawn in it is being stretched.
     void cameraChanged();
     void interactionEnded();
     void rampChanged();
     void qualityChanged();
+    void viewResized();
 
 private:
     void buildControls();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -579,6 +579,33 @@ if(TARGET amrexplorer_qt)
             "$<TARGET_FILE:test_particle_controller>")
     set_tests_properties(particle_controller PROPERTIES TIMEOUT 60)
 
+    add_executable(test_volume_controller
+        unit/test_volume_controller.cpp
+        "${PROJECT_SOURCE_DIR}/src/qt/VolumeController.cpp"
+        "${PROJECT_SOURCE_DIR}/src/qt/VolumeController.hpp"
+        "${PROJECT_SOURCE_DIR}/src/qt/VolumeWindow.cpp"
+        "${PROJECT_SOURCE_DIR}/src/qt/VolumeWindow.hpp"
+        "${PROJECT_SOURCE_DIR}/src/qt/IsoWidget.cpp"
+        "${PROJECT_SOURCE_DIR}/src/qt/IsoWidget.hpp"
+    )
+    set_target_properties(test_volume_controller PROPERTIES AUTOMOC ON)
+    target_include_directories(test_volume_controller
+        PRIVATE "${PROJECT_SOURCE_DIR}/src/qt")
+    target_link_libraries(test_volume_controller
+        PRIVATE
+            amrexplorer::pipeline
+            amrexplorer::render3d
+            amrexplorer::warnings
+            Qt6::Concurrent
+            Qt6::Core
+            Qt6::Gui
+            Qt6::Widgets
+    )
+    add_test(NAME volume_controller
+        COMMAND "${CMAKE_COMMAND}" -E env QT_QPA_PLATFORM=offscreen
+            "$<TARGET_FILE:test_volume_controller>")
+    set_tests_properties(volume_controller PROPERTIES TIMEOUT 60)
+
     add_executable(test_diagnostics_model
         unit/test_diagnostics_model.cpp
         "${PROJECT_SOURCE_DIR}/src/qt/DiagnosticsModel.cpp"
@@ -873,6 +900,19 @@ if(TARGET amrexplorer_qt)
         FIXTURES_REQUIRED remote_server_3d_materialized
         TIMEOUT 30)
 
+    # The same volume window over the in-process server (protocol 1.2): the
+    # frame is rendered on the server and displayed here.
+    add_test(
+        NAME qt_remote_volume_smoke
+        COMMAND "${CMAKE_COMMAND}" -E env QT_QPA_PLATFORM=offscreen
+            "$<TARGET_FILE:amrexplorer_qt>"
+            --remote-volume-smoke-test
+            "${remote_server_fixture_3d_dir}"
+    )
+    set_tests_properties(qt_remote_volume_smoke PROPERTIES
+        FIXTURES_REQUIRED remote_server_3d_materialized
+        TIMEOUT 60)
+
     add_test(
         NAME qt_remote_spherical_initial_geometry_smoke
         COMMAND "${CMAKE_COMMAND}" -E env QT_QPA_PLATFORM=offscreen
@@ -1094,6 +1134,20 @@ if(TARGET amrexplorer_qt)
             -P "${CMAKE_CURRENT_SOURCE_DIR}/qt_smoke_driver.cmake"
     )
     set_tests_properties(qt_slice_smoke_3d PROPERTIES TIMEOUT 30)
+    # The Volume Rendering window over the 3-D fixture, locally: opened as the
+    # View menu action opens it, its first frame must have lit pixels (the
+    # ray caster ran end to end through the session, pipeline and window).
+    add_test(
+        NAME qt_volume_smoke_3d
+        COMMAND "${CMAKE_COMMAND}"
+            "-DMATERIALIZER=$<TARGET_FILE:fixture_materializer>"
+            "-DAMREXPLORER_QT=$<TARGET_FILE:amrexplorer_qt>"
+            "-DSOURCE=${CMAKE_CURRENT_SOURCE_DIR}/data/plotfile_3d"
+            "-DWORK=${CMAKE_CURRENT_BINARY_DIR}/fixtures_volume_3d"
+            -DMODE=volume
+            -P "${CMAKE_CURRENT_SOURCE_DIR}/qt_smoke_driver.cmake"
+    )
+    set_tests_properties(qt_volume_smoke_3d PROPERTIES TIMEOUT 60)
     add_test(
         NAME qt_particle_visible_range_smoke_3d
         COMMAND "${CMAKE_COMMAND}"

--- a/tests/qt_smoke_driver.cmake
+++ b/tests/qt_smoke_driver.cmake
@@ -21,7 +21,7 @@
 #                 sequence-density-preserve |
 #                 sequence-equal-size-transform-preserve |
 #                 sequence-geometry-refit | sequence-noop | sequence-failure |
-#                 remote-canvas-wheel | remote-cell-aspect |
+#                 remote-canvas-wheel | remote-cell-aspect | volume |
 #                 scale-state | effective-scale |
 #                 arrow-key-routing | animation-dock-role | open-failure |
 #                 idle-ui-state | sequence-scale-report |
@@ -57,6 +57,9 @@ endmacro()
 if(MODE STREQUAL "slice")
     run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt")
     run_or_die("${AMREXPLORER_QT}" --slice-smoke-test "${WORK}/plt")
+elseif(MODE STREQUAL "volume")
+    run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt")
+    run_or_die("${AMREXPLORER_QT}" --volume-smoke-test "${WORK}/plt")
 elseif(MODE STREQUAL "sequence")
     run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt00000")
     run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt00010" "2.5")

--- a/tests/unit/test_ortho_projection.cpp
+++ b/tests/unit/test_ortho_projection.cpp
@@ -176,6 +176,41 @@ int main()
         }
     }
 
+    // backdropScale lines a rendered image up with the wireframe drawn over
+    // it, for a frame rendered at another size AND at another zoom. The image
+    // is drawn about the viewport centre, so a point at offset d from the
+    // image's centre lands at centre + scale * d: that has to be where
+    // projectPoint puts it for the current camera.
+    {
+        const auto view = amrvis::viewportFrame(500, 400);
+        // A half-size draft rendered at zoom 1, now displayed at zoom 1.15.
+        const auto drafted = amrvis::viewportFrame(250, 200);
+        for (const double zoom : {1.0, 1.15, 0.7, 4.0}) {
+            amrvis::OrthoCamera rendered{0.4, -0.3, 1.0};
+            auto shown = rendered;
+            shown.zoom = zoom;
+            const auto scale
+                = amrvis::backdropScale(view, shown.zoom, drafted, rendered.zoom);
+            const auto probe = point(1.0, 2.0, 3.0);
+            // Where the probe sits inside the rendered image...
+            const auto inImage
+                = amrvis::projectPoint(rendered, drafted, domain, probe);
+            // ...mapped by the scale, about the two centres...
+            const auto mappedX
+                = view.centerX + scale * (inImage.x - drafted.centerX);
+            const auto mappedY
+                = view.centerY + scale * (inImage.y - drafted.centerY);
+            // ...is where the wireframe draws it now.
+            const auto drawn = amrvis::projectPoint(shown, view, domain, probe);
+            require(near(mappedX, drawn.x) && near(mappedY, drawn.y),
+                "the backdrop scale does not line up with the wireframe");
+        }
+        // A degenerate magnification is reported as 1 rather than dividing.
+        require(near(amrvis::backdropScale(view, 0.0, drafted, 1.0), 1.0)
+                && near(amrvis::backdropScale(view, 1.0, drafted, 0.0), 1.0),
+            "a non-positive magnification did not fall back to 1");
+    }
+
     // The preset rays are axis-aligned with the expected sign.
     {
         const auto xy = amrvis::pixelRay(

--- a/tests/unit/test_volume_controller.cpp
+++ b/tests/unit/test_volume_controller.cpp
@@ -323,7 +323,8 @@ int main(int argc, char** argv)
                 && requests.front().range->minimum == 0.0
                 && requests.front().range->maximum == 4.0
                 && requests.front().samplesPerVoxel == 2
-                && requests.front().transfer.colors.size() == 253
+                && requests.front().transfer.colors.size()
+                    == static_cast<std::size_t>(amrvis::Palette::colorSlots)
                 && requests.front().maximumLevel == 1,
             "the opening request was not built from the view and the controls");
         require(controller.lastFrame().width == requests.front().outputSize[0]
@@ -371,6 +372,7 @@ int main(int argc, char** argv)
         // result is dropped as stale, never displayed.
         session->delayMs = 150;
         const auto framesBefore = observed.frames;
+        const auto staleBefore = observed.stale;
         controller.refresh();
         waitFor(application, [&] { return controller.renderInFlight(); },
             "the render before reset did not start");
@@ -378,7 +380,8 @@ int main(int argc, char** argv)
         require(!controller.windowOpen(), "reset did not close the window");
         waitFor(application, [&] { return !controller.renderInFlight(); },
             "the render did not end after reset");
-        require(observed.frames == framesBefore && observed.stale >= 1,
+        require(observed.frames == framesBefore
+                && observed.stale == staleBefore + 1,
             "a late result was displayed after reset");
         require(controller.lastFrame().pixels.empty(),
             "reset did not drop the last frame");
@@ -404,6 +407,7 @@ int main(int argc, char** argv)
         waitFor(application, [&] { return observed.frames == 1; },
             "the window did not recover after a failed render");
         session->delayMs = 150;
+        const auto staleBeforeCancel = observed.stale;
         controller.refresh();
         waitFor(application, [&] { return controller.renderInFlight(); },
             "the render before cancel did not start");
@@ -411,17 +415,23 @@ int main(int argc, char** argv)
         waitFor(application, [&] { return !controller.renderInFlight(); },
             "the cancelled render did not end");
         require(observed.failures.size() == 1 && observed.frames == 1
-                && observed.stale >= 1 && controller.windowOpen(),
+                && observed.stale == staleBeforeCancel + 1
+                && controller.windowOpen(),
             "a cancelled render was reported or displayed");
-        session->delayMs = 0;
         // Shutdown: a result arriving after the host began closing is dropped
-        // without touching the window.
+        // without touching the window. The render has to be in flight before
+        // shuttingDown is set -- refresh() only arms the throttle, so waiting
+        // on "no render running" would be satisfied before one ever started
+        // and the drop path would never be taken.
         controller.refresh();
+        waitFor(application, [&] { return controller.renderInFlight(); },
+            "the render before shutdown did not start");
         shuttingDown = true;
         waitFor(application, [&] { return observed.activity == 0
                                        && !controller.renderInFlight(); },
             "the render during shutdown did not end");
         require(observed.frames == 1, "a frame was displayed during shutdown");
+        session->delayMs = 0;
         shuttingDown = false;
         controller.closeWindow();
         require(!controller.windowOpen(), "closeWindow left the window open");
@@ -527,6 +537,43 @@ int main(int argc, char** argv)
         session->sessionFallback = false;
         waitFor(application, [&] { return !controller.renderInFlight(); },
             "the fallback render did not finish");
+        controller.closeWindow();
+    }
+
+    // A discrete change renders in full, and a resize that does not change
+    // the size renders not at all.
+    {
+        VolumeController controller(hooks());
+        Observed observed;
+        observe(controller, observed);
+        controller.showWindow(nullptr);
+        waitFor(application, [&] { return observed.frames == 1; },
+            "the first frame was not displayed");
+        waitFor(application, [&] { return !controller.renderInFlight(); },
+            "the opening render did not finish");
+        require(volumeWindow() != nullptr, "no volume window on screen");
+        const auto full = session->requestsSoFar().back().outputSize;
+
+        // The alpha checkbox is one completed choice, not a drag: it must not
+        // come back as a half-size single-sample draft.
+        auto before = session->requests.load();
+        emit volumeWindow()->paletteAlphaChanged();
+        waitFor(application, [&] { return session->requests == before + 1; },
+            "the alpha toggle did not render");
+        const auto toggled = session->requestsSoFar().back();
+        require(toggled.samplesPerVoxel == 2 && toggled.outputSize == full,
+            "a discrete alpha toggle was rendered as an interaction draft");
+        waitFor(application, [&] { return !controller.renderInFlight(); },
+            "the alpha toggle render did not finish");
+
+        // A resize signal that leaves the view the same size is the dock
+        // relaying itself out -- showFrame writes a label in it -- and must
+        // not schedule anything, or displaying a frame feeds the next render.
+        before = session->requests.load();
+        emit volumeWindow()->viewResized();
+        settle(application, 400);
+        require(session->requests == before,
+            "a resize to the same size scheduled a render");
         controller.closeWindow();
     }
 

--- a/tests/unit/test_volume_controller.cpp
+++ b/tests/unit/test_volume_controller.cpp
@@ -1,0 +1,419 @@
+// VolumeController against a fake session that renders synthetic frames:
+// the action's enablement follows the session; opening the window renders a
+// frame sized to the view; changes during a render coalesce into one more
+// render (never two outstanding); a moving camera gets a half-size,
+// single-sample draft and the settled camera a full frame; reset() closes
+// the window and drops a late result; a throwing session reports through
+// renderFailed and a cancelled one silently.
+
+#include "VolumeController.hpp"
+#include "VolumeWindow.hpp"
+#include "IsoWidget.hpp"
+
+#include <amrexplorer/data/DatasetSession.hpp>
+
+#include <QApplication>
+#include <QAction>
+#include <QCoreApplication>
+#include <QStringList>
+#include <QTimer>
+
+#include <atomic>
+#include <chrono>
+#include <cstdlib>
+#include <iostream>
+#include <mutex>
+#include <optional>
+#include <stdexcept>
+#include <thread>
+#include <vector>
+
+namespace {
+
+void require(bool condition, const char* message)
+{
+    if (!condition) {
+        std::cerr << "FAILED: " << message << '\n';
+        std::exit(1);
+    }
+}
+
+// A 3-D session whose renders are synthetic: every pixel lit, the request
+// recorded, after an optional delay so a render can be superseded or
+// cancelled in flight; `failing` throws instead.
+class FakeSession final : public amrvis::DatasetSession {
+public:
+    FakeSession(int dimension = 3)
+    {
+        m_metadata.dimension = dimension;
+        m_metadata.finestLevel = 1;
+        m_metadata.hasPhysicalGeometry = true;
+        m_metadata.physicalDomain = amrvis::RealBox{
+            amrvis::Real3{{0.0, 0.0, 0.0}}, amrvis::Real3{{1.0, 2.0, 3.0}}};
+        m_metadata.fields.push_back({"density", amrvis::Centering::Cell, {}});
+        for (int level = 0; level < 2; ++level) {
+            amrvis::LevelMetadata entry;
+            entry.level = level;
+            const int cells = level == 0 ? 3 : 7;
+            entry.domain = amrvis::IntBox{amrvis::Int3{{0, 0, 0}},
+                amrvis::Int3{{cells, cells, cells}}, amrvis::Int3{{0, 0, 0}}};
+            const auto size = level == 0 ? 0.25 : 0.125;
+            entry.cellSize = {{size, 2.0 * size, 3.0 * size}};
+            entry.boxes.push_back(entry.domain);
+            m_metadata.levels.push_back(entry);
+        }
+    }
+
+    std::atomic<bool> failing{false};
+    std::atomic<int> delayMs{0};
+    std::atomic<int> requests{0};
+    std::mutex requestsMutex;
+    std::vector<amrvis::VolumeRenderRequest> recorded;
+
+    std::vector<amrvis::VolumeRenderRequest> requestsSoFar()
+    {
+        const std::scoped_lock lock(requestsMutex);
+        return recorded;
+    }
+
+    [[nodiscard]] amrvis::DatasetId id() const noexcept override
+    {
+        return amrvis::DatasetId{1};
+    }
+    [[nodiscard]] const amrvis::DatasetMetadata& metadata() const noexcept override
+    {
+        return m_metadata;
+    }
+    [[nodiscard]] const amrvis::MetadataReadMetrics& metadataReadMetrics()
+        const noexcept override
+    {
+        return m_readMetrics;
+    }
+    [[nodiscard]] const std::string& fileVersion() const noexcept override
+    {
+        return m_version;
+    }
+    [[nodiscard]] const std::vector<amrvis::ParticleSpeciesMetadata>&
+    particleSpecies() const noexcept override
+    {
+        return m_species;
+    }
+    [[nodiscard]] amrvis::ViewDataResult requestView(
+        const amrvis::ViewDataRequest&, amrvis::StopToken) override
+    {
+        throw std::logic_error("not used");
+    }
+    [[nodiscard]] amrvis::DatasetPage requestDatasetPage(
+        const amrvis::DatasetPageRequest&, amrvis::StopToken) override
+    {
+        throw std::logic_error("not used");
+    }
+    [[nodiscard]] std::optional<amrvis::ValueRange> requestRange(
+        const amrvis::RangeRequest&, amrvis::StopToken) override
+    {
+        return amrvis::ValueRange{0.0, 10.0};
+    }
+    [[nodiscard]] bool rangeAvailable(
+        const amrvis::RangeRequest&) const noexcept override
+    {
+        return true;
+    }
+    [[nodiscard]] amrvis::ParticleSample requestParticleSample(
+        const std::string&, double, std::uint64_t, amrvis::StopToken) override
+    {
+        throw std::logic_error("not used");
+    }
+    [[nodiscard]] bool supportsVolumeRendering() const noexcept override
+    {
+        return m_metadata.dimension == 3;
+    }
+    [[nodiscard]] amrvis::VolumeFrame renderVolume(
+        const amrvis::VolumeRenderRequest& request,
+        amrvis::StopToken cancellation) override
+    {
+        {
+            const std::scoped_lock lock(requestsMutex);
+            recorded.push_back(request);
+        }
+        ++requests;
+        for (int waited = 0; waited < delayMs.load(); waited += 5) {
+            if (cancellation.stop_requested()) {
+                throw amrvis::ReadCancelled();
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(5));
+        }
+        if (failing) {
+            throw std::runtime_error("synthetic volume failure");
+        }
+        amrvis::VolumeFrame frame;
+        frame.width = request.outputSize[0];
+        frame.height = request.outputSize[1];
+        frame.pixels.assign(static_cast<std::size_t>(frame.width)
+            * static_cast<std::size_t>(frame.height), 0xFF4080C0U);
+        frame.usedRange = request.range.value_or(amrvis::VolumeRange{0.0, 1.0, false});
+        frame.metrics.gridDims = {2, 2, 2};
+        frame.metrics.coveredVoxels = 8;
+        return frame;
+    }
+    [[nodiscard]] amrvis::CacheMetrics cacheMetrics() const override
+    {
+        return {};
+    }
+    [[nodiscard]] bool setCacheBudget(std::uint64_t) override { return true; }
+    void clearUnpinnedCache() override {}
+    void close() noexcept override {}
+
+private:
+    amrvis::DatasetMetadata m_metadata;
+    amrvis::MetadataReadMetrics m_readMetrics;
+    std::string m_version;
+    std::vector<amrvis::ParticleSpeciesMetadata> m_species;
+};
+
+struct Observed {
+    int activity = 0;
+    int frames = 0;
+    int stale = 0;
+    QStringList failures;
+    QStringList statuses;
+};
+
+void observe(amrvis::qt::VolumeController& controller, Observed& observed)
+{
+    QObject::connect(&controller,
+        &amrvis::qt::VolumeController::renderActivityChanged, &controller,
+        [&observed](int delta) { observed.activity += delta; });
+    QObject::connect(&controller, &amrvis::qt::VolumeController::frameDisplayed,
+        &controller, [&observed] { ++observed.frames; });
+    QObject::connect(&controller, &amrvis::qt::VolumeController::staleResultDropped,
+        &controller, [&observed] { ++observed.stale; });
+    QObject::connect(&controller, &amrvis::qt::VolumeController::renderFailed,
+        &controller, [&observed](const QString& message) {
+            observed.failures << message;
+        });
+    QObject::connect(&controller, &amrvis::qt::VolumeController::statusMessage,
+        &controller, [&observed](const QString& message, int) {
+            observed.statuses << message;
+        });
+}
+
+// Runs the event loop until `done` or a timeout; leaves it with exit(), not
+// quit(), which would close the top-level volume window between waits.
+template <typename Predicate>
+void waitFor(QCoreApplication& application, Predicate done, const char* what)
+{
+    QTimer poll;
+    QTimer timeout;
+    timeout.setSingleShot(true);
+    bool timedOut = false;
+    QObject::connect(&timeout, &QTimer::timeout, &application,
+        [&application, &timedOut] {
+            timedOut = true;
+            application.exit(0);
+        });
+    QObject::connect(&poll, &QTimer::timeout, &application,
+        [&application, &done] {
+            if (done()) {
+                application.exit(0);
+            }
+        });
+    poll.start(5);
+    timeout.start(5000);
+    application.exec();
+    require(!timedOut, what);
+}
+
+// The one Volume window on screen (a top-level widget: the controller
+// parents it for placement only), so the test can drive its camera signals.
+amrvis::qt::VolumeWindow* volumeWindow()
+{
+    for (auto* widget : QApplication::topLevelWidgets()) {
+        if (auto* window = qobject_cast<amrvis::qt::VolumeWindow*>(widget)) {
+            return window;
+        }
+    }
+    return nullptr;
+}
+
+// A little settling time for events that must NOT happen.
+void settle(QCoreApplication& application, int milliseconds)
+{
+    QTimer timeout;
+    timeout.setSingleShot(true);
+    QObject::connect(&timeout, &QTimer::timeout, &application,
+        [&application] { application.exit(0); });
+    timeout.start(milliseconds);
+    application.exec();
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    QApplication application(argc, argv);
+    using amrvis::qt::VolumeController;
+
+    auto session = std::make_shared<FakeSession>();
+    std::shared_ptr<amrvis::DatasetSession> dataset = session;
+    bool shuttingDown = false;
+    amrvis::qt::RangeController::Selection rangeSelection;
+    rangeSelection.mode = amrvis::RangeMode::User;
+    rangeSelection.userRange = std::pair{0.0, 4.0};
+    amrvis::LevelSelection level{amrvis::CompositionPolicy::FinestAvailable, 1};
+    const auto& palette = amrvis::builtinPalette(amrvis::BuiltinPalette::Rainbow);
+    const auto hooks = [&] {
+        return VolumeController::Hooks{
+            [&dataset] { return dataset; },
+            [] { return std::optional{std::pair{amrvis::FieldId{0}, QString("density")}}; },
+            [&level] { return level; },
+            [&rangeSelection] { return rangeSelection; },
+            [&palette]() -> const amrvis::Palette& { return palette; },
+            [] { return std::array<double, 3>{0.5, 1.0, 1.5}; },
+            [] { return true; },
+            [&shuttingDown] { return shuttingDown; },
+        };
+    };
+
+    // The action follows the session: enabled for a 3-D one, disabled with
+    // none or a 2-D one, and re-derived by configureForDataset.
+    {
+        VolumeController controller(hooks());
+        auto* action = controller.createAction(&controller);
+        require(action->isEnabled(), "the action is disabled for a 3-D dataset");
+        dataset = nullptr;
+        controller.configureForDataset();
+        require(!action->isEnabled(), "the action stayed enabled with no dataset");
+        dataset = std::make_shared<FakeSession>(2);
+        controller.configureForDataset();
+        require(!action->isEnabled(), "the action was enabled for a 2-D dataset");
+        dataset = session;
+        controller.configureForDataset();
+        require(action->isEnabled(), "the action did not re-enable for a 3-D dataset");
+    }
+
+    // Opening the window renders one frame at the view's size, with the range
+    // resolved from the controls, and the frame reaches the window.
+    {
+        VolumeController controller(hooks());
+        Observed observed;
+        observe(controller, observed);
+        controller.showWindow(nullptr);
+        require(controller.windowOpen(), "the window did not open");
+        waitFor(application, [&] { return observed.frames == 1; },
+            "the first frame was not displayed");
+        require(session->requests == 1 && observed.activity == 0
+                && observed.failures.isEmpty(),
+            "the opening render did not run exactly once");
+        const auto requests = session->requestsSoFar();
+        require(requests.size() == 1
+                && requests.front().outputSize[0] >= 320
+                && requests.front().outputSize[1] >= 240
+                && requests.front().range.has_value()
+                && requests.front().range->minimum == 0.0
+                && requests.front().range->maximum == 4.0
+                && requests.front().samplesPerVoxel == 2
+                && requests.front().transfer.colors.size() == 253
+                && requests.front().maximumLevel == 1,
+            "the opening request was not built from the view and the controls");
+        require(controller.lastFrame().width == requests.front().outputSize[0]
+                && controller.lastFrame().height == requests.front().outputSize[1],
+            "the displayed frame is not the one the session rendered");
+
+        // Changes during a slow render coalesce: two refreshes and a ramp
+        // change while one runs make exactly one more render.
+        session->delayMs = 150;
+        controller.refresh();
+        waitFor(application, [&] { return session->requests == 2; },
+            "the refresh did not start a render");
+        controller.refresh();
+        controller.refresh();
+        waitFor(application, [&] { return observed.frames == 3; },
+            "the coalesced rerun did not display");
+        settle(application, 100);
+        require(session->requests == 3,
+            "changes during a render did not coalesce into one rerun");
+        session->delayMs = 0;
+
+        // A moving camera: a draft at half the view size with one sample per
+        // voxel, then, once it settles, a full frame.
+        const auto before = session->requests.load();
+        require(volumeWindow() != nullptr, "no volume window on screen");
+        emit volumeWindow()->cameraChanged();
+        waitFor(application, [&] { return session->requests == before + 1; },
+            "the camera move did not render a draft");
+        auto latest = session->requestsSoFar().back();
+        require(latest.samplesPerVoxel == 1
+                && latest.outputSize[0] <= requests.front().outputSize[0] / 2 + 1
+                && latest.outputSize[1] <= requests.front().outputSize[1] / 2 + 1,
+            "the draft frame is not half-size and single-sample");
+        emit volumeWindow()->interactionEnded();
+        waitFor(application, [&] { return session->requests == before + 2; },
+            "the settled camera did not render a full frame");
+        latest = session->requestsSoFar().back();
+        require(latest.samplesPerVoxel == 2
+                && latest.outputSize == requests.front().outputSize,
+            "the settled frame is not full-size");
+        waitFor(application, [&] { return !controller.renderInFlight(); },
+            "the settled render did not finish");
+
+        // reset() during a slow render: the window closes and the late
+        // result is dropped as stale, never displayed.
+        session->delayMs = 150;
+        const auto framesBefore = observed.frames;
+        controller.refresh();
+        waitFor(application, [&] { return controller.renderInFlight(); },
+            "the render before reset did not start");
+        controller.reset();
+        require(!controller.windowOpen(), "reset did not close the window");
+        waitFor(application, [&] { return !controller.renderInFlight(); },
+            "the render did not end after reset");
+        require(observed.frames == framesBefore && observed.stale >= 1,
+            "a late result was displayed after reset");
+        require(controller.lastFrame().pixels.empty(),
+            "reset did not drop the last frame");
+        session->delayMs = 0;
+    }
+
+    // A failing session reports through renderFailed once, and the window
+    // stays usable; a cancelled render is silent.
+    {
+        VolumeController controller(hooks());
+        Observed observed;
+        observe(controller, observed);
+        session->failing = true;
+        controller.showWindow(nullptr);
+        waitFor(application, [&] { return observed.failures.size() == 1; },
+            "the failed render was not reported");
+        require(observed.frames == 0 && controller.windowOpen()
+                && observed.failures.front().startsWith(
+                    QStringLiteral("Cannot render the volume")),
+            "the failure was reported wrongly or closed the window");
+        session->failing = false;
+        controller.refresh();
+        waitFor(application, [&] { return observed.frames == 1; },
+            "the window did not recover after a failed render");
+        session->delayMs = 150;
+        controller.refresh();
+        waitFor(application, [&] { return controller.renderInFlight(); },
+            "the render before cancel did not start");
+        controller.cancel();
+        waitFor(application, [&] { return !controller.renderInFlight(); },
+            "the cancelled render did not end");
+        require(observed.failures.size() == 1 && observed.frames == 1
+                && observed.stale >= 1 && controller.windowOpen(),
+            "a cancelled render was reported or displayed");
+        session->delayMs = 0;
+        // Shutdown: a result arriving after the host began closing is dropped
+        // without touching the window.
+        controller.refresh();
+        shuttingDown = true;
+        waitFor(application, [&] { return observed.activity == 0
+                                       && !controller.renderInFlight(); },
+            "the render during shutdown did not end");
+        require(observed.frames == 1, "a frame was displayed during shutdown");
+        shuttingDown = false;
+        controller.closeWindow();
+        require(!controller.windowOpen(), "closeWindow left the window open");
+    }
+    return 0;
+}

--- a/tests/unit/test_volume_controller.cpp
+++ b/tests/unit/test_volume_controller.cpp
@@ -435,6 +435,10 @@ int main(int argc, char** argv)
         shuttingDown = false;
         controller.closeWindow();
         require(!controller.windowOpen(), "closeWindow left the window open");
+        // The frame described the window that just closed, and holds a whole
+        // pixel buffer: closing drops it, as reset() does.
+        require(controller.lastFrame().pixels.empty(),
+            "closeWindow kept the closed window's frame");
     }
 
     // A camera that never stops moving still gets drafts. The render timer

--- a/tests/unit/test_volume_controller.cpp
+++ b/tests/unit/test_volume_controller.cpp
@@ -529,5 +529,25 @@ int main(int argc, char** argv)
             "the fallback render did not finish");
         controller.closeWindow();
     }
+
+    // The logarithmic flag rides on the VolumeRangeChoice, not on the request
+    // the controller hands over: the pipeline sets it per attempt, so nothing
+    // here writes it and only the arriving request proves it got through.
+    {
+        rangeSelection.logarithmic = true;
+        VolumeController controller(hooks());
+        Observed observed;
+        observe(controller, observed);
+        const auto before = session->requests.load();
+        controller.showWindow(nullptr);
+        waitFor(application, [&] { return session->requests == before + 1; },
+            "the logarithmic render did not run");
+        require(session->requestsSoFar().back().logarithmic,
+            "the logarithmic flag did not reach the request");
+        rangeSelection.logarithmic = false;
+        waitFor(application, [&] { return !controller.renderInFlight(); },
+            "the logarithmic render did not finish");
+        controller.closeWindow();
+    }
     return 0;
 }

--- a/tests/unit/test_volume_controller.cpp
+++ b/tests/unit/test_volume_controller.cpp
@@ -65,6 +65,9 @@ public:
     }
 
     std::atomic<bool> failing{false};
+    // Renders one level coarser than asked and says so in the frame, the way
+    // a server under its own cache pressure does.
+    std::atomic<bool> sessionFallback{false};
     std::atomic<int> delayMs{0};
     std::atomic<int> requests{0};
     std::mutex requestsMutex;
@@ -109,9 +112,13 @@ public:
         throw std::logic_error("not used");
     }
     [[nodiscard]] std::optional<amrvis::ValueRange> requestRange(
-        const amrvis::RangeRequest&, amrvis::StopToken) override
+        const amrvis::RangeRequest& request, amrvis::StopToken) override
     {
-        return amrvis::ValueRange{0.0, 10.0};
+        // Level-dependent on purpose: level 0 spans to 10, level 1 to 20, so
+        // a range resolved for the level that was asked for instead of the
+        // one that rendered shows up as the wrong maximum.
+        return amrvis::ValueRange{
+            0.0, 10.0 * static_cast<double>(request.maximumLevel + 1)};
     }
     [[nodiscard]] bool rangeAvailable(
         const amrvis::RangeRequest&) const noexcept override
@@ -153,6 +160,10 @@ public:
         frame.usedRange = request.range.value_or(amrvis::VolumeRange{0.0, 1.0, false});
         frame.metrics.gridDims = {2, 2, 2};
         frame.metrics.coveredVoxels = 8;
+        if (sessionFallback && request.maximumLevel > 0) {
+            frame.cacheFallbackFromLevel = request.maximumLevel;
+            frame.cacheFallbackToLevel = 0;
+        }
         return frame;
     }
     [[nodiscard]] amrvis::CacheMetrics cacheMetrics() const override
@@ -414,6 +425,102 @@ int main(int argc, char** argv)
         shuttingDown = false;
         controller.closeWindow();
         require(!controller.windowOpen(), "closeWindow left the window open");
+    }
+
+    // A camera that never stops moving still gets drafts. The render timer
+    // is a throttle, not a debounce: events arriving faster than its interval
+    // must not keep rearming it, or a drag renders nothing at all until the
+    // mouse is released and the stale backdrop sits under a moving wireframe.
+    {
+        VolumeController controller(hooks());
+        Observed observed;
+        observe(controller, observed);
+        controller.showWindow(nullptr);
+        waitFor(application, [&] { return observed.frames == 1; },
+            "the first frame was not displayed");
+        const auto before = session->requests.load();
+        require(volumeWindow() != nullptr, "no volume window on screen");
+        // Faster than the throttle, and never ended: exactly a drag in
+        // progress. interactionEnded is deliberately not emitted.
+        QTimer moving;
+        QObject::connect(&moving, &QTimer::timeout, &application, [] {
+            if (auto* window = volumeWindow()) {
+                emit window->cameraChanged();
+            }
+        });
+        moving.start(10);
+        waitFor(application, [&] { return session->requests >= before + 2; },
+            "a continuously moving camera rendered no drafts");
+        moving.stop();
+        require(session->requestsSoFar().back().samplesPerVoxel == 1,
+            "the frames rendered while the camera moved were not drafts");
+        waitFor(application, [&] { return !controller.renderInFlight(); },
+            "the drafts did not finish");
+        controller.closeWindow();
+    }
+
+    // cancel() disarms the settle timer. Left armed it fires after the
+    // cancellation and schedules a render of whatever dataset is published by
+    // then -- the outgoing sequence frame's, under the incoming one's
+    // geometry.
+    {
+        VolumeController controller(hooks());
+        Observed observed;
+        observe(controller, observed);
+        controller.showWindow(nullptr);
+        waitFor(application, [&] { return observed.frames == 1; },
+            "the first frame was not displayed");
+        waitFor(application, [&] { return !controller.renderInFlight(); },
+            "the opening render did not finish");
+        require(volumeWindow() != nullptr, "no volume window on screen");
+        // Arms the settle timer, then cancels well inside its interval.
+        emit volumeWindow()->cameraChanged();
+        waitFor(application,
+            [&] { return !controller.renderInFlight() && session->requests >= 2; },
+            "the camera move did not render a draft");
+        const auto after = session->requests.load();
+        controller.cancel();
+        // Longer than the settle interval: nothing may start on its own.
+        settle(application, 400);
+        require(session->requests == after,
+            "the settle timer started a render after cancel()");
+        controller.closeWindow();
+    }
+
+    // A Level range with a fallback: the session renders coarser than it was
+    // asked to, so the range has to be re-read for the level that actually
+    // rendered. Colouring level 0's pixels with level 1's statistics is the
+    // defect this guards -- the frame would claim a maximum of 20 when
+    // nothing it drew came from a level that reaches past 10.
+    {
+        session->sessionFallback = true;
+        rangeSelection.mode = amrvis::RangeMode::Level;
+        rangeSelection.userRange.reset();
+        VolumeController controller(hooks());
+        Observed observed;
+        observe(controller, observed);
+        // The fake records every render of the whole run, so the count this
+        // block cares about is the delta, not the size.
+        const auto rendersBefore = session->requests.load();
+        controller.showWindow(nullptr);
+        waitFor(application, [&] { return observed.frames == 1; },
+            "the frame after the fallback was not displayed");
+        require(session->requests == rendersBefore + 2,
+            "the one displayed frame did not cost exactly two renders: the "
+            "level asked for, then the level the fallback landed on");
+        const auto rendered = session->requestsSoFar();
+        const auto& last = rendered.back();
+        require(last.maximumLevel == 0 && last.range.has_value()
+                && last.range->maximum < 15.0,
+            "the repeated render did not re-resolve the range at level 0");
+        require(controller.lastFrame().usedRange.maximum < 15.0,
+            "the displayed frame kept the finer level's range");
+        rangeSelection.mode = amrvis::RangeMode::User;
+        rangeSelection.userRange = std::pair{0.0, 4.0};
+        session->sessionFallback = false;
+        waitFor(application, [&] { return !controller.renderInFlight(); },
+            "the fallback render did not finish");
+        controller.closeWindow();
     }
     return 0;
 }

--- a/tests/unit/test_volume_controller.cpp
+++ b/tests/unit/test_volume_controller.cpp
@@ -473,11 +473,18 @@ int main(int argc, char** argv)
         waitFor(application, [&] { return !controller.renderInFlight(); },
             "the opening render did not finish");
         require(volumeWindow() != nullptr, "no volume window on screen");
-        // Arms the settle timer, then cancels well inside its interval.
+        // Arms the settle timer and lets the draft finish, so what cancel()
+        // meets is a settle timer left armed by a completed draft. The fake
+        // counts renders for the whole run, so this waits on a delta: an
+        // absolute floor is already true here and would return before the
+        // throttle had fired, cancelling a draft that never ran.
+        const auto beforeDraft = session->requests.load();
         emit volumeWindow()->cameraChanged();
         waitFor(application,
-            [&] { return !controller.renderInFlight() && session->requests >= 2; },
+            [&] { return session->requests == beforeDraft + 1; },
             "the camera move did not render a draft");
+        waitFor(application, [&] { return !controller.renderInFlight(); },
+            "the draft did not finish");
         const auto after = session->requests.load();
         controller.cancel();
         // Longer than the settle interval: nothing may start on its own.


### PR DESCRIPTION
View > Volume Rendering... opens a window whose view is the iso quadrant's IsoWidget with the rendered volume drawn under its wireframe -- the same camera, so drag, wheel and the XY/XZ/YZ presets steer both -- and a dock of opacity-window, palette-alpha, quality and overlay controls. VolumeController owns the action and the window, follows the main window's field, level, range, log, palette and slice positions through Hooks, and schedules renders on a worker: one in flight, later changes coalesced into one rerun, half-size single-sample drafts while the camera moves and a full frame once it settles, late results dropped. The frame is drawn scaled about the viewport centre by the ratio of projection scales, so a draft still lines up with the wireframe. Covered by a unit test over a fake session and local and remote smoke tests.