### PR TITLE
let an unconfigured server sample what a client may ask for

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -326,9 +326,9 @@ match. Its own controls set the opacity:
   across the three axes in the domain's own proportions, so a long thin domain
   gets a long thin grid rather than a cube. A field finer than that is sampled
   at the coarser pitch; a level coarser than it is drawn at its own resolution.
-  On a remote plotfile the server sets its own ceiling, so **High** may look no
-  different from **Normal** unless the server allows more (see [Remote
-  datasets](#remote-datasets)).
+  A remote plotfile renders the same as a local one, unless the server was
+  started with a tighter ceiling of its own -- in which case **High** may look
+  no different from **Normal** (see [Remote datasets](#remote-datasets)).
 
 While the camera moves the window shows quick half-resolution drafts and
 renders the full frame once it settles. Rotating and zooming reuse the field
@@ -344,7 +344,10 @@ that speaks protocol 1.2; against an older server the menu item stays
 disabled. The server's `--max-volume-voxels` and `--volume-cache-mib` options
 set how large one volume and one dataset's cache may get. They are per volume
 and per dataset, not a total for the server, so sizing a host means multiplying
-them by how many datasets and connections you allow.
+them by how many datasets and connections you allow. `--max-volume-voxels`
+starts at the largest a client may ask for, so it is there to tighten a server
+rather than to open one up; a request wanting more than it permits is rendered
+at the lower detail rather than refused.
 
 **File > Export Image...** in the volume window saves the view, overlays
 included, as a PNG -- what is on screen when you pick it, including the
@@ -524,9 +527,11 @@ The **View** menu controls these optional panels:
 Window geometry, logarithmic mapping, palette, number format, and animation
 speed persist across sessions.
 
-Each open dataset has a 1 GiB data cache by default. Set
-`AMREXPLORER_CACHE_SIZE_MB` to a positive number of MiB before launching to change
-the initial budget:
+Each open dataset has a 1 GiB data cache by default -- and, while the volume
+window is open, a second cache of the same size for the grids it samples the
+field into, so a dataset being volume-rendered can hold up to twice that. Set
+`AMREXPLORER_CACHE_SIZE_MB` to a positive number of MiB before launching to
+change both:
 
 ```text
 AMREXPLORER_CACHE_SIZE_MB=2048 amrexplorer /path/to/plotfile

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -527,9 +527,11 @@ The **View** menu controls these optional panels:
 Window geometry, logarithmic mapping, palette, number format, and animation
 speed persist across sessions.
 
-Each open dataset has a 1 GiB data cache by default -- and, while the volume
-window is open, a second cache of the same size for the grids it samples the
-field into, so a dataset being volume-rendered can hold up to twice that. Set
+Each open dataset has a 1 GiB data cache by default, and volume rendering fills
+a second cache of the same size with the grids it samples the field into, so a
+dataset you have volume-rendered can hold up to twice that. Closing the volume
+window does not give that memory back -- the grids stay cached for as long as
+the dataset is open, so that reopening the window draws immediately. Set
 `AMREXPLORER_CACHE_SIZE_MB` to a positive number of MiB before launching to
 change both:
 

--- a/docs/volume-rendering-plan.md
+++ b/docs/volume-rendering-plan.md
@@ -83,7 +83,7 @@ Resolved defaults (routine calls, stated so nobody re-asks): alpha byte =
 legacy percent, `opacity = min(1, byte/100)` (Amrvis `Palette.cpp:670`);
 `reversed()` reverses RGB only; voxel budget 256^3 default / 512^3 hard cap;
 grid cache 256 MiB per session, server flags `--max-volume-voxels`,
-`--volume-cache-mb`; point sampling at voxel centres (box averaging later);
+`--volume-cache-mib`; point sampling at voxel centres (box averaging later);
 window mirrors the main window's field/level/range/log/palette (no own range
 controls); drafts at half the logical size, the settled frame at the view's
 device pixels (`volumeOutputSize`).

--- a/include/amrexplorer/remote/Server.hpp
+++ b/include/amrexplorer/remote/Server.hpp
@@ -45,19 +45,21 @@ struct ServerOptions {
     // request in flight, so an operator sizing a host has to do that
     // arithmetic rather than read either number as a ceiling.
     //
-    // maximumVolumeVoxels defaults *below* the protocol's own ceiling: a
-    // request may legally ask for maxVolumeVoxelBudget (512^3), which
-    // validateVolumeRenderRequest accepts, and an unconfigured server clamps
-    // it to defaultVolumeVoxelBudget (256^3) -- each axis halved, with no
-    // error, no warning, and nothing in the response that says so
-    // (validateSessionVolumeResult only checks the grid is not *larger* than
-    // asked, so a downgrade validates cleanly). A remote render of such a
-    // request therefore differs from the local one. Nothing raises the budget
-    // above the default today, which is the only reason this is latent;
-    // defaulting to maxVolumeVoxelBudget, and leaving --max-volume-voxels as
-    // the way to opt into something tighter, would make an unconfigured
-    // server transparent.
-    std::uint64_t maximumVolumeVoxels = defaultVolumeVoxelBudget;
+    // maximumVolumeVoxels defaults to the protocol's own ceiling, so an
+    // unconfigured server samples whatever a request may legally ask for and
+    // a remote render matches the local one. It used to default to
+    // defaultVolumeVoxelBudget (256^3), below the ceiling
+    // validateVolumeRenderRequest accepts, and the volume window's High preset
+    // asks for 384^3: every High render against an unconfigured server came
+    // back as Normal, with no error, no warning, and nothing in the response
+    // that said so (validateSessionVolumeResult only checks the grid is not
+    // *larger* than asked, so a downgrade validates cleanly).
+    //
+    // --max-volume-voxels is now purely the way to opt into something
+    // tighter. That still clamps silently, which is defensible for a limit an
+    // operator chose -- and the frame does carry the grid it used, which the
+    // window puts in its status line -- but nothing says the cap is why.
+    std::uint64_t maximumVolumeVoxels = maxVolumeVoxelBudget;
     std::uint64_t volumeGridCacheBytes = defaultVolumeGridCacheBytes;
     std::string softwareVersion = "unknown";
     // Per-session access token. Clients must present a byte-identical token in

--- a/tests/integration/test_remote_volume.cpp
+++ b/tests/integration/test_remote_volume.cpp
@@ -196,7 +196,22 @@ int main(int argc, char* argv[])
             smallSession->close();
         }
 
+        // --- an unconfigured server does not cap below the protocol -----
+        // It used to default to 256^3 while a request may legally ask for
+        // 512^3 and the volume window's High preset asks for 384^3, so every
+        // High render against a default server came back at Normal's detail
+        // with nothing saying so. Asserted on the option rather than on a
+        // rendered grid because the fixtures here are far smaller than any of
+        // these budgets: their grids are bounded by the data, so no frame from
+        // them can tell the two defaults apart.
+        require(ServerOptions{}.maximumVolumeVoxels
+                == amrvis::maxVolumeVoxelBudget,
+            "an unconfigured server caps the sampled grid below the ceiling "
+            "a request may ask for");
+
         // --- the server's voxel cap clamps the request ------------------
+        // And the contrast: a cap the operator chose still clamps, which is
+        // what --max-volume-voxels is now solely for.
         {
             ServerOptions capped;
             capped.workerCount = 1;

--- a/tools/amrexplorer_server/main.cpp
+++ b/tools/amrexplorer_server/main.cpp
@@ -46,8 +46,9 @@ void printUsage(std::ostream& output)
         << "  --max-datasets COUNT maximum open datasets per connection\n"
         << "  --max-volume-voxels N\n"
         << "                       maximum voxels sampled per volume render;\n"
-        << "                       default 256^3, ceiling 512^3. A request\n"
-        << "                       asking for more is clamped, not refused\n"
+        << "                       defaults to the 512^3 ceiling, so this is\n"
+        << "                       only for tightening. A request asking for\n"
+        << "                       more is clamped, not refused\n"
         << "  --volume-cache-mib MIB\n"
         << "                       per-dataset cache of sampled volume grids\n"
         << "  --write-stall-timeout-seconds SECONDS\n"
@@ -187,6 +188,8 @@ int main(int argc, char* argv[])
 {
     try {
         amrvis::remote::ServerOptions options;
+        // Whether either volume limit was given, for the warning below.
+        bool volumeLimitsChosen = false;
         options.softwareVersion = AMREXPLORER_VERSION;
         bool stdio = false;
         bool portGiven = false;
@@ -241,6 +244,7 @@ int main(int argc, char* argv[])
                         "--max-volume-voxels is outside its allowed range");
                 }
                 options.maximumVolumeVoxels = voxels;
+                volumeLimitsChosen = true;
             } else if (option == "--volume-cache-mib") {
                 const auto mebibytes
                     = parseUnsigned<std::uint32_t>(value, "--volume-cache-mib");
@@ -256,6 +260,7 @@ int main(int argc, char* argv[])
                 }
                 options.volumeGridCacheBytes
                     = static_cast<std::uint64_t>(mebibytes) * oneMebibyte;
+                volumeLimitsChosen = true;
             } else if (option == "--write-stall-timeout-seconds") {
                 const auto seconds = parseUnsigned<std::uint32_t>(
                     value, "--write-stall-timeout-seconds");
@@ -298,7 +303,16 @@ int main(int argc, char* argv[])
         // frame says which of the two happened. Warned about once here, where
         // the flags that caused it are still in view, rather than refused in
         // the server, which would take the deliberate case with it.
-        if (options.maximumVolumeVoxels * 4ULL > options.volumeGridCacheBytes) {
+        //
+        // Only when one of the two flags was actually given. The voxel cap now
+        // defaults to the 512^3 ceiling, which is 512 MiB of floats and more
+        // than the default grid cache holds, so the condition is true of every
+        // unconfigured server -- and a warning printed on every start is one
+        // nobody reads. What it is for is a configuration the operator chose;
+        // nothing the GUI asks for reaches 512^3 anyway, its High preset being
+        // 384^3, which the default cache does hold.
+        if (volumeLimitsChosen
+            && options.maximumVolumeVoxels * 4ULL > options.volumeGridCacheBytes) {
             std::cerr << "warning: --volume-cache-mib cannot hold one grid of "
                          "--max-volume-voxels voxels, so a request asking for "
                          "that many will render uncached every time; smaller "


### PR DESCRIPTION
The voxel cap defaulted to 256^3 while the volume window's High preset asks for 384^3, so every High render against a default server came back at Normal's detail with nothing saying so. It now defaults to the ceiling a request may legally reach, leaving --max-volume-voxels as the way to tighten a server. The CLI's "cache cannot hold one grid" warning would otherwise fire on every default start, so it now fires only for a limit the operator actually gave. The guide's cache figure also said 1 GiB per dataset without mentioning the second pool of the same size that volume rendering adds.