### PR TITLE
draft the volume while a sequence plays

### DIFF
--- a/src/qt/IsoWidget.cpp
+++ b/src/qt/IsoWidget.cpp
@@ -70,14 +70,26 @@ IsoWidget::IsoWidget(QWidget* parent)
 
 void IsoWidget::setGeometry(const DatasetMetadata& metadata)
 {
+    const bool hadGeometry = m_hasGeometry;
+    const auto previousDomain = m_domain;
     m_hasGeometry = metadata.dimension == 3;
     m_domain = datasetSampleBounds(metadata);
     m_levels.clear();
-    // The frame belonged to the previous geometry: kept, it would be drawn
-    // under a wireframe for a domain it was not sampled from, and scaled by a
-    // projection that no longer describes it.
-    m_backdrop = QImage();
-    m_backdropCamera = OrthoCamera{};
+    // The frame belonged to the previous geometry: kept across a domain that
+    // moved, it would be drawn under a wireframe for a region it was not
+    // sampled from, and scaled by a projection that no longer describes it.
+    //
+    // A domain that did not move is the sequence case -- every frame of a
+    // plotfile sequence re-pushes the same geometry -- and there the frame is
+    // still in the right place. It is a previous time step's data, which is
+    // what keeps the view showing something while the next one renders
+    // instead of blanking on every frame. The projection is in normalised
+    // domain coordinates, so an unchanged domain leaves it unchanged; the
+    // level boxes are redrawn from the new metadata either way.
+    if (!m_hasGeometry || !hadGeometry || m_domain != previousDomain) {
+        m_backdrop = QImage();
+        m_backdropCamera = OrthoCamera{};
+    }
     if (m_hasGeometry) {
         m_levels.reserve(metadata.levels.size());
         for (const auto& level : metadata.levels) {

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -397,7 +397,7 @@ MainWindow::MainWindow(QWidget* parent)
             m_initialStopSource.request_stop();
             m_linePlotStopSource.request_stop();
             m_particleController->cancel();
-            m_volumeController->cancel();
+            m_volumeController->frameSwitchStarted();
             m_pendingAllViews = false;
             m_pendingViews.clear();
             m_sliceDebounce->stop();

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -495,6 +495,7 @@ MainWindow::MainWindow(QWidget* parent)
             [this] { return m_slicePosition3d; },
             [this] { return m_slicePlanesAction->isChecked(); },
             [this] { return m_closing; },
+            [this] { return m_playbackMode == PlaybackMode::Sequence; },
         },
         this);
     connect(m_volumeController, &VolumeController::renderActivityChanged, this,

--- a/src/qt/MainWindowSlice.cpp
+++ b/src/qt/MainWindowSlice.cpp
@@ -1750,6 +1750,7 @@ void MainWindow::toggleSequencePlayback()
 
 void MainWindow::setPlaybackMode(PlaybackMode mode)
 {
+    const bool wasSequence = m_playbackMode == PlaybackMode::Sequence;
     m_playbackMode = mode;
     m_animationPanel->setSweepPlaying(mode == PlaybackMode::Sweep);
     m_animationPanel->setSequencePlaying(mode == PlaybackMode::Sequence);
@@ -1757,6 +1758,13 @@ void MainWindow::setPlaybackMode(PlaybackMode mode)
         m_playbackTimer->stop();
     } else {
         m_playbackTimer->start(m_animationPanel->frameDelayMs());
+    }
+    // Every frame of a sequence renders the volume as a draft, so what is
+    // standing in the window when playback stops is a half-size one. Ask for
+    // it again now that frames have stopped arriving; with no volume window
+    // open this does nothing.
+    if (wasSequence && mode != PlaybackMode::Sequence) {
+        m_volumeController->refresh();
     }
 }
 

--- a/src/qt/VolumeController.cpp
+++ b/src/qt/VolumeController.cpp
@@ -215,6 +215,16 @@ void VolumeController::configureForDataset()
     // for the outgoing dataset and must not be displayed against this one.
     cancel();
     pushGeometry();
+    // Sequence playback lands here once per frame. Dropping the frame each
+    // time left the window blank for the whole run -- a full ray cast never
+    // finished before the next frame cancelled it -- so the frame that is up
+    // stays up until the next draft replaces it. Nothing is shown against a
+    // geometry it does not belong to: a push that moved the domain drops the
+    // frame in IsoWidget::setGeometry, whatever this decides.
+    if (m_hooks.sequencePlaying && m_hooks.sequencePlaying()) {
+        scheduleRender();
+        return;
+    }
     m_window->clearFrame();
     // The frame just cleared belonged to the outgoing dataset; lastFrame()
     // would otherwise keep reporting it as this one's.
@@ -319,9 +329,13 @@ void VolumeController::startRender()
     request.camera = m_window->camera();
     // Mid-interaction (a moving camera, a resize, a dragged slider) gets a
     // half-size, single-sample draft; a settled view the full frame at the
-    // view's size.
-    const int width = std::max(1, m_interacting ? viewSize.width() / 2 : viewSize.width());
-    const int height = std::max(1, m_interacting ? viewSize.height() / 2 : viewSize.height());
+    // view's size. Sequence playback drafts for the same reason: the next
+    // frame arrives before a full ray cast could finish, so asking for one
+    // means every frame is cancelled unseen.
+    const bool draft = m_interacting
+        || (m_hooks.sequencePlaying && m_hooks.sequencePlaying());
+    const int width = std::max(1, draft ? viewSize.width() / 2 : viewSize.width());
+    const int height = std::max(1, draft ? viewSize.height() / 2 : viewSize.height());
     request.outputSize = {std::min(width, maxVolumeOutputDimension),
         std::min(height, maxVolumeOutputDimension)};
     // No request.logarithmic here: the choice built below carries it, and
@@ -329,7 +343,7 @@ void VolumeController::startRender()
     request.transfer = makeVolumeTransferFunction(
         m_hooks.palette ? m_hooks.palette() : builtinPalette(BuiltinPalette::Rainbow),
         m_window->ramp());
-    request.samplesPerVoxel = m_interacting ? 1 : quality.samplesPerVoxel;
+    request.samplesPerVoxel = draft ? 1 : quality.samplesPerVoxel;
     request.maximumVoxels = quality.maximumVoxels;
 
     const auto generation = ++m_generation;

--- a/src/qt/VolumeController.cpp
+++ b/src/qt/VolumeController.cpp
@@ -213,7 +213,20 @@ void VolumeController::configureForDataset()
     }
     // Before the new geometry goes in: a frame still in flight was rendered
     // for the outgoing dataset and must not be displayed against this one.
-    cancel();
+    //
+    // Playback abandons it without stopping the render throttle. Stopping it
+    // here and starting it again below pushes the pending render out by a
+    // full interval on every frame, so at frame intervals shorter than the
+    // throttle's own -- the Speed slider goes down to 1 ms -- it never
+    // elapses and nothing renders at all. Left armed it fires on schedule and
+    // renders whichever frame is current by then, which is exactly what it
+    // does for a continuous drag.
+    const bool playing = m_hooks.sequencePlaying && m_hooks.sequencePlaying();
+    if (playing) {
+        abandonInFlight();
+    } else {
+        cancel();
+    }
     pushGeometry();
     // Sequence playback lands here once per frame. Dropping the frame each
     // time left the window blank for the whole run -- a full ray cast never
@@ -221,7 +234,7 @@ void VolumeController::configureForDataset()
     // stays up until the next draft replaces it. Nothing is shown against a
     // geometry it does not belong to: a push that moved the domain drops the
     // frame in IsoWidget::setGeometry, whatever this decides.
-    if (m_hooks.sequencePlaying && m_hooks.sequencePlaying()) {
+    if (playing) {
         scheduleRender();
         return;
     }
@@ -267,12 +280,19 @@ void VolumeController::reset()
     refreshActionEnabled();
 }
 
-void VolumeController::cancel()
+void VolumeController::abandonInFlight()
 {
     ++m_generation;
     m_stopSource.request_stop();
     m_stopSource = StopSource{};
+    // The pending rerun was for the work being abandoned. A caller that still
+    // wants one asks again.
     m_rerun = false;
+}
+
+void VolumeController::cancel()
+{
+    abandonInFlight();
     m_debounce->stop();
     // The settle timer too, and the interaction it stands for: left armed, it
     // fires after the cancellation and schedules a render of whatever dataset

--- a/src/qt/VolumeController.cpp
+++ b/src/qt/VolumeController.cpp
@@ -247,6 +247,19 @@ void VolumeController::configureForDataset()
     scheduleRender();
 }
 
+void VolumeController::frameSwitchStarted()
+{
+    // See the declaration: playback must not lose the pending render, because
+    // this runs once per frame and re-arming the throttle on each one means it
+    // never fires. The frame in flight goes either way -- it was built for the
+    // frame being replaced.
+    if (m_hooks.sequencePlaying && m_hooks.sequencePlaying()) {
+        abandonInFlight();
+    } else {
+        cancel();
+    }
+}
+
 void VolumeController::refresh()
 {
     if (!m_window) {

--- a/src/qt/VolumeController.hpp
+++ b/src/qt/VolumeController.hpp
@@ -38,10 +38,10 @@ class VolumeWindow;
 // runs it on a worker through the session (locally or on the server), and
 // pushes the frame back into the window. One render is in flight at a time;
 // a change during one is remembered and rendered after it. While the camera
-// is moving, the view is being resized or an opacity slider is being dragged,
-// the frames are half-size, one-sample drafts; once that settles, a full
-// frame. Late results (a superseded generation, a closed
-// window, a shutting-down host) are dropped, never displayed.
+// is moving, the view is being resized, an opacity slider is being dragged or
+// a plotfile sequence is playing, the frames are half-size, one-sample drafts;
+// once that settles, a full frame. Late results (a superseded generation, a
+// closed window, a shutting-down host) are dropped, never displayed.
 class VolumeController final : public QObject {
     Q_OBJECT
 
@@ -63,6 +63,11 @@ public:
         // True once application shutdown began: late results are dropped
         // without touching the GUI.
         std::function<bool()> isShuttingDown;
+        // True while plotfile-sequence playback is running. Frames arrive
+        // faster than a full ray cast finishes, so they are drafted like a
+        // moving camera and the frame already up is left in place until the
+        // next draft replaces it.
+        std::function<bool()> sequencePlaying;
     };
 
     VolumeController(Hooks hooks, QObject* parent = nullptr);

--- a/src/qt/VolumeController.hpp
+++ b/src/qt/VolumeController.hpp
@@ -117,6 +117,13 @@ private:
     // The window is going away, closed here or by the user: abandon the render
     // in flight and forget that a frame was ever shown in it.
     void forgetWindow();
+    // Abandons whatever is in flight -- its result is dropped as stale -- and
+    // leaves the render throttle armed. cancel() is this plus stopping the
+    // throttle and the interaction it stands for; sequence playback needs
+    // only this half, because stopping the throttle and starting it again on
+    // every frame means it never elapses at the frame intervals the Speed
+    // slider allows, and nothing renders at all.
+    void abandonInFlight();
     [[nodiscard]] QString describe(
         const VolumeDisplayResult& result, const QString& fieldName) const;
 

--- a/src/qt/VolumeController.hpp
+++ b/src/qt/VolumeController.hpp
@@ -88,8 +88,17 @@ public:
     // or palette changed. slicePositionsChanged / slicePlanesVisibilityChanged:
     // overlay-only, no render. reset: the dataset is going away -- cancel,
     // close the window, disable the action. cancel: in-flight work is
-    // abandoned (a frame switch, shutdown); the window stays.
+    // abandoned (shutdown, a dataset going away); the window stays.
     void configureForDataset();
+    // A sequence frame switch has begun, before the frame has loaded: the work
+    // in flight was built for the outgoing frame and is abandoned. While
+    // playback runs the pending render is left alone -- this happens once per
+    // frame, and stopping the throttle here only to re-arm it when the frame
+    // arrives pushes that render out by a full interval every time, so at the
+    // frame intervals the Speed slider allows it never elapses and nothing
+    // renders at all. A single step is not on a clock and takes the cancel()
+    // form, which leaves nothing pending against the frame being replaced.
+    void frameSwitchStarted();
     void refresh();
     void slicePositionsChanged();
     void slicePlanesVisibilityChanged();

--- a/tests/unit/test_volume_controller.cpp
+++ b/tests/unit/test_volume_controller.cpp
@@ -14,6 +14,7 @@
 #include <amrexplorer/data/DatasetSession.hpp>
 
 #include <QApplication>
+#include <QColor>
 #include <QAction>
 #include <QCoreApplication>
 #include <QStringList>
@@ -296,11 +297,23 @@ int main(int argc, char** argv)
         };
         require(magenta(withFrame) > 0,
             "the backdrop was not drawn, so this cannot see it being dropped");
-        // Different 3-D geometry: the flag stays set, so only the clear can
-        // remove the frame.
+        // The same geometry pushed again keeps it. Every frame of a plotfile
+        // sequence re-pushes the geometry it already has, and dropping the
+        // frame each time is what left the volume window blank for the whole
+        // of a playback: the projection is in normalised domain coordinates,
+        // so an unmoved domain leaves the frame exactly where it belongs.
+        widget.setGeometry(geometry.metadata());
+        application.processEvents();
+        require(magenta(amrvis::qt::renderWidgetWithoutChildren(widget, 1.0))
+                > 0,
+            "re-pushing the same geometry dropped a frame that still fits it");
+        // Different 3-D geometry: the domain the frame was placed in has
+        // moved, so the frame goes. What places it is datasetSampleBounds --
+        // the finest level's extent -- and not physicalDomain, which that
+        // function ignores whenever there are levels, so moving the extent is
+        // what makes this a different geometry at all.
         auto other = geometry.metadata();
-        other.physicalDomain = amrvis::RealBox{
-            amrvis::Real3{{0.0, 0.0, 0.0}}, amrvis::Real3{{2.0, 3.0, 4.0}}};
+        other.levels.back().cellSize = {{1.0, 2.0, 3.0}};
         widget.setGeometry(other);
         application.processEvents();
         require(magenta(amrvis::qt::renderWidgetWithoutChildren(widget, 1.0))
@@ -311,6 +324,7 @@ int main(int argc, char** argv)
     auto session = std::make_shared<FakeSession>();
     std::shared_ptr<amrvis::DatasetSession> dataset = session;
     bool shuttingDown = false;
+    bool playingSequence = false;
     amrvis::qt::RangeController::Selection rangeSelection;
     rangeSelection.mode = amrvis::RangeMode::User;
     rangeSelection.userRange = std::pair{0.0, 4.0};
@@ -326,6 +340,7 @@ int main(int argc, char** argv)
             [] { return std::array<double, 3>{0.5, 1.0, 1.5}; },
             [] { return true; },
             [&shuttingDown] { return shuttingDown; },
+            [&playingSequence] { return playingSequence; },
         };
     };
 
@@ -642,6 +657,105 @@ int main(int argc, char** argv)
         rangeSelection.logarithmic = false;
         waitFor(application, [&] { return !controller.renderInFlight(); },
             "the logarithmic render did not finish");
+        controller.closeWindow();
+    }
+
+    // Sequence playback. Every frame of a sequence lands in
+    // configureForDataset, and a full-quality ray cast does not finish before
+    // the next frame cancels it -- so asking for one meant no frame was ever
+    // displayed and the window stayed blank for the whole run, while each
+    // frame still burned a grid sample and a ray cast. Playback drafts, the
+    // way a moving camera does, and leaves the frame already up in place.
+    {
+        VolumeController controller(hooks());
+        Observed observed;
+        observe(controller, observed);
+        controller.showWindow(nullptr);
+        waitFor(application, [&] { return observed.frames == 1; },
+            "the opening frame was not displayed");
+        auto* const view = volumeWindow() != nullptr
+            ? volumeWindow()->findChild<amrvis::qt::IsoWidget*>() : nullptr;
+        require(view != nullptr, "no view in the volume window");
+        application.processEvents();
+        // Pixels of the frame FakeSession renders, as the view draws it:
+        // counting them is how "the window is not blank" gets stated. The
+        // match is exact, not near: the overlays drawn over the grey
+        // background -- slice planes, level outlines -- blend to within a
+        // couple of dozen levels of this colour, and a tolerance wide enough
+        // to allow for them counts about 1400 of them whether a frame is
+        // there or not. The frame is drawn with a smooth transform, so its
+        // edge pixels blend and only its interior is exact; that is still
+        // most of the view.
+        const auto rendered = [view] {
+            const auto image = amrvis::qt::renderWidgetWithoutChildren(*view, 1.0);
+            int found = 0;
+            for (int y = 0; y < image.height(); ++y) {
+                for (int x = 0; x < image.width(); ++x) {
+                    found += image.pixelColor(x, y) == QColor(0x40, 0x80, 0xC0)
+                        ? 1 : 0;
+                }
+            }
+            return found;
+        };
+        require(rendered() > 0,
+            "the opening frame is not on screen, so this cannot see it kept");
+        const auto full = session->requestsSoFar().back().outputSize;
+        require(session->requestsSoFar().back().samplesPerVoxel == 2,
+            "the opening frame was not a full one");
+
+        // A frame arriving while playback runs: drafted, and what is on
+        // screen stays there until the draft replaces it.
+        //
+        // The render is made slow on purpose. What has to hold is that the
+        // view still shows something *while* the next frame renders, so the
+        // check has to happen in that window -- with a fast render the draft
+        // lands first and then the assertions below pass on the new frame
+        // whether the old one was dropped or not.
+        session->delayMs = 400;
+        playingSequence = true;
+        auto before = session->requests.load();
+        auto framesBefore = observed.frames;
+        controller.configureForDataset();
+        waitFor(application, [&] { return session->requests == before + 1; },
+            "a sequence frame did not schedule a render");
+        const auto drafted = session->requestsSoFar().back();
+        require(drafted.samplesPerVoxel == 1
+                && drafted.outputSize[0] <= full[0] / 2 + 1
+                && drafted.outputSize[1] <= full[1] / 2 + 1,
+            "a sequence frame asked for a full ray cast, which the next frame "
+            "cancels before it finishes");
+        // Still mid-render, so anything on screen is the previous frame and
+        // not this one. Without this the two checks below prove nothing.
+        require(controller.renderInFlight() && observed.frames == framesBefore,
+            "the sequence render finished before the view could be checked");
+        require(rendered() > 0,
+            "a sequence frame blanked the view instead of leaving the "
+            "previous frame up while the next one rendered");
+        require(controller.lastFrame().width == full[0],
+            "a sequence frame dropped the frame it was still displaying");
+        session->delayMs = 0;
+        waitFor(application, [&] { return observed.frames == framesBefore + 1; },
+            "the drafted sequence frame was never displayed");
+        waitFor(application, [&] { return !controller.renderInFlight(); },
+            "the drafted sequence frame did not finish");
+
+        // And the contrast that keeps those two honest: with playback stopped,
+        // the same call blanks the view and drops the frame, which is what a
+        // dataset switch has to do.
+        playingSequence = false;
+        before = session->requests.load();
+        controller.configureForDataset();
+        require(rendered() == 0,
+            "an ordinary dataset switch left the outgoing frame on screen");
+        require(controller.lastFrame().pixels.empty(),
+            "an ordinary dataset switch kept the outgoing frame");
+        waitFor(application, [&] { return session->requests == before + 1; },
+            "the dataset switch did not render");
+        const auto restored = session->requestsSoFar().back();
+        require(restored.samplesPerVoxel == 2 && restored.outputSize == full,
+            "the render after playback stopped is still a draft");
+        waitFor(application, [&] { return !controller.renderInFlight(); },
+            "the full render did not finish");
         controller.closeWindow();
     }
     return 0;

--- a/tests/unit/test_volume_controller.cpp
+++ b/tests/unit/test_volume_controller.cpp
@@ -758,5 +758,40 @@ int main(int argc, char** argv)
             "the full render did not finish");
         controller.closeWindow();
     }
+
+    // Frames arriving faster than the render throttle's own interval must
+    // still render. Every arrival abandons the render in flight, and doing
+    // that through cancel() -- which stops the throttle -- pushed the pending
+    // render out by another full interval each time, so at the frame
+    // intervals the Speed slider allows (601 - value ms, down to 1) the
+    // throttle never elapsed and nothing was rendered at all. That is the
+    // same blank window this change is about, reached the other way.
+    {
+        VolumeController controller(hooks());
+        Observed observed;
+        observe(controller, observed);
+        controller.showWindow(nullptr);
+        waitFor(application, [&] { return observed.frames == 1; },
+            "the opening frame was not displayed");
+        playingSequence = true;
+        const auto before = session->requests.load();
+        const auto framesBefore = observed.frames;
+        // Twelve arrivals 20 ms apart: half the throttle's interval.
+        for (int arrival = 0; arrival < 12; ++arrival) {
+            controller.configureForDataset();
+            settle(application, 20);
+        }
+        // The count is not pinned -- it depends on how a 40 ms throttle lines
+        // up with 20 ms arrivals across 240 ms, and a slow machine only gets
+        // more. What matters is that it is not zero.
+        require(session->requests > before + 2,
+            "frames arriving faster than the render throttle rendered nothing");
+        require(observed.frames > framesBefore,
+            "nothing was displayed during fast playback");
+        playingSequence = false;
+        waitFor(application, [&] { return !controller.renderInFlight(); },
+            "the last playback render did not finish");
+        controller.closeWindow();
+    }
     return 0;
 }

--- a/tests/unit/test_volume_controller.cpp
+++ b/tests/unit/test_volume_controller.cpp
@@ -774,20 +774,45 @@ int main(int argc, char** argv)
         waitFor(application, [&] { return observed.frames == 1; },
             "the opening frame was not displayed");
         playingSequence = true;
-        const auto before = session->requests.load();
-        const auto framesBefore = observed.frames;
-        // Twelve arrivals 20 ms apart: half the throttle's interval.
-        for (int arrival = 0; arrival < 12; ++arrival) {
+        auto before = session->requests.load();
+        // Both halves of what the host does per frame, in order: the switch
+        // starts before the frame has loaded, then the frame arrives. Driving
+        // only the second half is what let an earlier version of this test
+        // pass while production still starved -- the switch is where the
+        // throttle was being stopped.
+        const auto arrive = [&controller, &application](int gapMs) {
+            controller.frameSwitchStarted();
             controller.configureForDataset();
-            settle(application, 20);
+            settle(application, gapMs);
+        };
+        // Sixteen arrivals 20 ms apart: half the throttle's interval.
+        for (int arrival = 0; arrival < 16; ++arrival) {
+            arrive(20);
         }
-        // The count is not pinned -- it depends on how a 40 ms throttle lines
-        // up with 20 ms arrivals across 240 ms, and a slow machine only gets
-        // more. What matters is that it is not zero.
+        // The count is not pinned -- a 40 ms throttle across 320 ms of
+        // arrivals is around eight, and the bar below is three, because a
+        // throttle that fires while a render is still in flight starts
+        // nothing and waits for the next arrival to re-arm it. What matters is
+        // that it is not zero, which is what stopping the throttle produced.
+        //
+        // Renders started, not frames displayed: at arrivals this fast every
+        // render is superseded by the next arrival before it can finish, so
+        // whether any particular one survives to be shown is a race, and
+        // asserting on it failed on macOS. Nothing can ray-cast faster than
+        // the frames arrive; what this pins is that the attempts keep coming.
         require(session->requests > before + 2,
             "frames arriving faster than the render throttle rendered nothing");
-        require(observed.frames > framesBefore,
-            "nothing was displayed during fast playback");
+
+        // At arrivals slower than the throttle, frames do reach the screen.
+        // This is the user-visible half, and it needs a rate at which a render
+        // has room to finish between arrivals.
+        before = session->requests.load();
+        const auto framesBefore = observed.frames;
+        for (int arrival = 0; arrival < 3; ++arrival) {
+            arrive(150);
+        }
+        require(session->requests > before && observed.frames > framesBefore,
+            "playback at an ordinary speed displayed nothing");
         playingSequence = false;
         waitFor(application, [&] { return !controller.renderInFlight(); },
             "the last playback render did not finish");


### PR DESCRIPTION
Every sequence frame cancelled the render in flight, blanked the view and asked for a full-quality ray cast that the next frame cancelled before it finished -- so nothing was ever displayed and the window stayed blank for the whole playback, while each frame still burned a ray cast. Playback now drafts the way a moving camera does, and the frame already up stays up until the draft replaces it: IsoWidget keeps its backdrop when the sampled domain has not moved, which is every frame of a sequence. Stopping playback asks for a full frame.