### PR TITLE
render only the region the slice views show

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -320,6 +320,13 @@ match. Its own controls set the opacity:
   own alpha ramp instead of the linear window. Legacy Amrvis `.pal` files
   carry such a ramp (the shipped palettes have a plain 0-100 % ramp), and
   the window still applies the *from* / *to* limits and the maximum to it.
+- **Only the visible region** samples just the part of the domain the slice
+  views are zoomed into, instead of all of it. The budget below is then spent
+  on that part alone, so a region small enough to fit is drawn at the finest
+  level's own resolution rather than a coarsened one -- which is the way to
+  see fine detail in a field too large to sample whole. Each slice view
+  narrows the two axes it shows, and the volume follows them as you zoom. Off
+  by default; with nothing zoomed it makes no difference.
 - **Quality** trades speed for detail: it sets how many samples are taken per
   cell along each ray and how many cells the field is sampled into altogether
   -- about 2 million on Draft, 17 million on Normal, 57 million on High, spread

--- a/src/qt/ImageView.cpp
+++ b/src/qt/ImageView.cpp
@@ -819,6 +819,9 @@ void ImageView::resizeEvent(QResizeEvent* event)
         fitImage();
     }
     emit viewportResized(viewport()->size());
+    // A resize changes how much of the raster is on screen even when nothing
+    // moved, and in Fit mode fitImage above has just changed the transform.
+    emit viewportMoved();
 }
 
 void ImageView::scrollContentsBy(int dx, int dy)
@@ -827,6 +830,10 @@ void ImageView::scrollContentsBy(int dx, int dy)
     if (m_placement.has_value()) {
         emit canvasScrolled();
     }
+    // Unconditionally, unlike canvasScrolled: a local view scrolls its own
+    // raster under the viewport with no placement set, which moves what is
+    // visible just as much.
+    emit viewportMoved();
 }
 
 void ImageView::keyPressEvent(QKeyEvent* event)

--- a/src/qt/ImageView.hpp
+++ b/src/qt/ImageView.hpp
@@ -211,6 +211,12 @@ signals:
     // The viewport scrolled over a virtual canvas — the owner should check
     // whether newly visible cells need fetching.
     void canvasScrolled();
+    // What visibleImageRect() returns may have moved: the viewport scrolled or
+    // was resized. Separate from canvasScrolled, which is specific to a
+    // virtual canvas and fires only over one, and from zoomChanged, which
+    // covers a wheel zoom. Between the three, every way the visible part of
+    // the raster can change without the raster itself changing is reported.
+    void viewportMoved();
     void panDragBegan();
     // Total scene-coordinate offset since the drag began, plus the latest
     // viewport-pixel step (for view-only panning).

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -496,15 +496,39 @@ MainWindow::MainWindow(QWidget* parent)
             [this] { return m_slicePlanesAction->isChecked(); },
             [this] { return m_closing; },
             [this] {
-                // The three plane views' zooms as one box. Each view narrows
-                // only the axes it shows, so this is where they are combined
-                // rather than in the controller, which has no view to ask.
+                // What the three plane views actually show, as one box. Each
+                // narrows only the axes it displays, so this is where they are
+                // combined rather than in the controller, which has no view to
+                // ask.
+                //
+                // Derived from the raster the view holds and the part of it on
+                // screen, NOT from state.visibleRegion: that field records the
+                // region a slice was last *fetched* for, and a mouse-wheel
+                // zoom or a scroll moves what you can see without re-fetching
+                // anything. Reading it meant the box stayed at the whole
+                // domain after the most ordinary way of zooming in, so the
+                // check box appeared to do nothing.
                 const auto domain = m_dataset
                     ? datasetSampleBounds(m_dataset->metadata())
                     : RealBox{};
                 std::array<std::optional<RealBox>, 3> regions{};
-                for (std::size_t view = 0; view < m_planeViews.size(); ++view) {
-                    regions[view] = m_planeViews[view].visibleRegion;
+                for (std::size_t index = 0; index < m_planeViews.size();
+                    ++index) {
+                    const auto& state = m_planeViews[index];
+                    if (state.view == nullptr || !state.view->hasImage()
+                        || state.plane->width <= 0
+                        || state.plane->height <= 0) {
+                        continue;
+                    }
+                    const auto visible = state.view->visibleImageRect();
+                    if (visible.isEmpty()) {
+                        continue;
+                    }
+                    regions[index] = physicalRegionForRasterRect(
+                        state.plane->physicalRegion,
+                        static_cast<double>(state.plane->width),
+                        static_cast<double>(state.plane->height), visible,
+                        displayAxes(state.normal));
                 }
                 return volumeVisibleRegion(domain, regions);
             },
@@ -714,7 +738,12 @@ void MainWindow::wireView(PlaneViewState& state)
     // every view to find. Guarding on the active view suppressed the Mixed the
     // signal was added to surface.
     connect(view, &ImageView::zoomChanged, this,
-        [this] { refreshScaleReport(); });
+        [this] {
+            refreshScaleReport();
+            // A wheel zoom re-requests nothing, so the slice funnel never sees
+            // it; the volume's region of interest still has to follow.
+            m_volumeController->regionChanged();
+        });
     connect(view, &ImageView::fitRequested, this,
         [this, &state] {
             resetViewZoom(state);
@@ -739,7 +768,12 @@ void MainWindow::wireView(PlaneViewState& state)
             }
         });
     connect(view, &ImageView::canvasScrolled, this,
-        [this, &state] { updateRemoteFixedScaleDemand(state); });
+        [this, &state] {
+            updateRemoteFixedScaleDemand(state);
+            // Scrolling a fixed-scale view moves what is on screen without
+            // changing the raster, so this is the only notice of it.
+            m_volumeController->regionChanged();
+        });
     connect(view, &ImageView::panStepRequested, this,
         [this, &state](const QPointF& direction) {
             ++m_panStepRequests;

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -495,6 +495,19 @@ MainWindow::MainWindow(QWidget* parent)
             [this] { return m_slicePosition3d; },
             [this] { return m_slicePlanesAction->isChecked(); },
             [this] { return m_closing; },
+            [this] {
+                // The three plane views' zooms as one box. Each view narrows
+                // only the axes it shows, so this is where they are combined
+                // rather than in the controller, which has no view to ask.
+                const auto domain = m_dataset
+                    ? datasetSampleBounds(m_dataset->metadata())
+                    : RealBox{};
+                std::array<std::optional<RealBox>, 3> regions{};
+                for (std::size_t view = 0; view < m_planeViews.size(); ++view) {
+                    regions[view] = m_planeViews[view].visibleRegion;
+                }
+                return volumeVisibleRegion(domain, regions);
+            },
             [this] { return m_playbackMode == PlaybackMode::Sequence; },
         },
         this);

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -768,12 +768,12 @@ void MainWindow::wireView(PlaneViewState& state)
             }
         });
     connect(view, &ImageView::canvasScrolled, this,
-        [this, &state] {
-            updateRemoteFixedScaleDemand(state);
-            // Scrolling a fixed-scale view moves what is on screen without
-            // changing the raster, so this is the only notice of it.
-            m_volumeController->regionChanged();
-        });
+        [this, &state] { updateRemoteFixedScaleDemand(state); });
+    // Scrolling or resizing moves what is on screen without changing the
+    // raster. canvasScrolled cannot carry this: it fires only over a virtual
+    // canvas, so a local fixed-scale scroll emitted nothing at all.
+    connect(view, &ImageView::viewportMoved, this,
+        [this] { m_volumeController->regionChanged(); });
     connect(view, &ImageView::panStepRequested, this,
         [this, &state](const QPointF& direction) {
             ++m_panStepRequests;

--- a/src/qt/MainWindowInteraction.cpp
+++ b/src/qt/MainWindowInteraction.cpp
@@ -887,13 +887,11 @@ void MainWindow::applyRubberBandZoom(
     const auto& region = plane.physicalRegion;
     const auto xExtent = region.upper[xAxis] - region.lower[xAxis];
     const auto yExtent = region.upper[yAxis] - region.lower[yAxis];
-    auto visible = region;
-    visible.lower[xAxis] = region.lower[xAxis] + clamped.left() / width * xExtent;
-    visible.upper[xAxis] = region.lower[xAxis] + clamped.right() / width * xExtent;
-    visible.lower[yAxis] = region.lower[yAxis]
-        + (height - clamped.bottom()) / height * yExtent;
-    visible.upper[yAxis] = region.lower[yAxis]
-        + (height - clamped.top()) / height * yExtent;
+    // Shared with the volume's region of interest, which maps the same way
+    // from the part of the raster on screen. The reverse mapping below, back
+    // to scene pixels, is this function's own.
+    auto visible = physicalRegionForRasterRect(
+        region, width, height, clamped, axes);
     // Local slices use one output pixel per finest cell, so their edges land
     // on cell boundaries. Remote slices are viewport-resampled; retaining the
     // exact selection keeps an arbitrary rubber-band aspect ratio intact.

--- a/src/qt/MainWindowSlice.cpp
+++ b/src/qt/MainWindowSlice.cpp
@@ -961,6 +961,12 @@ void MainWindow::showSlice(PlaneViewState& state, SliceDisplayResult display)
     m_diagnosticsModel->setSliceMetrics(display.slice.metrics.blocksRead,
         display.slice.metrics.cacheHits, display.slice.metrics.payloadBytesRead);
     statusBar()->clearMessage();
+
+    // The region a limited volume render covers is read off this raster, so it
+    // is only now that a pan or a rubber-band zoom can be measured: the
+    // scheduling call that fetched this plane ran while the previous one was
+    // still displayed, and would have measured that.
+    m_volumeController->regionChanged();
 }
 
 int MainWindow::slicesInFlight() const

--- a/src/qt/MainWindowSlice.cpp
+++ b/src/qt/MainWindowSlice.cpp
@@ -188,6 +188,10 @@ void MainWindow::scheduleSliceRequest(bool rasterDirty)
         m_pendingRasterDirty = m_pendingRasterDirty || rasterDirty;
         m_pendingAllViews = true;
         m_sliceDebounce->start();
+        // A zoom or pan lands here, and with the volume window limited to what
+        // the views show it has to follow. Only a region that actually moved
+        // renders; most calls through here have not moved it.
+        m_volumeController->regionChanged();
     }
 }
 
@@ -208,6 +212,7 @@ void MainWindow::scheduleSliceRequest(PlaneViewState& state, bool rasterDirty)
             m_pendingViews.push_back(&state);
         }
         m_sliceDebounce->start();
+        m_volumeController->regionChanged();
     }
 }
 

--- a/src/qt/PlaneMapping.hpp
+++ b/src/qt/PlaneMapping.hpp
@@ -4,10 +4,44 @@
 #include <amrexplorer/core/Geometry.hpp>
 
 #include <QPointF>
+#include <QRectF>
 
 #include <array>
 
 namespace amrvis::qt {
+
+// The physical box that a rectangle of raster pixels covers, given the box the
+// whole raster covers. Only the two axes the view displays are narrowed;
+// `rasterRegion`'s third stays as it is, which for a slice is the thickness the
+// plane was requested with.
+//
+// Raster rows count down while physical coordinates count up, so the vertical
+// edges swap: the rect's *bottom* gives the lower physical bound. Getting that
+// backwards mirrors the region about the plane's middle, which looks entirely
+// plausible on a symmetric domain -- which is why this is one definition used
+// by both callers rather than the formula written out twice.
+[[nodiscard]] inline RealBox physicalRegionForRasterRect(
+    const RealBox& rasterRegion, double rasterWidth, double rasterHeight,
+    const QRectF& rasterRect, const std::array<int, 2>& axes) noexcept
+{
+    auto region = rasterRegion;
+    if (!(rasterWidth > 0.0) || !(rasterHeight > 0.0)) {
+        return region;
+    }
+    const auto xAxis = static_cast<std::size_t>(axes[0]);
+    const auto yAxis = static_cast<std::size_t>(axes[1]);
+    const auto xExtent = rasterRegion.upper[xAxis] - rasterRegion.lower[xAxis];
+    const auto yExtent = rasterRegion.upper[yAxis] - rasterRegion.lower[yAxis];
+    region.lower[xAxis]
+        = rasterRegion.lower[xAxis] + rasterRect.left() / rasterWidth * xExtent;
+    region.upper[xAxis]
+        = rasterRegion.lower[xAxis] + rasterRect.right() / rasterWidth * xExtent;
+    region.lower[yAxis] = rasterRegion.lower[yAxis]
+        + (rasterHeight - rasterRect.bottom()) / rasterHeight * yExtent;
+    region.upper[yAxis] = rasterRegion.lower[yAxis]
+        + (rasterHeight - rasterRect.top()) / rasterHeight * yExtent;
+    return region;
+}
 
 // Converts between a view's logical in-plane physical coordinates (dataset
 // axes 0 and 1 -- (x, y) for Cartesian, (r, theta) for 2-D spherical) and

--- a/src/qt/VolumeController.cpp
+++ b/src/qt/VolumeController.cpp
@@ -37,6 +37,30 @@ std::array<int, 2> volumeOutputSize(
         bound(viewSize.height() * devicePixelRatio)};
 }
 
+RealBox volumeVisibleRegion(const RealBox& domain,
+    const std::array<std::optional<RealBox>, 3>& viewRegions) noexcept
+{
+    auto region = domain;
+    for (const auto& view : viewRegions) {
+        const auto& visible = view ? *view : domain;
+        for (std::size_t axis = 0; axis < 3; ++axis) {
+            region.lower[axis]
+                = std::max(region.lower[axis], visible.lower[axis]);
+            region.upper[axis]
+                = std::min(region.upper[axis], visible.upper[axis]);
+        }
+    }
+    // See the declaration: an axis the views do not share goes back to the
+    // domain. Written as `!(upper > lower)` so a NaN edge takes this path too.
+    for (std::size_t axis = 0; axis < 3; ++axis) {
+        if (!(region.upper[axis] > region.lower[axis])) {
+            region.lower[axis] = domain.lower[axis];
+            region.upper[axis] = domain.upper[axis];
+        }
+    }
+    return region;
+}
+
 VolumeController::VolumeController(Hooks hooks, QObject* parent)
     : QObject(parent)
     , m_hooks(std::move(hooks))
@@ -155,6 +179,9 @@ void VolumeController::showWindow(QWidget* parent)
     // scale change looks like there.
     connect(window, &VolumeWindow::viewScaleChanged, this, endInteraction);
     connect(window, &VolumeWindow::qualityChanged, this, endInteraction);
+    // Toggling the region limit moves the box in one step, in both
+    // directions, so it renders at once rather than drafting.
+    connect(window, &VolumeWindow::regionLimitChanged, this, endInteraction);
     connect(window, &VolumeWindow::paletteAlphaChanged, this, endInteraction);
     // A close from the title bar: closeWindow drops this connection before
     // closing, so reaching here means the user closed the window and nothing
@@ -199,6 +226,7 @@ void VolumeController::forgetWindow()
     cancel();
     m_frameShown = false;
     m_lastRenderViewSize = QSize{};
+    m_lastRenderRegion = RealBox{};
     // The frame belonged to the window that is going away: keeping it holds a
     // whole pixel buffer for the life of the process and leaves lastFrame()
     // describing a window that no longer exists.
@@ -296,6 +324,28 @@ void VolumeController::frameSwitchStarted()
     } else {
         cancel();
     }
+}
+
+void VolumeController::regionChanged()
+{
+    // Nothing to do unless the window is asking to be limited: with the toggle
+    // off the region is the domain whatever the views do, and this is called
+    // for every scheduled slice request -- a zoom, a pan, a slice move, a
+    // field change all arrive here.
+    if (!m_window || !m_window->limitToVisibleRegion()) {
+        return;
+    }
+    const auto dataset = m_hooks.dataset ? m_hooks.dataset() : nullptr;
+    if (!dataset) {
+        return;
+    }
+    const auto region = m_hooks.visibleRegion
+        ? m_hooks.visibleRegion()
+        : datasetSampleBounds(dataset->metadata());
+    if (region == m_lastRenderRegion) {
+        return;
+    }
+    scheduleRender();
 }
 
 void VolumeController::refresh()
@@ -396,7 +446,12 @@ void VolumeController::startRender()
     request.field = field->first;
     request.maximumLevel = std::clamp(level.maximumLevel, 0, metadata.finestLevel);
     request.composition = level.composition;
-    request.region = datasetSampleBounds(metadata);
+    // The whole domain, or what the slice views show when the window asks to
+    // be limited to it. Remembered so regionChanged can spot the next move.
+    request.region = m_window->limitToVisibleRegion() && m_hooks.visibleRegion
+        ? m_hooks.visibleRegion()
+        : datasetSampleBounds(metadata);
+    m_lastRenderRegion = request.region;
     request.camera = m_window->camera();
     // Mid-interaction (a moving camera, a resize, a dragged slider) gets a
     // half-size, single-sample draft; a settled view the full frame at the

--- a/src/qt/VolumeController.hpp
+++ b/src/qt/VolumeController.hpp
@@ -54,6 +54,27 @@ class VolumeWindow;
 [[nodiscard]] std::array<int, 2> volumeOutputSize(
     QSize viewSize, qreal devicePixelRatio, bool draft) noexcept;
 
+// The box to sample when the volume is limited to what the slice views show:
+// `domain` narrowed by each view's visible region.
+//
+// A plane view narrows only the two axes it displays and leaves the third at
+// the domain, so intersecting all three gives, per axis, the narrower of the
+// two views that show it. With nothing zoomed every region is the domain and
+// the answer is the domain, which is what an unlimited render asks for anyway.
+//
+// Two views can disagree past overlapping: zoom the YZ view into the bottom of
+// z and the XZ view into the top and no z is visible in both. Such an axis
+// falls back to the whole domain rather than collapsing the box -- there is no
+// z both views show, so narrowing it would be a guess, and an empty box is not
+// renderable at all.
+//
+// Worth the narrowing because the grid is sized from the region: volumeGridDims
+// counts the region's own cells and only downsamples if they exceed the voxel
+// budget, so a small enough region is sampled at the finest level's pitch
+// instead of a coarsened one.
+[[nodiscard]] RealBox volumeVisibleRegion(const RealBox& domain,
+    const std::array<std::optional<RealBox>, 3>& viewRegions) noexcept;
+
 // The volume view's state machine, extracted from MainWindow the way the
 // other collaborators are: it owns the Volume Rendering... action and the
 // Volume window, decides when a render is due -- a camera move, a changed
@@ -87,6 +108,9 @@ public:
         // True once application shutdown began: late results are dropped
         // without touching the GUI.
         std::function<bool()> isShuttingDown;
+        // What the slice views currently show, as one box: the region a
+        // render is limited to while the window's own toggle asks for it.
+        std::function<RealBox()> visibleRegion;
         // True while plotfile-sequence playback is running. Frames arrive
         // faster than a full ray cast finishes, so they are drafted like a
         // moving camera and the frame already up is left in place until the
@@ -123,6 +147,10 @@ public:
     // renders at all. A single step is not on a clock and takes the cancel()
     // form, which leaves nothing pending against the frame being replaced.
     void frameSwitchStarted();
+    // Something that can move the visible region happened. Cheap and frequent
+    // -- every scheduled slice request calls it -- so it renders only when the
+    // region a frame would use differs from the one on screen.
+    void regionChanged();
     void refresh();
     void slicePositionsChanged();
     void slicePlanesVisibilityChanged();
@@ -172,6 +200,9 @@ private:
     // is layout churn, not a resize, and rendering for it would be a loop fed
     // by its own output (showFrame writes a label in the same dock).
     QSize m_lastRenderViewSize;
+    // The region the frame on screen was sampled from, so regionChanged can
+    // tell a real move from the many calls that are not one.
+    RealBox m_lastRenderRegion{};
     StopSource m_stopSource;
     std::uint64_t m_generation = 0;
     bool m_inFlight = false;

--- a/src/qt/VolumeWindow.cpp
+++ b/src/qt/VolumeWindow.cpp
@@ -181,6 +181,17 @@ void VolumeWindow::buildControls()
     m_qualityCombo->addItem(tr("High"), 2);
     m_qualityCombo->setCurrentIndex(1);
     form->addRow(tr("Quality:"), m_qualityCombo);
+    // Off by default: limiting the region is a deliberate act, and a volume
+    // that cropped itself because a slice view happened to be zoomed would be
+    // a surprise on opening the window.
+    m_regionCheck = new QCheckBox(tr("Only the visible region"), panel);
+    // Named so a test can reach this one rather than whichever check box
+    // findChild happens to return first.
+    m_regionCheck->setObjectName(QStringLiteral("volumeRegionLimitCheck"));
+    m_regionCheck->setToolTip(
+        tr("Sample only the part of the domain the slice views are zoomed to, "
+           "which spends the voxel budget on it instead of the whole field"));
+    form->addRow(QString(), m_regionCheck);
     m_boxesCheck = new QCheckBox(tr("Grid boxes"), panel);
     m_boxesCheck->setChecked(true);
     m_outlineCheck = new QCheckBox(tr("Domain outline"), panel);
@@ -230,6 +241,8 @@ void VolumeWindow::buildControls()
         [this] { emit paletteAlphaChanged(); });
     connect(m_qualityCombo, qOverload<int>(&QComboBox::currentIndexChanged), this,
         [this](int) { emit qualityChanged(); });
+    connect(m_regionCheck, &QCheckBox::toggled, this,
+        [this] { emit regionLimitChanged(); });
     connect(m_boxesCheck, &QCheckBox::toggled, this,
         [this](bool checked) { m_view->setLevelBoxesVisible(checked); });
     connect(m_outlineCheck, &QCheckBox::toggled, this,
@@ -315,6 +328,11 @@ const OrthoCamera& VolumeWindow::camera() const noexcept
 QSize VolumeWindow::viewSize() const
 {
     return m_view->size();
+}
+
+bool VolumeWindow::limitToVisibleRegion() const
+{
+    return m_regionCheck->isChecked();
 }
 
 qreal VolumeWindow::viewDevicePixelRatio() const

--- a/src/qt/VolumeWindow.hpp
+++ b/src/qt/VolumeWindow.hpp
@@ -67,6 +67,8 @@ public:
     // multiplied by to cover the pixels the display actually has.
     [[nodiscard]] qreal viewDevicePixelRatio() const;
     [[nodiscard]] OpacityRamp ramp() const;
+    // Whether the render should cover only what the slice views show.
+    [[nodiscard]] bool limitToVisibleRegion() const;
     [[nodiscard]] Quality quality() const;
 
 signals:
@@ -81,6 +83,7 @@ signals:
     void rampChanged();
     void paletteAlphaChanged();
     void qualityChanged();
+    void regionLimitChanged();
     void viewResized();
     void viewScaleChanged();
 
@@ -94,6 +97,7 @@ private:
     QSlider* m_maximumSlider = nullptr;
     QCheckBox* m_paletteAlpha = nullptr;
     QComboBox* m_qualityCombo = nullptr;
+    QCheckBox* m_regionCheck = nullptr;
     QCheckBox* m_boxesCheck = nullptr;
     QCheckBox* m_outlineCheck = nullptr;
     QLabel* m_lowLabel = nullptr;

--- a/tests/unit/test_image_view_pan.cpp
+++ b/tests/unit/test_image_view_pan.cpp
@@ -37,6 +37,65 @@ QImage solidImage(int width, int height)
 void scrollBarPanFollowsContentDelta()
 {
     amrvis::qt::ImageView view;
+    // A local view reports its own scrolling and resizing. canvasScrolled does
+    // not: it fires only over a virtual canvas, so the volume window's region
+    // of interest -- which is read off visibleImageRect() -- was wired to a
+    // signal that never came for a local fixed-scale view, and stopped
+    // following the viewport the moment you touched a scroll bar.
+    {
+        amrvis::qt::ImageView local;
+        local.resize(200, 150);
+        local.show();
+        QApplication::processEvents();
+        local.setImage(solidImage(800, 600));
+        local.setFixedScale(2);
+        QApplication::processEvents();
+        int moved = 0;
+        int scrolled = 0;
+        QObject::connect(&local, &amrvis::qt::ImageView::viewportMoved,
+            &local, [&moved] { ++moved; });
+        QObject::connect(&local, &amrvis::qt::ImageView::canvasScrolled,
+            &local, [&scrolled] { ++scrolled; });
+        auto* bar = local.horizontalScrollBar();
+        require(bar->maximum() > 0,
+            "the fixed-scale view did not scroll, so this proves nothing");
+        bar->setValue(bar->maximum() / 2);
+        QApplication::processEvents();
+        require(moved > 0, "a local scroll reported no viewport movement");
+        require(scrolled == 0,
+            "canvasScrolled fired without a virtual canvas, so it is not the "
+            "signal this test says it is");
+    }
+
+    // And a resize on its own, in the arrangement that needs it: a scrolled
+    // view sitting at offset zero, grown so that more of the raster shows
+    // without either bar moving. Fit mode cannot exercise this -- it always
+    // shows the whole raster, so its region does not change with the window --
+    // and a view scrolled away from zero reports the resize through its bars
+    // instead, proving nothing about the resize itself.
+    {
+        amrvis::qt::ImageView grown;
+        grown.resize(200, 150);
+        grown.show();
+        QApplication::processEvents();
+        grown.setImage(solidImage(800, 600));
+        grown.setFixedScale(2);
+        QApplication::processEvents();
+        require(grown.horizontalScrollBar()->value() == 0
+                && grown.verticalScrollBar()->value() == 0,
+            "the view is not at offset zero, so growing it would move a bar");
+        const auto before = grown.visibleImageRect();
+        int moved = 0;
+        QObject::connect(&grown, &amrvis::qt::ImageView::viewportMoved,
+            &grown, [&moved] { ++moved; });
+        grown.resize(360, 280);
+        QApplication::processEvents();
+        require(grown.visibleImageRect() != before,
+            "growing the view did not change what is visible, so there is "
+            "nothing here to report");
+        require(moved > 0, "a viewport resize reported no viewport movement");
+    }
+
     view.resize(200, 150);
     view.show();
     QApplication::processEvents();

--- a/tests/unit/test_image_view_pan.cpp
+++ b/tests/unit/test_image_view_pan.cpp
@@ -81,9 +81,16 @@ void scrollBarPanFollowsContentDelta()
         grown.setImage(solidImage(800, 600));
         grown.setFixedScale(2);
         QApplication::processEvents();
-        require(grown.horizontalScrollBar()->value() == 0
-                && grown.verticalScrollBar()->value() == 0,
-            "the view is not at offset zero, so growing it would move a bar");
+        // Put the bars at their minima rather than asserting they are there:
+        // where setFixedScale leaves them is the platform's business, and on
+        // macOS it is not zero, which failed this before it reached the resize
+        // it exists to check. At the minimum, growing the view cannot move a
+        // bar -- a clamp can only hold it where it is.
+        grown.horizontalScrollBar()->setValue(
+            grown.horizontalScrollBar()->minimum());
+        grown.verticalScrollBar()->setValue(
+            grown.verticalScrollBar()->minimum());
+        QApplication::processEvents();
         const auto before = grown.visibleImageRect();
         int moved = 0;
         QObject::connect(&grown, &amrvis::qt::ImageView::viewportMoved,

--- a/tests/unit/test_volume_controller.cpp
+++ b/tests/unit/test_volume_controller.cpp
@@ -6,6 +6,7 @@
 // the window and drops a late result; a throwing session reports through
 // renderFailed and a cancelled one silently.
 
+#include "PlaneMapping.hpp"
 #include "VolumeController.hpp"
 #include "VolumeWindow.hpp"
 #include "IsoWidget.hpp"
@@ -16,6 +17,7 @@
 #include <QApplication>
 #include <QColor>
 #include <QAction>
+#include <QRectF>
 #include <QCheckBox>
 #include <QEvent>
 #include <QCoreApplication>
@@ -316,6 +318,52 @@ int main(int argc, char** argv)
         require(volumeOutputSize(view, 0.0, false)
                 == std::array<int, 2>{1, 1},
             "a zero ratio was not bounded to a legal size");
+    }
+
+    // --- raster pixels to a physical box --------------------------------
+    // The mapping the region of interest reads the viewport through, and the
+    // one a rubber-band zoom fetches through. Its trap is the vertical flip:
+    // raster rows count down, physical coordinates count up.
+    {
+        using amrvis::qt::physicalRegionForRasterRect;
+        const amrvis::RealBox raster{amrvis::Real3{{0.0, 0.0, 100.0}},
+            amrvis::Real3{{10.0, 20.0, 130.0}}};
+        const std::array<int, 2> axes{0, 1};   // an XY view: x across, y up
+        const auto whole = physicalRegionForRasterRect(
+            raster, 40.0, 30.0, QRectF(0.0, 0.0, 40.0, 30.0), axes);
+        require(whole == raster,
+            "the whole raster did not map back to the whole region");
+
+        // The left half of the raster is the low half of x.
+        const auto left = physicalRegionForRasterRect(
+            raster, 40.0, 30.0, QRectF(0.0, 0.0, 20.0, 30.0), axes);
+        require(left.lower[0] == 0.0 && left.upper[0] == 5.0,
+            "the left half of the raster is not the low half of x");
+        require(left.lower[1] == 0.0 && left.upper[1] == 20.0,
+            "narrowing x moved y as well");
+
+        // The TOP rows of the raster are the HIGH half of y. Getting this
+        // backwards mirrors the region about the middle of the plane, which
+        // on a symmetric domain looks entirely reasonable.
+        const auto top = physicalRegionForRasterRect(
+            raster, 40.0, 30.0, QRectF(0.0, 0.0, 40.0, 15.0), axes);
+        require(top.lower[1] == 10.0 && top.upper[1] == 20.0,
+            "the top of the raster did not map to the high half of y");
+        const auto bottom = physicalRegionForRasterRect(
+            raster, 40.0, 30.0, QRectF(0.0, 15.0, 40.0, 15.0), axes);
+        require(bottom.lower[1] == 0.0 && bottom.upper[1] == 10.0,
+            "the bottom of the raster did not map to the low half of y");
+
+        // The axis the view does not show keeps the plane's own extent, which
+        // is what stops three intersected views from collapsing every axis.
+        require(top.lower[2] == 100.0 && top.upper[2] == 130.0,
+            "the axis the view does not display was narrowed");
+
+        // A raster with no pixels has no mapping to make; the region stands.
+        require(physicalRegionForRasterRect(
+                    raster, 0.0, 30.0, QRectF(0.0, 0.0, 1.0, 1.0), axes)
+                == raster,
+            "an empty raster did not leave the region alone");
     }
 
     // --- the region the views leave visible ------------------------------

--- a/tests/unit/test_volume_controller.cpp
+++ b/tests/unit/test_volume_controller.cpp
@@ -16,6 +16,7 @@
 #include <QApplication>
 #include <QColor>
 #include <QAction>
+#include <QCheckBox>
 #include <QEvent>
 #include <QCoreApplication>
 #include <QStringList>
@@ -317,6 +318,75 @@ int main(int argc, char** argv)
             "a zero ratio was not bounded to a legal size");
     }
 
+    // --- the region the views leave visible ------------------------------
+    // Each plane view narrows only the two axes it shows, so the answer per
+    // axis is the narrower of the two views that show it.
+    {
+        using amrvis::qt::volumeVisibleRegion;
+        const amrvis::RealBox domain{amrvis::Real3{{0.0, 0.0, 0.0}},
+            amrvis::Real3{{10.0, 20.0, 30.0}}};
+        // Nothing zoomed: the domain, which is what an unlimited render asks
+        // for anyway, so turning the limit on changes nothing until a zoom.
+        require(volumeVisibleRegion(domain, {}) == domain,
+            "with no view zoomed the region is not the whole domain");
+
+        // The XY view (normal 2) zoomed in x and y; z untouched by it.
+        auto xy = domain;
+        xy.lower[0] = 2.0;
+        xy.upper[0] = 6.0;
+        xy.lower[1] = 5.0;
+        xy.upper[1] = 9.0;
+        auto narrowed = volumeVisibleRegion(domain,
+            {std::nullopt, std::nullopt, std::optional{xy}});
+        require(narrowed.lower[0] == 2.0 && narrowed.upper[0] == 6.0
+                && narrowed.lower[1] == 5.0 && narrowed.upper[1] == 9.0
+                && narrowed.lower[2] == 0.0 && narrowed.upper[2] == 30.0,
+            "one zoomed view did not narrow exactly the axes it shows");
+
+        // A second view narrowing a shared axis further: the YZ view (normal
+        // 0) shows y and z, so y is the tighter of the two and z is its own.
+        auto yz = domain;
+        yz.lower[1] = 6.0;
+        yz.upper[1] = 7.0;
+        yz.lower[2] = 3.0;
+        yz.upper[2] = 4.0;
+        narrowed = volumeVisibleRegion(domain,
+            {std::optional{yz}, std::nullopt, std::optional{xy}});
+        require(narrowed.lower[1] == 6.0 && narrowed.upper[1] == 7.0
+                && narrowed.lower[2] == 3.0 && narrowed.upper[2] == 4.0
+                && narrowed.lower[0] == 2.0 && narrowed.upper[0] == 6.0,
+            "two views sharing an axis did not intersect on it");
+
+        // Views that share no part of an axis: zoom YZ into the bottom of z
+        // and XZ into the top. That axis goes back to the domain rather than
+        // collapsing the box, which would not be renderable.
+        auto lowZ = domain;
+        lowZ.lower[2] = 0.0;
+        lowZ.upper[2] = 5.0;
+        auto highZ = domain;
+        highZ.lower[2] = 25.0;
+        highZ.upper[2] = 30.0;
+        const auto disjoint = volumeVisibleRegion(domain,
+            {std::optional{lowZ}, std::optional{highZ}, std::nullopt});
+        require(disjoint.lower[2] == 0.0 && disjoint.upper[2] == 30.0,
+            "an axis the views do not share did not fall back to the domain");
+        require(disjoint.valid(3),
+            "disjoint view zooms produced a box that cannot be rendered");
+        // The axes they *do* agree on are still narrowed -- the fallback is
+        // per axis, not the whole box.
+        auto lowZAlso = lowZ;
+        lowZAlso.lower[0] = 1.0;
+        lowZAlso.upper[0] = 2.0;
+        auto highZAlso = highZ;
+        highZAlso.lower[0] = 1.0;
+        highZAlso.upper[0] = 2.0;
+        const auto mixed = volumeVisibleRegion(domain,
+            {std::optional{lowZAlso}, std::optional{highZAlso}, std::nullopt});
+        require(mixed.lower[0] == 1.0 && mixed.upper[0] == 2.0
+                && mixed.lower[2] == 0.0 && mixed.upper[2] == 30.0,
+            "the domain fallback threw away an axis the views did agree on");
+    }
+
     // New geometry drops the frame that belonged to the old geometry: kept, it
     // would be drawn under a wireframe for a domain it was never sampled from,
     // and scaled by a projection that no longer describes it. Checked through
@@ -376,6 +446,7 @@ int main(int argc, char** argv)
     std::shared_ptr<amrvis::DatasetSession> dataset = session;
     bool shuttingDown = false;
     bool playingSequence = false;
+    std::array<std::optional<amrvis::RealBox>, 3> viewRegions{};
     amrvis::qt::RangeController::Selection rangeSelection;
     rangeSelection.mode = amrvis::RangeMode::User;
     rangeSelection.userRange = std::pair{0.0, 4.0};
@@ -391,6 +462,11 @@ int main(int argc, char** argv)
             [] { return std::array<double, 3>{0.5, 1.0, 1.5}; },
             [] { return true; },
             [&shuttingDown] { return shuttingDown; },
+            [&viewRegions, &session] {
+                return amrvis::qt::volumeVisibleRegion(
+                    amrvis::datasetSampleBounds(session->metadata()),
+                    viewRegions);
+            },
             [&playingSequence] { return playingSequence; },
         };
     };
@@ -750,6 +826,73 @@ int main(int argc, char** argv)
         waitFor(application, [&] { return !controller.renderInFlight(); },
             "the logarithmic render did not finish");
         controller.closeWindow();
+    }
+
+    // The region limit: off by default, and what it puts in the request.
+    {
+        VolumeController controller(hooks());
+        Observed observed;
+        observe(controller, observed);
+        controller.showWindow(nullptr);
+        waitFor(application, [&] { return observed.frames == 1; },
+            "the opening frame was not displayed");
+        const auto domain
+            = amrvis::datasetSampleBounds(session->metadata());
+        require(session->requestsSoFar().back().region == domain,
+            "the opening render did not cover the whole domain");
+
+        // A zoomed view while the limit is off changes nothing: no render is
+        // due, and the region stays the domain.
+        auto zoomed = domain;
+        zoomed.lower[0] = 0.5 * (domain.lower[0] + domain.upper[0]);
+        viewRegions[2] = zoomed;
+        auto before = session->requests.load();
+        controller.regionChanged();
+        settle(application, 200);
+        require(session->requests == before,
+            "a view zoom rendered with the region limit switched off");
+
+        // Turning it on renders once, at the narrowed region.
+        auto* const window = volumeWindow();
+        require(window != nullptr, "no volume window on screen");
+        QMetaObject::invokeMethod(window, [window] {
+            window->findChild<QCheckBox*>(
+                       QStringLiteral("volumeRegionLimitCheck"))
+                ->setChecked(true);
+        });
+        application.processEvents();
+        waitFor(application, [&] { return session->requests == before + 1; },
+            "turning the region limit on did not render");
+        require(session->requestsSoFar().back().region == zoomed,
+            "the limited render did not cover the region the views show");
+        require(session->requestsSoFar().back().samplesPerVoxel == 2,
+            "the limited render was a draft rather than a full frame");
+        waitFor(application, [&] { return !controller.renderInFlight(); },
+            "the limited render did not finish");
+
+        // With it on, a view that moves renders again...
+        before = session->requests.load();
+        zoomed.upper[1] = 0.5 * (domain.lower[1] + domain.upper[1]);
+        viewRegions[2] = zoomed;
+        controller.regionChanged();
+        waitFor(application, [&] { return session->requests == before + 1; },
+            "a moved view did not re-render the limited region");
+        require(session->requestsSoFar().back().region == zoomed,
+            "the re-render did not pick up the moved region");
+        waitFor(application, [&] { return !controller.renderInFlight(); },
+            "the re-render did not finish");
+
+        // ...and one that has not moved does not. Every scheduled slice
+        // request calls this, so a region that is where the frame on screen
+        // came from must cost nothing.
+        before = session->requests.load();
+        controller.regionChanged();
+        controller.regionChanged();
+        settle(application, 200);
+        require(session->requests == before,
+            "an unchanged region rendered again anyway");
+        controller.closeWindow();
+        viewRegions = {};
     }
 
     // Sequence playback. Every frame of a sequence lands in


### PR DESCRIPTION
A check box in the volume dock limits the render to the part of the domain the views are zoomed into. Worth more than cropping: volumeGridDims counts the region's own cells and downsamples only when they exceed the voxel budget, so a small enough region is sampled at the finest level's pitch instead of a coarsened one. Nothing below the GUI needed changing -- the request field was plumbed and the caster already clips to a region that is not the domain, with the camera still normalised to the domain so the wireframe keeps lining up. Off by default; each view narrows the two axes it shows, and an axis two views do not share falls back to the whole domain.