### PR TITLE
edit the volume's opacity as a curve on the palette

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -308,18 +308,22 @@ domain while the slices show three planes through it -- so the same color can
 mean different values in the two. Pick File or Level when you need them to
 match. Its own controls set the opacity:
 
-- **Opacity from / to** window the color range: the opacity ramps linearly
-  from *from* to *to*, and everything outside that window -- below *from* and
-  above *to* -- is fully transparent. Narrow the window around the values of
-  interest to see them through the rest; note that raising *from* hides the
-  cold end and lowering *to* hides the hot end. Setting the two equal leaves a
-  single opaque shell at that value.
-- **Maximum opacity** scales the whole ramp; lower it to look deeper into a
-  dense field.
+- **Opacity** is a curve drawn over the palette it shapes: left to right is
+  the color range, bottom to top is transparent to opaque. Drag a point to
+  move it, click the plot to add one, right-click a point to remove it. The
+  two end points stay at the ends of the range and move only up and down, so
+  the curve always covers it.
+
+  It starts as a straight line from transparent at the cold end to opaque at
+  the hot end. Pull the low end up to see faint values, pull a stretch down to
+  look through a feature that is hiding what is behind it, or pull everything
+  down except one narrow band to leave a shell at those values. A band pulled
+  to the bottom is fully transparent.
 - **Use palette alpha ramp** takes each color's opacity from the palette's
-  own alpha ramp instead of the linear window. Legacy Amrvis `.pal` files
-  carry such a ramp (the shipped palettes have a plain 0-100 % ramp), and
-  the window still applies the *from* / *to* limits and the maximum to it.
+  own alpha ramp instead of the curve. Legacy Amrvis `.pal` files carry such a
+  ramp (the shipped palettes have a plain 0-100 % ramp), and the curve then
+  says only which values are shown at all: anywhere you pull it to the bottom
+  stays transparent.
 - **Only the visible region** samples just the part of the domain the slice
   views are zoomed into, instead of all of it. The budget below is then spent
   on that part alone, so a region small enough to fit is drawn at the finest

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -320,10 +320,10 @@ match. Its own controls set the opacity:
   down except one narrow band to leave a shell at those values. A band pulled
   to the bottom is fully transparent.
 - **Use palette alpha ramp** takes each color's opacity from the palette's
-  own alpha ramp instead of the curve. Legacy Amrvis `.pal` files carry such a
-  ramp (the shipped palettes have a plain 0-100 % ramp), and the curve then
-  says only which values are shown at all: anywhere you pull it to the bottom
-  stays transparent.
+  own alpha ramp instead of the curve, exactly as the palette author wrote it.
+  Legacy Amrvis `.pal` files carry such a ramp; the shipped palettes have a
+  plain 0-100 % ramp. The two are alternatives, so the curve is greyed out
+  while this is ticked.
 - **Only the visible region** samples just the part of the domain the slice
   views are zoomed into, instead of all of it. The budget below is then spent
   on that part alone, so a region small enough to fit is drawn at the finest

--- a/include/amrexplorer/pipeline/VolumePipeline.hpp
+++ b/include/amrexplorer/pipeline/VolumePipeline.hpp
@@ -76,6 +76,9 @@ struct OpacityRamp {
     // and the maximum above -- it says the same kind of thing with more than
     // three numbers -- and empty leaves that path exactly as it was, which is
     // what keeps a caller that never touches a curve rendering what it did.
+    //
+    // usePaletteAlpha wins over it: the two are alternative sources rather
+    // than layers, and a palette's authored ramp is handed back as authored.
     std::vector<OpacityPoint> curve;
     friend bool operator==(const OpacityRamp&, const OpacityRamp&) = default;
 };

--- a/include/amrexplorer/pipeline/VolumePipeline.hpp
+++ b/include/amrexplorer/pipeline/VolumePipeline.hpp
@@ -11,6 +11,7 @@
 #include <memory>
 #include <optional>
 #include <utility>
+#include <vector>
 
 namespace amrvis {
 
@@ -20,6 +21,42 @@ namespace amrvis {
 // frame under the negotiated size, and retries a render that overran the
 // block cache at a coarser level. Qt-free.
 
+// One control point of an opacity curve: `opacity` at `position`, both in
+// [0, 1] -- position over the colour range, opacity from transparent to
+// opaque.
+struct OpacityPoint {
+    double position = 0.0;
+    double opacity = 0.0;
+    friend bool operator==(const OpacityPoint&, const OpacityPoint&) = default;
+};
+
+// The two points that reproduce the default window: transparent at the bottom
+// of the range, opaque at the top.
+[[nodiscard]] std::vector<OpacityPoint> defaultOpacityCurve();
+
+// The curve's value at `position`, linearly between the points either side of
+// it and flat outside the outermost ones. An empty curve is transparent
+// everywhere; the points are assumed sorted, which every editing function
+// below maintains.
+[[nodiscard]] double opacityCurveValue(
+    const std::vector<OpacityPoint>& curve, double position);
+
+// Editing, as pure functions on the point list, because this is where the
+// mistakes live: a point dragged past its neighbour, an end point dragged off
+// the range, a curve left unsorted for opacityCurveValue to read.
+//
+// insert: a new point, keeping the list sorted; returns its index.
+// move: point `index` to (position, opacity), clamped into [0, 1] and, for an
+//   interior point, between its neighbours. The two end points keep their
+//   positions -- the curve has to span the range -- and move only in opacity.
+// remove: point `index`, unless it is an end point or the curve would be left
+//   with fewer than two.
+[[nodiscard]] std::size_t insertOpacityPoint(
+    std::vector<OpacityPoint>& curve, double position, double opacity);
+void moveOpacityPoint(std::vector<OpacityPoint>& curve, std::size_t index,
+    double position, double opacity);
+bool removeOpacityPoint(std::vector<OpacityPoint>& curve, std::size_t index);
+
 // The opacity controls: a window over the colour range (in normalised
 // [0, 1] of the range) that ramps linearly from transparent at the low
 // threshold to maximumOpacity at the high one -- or, with usePaletteAlpha
@@ -27,11 +64,19 @@ namespace amrvis {
 // opacity, windowed and scaled the same way. A window too narrow to hold
 // an entry (the thresholds may be equal) selects the one nearest it, at
 // full opacity.
+//
+// A shaped curve replaces the window when one is given: see `curve` below.
 struct OpacityRamp {
     double lowThreshold = 0.0;
     double highThreshold = 1.0;
     double maximumOpacity = 1.0;
     bool usePaletteAlpha = false;
+    // Control points of a piecewise-linear opacity curve over the same
+    // normalised range, in ascending position. Non-empty replaces the window
+    // and the maximum above -- it says the same kind of thing with more than
+    // three numbers -- and empty leaves that path exactly as it was, which is
+    // what keeps a caller that never touches a curve rendering what it did.
+    std::vector<OpacityPoint> curve;
     friend bool operator==(const OpacityRamp&, const OpacityRamp&) = default;
 };
 

--- a/src/pipeline/VolumePipeline.cpp
+++ b/src/pipeline/VolumePipeline.cpp
@@ -101,24 +101,25 @@ VolumeTransferFunction makeVolumeTransferFunction(
     constexpr int entryCount = Palette::colorSlots;
     transfer.colors.reserve(static_cast<std::size_t>(entryCount));
     transfer.opacities.reserve(static_cast<std::size_t>(entryCount));
-    if (!ramp.curve.empty()) {
-        // The curve is the opacity, entry by entry. usePaletteAlpha still
-        // substitutes the palette's own per-slot alpha, as it does for the
-        // window below, and the curve then says only where opacity is zero --
-        // so a palette ramp is shaped by where the curve has been pulled to
-        // nothing, not multiplied into a different ramp.
-        const bool paletteAlpha = ramp.usePaletteAlpha && palette.hasAlphaRamp();
+    // A curve and the palette's own alpha ramp are alternatives, not layers.
+    // The curve had gated the palette's alpha -- zero where the curve was zero
+    // -- which sounded like shaping it and was very nearly inert: the entries
+    // land at k / 252, a curve touching zero at a single point almost never
+    // touches one of them, and so dragging a point anywhere at all left the
+    // table unchanged. Multiplying instead would make the curve bite, but it
+    // would also distort every authored ramp by whatever the curve happens to
+    // be, and the reason to tick that box is to get the ramp as authored. So
+    // with the box in effect the curve stands aside, and the window path below
+    // -- at its defaults, which VolumeWindow leaves untouched -- hands back
+    // that ramp verbatim.
+    if (!ramp.curve.empty() && !(ramp.usePaletteAlpha && palette.hasAlphaRamp())) {
         const auto last = static_cast<double>(entryCount - 1);
         for (int entry = 0; entry < entryCount; ++entry) {
             const auto slot = Palette::paletteStart + entry;
             transfer.colors.push_back(palette.slotArgb(slot) & 0x00FFFFFFU);
-            const auto shaped = opacityCurveValue(
-                ramp.curve, static_cast<double>(entry) / last);
-            const auto opacity = paletteAlpha
-                ? (shaped > 0.0 ? palette.opacity(slot) : 0.0)
-                : shaped;
-            transfer.opacities.push_back(
-                static_cast<float>(std::clamp(opacity, 0.0, 1.0)));
+            transfer.opacities.push_back(static_cast<float>(std::clamp(
+                opacityCurveValue(ramp.curve, static_cast<double>(entry) / last),
+                0.0, 1.0)));
         }
         return transfer;
     }

--- a/src/pipeline/VolumePipeline.cpp
+++ b/src/pipeline/VolumePipeline.cpp
@@ -14,6 +14,86 @@
 
 namespace amrvis {
 
+std::vector<OpacityPoint> defaultOpacityCurve()
+{
+    return {OpacityPoint{0.0, 0.0}, OpacityPoint{1.0, 1.0}};
+}
+
+double opacityCurveValue(
+    const std::vector<OpacityPoint>& curve, double position)
+{
+    if (curve.empty()) {
+        return 0.0;
+    }
+    if (!(position > curve.front().position)) {
+        return curve.front().opacity;
+    }
+    if (!(position < curve.back().position)) {
+        return curve.back().opacity;
+    }
+    for (std::size_t index = 1; index < curve.size(); ++index) {
+        const auto& upper = curve[index];
+        if (position > upper.position) {
+            continue;
+        }
+        const auto& lower = curve[index - 1];
+        const auto span = upper.position - lower.position;
+        if (!(span > 0.0)) {
+            // Guards the division, nothing more. Two points at one position
+            // form a step, and the segment *ending* at that position is found
+            // first, so a query exactly there returns through the branch below
+            // with span > 0 and this is not reached from any curve the editing
+            // functions can build. Left in because the alternative is a
+            // division by zero if those early returns ever change.
+            return upper.opacity;
+        }
+        const auto fraction = (position - lower.position) / span;
+        return lower.opacity + fraction * (upper.opacity - lower.opacity);
+    }
+    return curve.back().opacity;
+}
+
+std::size_t insertOpacityPoint(
+    std::vector<OpacityPoint>& curve, double position, double opacity)
+{
+    const OpacityPoint point{std::clamp(position, 0.0, 1.0),
+        std::clamp(opacity, 0.0, 1.0)};
+    const auto at = std::upper_bound(curve.begin(), curve.end(), point,
+        [](const OpacityPoint& left, const OpacityPoint& right) {
+            return left.position < right.position;
+        });
+    const auto index = static_cast<std::size_t>(at - curve.begin());
+    curve.insert(at, point);
+    return index;
+}
+
+void moveOpacityPoint(std::vector<OpacityPoint>& curve, std::size_t index,
+    double position, double opacity)
+{
+    if (index >= curve.size()) {
+        return;
+    }
+    curve[index].opacity = std::clamp(opacity, 0.0, 1.0);
+    // The end points anchor the curve to the ends of the range, so they give
+    // up their position: a curve that stopped short of either end would have
+    // to invent a value out there, and opacityCurveValue holds the outermost
+    // one flat precisely so it never has to.
+    if (index == 0 || index + 1 == curve.size()) {
+        return;
+    }
+    curve[index].position = std::clamp(position,
+        curve[index - 1].position, curve[index + 1].position);
+}
+
+bool removeOpacityPoint(std::vector<OpacityPoint>& curve, std::size_t index)
+{
+    if (curve.size() <= 2 || index == 0 || index + 1 >= curve.size()) {
+        return false;
+    }
+    curve.erase(curve.begin() + static_cast<std::ptrdiff_t>(index));
+    return true;
+}
+
 VolumeTransferFunction makeVolumeTransferFunction(
     const Palette& palette, const OpacityRamp& ramp)
 {
@@ -21,6 +101,27 @@ VolumeTransferFunction makeVolumeTransferFunction(
     constexpr int entryCount = Palette::colorSlots;
     transfer.colors.reserve(static_cast<std::size_t>(entryCount));
     transfer.opacities.reserve(static_cast<std::size_t>(entryCount));
+    if (!ramp.curve.empty()) {
+        // The curve is the opacity, entry by entry. usePaletteAlpha still
+        // substitutes the palette's own per-slot alpha, as it does for the
+        // window below, and the curve then says only where opacity is zero --
+        // so a palette ramp is shaped by where the curve has been pulled to
+        // nothing, not multiplied into a different ramp.
+        const bool paletteAlpha = ramp.usePaletteAlpha && palette.hasAlphaRamp();
+        const auto last = static_cast<double>(entryCount - 1);
+        for (int entry = 0; entry < entryCount; ++entry) {
+            const auto slot = Palette::paletteStart + entry;
+            transfer.colors.push_back(palette.slotArgb(slot) & 0x00FFFFFFU);
+            const auto shaped = opacityCurveValue(
+                ramp.curve, static_cast<double>(entry) / last);
+            const auto opacity = paletteAlpha
+                ? (shaped > 0.0 ? palette.opacity(slot) : 0.0)
+                : shaped;
+            transfer.opacities.push_back(
+                static_cast<float>(std::clamp(opacity, 0.0, 1.0)));
+        }
+        return transfer;
+    }
     // Refused rather than clamped: std::clamp returns a NaN unchanged (it
     // compares, and every comparison against a NaN is false), and the casts
     // to int below are undefined for one. A control that is not a number is

--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -20,6 +20,7 @@ add_executable(amrexplorer_qt
     ImageView.cpp
     ImageView.hpp
     IsoWidget.cpp
+    OpacityCurveWidget.cpp
     IsoWidget.hpp
     LinePlotRequest.hpp
     LinePlotWindow.cpp

--- a/src/qt/OpacityCurveWidget.cpp
+++ b/src/qt/OpacityCurveWidget.cpp
@@ -1,0 +1,225 @@
+#include "OpacityCurveWidget.hpp"
+
+#include <QMouseEvent>
+#include <QPainter>
+#include <QPaintEvent>
+#include <QPen>
+#include <QPolygonF>
+#include <QSizePolicy>
+
+#include <algorithm>
+#include <cmath>
+
+namespace amrvis::qt {
+
+namespace {
+
+// Half the side of a control point's square, in pixels, and the distance a
+// press may miss one by and still take it. The grab radius is the larger of
+// the two: a 3-pixel square is hard to hit exactly with a mouse.
+constexpr double handleHalf = 3.0;
+constexpr double grabRadius = 6.0;
+
+} // namespace
+
+OpacityCurveWidget::OpacityCurveWidget(QWidget* parent)
+    : QWidget(parent)
+{
+    setMinimumHeight(96);
+    setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+    setToolTip(tr("Drag a point to shape the opacity; click the curve to add "
+                  "one, right-click a point to remove it"));
+    // The plot is the whole widget, and every press inside it means something,
+    // so it takes the mouse rather than passing clicks to the dock.
+    setFocusPolicy(Qt::ClickFocus);
+}
+
+void OpacityCurveWidget::setColorPalette(const Palette* palette)
+{
+    m_palette = palette;
+    update();
+}
+
+void OpacityCurveWidget::setCurve(std::vector<OpacityPoint> curve)
+{
+    // A curve with fewer than two points cannot span the range, and every
+    // edit below assumes two ends it may not remove.
+    m_curve = curve.size() >= 2 ? std::move(curve) : defaultOpacityCurve();
+    m_dragging = -1;
+    update();
+}
+
+QRectF OpacityCurveWidget::plotRect() const
+{
+    return QRectF(rect()).adjusted(
+        handleHalf + 1.0, handleHalf + 1.0, -handleHalf - 1.0, -handleHalf - 1.0);
+}
+
+QPointF OpacityCurveWidget::widgetPosition(const OpacityPoint& point) const
+{
+    const auto plot = plotRect();
+    // Opacity counts up, pixels count down.
+    return QPointF(plot.left() + point.position * plot.width(),
+        plot.bottom() - point.opacity * plot.height());
+}
+
+OpacityPoint OpacityCurveWidget::curvePosition(const QPointF& position) const
+{
+    const auto plot = plotRect();
+    if (!(plot.width() > 0.0) || !(plot.height() > 0.0)) {
+        return {};
+    }
+    return {std::clamp((position.x() - plot.left()) / plot.width(), 0.0, 1.0),
+        std::clamp((plot.bottom() - position.y()) / plot.height(), 0.0, 1.0)};
+}
+
+int OpacityCurveWidget::pointAt(const QPointF& position) const
+{
+    int closest = -1;
+    double best = grabRadius * grabRadius;
+    for (std::size_t index = 0; index < m_curve.size(); ++index) {
+        const auto at = widgetPosition(m_curve[index]);
+        const auto dx = at.x() - position.x();
+        const auto dy = at.y() - position.y();
+        const auto distance = dx * dx + dy * dy;
+        // Strictly nearer, so two points at one position give the lower index
+        // and a drag is repeatable rather than depending on iteration order.
+        if (distance < best) {
+            best = distance;
+            closest = static_cast<int>(index);
+        }
+    }
+    return closest;
+}
+
+void OpacityCurveWidget::paintEvent(QPaintEvent* event)
+{
+    QPainter painter(this);
+    painter.fillRect(event->rect(), palette().color(QPalette::Base));
+    const auto plot = plotRect();
+    if (!(plot.width() > 0.0) || !(plot.height() > 0.0)) {
+        return;
+    }
+
+    // The palette behind the curve, one band per data slot, so a point sits
+    // over the colour it is shaping. Dimmed by the curve drawn over it: the
+    // bands are the reference, not the subject.
+    if (m_palette != nullptr) {
+        constexpr int entries = Palette::colorSlots;
+        const auto bandWidth = plot.width() / static_cast<double>(entries);
+        for (int entry = 0; entry < entries; ++entry) {
+            const auto argb
+                = m_palette->slotArgb(Palette::paletteStart + entry);
+            QColor band(QRgb(argb | 0xFF000000U));
+            band.setAlpha(90);
+            const auto left
+                = plot.left() + static_cast<double>(entry) * bandWidth;
+            // A whole pixel wider than the band, so rounding cannot leave a
+            // background-coloured seam between two bands.
+            painter.fillRect(
+                QRectF(left, plot.top(), bandWidth + 1.0, plot.height()), band);
+        }
+    }
+
+    painter.setRenderHint(QPainter::Antialiasing, true);
+    // The area under the curve, so "more opaque" reads as "more filled" at a
+    // glance rather than needing the axis to be worked out.
+    QPolygonF under;
+    under << QPointF(plot.left(), plot.bottom());
+    for (const auto& point : m_curve) {
+        under << widgetPosition(point);
+    }
+    under << QPointF(plot.right(), plot.bottom());
+    auto fill = palette().color(QPalette::WindowText);
+    fill.setAlpha(40);
+    painter.setPen(Qt::NoPen);
+    painter.setBrush(fill);
+    painter.drawPolygon(under);
+
+    QPolygonF line;
+    for (const auto& point : m_curve) {
+        line << widgetPosition(point);
+    }
+    painter.setBrush(Qt::NoBrush);
+    painter.setPen(QPen(palette().color(QPalette::WindowText), 2.0));
+    painter.drawPolyline(line);
+
+    // The control points last, over the curve they define.
+    painter.setBrush(palette().color(QPalette::Base));
+    for (std::size_t index = 0; index < m_curve.size(); ++index) {
+        const auto at = widgetPosition(m_curve[index]);
+        painter.setPen(QPen(palette().color(QPalette::WindowText),
+            static_cast<int>(index) == m_dragging ? 2.5 : 1.5));
+        painter.drawRect(QRectF(at.x() - handleHalf, at.y() - handleHalf,
+            2.0 * handleHalf, 2.0 * handleHalf));
+    }
+
+    painter.setRenderHint(QPainter::Antialiasing, false);
+    painter.setBrush(Qt::NoBrush);
+    painter.setPen(palette().color(QPalette::Mid));
+    painter.drawRect(plot);
+}
+
+void OpacityCurveWidget::mousePressEvent(QMouseEvent* event)
+{
+    const auto position = event->position();
+    const auto hit = pointAt(position);
+    if (event->button() == Qt::RightButton) {
+        // Removal, and only of a point actually under the cursor: a
+        // right-click on empty plot is not an attempt to delete the nearest
+        // thing. removeOpacityPoint refuses the two ends on its own.
+        if (hit >= 0
+            && removeOpacityPoint(m_curve, static_cast<std::size_t>(hit))) {
+            m_dragging = -1;
+            update();
+            emit curveChanged();
+        }
+        event->accept();
+        return;
+    }
+    if (event->button() != Qt::LeftButton) {
+        QWidget::mousePressEvent(event);
+        return;
+    }
+    if (hit >= 0) {
+        m_dragging = hit;
+    } else {
+        // A press on empty plot adds a point there and drags it, so shaping a
+        // curve is one gesture per point rather than click-then-find-it.
+        const auto added = curvePosition(position);
+        m_dragging = static_cast<int>(
+            insertOpacityPoint(m_curve, added.position, added.opacity));
+        emit curveChanged();
+    }
+    update();
+    event->accept();
+}
+
+void OpacityCurveWidget::mouseMoveEvent(QMouseEvent* event)
+{
+    if (m_dragging < 0) {
+        QWidget::mouseMoveEvent(event);
+        return;
+    }
+    const auto moved = curvePosition(event->position());
+    moveOpacityPoint(m_curve, static_cast<std::size_t>(m_dragging),
+        moved.position, moved.opacity);
+    update();
+    emit curveChanged();
+    event->accept();
+}
+
+void OpacityCurveWidget::mouseReleaseEvent(QMouseEvent* event)
+{
+    if (m_dragging < 0) {
+        QWidget::mouseReleaseEvent(event);
+        return;
+    }
+    m_dragging = -1;
+    // No signal here: every step of the drag already emitted one, and the
+    // controller's settle timer turns the last of them into the full frame.
+    update();
+    event->accept();
+}
+
+} // namespace amrvis::qt

--- a/src/qt/OpacityCurveWidget.hpp
+++ b/src/qt/OpacityCurveWidget.hpp
@@ -1,0 +1,72 @@
+#pragma once
+
+// The opacity curve, drawn over the palette it shapes and edited in place.
+// Replaces the two-threshold window and the maximum: it says the same kind of
+// thing with as many control points as the field needs, so a feature buried
+// between two others can be given its own opacity without also revealing them.
+//
+// The editing rules are not here. They are pure functions on the point list in
+// VolumePipeline.hpp -- insert, move, remove, evaluate -- because that is where
+// the mistakes live (a point dragged past its neighbour, an end point pulled
+// off the range) and they are worth pinning without a widget to drive. This
+// class maps pixels to and from those points and paints the result.
+
+#include <amrexplorer/pipeline/VolumePipeline.hpp>
+#include <amrexplorer/render2d/Palette.hpp>
+
+#include <QPointF>
+#include <QRectF>
+#include <QWidget>
+
+#include <cstddef>
+#include <vector>
+
+namespace amrvis::qt {
+
+class OpacityCurveWidget final : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit OpacityCurveWidget(QWidget* parent = nullptr);
+
+    // The palette painted behind the curve, so a control point sits over the
+    // colour it makes transparent. Null draws the plot without it.
+    void setColorPalette(const Palette* palette);
+    [[nodiscard]] const std::vector<OpacityPoint>& curve() const noexcept
+    {
+        return m_curve;
+    }
+    // Replaces the curve without emitting curveChanged: for restoring one, not
+    // for editing it.
+    void setCurve(std::vector<OpacityPoint> curve);
+
+signals:
+    // One per edit, including every step of a drag -- the same shape the
+    // sliders had, so the window relays it as rampChanged and the controller's
+    // draft-then-settle path carries it with nothing new wired.
+    void curveChanged();
+
+protected:
+    void paintEvent(QPaintEvent* event) override;
+    void mousePressEvent(QMouseEvent* event) override;
+    void mouseMoveEvent(QMouseEvent* event) override;
+    void mouseReleaseEvent(QMouseEvent* event) override;
+
+private:
+    // The plot inside its border, inset far enough that a control point on any
+    // edge is drawn whole rather than clipped in half.
+    [[nodiscard]] QRectF plotRect() const;
+    [[nodiscard]] QPointF widgetPosition(const OpacityPoint& point) const;
+    [[nodiscard]] OpacityPoint curvePosition(const QPointF& position) const;
+    // The index of the control point under `position`, or -1.
+    [[nodiscard]] int pointAt(const QPointF& position) const;
+
+    const Palette* m_palette = nullptr;
+    std::vector<OpacityPoint> m_curve = defaultOpacityCurve();
+    // The point being dragged, or -1. Held as an index because the edit
+    // functions take one, and a drag cannot reorder the list -- moveOpacityPoint
+    // clamps an interior point between its neighbours.
+    int m_dragging = -1;
+};
+
+} // namespace amrvis::qt

--- a/src/qt/VolumeWindow.cpp
+++ b/src/qt/VolumeWindow.cpp
@@ -155,9 +155,11 @@ void VolumeWindow::buildControls()
     m_curve->setObjectName(QStringLiteral("volumeOpacityCurve"));
     form->addRow(tr("Opacity:"), m_curve);
     m_paletteAlpha = new QCheckBox(tr("Use palette alpha ramp"), panel);
+    m_paletteAlpha->setObjectName(QStringLiteral("volumePaletteAlphaCheck"));
     m_paletteAlpha->setToolTip(tr("Take each colour's opacity from the palette's "
                                   "alpha ramp (legacy .pal files carry one) "
-                                  "instead of the linear window above."));
+                                  "instead of the curve above, which is "
+                                  "disabled while this is on."));
     form->addRow(QString(), m_paletteAlpha);
     m_qualityCombo = new QComboBox(panel);
     m_qualityCombo->addItem(tr("Draft"), 0);
@@ -259,7 +261,7 @@ void VolumeWindow::setPaletteHasAlpha(bool hasAlpha)
     }
     m_paletteAlpha->setToolTip(hasAlpha
         ? tr("Take each colour's opacity from the palette's alpha ramp "
-             "instead of the linear window above.")
+             "instead of the curve above, which is disabled while this is on.")
         : tr("This palette carries no alpha ramp; load a legacy .pal file "
              "with one to enable this."));
 }

--- a/src/qt/VolumeWindow.cpp
+++ b/src/qt/VolumeWindow.cpp
@@ -1,6 +1,7 @@
 #include "VolumeWindow.hpp"
 
 #include "IsoWidget.hpp"
+#include "OpacityCurveWidget.hpp"
 #include "WidgetImageExport.hpp"
 
 #include <QAction>
@@ -144,32 +145,15 @@ void VolumeWindow::buildControls()
     auto* form = new QFormLayout;
     form->setFieldGrowthPolicy(QFormLayout::AllNonFixedFieldsGrow);
 
-    // The opacity window over the colour range: transparent below "from",
-    // ramping to the maximum at "to"; the labels read the slider positions.
-    const auto makeSlider = [panel](int initial) {
-        auto* slider = new QSlider(Qt::Horizontal, panel);
-        slider->setRange(0, 100);
-        slider->setValue(initial);
-        return slider;
-    };
-    m_lowSlider = makeSlider(0);
-    m_highSlider = makeSlider(100);
-    m_maximumSlider = makeSlider(100);
-    m_lowLabel = new QLabel(panel);
-    m_highLabel = new QLabel(panel);
-    m_maximumLabel = new QLabel(panel);
-    const auto rampRow = [panel](QSlider* slider, QLabel* label) {
-        auto* row = new QWidget(panel);
-        auto* rowLayout = new QHBoxLayout(row);
-        rowLayout->setContentsMargins(0, 0, 0, 0);
-        rowLayout->addWidget(slider, 1);
-        label->setMinimumWidth(36);
-        rowLayout->addWidget(label);
-        return row;
-    };
-    form->addRow(tr("Opacity from:"), rampRow(m_lowSlider, m_lowLabel));
-    form->addRow(tr("Opacity to:"), rampRow(m_highSlider, m_highLabel));
-    form->addRow(tr("Maximum opacity:"), rampRow(m_maximumSlider, m_maximumLabel));
+    // The opacity over the colour range, as a curve drawn on the palette it
+    // shapes. It replaces the "from" / "to" / maximum sliders: those were
+    // three numbers describing one linear ramp, and a field with something
+    // interesting between two duller features could not be given its own
+    // opacity without also revealing them. The default curve is that linear
+    // ramp, so an untouched window renders what it always did.
+    m_curve = new OpacityCurveWidget(panel);
+    m_curve->setObjectName(QStringLiteral("volumeOpacityCurve"));
+    form->addRow(tr("Opacity:"), m_curve);
     m_paletteAlpha = new QCheckBox(tr("Use palette alpha ramp"), panel);
     m_paletteAlpha->setToolTip(tr("Take each colour's opacity from the palette's "
                                   "alpha ramp (legacy .pal files carry one) "
@@ -210,33 +194,10 @@ void VolumeWindow::buildControls()
     dock->setWidget(panel);
     addDockWidget(Qt::RightDockWidgetArea, dock);
 
-    const auto updateLabels = [this] {
-        m_lowLabel->setText(QStringLiteral("%1%").arg(m_lowSlider->value()));
-        m_highLabel->setText(QStringLiteral("%1%").arg(m_highSlider->value()));
-        m_maximumLabel->setText(
-            QStringLiteral("%1%").arg(m_maximumSlider->value()));
-    };
-    updateLabels();
     // The window is kept ordered: dragging one threshold past the other
     // pushes the other along.
-    connect(m_lowSlider, &QSlider::valueChanged, this, [this, updateLabels](int value) {
-        if (m_highSlider->value() < value) {
-            m_highSlider->setValue(value);
-        }
-        updateLabels();
-        emit rampChanged();
-    });
-    connect(m_highSlider, &QSlider::valueChanged, this, [this, updateLabels](int value) {
-        if (m_lowSlider->value() > value) {
-            m_lowSlider->setValue(value);
-        }
-        updateLabels();
-        emit rampChanged();
-    });
-    connect(m_maximumSlider, &QSlider::valueChanged, this, [this, updateLabels] {
-        updateLabels();
-        emit rampChanged();
-    });
+    connect(m_curve, &OpacityCurveWidget::curveChanged, this,
+        [this] { emit rampChanged(); });
     connect(m_paletteAlpha, &QCheckBox::toggled, this,
         [this] { emit paletteAlphaChanged(); });
     connect(m_qualityCombo, qOverload<int>(&QComboBox::currentIndexChanged), this,
@@ -266,6 +227,7 @@ void VolumeWindow::setSlicePlanesVisible(bool visible)
 
 void VolumeWindow::setColorPalette(const Palette* palette)
 {
+    m_curve->setColorPalette(palette);
     m_view->setColorPalette(palette);
 }
 
@@ -342,17 +304,14 @@ qreal VolumeWindow::viewDevicePixelRatio() const
 
 OpacityRamp VolumeWindow::ramp() const
 {
-    // Every field comes from a slider in [0, 100], and buildControls keeps
-    // low <= high by pushing the other along. makeVolumeTransferFunction
-    // throws on a non-finite or inverted window, so anything that lets these
-    // controls produce one -- a text entry, a restored setting -- has to
-    // resolve it here rather than hand it to the render.
-
+    // The curve carries the shape, so the window fields stay at their
+    // defaults and go unread: makeVolumeTransferFunction takes the curve
+    // branch whenever one is set, which this always is. The widget keeps the
+    // points sorted, in range, and at least two -- the invariants that branch
+    // reads them under.
     OpacityRamp ramp;
-    ramp.lowThreshold = m_lowSlider->value() / 100.0;
-    ramp.highThreshold = m_highSlider->value() / 100.0;
-    ramp.maximumOpacity = m_maximumSlider->value() / 100.0;
     ramp.usePaletteAlpha = m_paletteAlpha->isEnabled() && m_paletteAlpha->isChecked();
+    ramp.curve = m_curve->curve();
     return ramp;
 }
 

--- a/src/qt/VolumeWindow.cpp
+++ b/src/qt/VolumeWindow.cpp
@@ -198,8 +198,12 @@ void VolumeWindow::buildControls()
     // pushes the other along.
     connect(m_curve, &OpacityCurveWidget::curveChanged, this,
         [this] { emit rampChanged(); });
-    connect(m_paletteAlpha, &QCheckBox::toggled, this,
-        [this] { emit paletteAlphaChanged(); });
+    connect(m_paletteAlpha, &QCheckBox::toggled, this, [this] {
+        // The curve has no say while the palette's own ramp is in use, so it
+        // is disabled rather than left looking editable and doing nothing.
+        syncCurveEnabled();
+        emit paletteAlphaChanged();
+    });
     connect(m_qualityCombo, qOverload<int>(&QComboBox::currentIndexChanged), this,
         [this](int) { emit qualityChanged(); });
     connect(m_regionCheck, &QCheckBox::toggled, this,
@@ -231,9 +235,19 @@ void VolumeWindow::setColorPalette(const Palette* palette)
     m_view->setColorPalette(palette);
 }
 
+void VolumeWindow::syncCurveEnabled()
+{
+    // The same condition ramp() reports usePaletteAlpha under, so what the
+    // control offers and what the render does cannot disagree: a ticked box on
+    // a palette with no ramp is not in effect, and the curve stays editable.
+    m_curve->setEnabled(
+        !(m_paletteAlpha->isEnabled() && m_paletteAlpha->isChecked()));
+}
+
 void VolumeWindow::setPaletteHasAlpha(bool hasAlpha)
 {
     m_paletteAlpha->setEnabled(hasAlpha);
+    syncCurveEnabled();
     if (!hasAlpha && m_paletteAlpha->isChecked()) {
         // ramp() ands in isEnabled(), so the render already ignores a ticked
         // box on a palette with no ramp -- but the box would sit there ticked,

--- a/src/qt/VolumeWindow.cpp
+++ b/src/qt/VolumeWindow.cpp
@@ -320,11 +320,16 @@ qreal VolumeWindow::viewDevicePixelRatio() const
 
 OpacityRamp VolumeWindow::ramp() const
 {
-    // The curve carries the shape, so the window fields stay at their
-    // defaults and go unread: makeVolumeTransferFunction takes the curve
-    // branch whenever one is set, which this always is. The widget keeps the
-    // points sorted, in range, and at least two -- the invariants that branch
-    // reads them under.
+    // usePaletteAlpha decides which of the two shapes the render reads. With
+    // it off, makeVolumeTransferFunction takes the curve. With it on, the
+    // curve stands aside and that function reads the window fields instead --
+    // which is why they are left at their defaults here rather than set from
+    // anything. At those defaults the window spans the whole range at full
+    // maximum, so it is no window at all and the palette's authored ramp comes
+    // back untouched, which is the reason to tick the box.
+    //
+    // The widget keeps the points sorted, in range, and at least two: the
+    // invariants the curve branch reads them under.
     OpacityRamp ramp;
     ramp.usePaletteAlpha = m_paletteAlpha->isEnabled() && m_paletteAlpha->isChecked();
     ramp.curve = m_curve->curve();

--- a/src/qt/VolumeWindow.hpp
+++ b/src/qt/VolumeWindow.hpp
@@ -23,6 +23,7 @@ class Palette;
 namespace amrvis::qt {
 
 class IsoWidget;
+class OpacityCurveWidget;
 
 // The Volume Rendering window: an IsoWidget in the middle -- the same
 // orthographic view as the main window's iso quadrant, drag to rotate, wheel
@@ -77,7 +78,8 @@ signals:
     // changed size, so the frame drawn in it is being stretched.
     void cameraChanged();
     void interactionEnded();
-    // rampChanged is the sliders, which arrive continuously while dragged;
+    // rampChanged is the opacity curve, which arrives continuously while
+    // dragged;
     // paletteAlphaChanged is the checkbox, one discrete choice like the
     // quality combo.
     void rampChanged();
@@ -92,17 +94,12 @@ private:
     void exportImage();
 
     IsoWidget* m_view = nullptr;
-    QSlider* m_lowSlider = nullptr;
-    QSlider* m_highSlider = nullptr;
-    QSlider* m_maximumSlider = nullptr;
+    OpacityCurveWidget* m_curve = nullptr;
     QCheckBox* m_paletteAlpha = nullptr;
     QComboBox* m_qualityCombo = nullptr;
     QCheckBox* m_regionCheck = nullptr;
     QCheckBox* m_boxesCheck = nullptr;
     QCheckBox* m_outlineCheck = nullptr;
-    QLabel* m_lowLabel = nullptr;
-    QLabel* m_highLabel = nullptr;
-    QLabel* m_maximumLabel = nullptr;
     QLabel* m_status = nullptr;
     QLabel* m_rendering = nullptr;
 };

--- a/src/qt/VolumeWindow.hpp
+++ b/src/qt/VolumeWindow.hpp
@@ -91,6 +91,9 @@ signals:
 
 private:
     void buildControls();
+    // Follows the palette-alpha box: the curve is editable only when it is the
+    // opacity source.
+    void syncCurveEnabled();
     void exportImage();
 
     IsoWidget* m_view = nullptr;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -607,6 +607,7 @@ if(TARGET amrexplorer_qt)
         "${PROJECT_SOURCE_DIR}/src/qt/VolumeWindow.cpp"
         "${PROJECT_SOURCE_DIR}/src/qt/VolumeWindow.hpp"
         "${PROJECT_SOURCE_DIR}/src/qt/IsoWidget.cpp"
+        "${PROJECT_SOURCE_DIR}/src/qt/OpacityCurveWidget.cpp"
         "${PROJECT_SOURCE_DIR}/src/qt/IsoWidget.hpp"
     )
     set_target_properties(test_volume_controller PROPERTIES AUTOMOC ON)

--- a/tests/integration/test_volume_pipeline.cpp
+++ b/tests/integration/test_volume_pipeline.cpp
@@ -237,9 +237,103 @@ int main()
             require(std::abs(plain.opacities[i] - expected) <= 1.0e-6F,
                 "the default ramp is not linear over the whole range");
         }
+        // --- the opacity curve ------------------------------------------
+        // The default curve says what the default window says. This is the
+        // whole reason the curve is allowed to replace the window: someone who
+        // never touches it renders exactly what they rendered before.
+        amrvis::OpacityRamp curved;
+        curved.curve = amrvis::defaultOpacityCurve();
+        const auto fromCurve
+            = amrvis::makeVolumeTransferFunction(palette, curved);
+        require(fromCurve.opacities == plain.opacities,
+            "the default curve does not reproduce the default window");
+        require(fromCurve.colors == plain.colors,
+            "the curve path did not lay down the same colours");
+
+        // Evaluation: between the points either side, flat outside the ends.
+        {
+            using amrvis::opacityCurveValue;
+            const std::vector<amrvis::OpacityPoint> curve{
+                {0.0, 0.0}, {0.5, 1.0}, {1.0, 0.25}};
+            require(opacityCurveValue(curve, 0.0) == 0.0
+                    && opacityCurveValue(curve, 0.5) == 1.0
+                    && opacityCurveValue(curve, 1.0) == 0.25,
+                "the curve does not pass through its own control points");
+            require(std::abs(opacityCurveValue(curve, 0.25) - 0.5) <= 1.0e-12,
+                "the curve is not linear between two points");
+            require(std::abs(opacityCurveValue(curve, 0.75) - 0.625) <= 1.0e-12,
+                "the curve is not linear on its falling side");
+            // Outside the outermost points it holds, so nothing has to be
+            // invented past the ends of the range.
+            require(opacityCurveValue(curve, -1.0) == 0.0
+                    && opacityCurveValue(curve, 2.0) == 0.25,
+                "the curve did not hold its end values outside the range");
+            require(opacityCurveValue({}, 0.5) == 0.0,
+                "an empty curve is not transparent");
+            // Two points at one position form a step. Exactly at it, the
+            // side below wins -- the segment ending there is found first --
+            // and just above it the upper value does. Pinned because either
+            // is defensible and the widget lets a drag produce one.
+            const std::vector<amrvis::OpacityPoint> step{
+                {0.0, 0.0}, {0.5, 0.2}, {0.5, 0.9}, {1.0, 1.0}};
+            require(opacityCurveValue(step, 0.5) == 0.2,
+                "a step did not take the value below it at its own position");
+            require(opacityCurveValue(step, 0.5 + 1.0e-9) > 0.85,
+                "just above a step did not take the value above it");
+        }
+
+        // Editing. These are where the mistakes live, so they are pinned
+        // rather than left to the widget to get right.
+        {
+            auto curve = amrvis::defaultOpacityCurve();
+            const auto middle
+                = amrvis::insertOpacityPoint(curve, 0.5, 0.75);
+            require(middle == 1 && curve.size() == 3
+                    && curve[1] == amrvis::OpacityPoint{0.5, 0.75},
+                "an inserted point did not land in order");
+            // Inserted out of order, and clamped.
+            const auto low = amrvis::insertOpacityPoint(curve, 0.25, 4.0);
+            require(low == 1 && curve[1].position == 0.25
+                    && curve[1].opacity == 1.0,
+                "an inserted point was not sorted and clamped");
+
+            // An interior point cannot pass its neighbours.
+            amrvis::moveOpacityPoint(curve, 2, 5.0, 0.5);
+            require(curve[2].position == curve[3].position,
+                "an interior point moved past its neighbour");
+            amrvis::moveOpacityPoint(curve, 2, -5.0, 0.5);
+            require(curve[2].position == curve[1].position,
+                "an interior point moved below its neighbour");
+
+            // The ends keep their positions -- the curve spans the range --
+            // and move only in opacity.
+            amrvis::moveOpacityPoint(curve, 0, 0.9, 0.4);
+            require(curve[0].position == 0.0 && curve[0].opacity == 0.4,
+                "the low end point did not stay at the bottom of the range");
+            const auto lastIndex = curve.size() - 1;
+            amrvis::moveOpacityPoint(curve, lastIndex, 0.1, 0.2);
+            require(curve[lastIndex].position == 1.0
+                    && curve[lastIndex].opacity == 0.2,
+                "the high end point did not stay at the top of the range");
+            amrvis::moveOpacityPoint(curve, 99, 0.5, 0.5);   // no such point
+            require(curve.size() == 4, "moving a point that is not there grew "
+                                      "the curve");
+
+            // Removal takes interior points only, and never the last two.
+            require(!amrvis::removeOpacityPoint(curve, 0)
+                    && !amrvis::removeOpacityPoint(curve, curve.size() - 1),
+                "an end point was removed, leaving the curve short of the "
+                "range");
+            require(amrvis::removeOpacityPoint(curve, 1) && curve.size() == 3,
+                "an interior point was not removed");
+            auto pair = amrvis::defaultOpacityCurve();
+            require(!amrvis::removeOpacityPoint(pair, 1) && pair.size() == 2,
+                "a two-point curve was reduced below two points");
+        }
+
         // A window: transparent outside [0.25, 0.75], ramping inside to the
         // maximum opacity at the top.
-        amrvis::OpacityRamp windowed{0.25, 0.75, 0.5, false};
+        amrvis::OpacityRamp windowed{0.25, 0.75, 0.5, false, {}};
         const auto window = amrvis::makeVolumeTransferFunction(palette, windowed);
         require(window.opacities[0] == 0.0F && window.opacities[252] == 0.0F
                 && window.opacities[50] == 0.0F,
@@ -251,9 +345,9 @@ int main()
         // Equal thresholds (the coupled sliders allow them) and a window
         // narrower than the entry pitch select the single nearest entry,
         // opaque, rather than nothing: 0.3 * 252 = 75.6 -> entry 76.
-        for (const amrvis::OpacityRamp narrow :
-            {amrvis::OpacityRamp{0.3, 0.3, 1.0, false},
-                amrvis::OpacityRamp{0.299, 0.301, 1.0, false}}) {
+        for (const amrvis::OpacityRamp& narrow :
+            {amrvis::OpacityRamp{0.3, 0.3, 1.0, false, {}},
+                amrvis::OpacityRamp{0.299, 0.301, 1.0, false, {}}}) {
             const auto shell = amrvis::makeVolumeTransferFunction(palette, narrow);
             for (int entry = 0; entry < 253; ++entry) {
                 const auto i = static_cast<std::size_t>(entry);
@@ -264,7 +358,7 @@ int main()
         // A window holding a few entries ramps over exactly those, the top
         // one at the maximum: [0.30, 0.31] * 252 = [75.6, 78.12] -> 76..78.
         const auto few = amrvis::makeVolumeTransferFunction(
-            palette, amrvis::OpacityRamp{0.30, 0.31, 0.8, false});
+            palette, amrvis::OpacityRamp{0.30, 0.31, 0.8, false, {}});
         require(few.opacities[75] == 0.0F && few.opacities[76] == 0.0F
                 && std::abs(few.opacities[77] - 0.4F) <= 1.0e-6F
                 && std::abs(few.opacities[78] - 0.8F) <= 1.0e-6F
@@ -272,8 +366,26 @@ int main()
             "a few-entry window did not ramp over its entries to the maximum");
         // The palette's alpha ramp, when asked for and present; the plain
         // ramp when the palette has none.
-        amrvis::OpacityRamp fromPalette{0.0, 1.0, 1.0, true};
+        amrvis::OpacityRamp fromPalette{0.0, 1.0, 1.0, true, {}};
         const auto alphaPalette = syntheticPalette(true);
+        // With a curve, usePaletteAlpha still substitutes the palette's own
+        // alpha; the curve says only where opacity is zero. So a palette ramp
+        // keeps its shape and the curve windows it, rather than the two being
+        // multiplied into a third shape nobody chose.
+        {
+            amrvis::OpacityRamp shaped;
+            shaped.usePaletteAlpha = true;
+            shaped.curve = {{0.0, 0.0}, {0.5, 0.0}, {0.6, 1.0}, {1.0, 1.0}};
+            const auto gated
+                = amrvis::makeVolumeTransferFunction(alphaPalette, shaped);
+            require(gated.opacities[0] == 0.0F && gated.opacities[100] == 0.0F,
+                "the curve did not clear the entries it pulled to nothing");
+            const auto slot = amrvis::Palette::paletteStart + 200;
+            require(std::abs(gated.opacities[200]
+                        - static_cast<float>(alphaPalette.opacity(slot)))
+                    <= 1.0e-6F,
+                "an entry the curve kept did not take the palette's alpha");
+        }
         const auto withAlpha = amrvis::makeVolumeTransferFunction(alphaPalette, fromPalette);
         require(withAlpha.opacities[0] == 1.0F   // slot 3: 3 % 3 == 0 -> 100 %
                 && std::abs(withAlpha.opacities[1] - 0.2F) <= 1.0e-6F,
@@ -334,10 +446,10 @@ int main()
             }
             return false;
         };
-        require(refusesRamp({0.8, 0.2, 1.0, false}),
+        require(refusesRamp({0.8, 0.2, 1.0, false, {}}),
             "an inverted opacity window was accepted");
-        require(refusesRamp({std::nan(""), 1.0, 1.0, false})
-                && refusesRamp({0.0, 1.0, std::nan(""), false}),
+        require(refusesRamp({std::nan(""), 1.0, 1.0, false, {}})
+                && refusesRamp({0.0, 1.0, std::nan(""), false, {}}),
             "a non-finite opacity control was accepted");
         // The smallest budget that does fit one pixel still yields one pixel.
         const auto minimum = static_cast<std::uint32_t>(
@@ -421,7 +533,7 @@ int main()
         request.range = amrvis::VolumeRange{1.0, 2.0, false};
         request.transfer = amrvis::makeVolumeTransferFunction(
             amrvis::builtinPalette(amrvis::BuiltinPalette::Rainbow),
-            amrvis::OpacityRamp{0.5, 1.0, 1.0, false});
+            amrvis::OpacityRamp{0.5, 1.0, 1.0, false, {}});
         request.maximumVoxels = 4096;
         const auto first = amrvis::executeVolumeRenderWithFallback(dataset, request);
         require(first.frame.width == 64 && first.frame.height == 48

--- a/tests/integration/test_volume_pipeline.cpp
+++ b/tests/integration/test_volume_pipeline.cpp
@@ -368,23 +368,54 @@ int main()
         // ramp when the palette has none.
         amrvis::OpacityRamp fromPalette{0.0, 1.0, 1.0, true, {}};
         const auto alphaPalette = syntheticPalette(true);
-        // With a curve, usePaletteAlpha still substitutes the palette's own
-        // alpha; the curve says only where opacity is zero. So a palette ramp
-        // keeps its shape and the curve windows it, rather than the two being
-        // multiplied into a third shape nobody chose.
+        // A curve and the palette's own alpha are alternatives: with the box
+        // in effect the palette's ramp comes back as authored, whatever the
+        // curve says. The curve used to gate it -- zero where the curve was
+        // zero -- which almost never bit, because the entries land at k / 252
+        // and a curve touching zero at one point misses all of them. This
+        // shape is exactly that case: a V with its floor at 0.501.
         {
             amrvis::OpacityRamp shaped;
             shaped.usePaletteAlpha = true;
-            shaped.curve = {{0.0, 0.0}, {0.5, 0.0}, {0.6, 1.0}, {1.0, 1.0}};
-            const auto gated
+            shaped.curve = {{0.0, 1.0}, {0.501, 0.0}, {1.0, 1.0}};
+            const auto authored
                 = amrvis::makeVolumeTransferFunction(alphaPalette, shaped);
-            require(gated.opacities[0] == 0.0F && gated.opacities[100] == 0.0F,
-                "the curve did not clear the entries it pulled to nothing");
+            amrvis::OpacityRamp plainAlpha;
+            plainAlpha.usePaletteAlpha = true;
+            const auto reference
+                = amrvis::makeVolumeTransferFunction(alphaPalette, plainAlpha);
+            require(authored.opacities == reference.opacities,
+                "the curve altered a palette's authored alpha ramp");
+            // And it is that ramp, not a flat or empty one, so the comparison
+            // above is not two identical mistakes.
             const auto slot = amrvis::Palette::paletteStart + 200;
-            require(std::abs(gated.opacities[200]
+            require(std::abs(authored.opacities[200]
                         - static_cast<float>(alphaPalette.opacity(slot)))
                     <= 1.0e-6F,
-                "an entry the curve kept did not take the palette's alpha");
+                "the palette-alpha path did not hand back the palette's own "
+                "opacity");
+            // Entries 0 and 1: the synthetic ramp is 100 % on every third
+            // slot and 20 % elsewhere, and paletteStart is 3, so these two
+            // differ where 10 and 200 happen to collide.
+            require(authored.opacities[0] != authored.opacities[1],
+                "the reference ramp is flat, so matching it proves nothing");
+
+            // And a curve that gating *would* have bitten on: flat at zero
+            // over the bottom half, so entries there landed on it. The V above
+            // cannot tell the old rule from the new one -- gating left it
+            // unchanged too -- so without this case the bug passes.
+            amrvis::OpacityRamp flatBottom;
+            flatBottom.usePaletteAlpha = true;
+            flatBottom.curve = {{0.0, 0.0}, {0.5, 0.0}, {0.6, 1.0}, {1.0, 1.0}};
+            const auto unshaped
+                = amrvis::makeVolumeTransferFunction(alphaPalette, flatBottom);
+            require(unshaped.opacities == reference.opacities,
+                "a curve pulled to nothing still cleared the palette's own "
+                "alpha, so the two are being layered rather than chosen "
+                "between");
+            require(reference.opacities[50] > 0.0F,
+                "the reference ramp is already zero there, so the check above "
+                "proves nothing");
         }
         const auto withAlpha = amrvis::makeVolumeTransferFunction(alphaPalette, fromPalette);
         require(withAlpha.opacities[0] == 1.0F   // slot 3: 3 % 3 == 0 -> 100 %

--- a/tests/unit/test_volume_controller.cpp
+++ b/tests/unit/test_volume_controller.cpp
@@ -1016,6 +1016,78 @@ int main(int argc, char** argv)
             "the edited curve did not change the opacities in the request");
         require(std::abs(static_cast<double>(shaped[midEntry]) - 0.75) <= 0.06,
             "the middle entry is not the opacity the point was dropped at");
+
+        // Dragging a point that is already there -- the gesture the whole
+        // control exists for, and the one a press-to-insert test does not
+        // touch. The point added above sits under `middle`, so a press there
+        // takes it rather than adding another.
+        auto moved = session->requests.load();
+        const QPointF lower(0.5 * widget->width(), 0.75 * widget->height());
+        QMouseEvent grab(QEvent::MouseButtonPress, middle,
+            widget->mapToGlobal(middle), Qt::LeftButton, Qt::LeftButton,
+            Qt::NoModifier);
+        QApplication::sendEvent(widget, &grab);
+        require(widget->curve().size() == 3,
+            "pressing an existing point added another one instead of taking "
+            "it");
+        QMouseEvent drag(QEvent::MouseMove, lower, widget->mapToGlobal(lower),
+            Qt::NoButton, Qt::LeftButton, Qt::NoModifier);
+        QApplication::sendEvent(widget, &drag);
+        QMouseEvent letGo(QEvent::MouseButtonRelease, lower,
+            widget->mapToGlobal(lower), Qt::LeftButton, Qt::NoButton,
+            Qt::NoModifier);
+        QApplication::sendEvent(widget, &letGo);
+        require(widget->curve()[1].opacity < 0.4,
+            "dragging the point down did not lower its opacity");
+        waitFor(application, [&] { return session->requests > moved; },
+            "dragging a point did not render");
+        waitFor(application, [&] { return !controller.renderInFlight(); },
+            "the render after the drag did not finish");
+        const auto dragged = session->requestsSoFar().back().transfer.opacities;
+        require(std::abs(static_cast<double>(dragged[midEntry]) - 0.25) <= 0.06,
+            "the drag did not reach the opacities in the request");
+
+        // Quiesce before the next check. The drag armed the settle timer, and
+        // its full frame arriving later would stand in for the render the
+        // removal is supposed to cause -- which it did, until this was here.
+        settle(application, 500);
+        waitFor(application, [&] { return !controller.renderInFlight(); },
+            "the drag's renders did not finish");
+        auto removed = session->requests.load();
+        settle(application, 150);
+        require(session->requests == removed,
+            "the volume was still rendering of its own accord, so the next "
+            "check could not be the removal's doing");
+
+        // And right-clicking a point removes it, which also has to render:
+        // the volume is showing a curve that no longer exists.
+        QMouseEvent unwanted(QEvent::MouseButtonPress, lower,
+            widget->mapToGlobal(lower), Qt::RightButton, Qt::RightButton,
+            Qt::NoModifier);
+        QApplication::sendEvent(widget, &unwanted);
+        require(widget->curve().size() == 2,
+            "right-clicking a point did not remove it");
+        waitFor(application, [&] { return session->requests > removed; },
+            "removing a point did not render");
+        waitFor(application, [&] { return !controller.renderInFlight(); },
+            "the render after the removal did not finish");
+        const auto restored = session->requestsSoFar().back().transfer.opacities;
+        require(std::abs(static_cast<double>(restored[midEntry]) - 0.5) <= 0.02,
+            "removing the point did not put the straight ramp back");
+
+        // The two ends are not removable -- the curve has to span the range --
+        // and refusing must not pass for an edit either.
+        const auto ends = session->requests.load();
+        const QPointF corner(0.0, static_cast<double>(widget->height()));
+        QMouseEvent atEnd(QEvent::MouseButtonPress, corner,
+            widget->mapToGlobal(corner), Qt::RightButton, Qt::RightButton,
+            Qt::NoModifier);
+        QApplication::sendEvent(widget, &atEnd);
+        require(widget->curve().size() == 2,
+            "an end point was removed, leaving the curve short of the range");
+        settle(application, 200);
+        require(session->requests == ends,
+            "refusing to remove an end point rendered anyway");
         controller.closeWindow();
     }
 

--- a/tests/unit/test_volume_controller.cpp
+++ b/tests/unit/test_volume_controller.cpp
@@ -6,6 +6,7 @@
 // the window and drops a late result; a throwing session reports through
 // renderFailed and a cancelled one silently.
 
+#include "OpacityCurveWidget.hpp"
 #include "PlaneMapping.hpp"
 #include "VolumeController.hpp"
 #include "VolumeWindow.hpp"
@@ -20,6 +21,7 @@
 #include <QRectF>
 #include <QCheckBox>
 #include <QEvent>
+#include <QMouseEvent>
 #include <QCoreApplication>
 #include <QStringList>
 #include <QTimer>
@@ -941,6 +943,80 @@ int main(int argc, char** argv)
             "an unchanged region rendered again anyway");
         controller.closeWindow();
         viewRegions = {};
+    }
+
+    // The opacity curve, driven the way a user drives it. The point of this
+    // test is the chain, not the arithmetic: a press on the widget has to reach
+    // the opacities in the request. The curve's own rules are pinned as pure
+    // functions in test_volume_pipeline; what is checked here is that editing
+    // it renders, and renders the shape that was drawn.
+    {
+        VolumeController controller(hooks());
+        Observed observed;
+        observe(controller, observed);
+        controller.showWindow(nullptr);
+        waitFor(application, [&] { return observed.frames == 1; },
+            "the opening frame was not displayed");
+        auto* const window = volumeWindow();
+        require(window != nullptr, "no volume window on screen");
+        auto* const widget
+            = window->findChild<amrvis::qt::OpacityCurveWidget*>(
+                QStringLiteral("volumeOpacityCurve"));
+        require(widget != nullptr, "no opacity curve in the volume window");
+        require(widget->width() > 16 && widget->height() > 16,
+            "the curve widget has no room, so a press cannot land in its plot");
+        require(widget->curve().size() == 2,
+            "the curve did not open as the two-point default");
+
+        // The opening frame used that default, which is the linear ramp the
+        // sliders used to produce.
+        const auto opening = session->requestsSoFar().back().transfer.opacities;
+        require(opening.size() == static_cast<std::size_t>(
+                    amrvis::Palette::colorSlots),
+            "the transfer function is not one entry per slot");
+        require(opening.front() == 0.0F
+                && std::abs(opening.back() - 1.0F) <= 1.0e-6F,
+            "the default curve did not render as a full ramp");
+
+        // A press in the upper middle of the plot: adds a point there and
+        // starts dragging it, which is one gesture in the widget.
+        const auto before = session->requests.load();
+        const QPointF middle(0.5 * widget->width(), 0.25 * widget->height());
+        QMouseEvent press(QEvent::MouseButtonPress, middle,
+            widget->mapToGlobal(middle), Qt::LeftButton, Qt::LeftButton,
+            Qt::NoModifier);
+        QApplication::sendEvent(widget, &press);
+        QMouseEvent release(QEvent::MouseButtonRelease, middle,
+            widget->mapToGlobal(middle), Qt::LeftButton, Qt::NoButton,
+            Qt::NoModifier);
+        QApplication::sendEvent(widget, &release);
+        require(widget->curve().size() == 3,
+            "pressing the plot did not add a control point");
+
+        // ...which reaches a render, through rampChanged and the same
+        // draft-then-settle path the camera uses. Nothing new was wired for
+        // this, and that is exactly what has to be checked rather than assumed.
+        waitFor(application, [&] { return session->requests > before; },
+            "editing the opacity curve did not render");
+        waitFor(application, [&] { return !controller.renderInFlight(); },
+            "the render after the curve edit did not finish");
+        // The settle turns the drag's draft into a full frame.
+        waitFor(application,
+            [&] {
+                return session->requestsSoFar().back().samplesPerVoxel == 2;
+            },
+            "the curve edit never settled into a full frame");
+
+        // And the shape that was drawn is the shape that was rendered: the new
+        // point sits at three quarters opacity in the middle of the range, so
+        // the middle entry is far above the linear ramp's half.
+        const auto shaped = session->requestsSoFar().back().transfer.opacities;
+        const auto midEntry = shaped.size() / 2;
+        require(shaped[midEntry] > opening[midEntry] + 0.1F,
+            "the edited curve did not change the opacities in the request");
+        require(std::abs(static_cast<double>(shaped[midEntry]) - 0.75) <= 0.06,
+            "the middle entry is not the opacity the point was dropped at");
+        controller.closeWindow();
     }
 
     // Sequence playback. Every frame of a sequence lands in

--- a/tests/unit/test_volume_controller.cpp
+++ b/tests/unit/test_volume_controller.cpp
@@ -1075,6 +1075,48 @@ int main(int argc, char** argv)
         require(std::abs(static_cast<double>(restored[midEntry]) - 0.5) <= 0.02,
             "removing the point did not put the straight ramp back");
 
+        // The palette's own alpha takes over from the curve, so the curve is
+        // disabled: it has no say while that box is in effect, and a control
+        // that looks editable and does nothing is the defect this replaced.
+        // Driven through setPaletteHasAlpha because the palette here carries
+        // no ramp, which is what leaves the box disabled.
+        auto* const alphaBox = window->findChild<QCheckBox*>(
+            QStringLiteral("volumePaletteAlphaCheck"));
+        require(alphaBox != nullptr, "no palette-alpha box in the volume window");
+        require(widget->isEnabled(),
+            "the curve is not editable with the palette-alpha box clear");
+        window->setPaletteHasAlpha(true);
+        require(alphaBox->isEnabled(),
+            "the box did not enable for a palette with a ramp, so ticking it "
+            "below would not be in effect");
+        alphaBox->setChecked(true);
+        require(!widget->isEnabled(),
+            "the curve stayed editable while the palette's own alpha was the "
+            "opacity source");
+        alphaBox->setChecked(false);
+        require(widget->isEnabled(),
+            "the curve did not become editable again when the palette's alpha "
+            "was switched off");
+
+        // And the other way the box can stop being in effect: a palette with
+        // no ramp arriving while it is ticked. The box unticks itself behind a
+        // signal blocker, so its own toggle cannot re-enable the curve and
+        // setPaletteHasAlpha has to.
+        alphaBox->setChecked(true);
+        require(!widget->isEnabled(), "the curve is editable again already");
+        window->setPaletteHasAlpha(false);
+        require(!alphaBox->isChecked() && !alphaBox->isEnabled(),
+            "the box did not stand down for a palette with no ramp");
+        require(widget->isEnabled(),
+            "the curve stayed disabled after the palette that justified "
+            "disabling it went away");
+        // And quiesced, for the same reason the removal check above is: those
+        // toggles each scheduled a render, and one still in the throttle when
+        // the next check takes its baseline reads as that check's doing.
+        settle(application, 500);
+        waitFor(application, [&] { return !controller.renderInFlight(); },
+            "the renders from toggling palette alpha did not finish");
+
         // The two ends are not removable -- the curve has to span the range --
         // and refusing must not pass for an edit either.
         const auto ends = session->requests.load();


### PR DESCRIPTION
Replaces the from / to / maximum sliders with a piecewise-linear curve drawn over the colours it shapes: drag a point, click to add one, right-click to remove. Three numbers could only describe one linear ramp, so a feature between two duller ones could not be given its own opacity without revealing them too. The editing rules are pure functions in the pipeline, which is where a point dragged past its neighbour or an end pulled off the range would go wrong; the widget only maps pixels to points. An empty curve leaves the old window path untouched and the default curve reproduces it entry for entry, so nothing renders differently until something sets one. Nothing new is wired to render it -- the curve emits rampChanged, the signal the sliders used.