### PR TITLE
render the settled volume frame at the display's pixels

### DIFF
--- a/docs/volume-rendering-plan.md
+++ b/docs/volume-rendering-plan.md
@@ -85,7 +85,8 @@ legacy percent, `opacity = min(1, byte/100)` (Amrvis `Palette.cpp:670`);
 grid cache 256 MiB per session, server flags `--max-volume-voxels`,
 `--volume-cache-mb`; point sampling at voxel centres (box averaging later);
 window mirrors the main window's field/level/range/log/palette (no own range
-controls); render at logical resolution (hi-DPI polish in the last PR).
+controls); drafts at half the logical size, the settled frame at the view's
+device pixels (`volumeOutputSize`).
 
 ## Phases (one PR each; sizes S/M/L)
 
@@ -326,7 +327,9 @@ concrete 1.2; `ARCHITECTURE.md` trust boundaries).
 ### PR8 — Polish and docs (S/M)
 Volume window "Export Image..." (PNG; `grab()` would bake the preset buttons
 in, so the view is rendered without its children); hi-DPI (device-resolution
-render, `viewportFrame(w·dpr, h·dpr, margin·dpr)` both sides); trilinear option
+render — `volumeOutputSize` scales the settled frame by the view's ratio, and
+`backdropScale` already divides out both projections' scales, so the margin
+term needed no change and the domain's pixels land 1:1); trilinear option
 (request field + wire field, quality High); `docs/user-guide.md` new "Volume
 rendering" section after "Working with 3-D data" (:269); `docs/ARCHITECTURE.md`
 layering diagram (`render3d`), collaborator table row, "Where to start reading"
@@ -376,9 +379,6 @@ row, threading note; `docs/building.md` unchanged.
 - **Isosurfaces** — extracted and shaded iso-value surfaces alongside the
   translucent volume; needs a marching-cubes pass over the sampled grid and
   a depth-composited draw.
-- **Hi-DPI** — render at device resolution (both sides using
-  `viewportFrame(w·dpr, h·dpr, margin·dpr)`); frames are logical-resolution
-  today.
 - **Trilinear sampling** — a request/wire field and the High quality preset;
   nearest-voxel today.
 - **Box-averaged downsampling** — when the voxel budget forces a coarser
@@ -392,13 +392,6 @@ row, threading note; `docs/building.md` unchanged.
   seam to join a sequence export.
 - **Frame compression on the wire** — RLE or 8-bit indexed pixels for slow
   links; half-resolution drafts are the mitigation today.
-- **Hi-DPI for the volume *render*.** The export buffer is scaled by the
-  device ratio, so the wireframe, grid boxes and slice planes gain real pixels
-  — but `VolumeController` still sizes the render request from the logical view
-  size, so the volume itself is interpolated up. PR8's item above reads as
-  delivered and only the export half is. Deferred on cost: scaling the render
-  quadruples the ray-cast and pushes on the quality voxel budget and the remote
-  frame budget.
 - **End-to-end coverage of "Export Image..."** — the rules it applies (the
   `.png` name, and rendering the view without the preset buttons parked over
   it) are unit-tested in `test_widget_image_export`, but nothing drives the menu

--- a/src/qt/IsoWidget.cpp
+++ b/src/qt/IsoWidget.cpp
@@ -4,6 +4,7 @@
 
 #include <amrexplorer/render2d/Palette.hpp>
 
+#include <QEvent>
 #include <QMouseEvent>
 #include <QPainter>
 #include <QPaintEvent>
@@ -120,6 +121,18 @@ void IsoWidget::setColorPalette(const Palette* palette)
 {
     m_palette = palette;
     update();
+}
+
+bool IsoWidget::event(QEvent* event)
+{
+    // Qt reports a scale change on its own, and only this way: moving to a
+    // screen with a different scale leaves the logical geometry alone, so no
+    // resize event follows it and nothing else would ask for a frame at the
+    // resolution the view now has.
+    if (event->type() == QEvent::DevicePixelRatioChange) {
+        emit viewScaleChanged();
+    }
+    return QWidget::event(event);
 }
 
 void IsoWidget::paintEvent(QPaintEvent* event)

--- a/src/qt/IsoWidget.cpp
+++ b/src/qt/IsoWidget.cpp
@@ -125,13 +125,20 @@ void IsoWidget::setColorPalette(const Palette* palette)
 
 bool IsoWidget::event(QEvent* event)
 {
-    // Qt reports a scale change on its own, and only this way: moving to a
-    // screen with a different scale leaves the logical geometry alone, so no
-    // resize event follows it and nothing else would ask for a frame at the
-    // resolution the view now has.
+    // A scale change leaves the logical geometry alone, so no resize event
+    // follows it and nothing else would ask for a frame at the resolution the
+    // view now has.
+    //
+    // Qt 6.6 added this event; this builds against 6.4, where it does not
+    // exist. There the screenChanged connection in VolumeController is the
+    // only trigger, which covers a window moved between displays -- the case
+    // that prompted this -- but not the scale of one display changing under a
+    // window that stays where it is.
+#if QT_VERSION >= QT_VERSION_CHECK(6, 6, 0)
     if (event->type() == QEvent::DevicePixelRatioChange) {
         emit viewScaleChanged();
     }
+#endif
     return QWidget::event(event);
 }
 

--- a/src/qt/IsoWidget.hpp
+++ b/src/qt/IsoWidget.hpp
@@ -68,8 +68,16 @@ signals:
     // The viewport changed size, so a backdrop rendered for the old one is
     // now being stretched: whoever renders it wants to render it again.
     void viewResized();
+    // The display's scale changed -- the window was moved to a screen with a
+    // different one. Separate from viewResized because no resize follows: the
+    // logical size is unchanged, so a renderer that compares logical sizes to
+    // spot layout churn would dismiss this as churn. Every device pixel the
+    // view is made of has changed size, and a frame rendered for the old ratio
+    // is now the wrong resolution.
+    void viewScaleChanged();
 
 protected:
+    bool event(QEvent* event) override;
     void paintEvent(QPaintEvent* event) override;
     void mousePressEvent(QMouseEvent* event) override;
     void mouseMoveEvent(QMouseEvent* event) override;

--- a/src/qt/VolumeController.cpp
+++ b/src/qt/VolumeController.cpp
@@ -7,6 +7,7 @@
 
 #include <QAction>
 #include <QFutureWatcher>
+#include <QScreen>
 #include <QTimer>
 #include <QWindow>
 #include <QtConcurrent/QtConcurrent>

--- a/src/qt/VolumeController.cpp
+++ b/src/qt/VolumeController.cpp
@@ -11,10 +11,29 @@
 #include <QtConcurrent/QtConcurrent>
 
 #include <algorithm>
+#include <cmath>
 #include <exception>
 #include <utility>
 
 namespace amrvis::qt {
+
+std::array<int, 2> volumeOutputSize(
+    QSize viewSize, qreal devicePixelRatio, bool draft) noexcept
+{
+    // The clamp is also what keeps an absurd ratio harmless: it can only ever
+    // produce a size inside the range the ray caster accepts.
+    const auto bound = [](double extent) {
+        return std::clamp(static_cast<int>(std::lround(extent)), 1,
+            maxVolumeOutputDimension);
+    };
+    if (draft) {
+        // Integer halving, as this has always done -- the draft size is not
+        // where the ratio belongs.
+        return {bound(viewSize.width() / 2), bound(viewSize.height() / 2)};
+    }
+    return {bound(viewSize.width() * devicePixelRatio),
+        bound(viewSize.height() * devicePixelRatio)};
+}
 
 VolumeController::VolumeController(Hooks hooks, QObject* parent)
     : QObject(parent)
@@ -367,10 +386,8 @@ void VolumeController::startRender()
     // means every frame is cancelled unseen.
     const bool draft = m_interacting
         || (m_hooks.sequencePlaying && m_hooks.sequencePlaying());
-    const int width = std::max(1, draft ? viewSize.width() / 2 : viewSize.width());
-    const int height = std::max(1, draft ? viewSize.height() / 2 : viewSize.height());
-    request.outputSize = {std::min(width, maxVolumeOutputDimension),
-        std::min(height, maxVolumeOutputDimension)};
+    request.outputSize = volumeOutputSize(
+        viewSize, m_window->viewDevicePixelRatio(), draft);
     // No request.logarithmic here: the choice built below carries it, and
     // the pipeline sets it from there before each attempt's range resolve.
     request.transfer = makeVolumeTransferFunction(

--- a/src/qt/VolumeController.cpp
+++ b/src/qt/VolumeController.cpp
@@ -162,13 +162,13 @@ void VolumeController::showWindow(QWidget* parent)
         [this] { forgetWindow(); });
     pushGeometry();
     window->show();
-    // A second trigger for the same thing. The widget event above is the
-    // mechanism Qt documents for a scale change, but it is delivered by the
-    // platform and cannot be provoked from a test here; this one is certain,
-    // because moving a window to another screen always emits it. It fires for
-    // a same-scale move too, which costs one full frame on a rare,
-    // user-initiated action -- cheaper than a frame left at the wrong
-    // resolution. The handle exists only once the window is shown.
+    // The other trigger for a scale change, and on Qt 6.4 -- the minimum this
+    // builds against -- the only one, since QEvent::DevicePixelRatioChange
+    // arrived in 6.6. Moving a window to another screen always emits this,
+    // which is the case that matters; it fires for a same-scale move too,
+    // costing one full frame on a rare, user-initiated action -- cheaper than
+    // a frame left at the wrong resolution. The handle exists only once the
+    // window is shown.
     if (auto* const handle = window->windowHandle()) {
         connect(handle, &QWindow::screenChanged, this, endInteraction);
     }

--- a/src/qt/VolumeController.cpp
+++ b/src/qt/VolumeController.cpp
@@ -8,6 +8,7 @@
 #include <QAction>
 #include <QFutureWatcher>
 #include <QTimer>
+#include <QWindow>
 #include <QtConcurrent/QtConcurrent>
 
 #include <algorithm>
@@ -145,6 +146,13 @@ void VolumeController::showWindow(QWidget* parent)
         scheduleRender();
     };
     connect(window, &VolumeWindow::interactionEnded, this, endInteraction);
+    // A scale change is a discrete event, not a drag, so it takes the
+    // immediate full-frame path rather than drafting: there is nothing more
+    // coming that a draft would be a placeholder for. It deliberately does
+    // not go through the viewResized handler, whose first act is to dismiss
+    // an unchanged logical size as layout churn -- which is exactly what a
+    // scale change looks like there.
+    connect(window, &VolumeWindow::viewScaleChanged, this, endInteraction);
     connect(window, &VolumeWindow::qualityChanged, this, endInteraction);
     connect(window, &VolumeWindow::paletteAlphaChanged, this, endInteraction);
     // A close from the title bar: closeWindow drops this connection before
@@ -154,6 +162,16 @@ void VolumeController::showWindow(QWidget* parent)
         [this] { forgetWindow(); });
     pushGeometry();
     window->show();
+    // A second trigger for the same thing. The widget event above is the
+    // mechanism Qt documents for a scale change, but it is delivered by the
+    // platform and cannot be provoked from a test here; this one is certain,
+    // because moving a window to another screen always emits it. It fires for
+    // a same-scale move too, which costs one full frame on a rare,
+    // user-initiated action -- cheaper than a frame left at the wrong
+    // resolution. The handle exists only once the window is shown.
+    if (auto* const handle = window->windowHandle()) {
+        connect(handle, &QWindow::screenChanged, this, endInteraction);
+    }
     window->raise();
     window->activateWindow();
     scheduleRender();

--- a/src/qt/VolumeController.hpp
+++ b/src/qt/VolumeController.hpp
@@ -30,6 +30,30 @@ namespace amrvis::qt {
 
 class VolumeWindow;
 
+// The pixel size to ray-cast the volume at: the view in *device* pixels for a
+// frame that will stay up, half the view's *logical* size for a draft. Both
+// bounded to at least one pixel and at most maxVolumeOutputDimension.
+//
+// Device pixels for the settled frame because a frame rendered at logical size
+// is stretched into a view whose wireframe and slice planes are drawn at the
+// display's real resolution -- a soft picture under sharp lines, and no
+// Quality setting recovers it, because the pixels were never asked for. The
+// slice path has always sized its requests this way
+// (MainWindow::viewportPixelSize); the volume path had not.
+//
+// Drafts deliberately ignore the ratio. They exist to keep a moving camera and
+// a playing sequence responsive, and scaling them would multiply the cost of
+// exactly the frames that get thrown away: a draft is the same size on a
+// hi-DPI display as anywhere else, and only the frame that stays gets the
+// extra pixels. So the step from draft to settled is larger on such a display
+// than on a 1x one -- which is the point, since that is where the settled
+// frame was worst.
+//
+// The ratio is a parameter rather than read from the widget here, which is
+// what lets the rule be tested without a scaled platform.
+[[nodiscard]] std::array<int, 2> volumeOutputSize(
+    QSize viewSize, qreal devicePixelRatio, bool draft) noexcept;
+
 // The volume view's state machine, extracted from MainWindow the way the
 // other collaborators are: it owns the Volume Rendering... action and the
 // Volume window, decides when a render is due -- a camera move, a changed

--- a/src/qt/VolumeWindow.cpp
+++ b/src/qt/VolumeWindow.cpp
@@ -315,6 +315,11 @@ QSize VolumeWindow::viewSize() const
     return m_view->size();
 }
 
+qreal VolumeWindow::viewDevicePixelRatio() const
+{
+    return m_view->devicePixelRatioF();
+}
+
 OpacityRamp VolumeWindow::ramp() const
 {
     // Every field comes from a slider in [0, 100], and buildControls keeps

--- a/src/qt/VolumeWindow.cpp
+++ b/src/qt/VolumeWindow.cpp
@@ -62,6 +62,8 @@ VolumeWindow::VolumeWindow(QWidget* parent)
         [this] { emit interactionEnded(); });
     connect(m_view, &IsoWidget::viewResized, this,
         [this] { emit viewResized(); });
+    connect(m_view, &IsoWidget::viewScaleChanged, this,
+        [this] { emit viewScaleChanged(); });
     buildControls();
 
     // File > Export Image...: the view as drawn (frame and overlays), as PNG.

--- a/src/qt/VolumeWindow.hpp
+++ b/src/qt/VolumeWindow.hpp
@@ -82,6 +82,7 @@ signals:
     void paletteAlphaChanged();
     void qualityChanged();
     void viewResized();
+    void viewScaleChanged();
 
 private:
     void buildControls();

--- a/src/qt/VolumeWindow.hpp
+++ b/src/qt/VolumeWindow.hpp
@@ -63,6 +63,9 @@ public:
 
     [[nodiscard]] const OrthoCamera& camera() const noexcept;
     [[nodiscard]] QSize viewSize() const;
+    // The view's device pixel ratio: what its logical size has to be
+    // multiplied by to cover the pixels the display actually has.
+    [[nodiscard]] qreal viewDevicePixelRatio() const;
     [[nodiscard]] OpacityRamp ramp() const;
     [[nodiscard]] Quality quality() const;
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -626,6 +626,16 @@ if(TARGET amrexplorer_qt)
         COMMAND "${CMAKE_COMMAND}" -E env QT_QPA_PLATFORM=offscreen
             "$<TARGET_FILE:test_volume_controller>")
     set_tests_properties(volume_controller PROPERTIES TIMEOUT 60)
+    # The same tests again on a scaled display. QT_SCALE_FACTOR makes the
+    # offscreen platform report a device pixel ratio of 2 while leaving logical
+    # sizes alone, which is the only way here to tell a request sized in device
+    # pixels from one sized in logical pixels -- the volume render was sized in
+    # logical ones, so every frame on such a display arrived soft.
+    add_test(NAME volume_controller_hidpi
+        COMMAND "${CMAKE_COMMAND}" -E env QT_QPA_PLATFORM=offscreen
+            QT_SCALE_FACTOR=2
+            "$<TARGET_FILE:test_volume_controller>")
+    set_tests_properties(volume_controller_hidpi PROPERTIES TIMEOUT 60)
 
     add_executable(test_diagnostics_model
         unit/test_diagnostics_model.cpp

--- a/tests/unit/test_volume_controller.cpp
+++ b/tests/unit/test_volume_controller.cpp
@@ -20,8 +20,10 @@
 #include <QStringList>
 #include <QTimer>
 
+#include <array>
 #include <atomic>
 #include <chrono>
+#include <cmath>
 #include <cstdlib>
 #include <iostream>
 #include <mutex>
@@ -266,6 +268,54 @@ int main(int argc, char** argv)
     QApplication application(argc, argv);
     using amrvis::qt::VolumeController;
 
+    // --- the size a frame is ray-cast at -------------------------------
+    // A settled frame covers the view's device pixels; a draft is half the
+    // view's logical size whatever the ratio, because it is thrown away.
+    // Tested against ratios no platform here provides -- the whole reason the
+    // ratio is a parameter.
+    {
+        using amrvis::qt::volumeOutputSize;
+        const QSize view(640, 480);
+        require(volumeOutputSize(view, 1.0, false)
+                == std::array<int, 2>{640, 480},
+            "a 1x settled frame is not the view's size");
+        require(volumeOutputSize(view, 2.0, false)
+                == std::array<int, 2>{1280, 960},
+            "a 2x settled frame was not rendered at the display's pixels");
+        require(volumeOutputSize(view, 1.5, false)
+                == std::array<int, 2>{960, 720},
+            "a fractional ratio was not applied");
+        // 1.25 * 641 = 801.25 and 1.25 * 483 = 603.75: rounded, not truncated.
+        require(volumeOutputSize(QSize(641, 483), 1.25, false)
+                == std::array<int, 2>{801, 604},
+            "a fractional ratio was truncated instead of rounded");
+        // Drafts: half the LOGICAL size, and the ratio makes no difference.
+        require(volumeOutputSize(view, 1.0, true)
+                == std::array<int, 2>{320, 240},
+            "a 1x draft is not half the view");
+        require(volumeOutputSize(view, 2.0, true)
+                == std::array<int, 2>{320, 240},
+            "a draft was scaled by the device pixel ratio");
+        require(volumeOutputSize(view, 3.0, true)
+                == std::array<int, 2>{320, 240},
+            "a draft was scaled by the device pixel ratio");
+        // Never zero, whatever it is handed, and never past what the ray
+        // caster accepts -- a 4K view at 3x would ask for 11520.
+        require(volumeOutputSize(QSize(1, 1), 1.0, true)
+                == std::array<int, 2>{1, 1},
+            "halving a one-pixel view produced no pixels");
+        require(volumeOutputSize(QSize(0, 0), 2.0, false)
+                == std::array<int, 2>{1, 1},
+            "an empty view produced no pixels");
+        require(volumeOutputSize(QSize(3840, 2160), 3.0, false)
+                == std::array<int, 2>{amrvis::maxVolumeOutputDimension,
+                    amrvis::maxVolumeOutputDimension},
+            "an oversized request was not bounded to what the caster takes");
+        require(volumeOutputSize(view, 0.0, false)
+                == std::array<int, 2>{1, 1},
+            "a zero ratio was not bounded to a legal size");
+    }
+
     // New geometry drops the frame that belonged to the old geometry: kept, it
     // would be drawn under a wireframe for a domain it was never sampled from,
     // and scaled by a projection that no longer describes it. Checked through
@@ -413,6 +463,7 @@ int main(int argc, char** argv)
         waitFor(application, [&] { return session->requests == before + 1; },
             "the camera move did not render a draft");
         auto latest = session->requestsSoFar().back();
+        const auto drafted = latest;
         require(latest.samplesPerVoxel == 1
                 && latest.outputSize[0] <= requests.front().outputSize[0] / 2 + 1
                 && latest.outputSize[1] <= requests.front().outputSize[1] / 2 + 1,
@@ -424,6 +475,21 @@ int main(int argc, char** argv)
         require(latest.samplesPerVoxel == 2
                 && latest.outputSize == requests.front().outputSize,
             "the settled frame is not full-size");
+        // And that full size is the view in device pixels, not logical ones.
+        // True at any ratio, so it holds in the ordinary run; the
+        // volume_controller_hidpi test runs this whole file at a ratio of 2,
+        // where the two differ. Read here rather than at the opening render
+        // because the view's size is settled by now.
+        const auto ratio = volumeWindow()->viewDevicePixelRatio();
+        const auto logicalView = volumeWindow()->viewSize();
+        require(latest.outputSize[0]
+                    == static_cast<int>(std::lround(logicalView.width() * ratio))
+                && latest.outputSize[1]
+                    == static_cast<int>(std::lround(logicalView.height() * ratio)),
+            "the settled frame was not rendered at the view's device pixels");
+        // The draft above stayed at the logical half size, ratio or not.
+        require(drafted.outputSize[0] == logicalView.width() / 2,
+            "the draft was scaled by the device pixel ratio");
         waitFor(application, [&] { return !controller.renderInFlight(); },
             "the settled render did not finish");
 

--- a/tests/unit/test_volume_controller.cpp
+++ b/tests/unit/test_volume_controller.cpp
@@ -705,13 +705,18 @@ int main(int argc, char** argv)
         require(session->requests == before,
             "a resize to the same size scheduled a render");
 
-        // Moving the window to a display with a different scale. Qt reports it
-        // as DevicePixelRatioChange and nothing else: the logical size does
-        // not change, so no resize follows -- which means the guard just
-        // above, the one that dismisses an unchanged size as layout churn,
-        // would swallow it and leave a frame at the old resolution up. It
-        // takes its own path for that reason, and the check above is what
+        // Moving the window to a display with a different scale. The logical
+        // size does not change, so no resize follows -- which means the guard
+        // just above, the one that dismisses an unchanged size as layout
+        // churn, would swallow it and leave a frame at the old resolution up.
+        // It takes its own path for that reason, and the check above is what
         // makes this one worth having.
+        //
+        // Only the event half can be driven from here, and only on the Qt
+        // versions that have it (6.6+). QWindow::screenChanged, the other
+        // trigger and the only one on Qt 6.4, cannot be emitted from outside
+        // the window it belongs to.
+#if QT_VERSION >= QT_VERSION_CHECK(6, 6, 0)
         auto* const scaled = volumeWindow()->findChild<amrvis::qt::IsoWidget*>();
         require(scaled != nullptr, "no view in the volume window");
         before = session->requests.load();
@@ -723,6 +728,7 @@ int main(int argc, char** argv)
             "the frame after a scale change was a draft, not the full frame");
         waitFor(application, [&] { return !controller.renderInFlight(); },
             "the render after a scale change did not finish");
+#endif
         controller.closeWindow();
     }
 

--- a/tests/unit/test_volume_controller.cpp
+++ b/tests/unit/test_volume_controller.cpp
@@ -16,6 +16,7 @@
 #include <QApplication>
 #include <QColor>
 #include <QAction>
+#include <QEvent>
 #include <QCoreApplication>
 #include <QStringList>
 #include <QTimer>
@@ -703,6 +704,25 @@ int main(int argc, char** argv)
         settle(application, 400);
         require(session->requests == before,
             "a resize to the same size scheduled a render");
+
+        // Moving the window to a display with a different scale. Qt reports it
+        // as DevicePixelRatioChange and nothing else: the logical size does
+        // not change, so no resize follows -- which means the guard just
+        // above, the one that dismisses an unchanged size as layout churn,
+        // would swallow it and leave a frame at the old resolution up. It
+        // takes its own path for that reason, and the check above is what
+        // makes this one worth having.
+        auto* const scaled = volumeWindow()->findChild<amrvis::qt::IsoWidget*>();
+        require(scaled != nullptr, "no view in the volume window");
+        before = session->requests.load();
+        QEvent scaleChange(QEvent::DevicePixelRatioChange);
+        QApplication::sendEvent(scaled, &scaleChange);
+        waitFor(application, [&] { return session->requests == before + 1; },
+            "a change of display scale did not render a new frame");
+        require(session->requestsSoFar().back().samplesPerVoxel == 2,
+            "the frame after a scale change was a draft, not the full frame");
+        waitFor(application, [&] { return !controller.renderInFlight(); },
+            "the render after a scale change did not finish");
         controller.closeWindow();
     }
 
@@ -870,15 +890,24 @@ int main(int argc, char** argv)
             "frames arriving faster than the render throttle rendered nothing");
 
         // At arrivals slower than the throttle, frames do reach the screen.
-        // This is the user-visible half, and it needs a rate at which a render
-        // has room to finish between arrivals.
-        before = session->requests.load();
-        const auto framesBefore = observed.frames;
+        // This is the user-visible half.
+        //
+        // Waited for rather than timed. An earlier version gave each arrival
+        // 150 ms and asserted afterwards, which failed on macOS: how long a
+        // render takes to start and come back is not something this can put a
+        // number on, and a number that holds on one machine is a flake on
+        // another. Waiting for the event says the same thing without the
+        // assumption -- and still fails, on the timeout, if nothing comes.
         for (int arrival = 0; arrival < 3; ++arrival) {
-            arrive(150);
+            const auto renders = session->requests.load();
+            const auto shown = observed.frames;
+            controller.frameSwitchStarted();
+            controller.configureForDataset();
+            waitFor(application, [&] { return session->requests > renders; },
+                "a sequence frame at an ordinary speed did not render");
+            waitFor(application, [&] { return observed.frames > shown; },
+                "a sequence frame at an ordinary speed was never displayed");
         }
-        require(session->requests > before && observed.frames > framesBefore,
-            "playback at an ordinary speed displayed nothing");
         playingSequence = false;
         waitFor(application, [&] { return !controller.renderInFlight(); },
             "the last playback render did not finish");


### PR DESCRIPTION
The request was sized from the view's logical size, so on a scaled display the frame was stretched under a wireframe drawn at full resolution and no Quality setting could recover it -- the slice path has always multiplied by the device ratio. volumeOutputSize does it for the frame that stays and leaves drafts at half the logical size, so interaction costs what it did before. The projection needed nothing: backdropScale divides out both frames' scales, so the domain's pixels land 1:1. A second ctest entry runs the tests under QT_SCALE_FACTOR=2, where sizing from logical pixels fails.