### PR TITLE
confirm before an export replaces a file

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -504,6 +504,11 @@ export creates separate `_xy`, `_xz`, and `_yz` images. Both formats reflect
 the current zoomed data region; only PNG includes visible overlays and the
 optional color scale.
 
+If the name you type does not already end in the format's suffix, one is added.
+Nothing already on disk is replaced without asking first -- including the
+per-plane files of a 3-D export, whose names are derived from the one you typed
+rather than being it.
+
 For an open plotfile sequence, **File > Export Animation...** writes numbered
 PNG frames. If `ffmpeg` is installed and available on `PATH`, AMReXplorer also
 encodes an MP4. Three-dimensional sequences produce separate output for each

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -504,11 +504,6 @@ export creates separate `_xy`, `_xz`, and `_yz` images. Both formats reflect
 the current zoomed data region; only PNG includes visible overlays and the
 optional color scale.
 
-If the name you type does not already end in the format's suffix, one is added.
-Nothing already on disk is replaced without asking first -- including the
-per-plane files of a 3-D export, whose names are derived from the one you typed
-rather than being it.
-
 For an open plotfile sequence, **File > Export Animation...** writes numbered
 PNG frames. If `ffmpeg` is installed and available on `PATH`, AMReXplorer also
 encodes an MP4. Three-dimensional sequences produce separate output for each

--- a/src/qt/MainWindowDataset.cpp
+++ b/src/qt/MainWindowDataset.cpp
@@ -1,4 +1,5 @@
 #include "MainWindowInternal.hpp"
+#include "WidgetImageExport.hpp"
 
 namespace amrvis::qt {
 
@@ -12,6 +13,53 @@ struct OpenedDataset {
     std::optional<FabSelectorBuild> fabSelector;
     std::shared_ptr<DatasetSession> session;
 };
+
+// Confirms what the save dialog could not: `targets` are the files the export
+// is about to write, `vetted` the one name the dialog returned. Anything else
+// it never saw -- the name after it gained the format's suffix, and the three
+// per-panel names a 3-D export derives from it. Returns false to abandon the
+// export; silent, returning true, when there is nothing the dialog has not
+// already asked.
+//
+// The default button is Cancel only when a file would be replaced. For the
+// ordinary "shot" -> "shot.png" notice there is nothing to lose, and
+// defaulting to Cancel there would throw the export away on the same reflexive
+// Return that dismissed the dialog a moment earlier.
+//
+// Titled through MainWindow::tr so it shares a translation context with the
+// window's other export strings rather than QObject's.
+[[nodiscard]] bool confirmExportTargets(QWidget* owner, const QString& vetted,
+    const QStringList& targets, const QString& format)
+{
+    const auto clobbered = existingExportTargets(vetted, targets);
+    // Only the single-file case reports a rename: a 3-D export always writes
+    // names the dialog did not see, and saying so on every one of them would
+    // be a prompt per export rather than a warning about losing something.
+    const bool renamed = targets.size() == 1 && targets.front() != vetted;
+    if (clobbered.isEmpty() && !renamed) {
+        return true;
+    }
+    QStringList paragraphs;
+    if (renamed) {
+        paragraphs << MainWindow::tr(
+            "Saving as %1 instead: the image is written as %2.")
+                          .arg(targets.front(), format);
+    }
+    if (clobbered.size() == 1) {
+        paragraphs << MainWindow::tr("%1 already exists and will be replaced.")
+                          .arg(clobbered.front());
+    } else if (!clobbered.isEmpty()) {
+        paragraphs << MainWindow::tr(
+            "These files already exist and will be replaced:")
+                + QLatin1Char('\n') + clobbered.join(QLatin1Char('\n'));
+    }
+    QMessageBox box(QMessageBox::Question, MainWindow::tr("Export Image"),
+        paragraphs.join(QStringLiteral("\n\n")),
+        QMessageBox::Save | QMessageBox::Cancel, owner);
+    box.setDefaultButton(
+        clobbered.isEmpty() ? QMessageBox::Save : QMessageBox::Cancel);
+    return box.exec() == QMessageBox::Save;
+}
 
 } // namespace
 
@@ -236,38 +284,49 @@ void MainWindow::exportImage()
     }
 
     QString selectedFilter;
-    auto filename = QFileDialog::getSaveFileName(
+    const auto chosen = QFileDialog::getSaveFileName(
         this, tr("Export scalar image"), QString(),
         tr("PNG image (*.png);;FITS float64 image (*.fits *.fit)"),
         &selectedFilter);
-    if (filename.isEmpty()) {
+    if (chosen.isEmpty()) {
         return;
     }
 
-    const bool hasFitsExtension = filename.endsWith(
-            QStringLiteral(".fits"), Qt::CaseInsensitive)
-        || filename.endsWith(QStringLiteral(".fit"), Qt::CaseInsensitive);
-    const bool hasPngExtension = filename.endsWith(
-        QStringLiteral(".png"), Qt::CaseInsensitive);
-    // An explicitly typed recognized extension wins over the selected filter.
+    // Which format, and the suffixes that already say it. An explicitly typed
+    // recognized extension wins over the selected filter.
+    const QStringList fitsSuffixes{
+        QStringLiteral(".fits"), QStringLiteral(".fit")};
+    const QStringList pngSuffixes{QStringLiteral(".png")};
+    const bool hasFitsExtension
+        = !carriedExportSuffix(chosen, fitsSuffixes).isEmpty();
+    const bool hasPngExtension
+        = !carriedExportSuffix(chosen, pngSuffixes).isEmpty();
     const bool fits = hasFitsExtension
         || (!hasPngExtension
             && selectedFilter.contains(QStringLiteral("*.fits")));
-    const QString extension = filename.endsWith(
-            QStringLiteral(".fit"), Qt::CaseInsensitive)
-        ? QStringLiteral(".fit")
-        : fits ? QStringLiteral(".fits") : QStringLiteral(".png");
 
-    // Normalize the chosen extension and get the base name used for the
-    // per-panel suffixes of a 3-D export.
-    QString base = filename;
-    if (base.endsWith(QStringLiteral(".fits"), Qt::CaseInsensitive)) {
-        base.chop(5);
-    } else if (base.endsWith(QStringLiteral(".fit"), Qt::CaseInsensitive)
-        || base.endsWith(QStringLiteral(".png"), Qt::CaseInsensitive)) {
-        base.chop(4);
-    }
-    filename = base + extension;
+    // The suffix to write under, and the base name the per-panel suffixes of a
+    // 3-D export hang off. A name that already says the format keeps the
+    // spelling it was typed in: chopping the suffix and re-appending a
+    // lowercase one -- what this did -- turned a typed "shot.PNG" into
+    // "shot.png", a different file on a case-sensitive filesystem, replaced
+    // without asking while the file the dialog had vetted was left alone.
+    const auto carried
+        = carriedExportSuffix(chosen, fits ? fitsSuffixes : pngSuffixes);
+    const QString extension = !carried.isEmpty()
+        ? carried
+        : fits ? QStringLiteral(".fits") : QStringLiteral(".png");
+    QString base = chosen;
+    base.chop(carried.size());
+    const QString filename = base + extension;
+    // One expression builds a panel's name, so the confirmation below cannot
+    // name a different set of files than the writes then produce.
+    const auto panelPath = [&base, &extension](std::size_t normal) {
+        constexpr std::array<const char*, 3> suffixes{"_yz", "_xz", "_xy"};
+        return base + QString::fromLatin1(suffixes[normal]) + extension;
+    };
+    const auto formatName
+        = fits ? QStringLiteral("FITS") : QStringLiteral("PNG");
 
     if (fits) {
         const auto writePlane = [this](const QString& outPath,
@@ -284,18 +343,38 @@ void MainWindow::exportImage()
             }
         };
         if (m_viewDimension == 3) {
-            constexpr std::array<const char*, 3> suffixes{"_yz", "_xz", "_xy"};
+            // Which panels, their names, and the data itself, all decided
+            // before anything is written: the confirmation below runs a nested
+            // event loop, so it has to cover every file at risk rather than
+            // the first of three, and what lands in them has to be what was on
+            // screen when the question was asked. The planes are immutable
+            // shared snapshots, so holding one costs a refcount and pins it
+            // against an arrival that installs a fresh pointer mid-prompt.
+            std::vector<std::pair<std::shared_ptr<const ScalarPlane>, QString>>
+                outputs;
             for (std::size_t normal = 0; normal < m_planeViews.size(); ++normal) {
                 const auto& state = m_planeViews[normal];
                 if (state.plane->width <= 0 || state.plane->height <= 0) {
                     continue;
                 }
-                const auto outPath = base
-                    + QString::fromLatin1(suffixes[normal]) + extension;
-                writePlane(outPath, *state.plane);
+                outputs.emplace_back(state.plane, panelPath(normal));
+            }
+            QStringList targets;
+            for (const auto& [plane, outPath] : outputs) {
+                targets << outPath;
+            }
+            if (!confirmExportTargets(this, chosen, targets, formatName)) {
+                return;
+            }
+            for (const auto& [plane, outPath] : outputs) {
+                writePlane(outPath, *plane);
             }
         } else if (m_activeView != nullptr) {
-            writePlane(filename, *m_activeView->plane);
+            const auto plane = m_activeView->plane;
+            if (!confirmExportTargets(this, chosen, {filename}, formatName)) {
+                return;
+            }
+            writePlane(filename, *plane);
         }
         return;
     }
@@ -316,16 +395,29 @@ void MainWindow::exportImage()
     const bool includeColorBar = choice.clickedButton() == withBar;
 
     if (m_viewDimension == 3) {
-        // Export all three panels: foo_xy.png, foo_xz.png, foo_yz.png.
-        constexpr std::array<const char*, 3> suffixes{"_yz", "_xz", "_xy"};
-        for (int normal = 0; normal < 3; ++normal) {
-            const auto idx = static_cast<std::size_t>(normal);
-            auto* panelView = m_planeViews[idx].view;
+        // Export all three panels: foo_xy.png, foo_xz.png, foo_yz.png. Which
+        // ones is settled before any of them is written, so the confirmation
+        // names exactly the files the writes will touch. The pictures are
+        // still composed afterwards, from the views: unlike the FITS path
+        // above there is no cheap snapshot to hold, and the color-bar prompt
+        // has always run an event loop here, so this is no wider a window
+        // than it was. The views themselves live as long as the window.
+        std::vector<std::pair<ImageView*, QString>> outputs;
+        for (std::size_t normal = 0; normal < m_planeViews.size(); ++normal) {
+            auto* panelView = m_planeViews[normal].view;
             if (panelView == nullptr || !panelView->hasImage()) {
                 continue;
             }
-            const auto outPath = base
-                + QString::fromLatin1(suffixes[idx]) + QStringLiteral(".png");
+            outputs.emplace_back(panelView, panelPath(normal));
+        }
+        QStringList targets;
+        for (const auto& [panelView, outPath] : outputs) {
+            targets << outPath;
+        }
+        if (!confirmExportTargets(this, chosen, targets, formatName)) {
+            return;
+        }
+        for (const auto& [panelView, outPath] : outputs) {
             const qreal scale = std::max(1.0,
                 panelView->transform().m11());
             const QImage composite = composeExportFrame(
@@ -336,6 +428,9 @@ void MainWindow::exportImage()
             }
         }
     } else {
+        if (!confirmExportTargets(this, chosen, {filename}, formatName)) {
+            return;
+        }
         const qreal exportScale = std::max(1.0, view->transform().m11());
         const QImage composite = composeExportFrame(
             view, includeColorBar, exportScale);

--- a/src/qt/WidgetImageExport.hpp
+++ b/src/qt/WidgetImageExport.hpp
@@ -1,27 +1,52 @@
 #pragma once
 
-// The two non-obvious rules in saving a widget's picture to a file, apart from
-// the window that owns the menu action. Both had shipped bugs that only a human
-// reading the diff caught, because neither was reachable from a test while it
-// lived inside a private slot; as free functions they are unit-tested against a
-// synthetic widget in tests/unit/test_widget_image_export.cpp.
+// The non-obvious rules in saving a widget's picture to a file, apart from the
+// window that owns the menu action: the name the bytes are written under, which
+// of the files an export is about to write are already there, and painting the
+// widget without the controls parked over it. Each had shipped a bug that only
+// a human reading the diff caught, because none was reachable from a test while
+// it lived inside a private slot; as free functions they are unit-tested in
+// tests/unit/test_widget_image_export.cpp.
 
+#include <QFileInfo>
 #include <QImage>
 #include <QPoint>
 #include <QRegion>
 #include <QString>
+#include <QStringList>
 #include <QWidget>
 
 namespace amrvis::qt {
 
-// The name to save PNG bytes under, given what the save dialog returned.
+// The suffix `chosen` already carries from `accepted`, spelled the way it was
+// typed, or an empty string if it carries none.
 //
-// QImage::save(path, "PNG") forces the format whatever the name says, so a name
-// that does not already say png gets it appended -- a typed "shot" would
-// otherwise hold PNG bytes under a name nothing opens. A name that does say it
-// comes back untouched, case included: chopping and re-appending turned
-// "shot.PNG" into "shot.png", which on a case-sensitive filesystem writes past
-// the file the dialog vetted and leaves the chosen one alone.
+// Case-insensitive on the way in and case-preserving on the way out: that is
+// the whole point of returning the text rather than a bool. Recognising
+// "shot.PNG" and then writing the lowercase spelling back is a different file
+// on a case-sensitive filesystem -- one the save dialog never vetted, silently
+// replaced, while the file the user picked is left alone.
+//
+// List `accepted` longest first, so a compound suffix (".tar.gz") is not
+// matched by its own tail (".gz").
+[[nodiscard]] inline QString carriedExportSuffix(
+    const QString& chosen, const QStringList& accepted)
+{
+    for (const auto& suffix : accepted) {
+        if (chosen.endsWith(suffix, Qt::CaseInsensitive)) {
+            return chosen.right(suffix.size());
+        }
+    }
+    return {};
+}
+
+// The name to write `canonical`-format bytes under, given what the save dialog
+// returned and the suffixes that already say that format.
+//
+// QImage::save(path, "PNG") -- and the FITS writer -- force the format whatever
+// the name says, so a name that says none of `accepted` gains `canonical`: a
+// typed "shot" would otherwise hold PNG bytes under a name nothing opens. A
+// name that already says the format comes back untouched, case included.
 //
 // One-way only: whether the name changed is the caller's comparison, because
 // that is the same question the overwrite prompt asks (the dialog confirmed the
@@ -31,13 +56,45 @@ namespace amrvis::qt {
 // leaves "shot.jpg" alone, and Qt applies it in selectedFiles() -- after a
 // native dialog has already run its own overwrite prompt on the unsuffixed
 // name. Both were tried and both were wrong.
-[[nodiscard]] inline QString pngExportPath(const QString& chosen)
+[[nodiscard]] inline QString exportPathWithSuffix(const QString& chosen,
+    const QStringList& accepted, const QString& canonical)
 {
-    if (chosen.isEmpty()
-        || chosen.endsWith(QStringLiteral(".png"), Qt::CaseInsensitive)) {
+    if (chosen.isEmpty() || !carriedExportSuffix(chosen, accepted).isEmpty()) {
         return chosen;
     }
-    return chosen + QStringLiteral(".png");
+    return chosen + canonical;
+}
+
+// The single-suffix case: PNG.
+[[nodiscard]] inline QString pngExportPath(const QString& chosen)
+{
+    return exportPathWithSuffix(
+        chosen, {QStringLiteral(".png")}, QStringLiteral(".png"));
+}
+
+// Which of the files an export is about to write are already on disk, so the
+// caller can name them before replacing them.
+//
+// `vetted` -- the name the save dialog returned -- is excluded: that one it
+// already confirmed, and asking twice about the same file is what teaches
+// someone to click through the prompt that matters. Everything else needs
+// asking about, because the dialog never saw it: a name that gained a suffix,
+// and the per-panel names a 3-D export derives from the one that was typed.
+//
+// The comparison is on the text, so on a case-insensitive filesystem a typed
+// "shot.PNG" beside an existing "shot.png" is asked about twice. That is the
+// harmless direction to be wrong in, and canonicalising here would mean a stat
+// per candidate and a different answer per platform.
+[[nodiscard]] inline QStringList existingExportTargets(
+    const QString& vetted, const QStringList& targets)
+{
+    QStringList existing;
+    for (const auto& target : targets) {
+        if (target != vetted && QFileInfo::exists(target)) {
+            existing.append(target);
+        }
+    }
+    return existing;
 }
 
 // `widget` and whatever it paints, at `devicePixelRatio`, WITHOUT its child

--- a/tests/unit/test_widget_image_export.cpp
+++ b/tests/unit/test_widget_image_export.cpp
@@ -1,12 +1,14 @@
-// The two rules in exporting a widget's picture: the file name PNG bytes are
-// saved under, and painting a widget without the controls parked over it.
+// The rules in exporting a widget's picture: the file name the bytes are saved
+// under, which of the files an export is about to write are already there, and
+// painting a widget without the controls parked over it.
 //
-// Both shipped a bug that only review caught, because both lived inside a
+// Each shipped a bug that only review caught, because each lived inside a
 // private slot nothing could call. The name rule shipped two: a typed "shot"
 // overwriting shot.png unasked, and chop-and-re-append rewriting "shot.PNG" to
-// "shot.png" -- the second introduced while fixing the first. The painting rule
-// shipped one: QWidget::grab() baking the volume view's XY/XZ/YZ preset buttons
-// into every exported frame.
+// "shot.png" -- the second introduced while fixing the first. The main window's
+// copy of it shipped both, plus a third: it writes up to three derived names
+// the save dialog never saw. The painting rule shipped one: QWidget::grab()
+// baking the volume view's XY/XZ/YZ preset buttons into every exported frame.
 //
 // The painting test does not use IsoWidget. It builds its own widget with a
 // child parked over it, so it pins the rule rather than the volume window's
@@ -16,9 +18,12 @@
 
 #include <QApplication>
 #include <QColor>
+#include <QFile>
 #include <QImage>
 #include <QPainter>
 #include <QPushButton>
+#include <QStringList>
+#include <QTemporaryDir>
 #include <QWidget>
 
 #include <cstdlib>
@@ -42,6 +47,34 @@ void requirePath(const char* chosen, const char* expected)
     }
     std::cerr << "FAILED: pngExportPath(\"" << chosen << "\") gave \""
               << actual.toStdString() << "\", expected \"" << expected << "\"\n";
+    std::exit(1);
+}
+
+void requireCarried(const char* chosen, const QStringList& accepted,
+    const char* expected)
+{
+    const auto actual = amrvis::qt::carriedExportSuffix(
+        QString::fromUtf8(chosen), accepted);
+    if (actual == QString::fromUtf8(expected)) {
+        return;
+    }
+    std::cerr << "FAILED: carriedExportSuffix(\"" << chosen << "\") gave \""
+              << actual.toStdString() << "\", expected \"" << expected
+              << "\"\n";
+    std::exit(1);
+}
+
+void requireSuffixed(const char* chosen, const QStringList& accepted,
+    const char* canonical, const char* expected)
+{
+    const auto actual = amrvis::qt::exportPathWithSuffix(
+        QString::fromUtf8(chosen), accepted, QString::fromUtf8(canonical));
+    if (actual == QString::fromUtf8(expected)) {
+        return;
+    }
+    std::cerr << "FAILED: exportPathWithSuffix(\"" << chosen << "\", \""
+              << canonical << "\") gave \"" << actual.toStdString()
+              << "\", expected \"" << expected << "\"\n";
     std::exit(1);
 }
 
@@ -143,6 +176,90 @@ int main(int argc, char** argv)
     // A trailing dot is not a suffix, so it gains one -- pinned so the
     // behaviour is chosen rather than accidental.
     requirePath("shot.", "shot..png");
+
+    // --- the suffix a name already carries -------------------------------
+    // Returned as it was typed, which is the whole reason this hands back the
+    // text and not a bool: the caller writes under the spelling it gets, and
+    // handing back the lowercase spelling is how "shot.PNG" became "shot.png".
+    const QStringList png{QStringLiteral(".png")};
+    const QStringList fits{QStringLiteral(".fits"), QStringLiteral(".fit")};
+    requireCarried("shot.png", png, ".png");
+    requireCarried("shot.PNG", png, ".PNG");
+    requireCarried("shot.PnG", png, ".PnG");
+    requireCarried("shot", png, "");
+    requireCarried("shot.jpg", png, "");
+    requireCarried("", png, "");
+    // Either suffix of a format with two of them, each in its own spelling.
+    requireCarried("shot.fits", fits, ".fits");
+    requireCarried("shot.fit", fits, ".fit");
+    requireCarried("shot.FITS", fits, ".FITS");
+    requireCarried("shot.Fit", fits, ".Fit");
+    requireCarried("shot.png", fits, "");
+    // Longest first, as the contract asks: a compound suffix is matched whole
+    // rather than by its own tail.
+    requireCarried("a.tar.gz",
+        {QStringLiteral(".tar.gz"), QStringLiteral(".gz")}, ".tar.gz");
+
+    // --- the name for a format with more than one suffix -----------------
+    // The main window's export, which is where all three of these shipped.
+    requireSuffixed("shot", fits, ".fits", "shot.fits");
+    // Already says the format: untouched, in the case it was typed. Both of
+    // these were rewritten to a lowercase ".fits" -- a different file on a
+    // case-sensitive filesystem, and for the second one a different format's
+    // suffix as well.
+    requireSuffixed("shot.FITS", fits, ".fits", "shot.FITS");
+    requireSuffixed("shot.fit", fits, ".fits", "shot.fit");
+    requireSuffixed("shot.FIT", fits, ".fits", "shot.FIT");
+    // Says some other format: it gains the one being written, rather than
+    // having its own replaced.
+    requireSuffixed("shot.jpg", fits, ".fits", "shot.jpg.fits");
+    requireSuffixed("", fits, ".fits", "");
+    // And the PNG wrapper is that same rule, so it stays in step with it.
+    requireSuffixed("shot.PNG", png, ".png", "shot.PNG");
+
+    // --- which of the files about to be written are already there --------
+    QTemporaryDir directory;
+    require(directory.isValid(), "could not make a temporary directory");
+    const auto inDirectory = [&directory](const char* name) {
+        return directory.filePath(QString::fromUtf8(name));
+    };
+    const auto touch = [](const QString& path) {
+        QFile file(path);
+        return file.open(QIODevice::WriteOnly) && file.write("x") == 1;
+    };
+    require(touch(inDirectory("shot_xz.png")), "could not make a file");
+    require(touch(inDirectory("typed.png")), "could not make a file");
+
+    // A 3-D export writes three names derived from the one the dialog vetted,
+    // so all three are candidates and the one already there is reported.
+    const QStringList panels{inDirectory("shot_yz.png"),
+        inDirectory("shot_xz.png"), inDirectory("shot_xy.png")};
+    const auto clobbered = amrvis::qt::existingExportTargets(
+        inDirectory("shot.png"), panels);
+    require(clobbered == QStringList{inDirectory("shot_xz.png")},
+        "the existing derived file was not the one and only one reported");
+
+    // The name the dialog returned is excluded even though it exists: that one
+    // it already confirmed, and asking twice is what teaches someone to click
+    // through the prompt that matters.
+    require(amrvis::qt::existingExportTargets(
+                inDirectory("typed.png"), {inDirectory("typed.png")})
+                .isEmpty(),
+        "the name the save dialog vetted was asked about a second time");
+    // ...but the same file under a name the dialog did not return is not.
+    require(amrvis::qt::existingExportTargets(
+                inDirectory("other.png"), {inDirectory("typed.png")})
+            == QStringList{inDirectory("typed.png")},
+        "an existing file the dialog never saw was not reported");
+    // Nothing there, nothing to say.
+    require(amrvis::qt::existingExportTargets(inDirectory("shot.png"),
+                {inDirectory("gone_yz.png"), inDirectory("gone_xy.png")})
+                .isEmpty(),
+        "files that do not exist were reported as existing");
+    require(amrvis::qt::existingExportTargets(
+                inDirectory("shot.png"), QStringList{})
+                .isEmpty(),
+        "an empty target list produced something to confirm");
 
     // --- painting the widget without its children ------------------------
     HostWidget host;


### PR DESCRIPTION
MainWindow::exportImage chopped the typed suffix and re-appended a lowercase one, so a typed "shot.PNG" wrote past "shot.png", and it checked nothing before writing -- a 3-D export replaced three files the save dialog never showed. The name now keeps the spelling it was typed in, and every file the export will write is decided before any of it is written, so one prompt names what would be replaced.

The two rules moved into WidgetImageExport.hpp, where they are testable: five mutations fail the unit test.