### PR TITLE
close one window without quitting the application

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -241,7 +241,7 @@ add_subdirectory(src/render2d)
 add_subdirectory(src/pipeline)
 
 if(AMREXPLORER_ENABLE_QT)
-    find_package(Qt6 6.4 REQUIRED COMPONENTS Concurrent Core Gui Widgets)
+    find_package(Qt6 6.4 REQUIRED COMPONENTS Concurrent Core Gui Test Widgets)
     add_subdirectory(src/qt)
 endif()
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -363,6 +363,9 @@ starts at the largest a client may ask for, so it is there to tighten a server
 rather than to open one up; a request wanting more than it permits is rendered
 at the lower detail rather than refused.
 
+**File > Close** in the volume window (Ctrl+W, Cmd+W on macOS) closes the
+volume window and leaves the viewer running.
+
 **File > Export Image...** in the volume window saves the view, overlays
 included, as a PNG -- what is on screen when you pick it, including the
 wireframe on its own before a volume has rendered. If the name you give does
@@ -566,7 +569,7 @@ Independent windows have independent datasets, caches, and view state.
 | Ctrl+1 through Ctrl+9 | Composite levels 0 through N |
 | Alt+0 through Alt+9 | Show exact level N |
 | Ctrl+D | Open the Dataset window |
-| Ctrl+W | Close the current window |
+| Ctrl+W | Close this window or the Volume window (the last one quits) |
 
 The same interaction summary is always available from **Help > Keyboard &
 Mouse...**.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -268,6 +268,9 @@ Choose **View > Dataset...** or press **Ctrl+D** to inspect raw values for
 the visible physical region. Values are grouped by AMR level. Clicking a
 value highlights the corresponding sample in the main view.
 
+The Dataset and line-plot windows close with their **Close** button or with
+Ctrl+W (Cmd+W on macOS), the same key that closes the main and volume windows.
+
 Choose **View > Number Format...** to set the `printf`-style format used for
 numeric readouts. The default is `%g`.
 
@@ -569,7 +572,7 @@ Independent windows have independent datasets, caches, and view state.
 | Ctrl+1 through Ctrl+9 | Composite levels 0 through N |
 | Alt+0 through Alt+9 | Show exact level N |
 | Ctrl+D | Open the Dataset window |
-| Ctrl+W | Close this window or the Volume window (the last one quits) |
+| Ctrl+W | Close the window in front (the last one quits) |
 
 The same interaction summary is always available from **Help > Keyboard &
 Mouse...**.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -34,6 +34,9 @@ You can also start without a path and use the File menu:
 - **Open MultiFab...** opens a standalone MultiFab header.
 - **Open New Window** creates an independent viewer for side-by-side
   comparison.
+- **Close Window** (Ctrl+W, Cmd+W on macOS) closes only the current window;
+  the other windows keep running. Closing the last one exits AMReXplorer,
+  which **Quit** does from any window.
 
 Cylindrical RZ and 3-D spherical plotfiles open normally but are displayed on
 their logical grid. **2-D spherical (r, θ)** plotfiles can also be shown in
@@ -563,6 +566,7 @@ Independent windows have independent datasets, caches, and view state.
 | Ctrl+1 through Ctrl+9 | Composite levels 0 through N |
 | Alt+0 through Alt+9 | Show exact level N |
 | Ctrl+D | Open the Dataset window |
+| Ctrl+W | Close the current window |
 
 The same interaction summary is always available from **Help > Keyboard &
 Mouse...**.

--- a/src/qt/CloseWindowAction.hpp
+++ b/src/qt/CloseWindowAction.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <QAction>
+#include <QKeySequence>
+#include <QObject>
+#include <QString>
+#include <QWidget>
+#include <Qt>
+
+namespace amrvis::qt {
+
+// The one close-window key for every top-level window that has one: Ctrl+W,
+// and Cmd+W on macOS, where Qt::CTRL is Command. Spelled out rather than taken
+// from QKeySequence::Close, whose first binding here is Ctrl+F4 -- and
+// setShortcut would take only that first one.
+[[nodiscard]] inline QKeySequence closeWindowShortcut()
+{
+    return QKeySequence(Qt::CTRL | Qt::Key_W);
+}
+
+// Gives one window that key. The action is added to the window itself, so the
+// key works in the windows that carry no menu bar (Dataset, Line Plot) as well
+// as in the two that show it in a File menu -- those take the returned action
+// and add it there.
+inline QAction* addCloseWindowAction(QWidget& window, const QString& text)
+{
+    auto* action = new QAction(text, &window);
+    action->setShortcut(closeWindowShortcut());
+    QObject::connect(action, &QAction::triggered, &window, &QWidget::close);
+    window.addAction(action);
+    return action;
+}
+
+} // namespace amrvis::qt

--- a/src/qt/DatasetWindow.cpp
+++ b/src/qt/DatasetWindow.cpp
@@ -1,6 +1,7 @@
 #include "DatasetWindow.hpp"
 
 #include <amrexplorer/pipeline/SlicePipeline.hpp>
+#include "CloseWindowAction.hpp"
 #include "NumberFormat.hpp"
 #include "QtErrorText.hpp"
 
@@ -163,6 +164,10 @@ DatasetWindow::DatasetWindow(DatasetRequest request, QWidget* parent)
     connect(refreshButton, &QPushButton::clicked, this,
         [this] { emit refreshRequested(); });
     connect(closeButton, &QPushButton::clicked, this, &QWidget::close);
+    // The same key that closes the other windows. There is no menu bar here to
+    // show it in, so the action lives on the window itself, next to the button.
+    addCloseWindowAction(*this, tr("&Close"))
+        ->setObjectName(QStringLiteral("datasetCloseAction"));
 
     startLoad();
 }

--- a/src/qt/LinePlotWindow.cpp
+++ b/src/qt/LinePlotWindow.cpp
@@ -1,4 +1,5 @@
 #include "LinePlotWindow.hpp"
+#include "CloseWindowAction.hpp"
 #include "NumberFormat.hpp"
 #include "Theme.hpp"
 
@@ -527,6 +528,10 @@ LinePlotWindow::LinePlotWindow(const QString& datasetName, QWidget* parent)
     connect(zoomButton, &QPushButton::clicked, m_plot, &LinePlotWidget::resetZoom);
     connect(markersBox, &QCheckBox::toggled, m_plot, &LinePlotWidget::setShowMarkers);
     connect(closeButton, &QPushButton::clicked, this, &QWidget::close);
+    // The same key that closes the other windows. There is no menu bar here to
+    // show it in, so the action lives on the window itself, next to the button.
+    addCloseWindowAction(*this, tr("&Close"))
+        ->setObjectName(QStringLiteral("linePlotCloseAction"));
 }
 
 void LinePlotWindow::setNumberFormat(QString format)

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -1,6 +1,7 @@
 #include "MainWindowInternal.hpp"
 #include "SshRemoteSession.hpp"
 
+#include "CloseWindowAction.hpp"
 #include "CurrentRowBulletDelegate.hpp"
 
 #include <QKeySequence>
@@ -1030,15 +1031,10 @@ void MainWindow::createMenus()
     connect(m_exportAnimationAction, &QAction::triggered,
         this, [this] { exportAnimation(); });
 
-    auto* closeWindowAction = new QAction(tr("&Close Window"), this);
-    closeWindowAction->setObjectName(QStringLiteral("closeWindowAction"));
-    // Spelled out rather than QKeySequence::Close: that standard key's first
-    // binding here is Ctrl+F4, and Ctrl+W is the one this action wants.
-    // Qt::CTRL is Command on macOS, so the same line gives Cmd+W there.
-    closeWindowAction->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_W));
     // This window only: the others keep running, and closing the last one is
     // what quits (Qt's quitOnLastWindowClosed).
-    connect(closeWindowAction, &QAction::triggered, this, [this] { close(); });
+    auto* closeWindowAction = addCloseWindowAction(*this, tr("&Close Window"));
+    closeWindowAction->setObjectName(QStringLiteral("closeWindowAction"));
 
     auto* quitAction = new QAction(tr("&Quit"), this);
     quitAction->setShortcut(QKeySequence::Quit);

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -1030,6 +1030,16 @@ void MainWindow::createMenus()
     connect(m_exportAnimationAction, &QAction::triggered,
         this, [this] { exportAnimation(); });
 
+    auto* closeWindowAction = new QAction(tr("&Close Window"), this);
+    closeWindowAction->setObjectName(QStringLiteral("closeWindowAction"));
+    // Spelled out rather than QKeySequence::Close: that standard key's first
+    // binding here is Ctrl+F4, and Ctrl+W is the one this action wants.
+    // Qt::CTRL is Command on macOS, so the same line gives Cmd+W there.
+    closeWindowAction->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_W));
+    // This window only: the others keep running, and closing the last one is
+    // what quits (Qt's quitOnLastWindowClosed).
+    connect(closeWindowAction, &QAction::triggered, this, [this] { close(); });
+
     auto* quitAction = new QAction(tr("&Quit"), this);
     quitAction->setShortcut(QKeySequence::Quit);
     // Application-wide: close every main window (each runs its own close
@@ -1051,6 +1061,7 @@ void MainWindow::createMenus()
     fileMenu->addAction(exportAction);
     fileMenu->addAction(m_exportAnimationAction);
     fileMenu->addSeparator();
+    fileMenu->addAction(closeWindowAction);
     fileMenu->addAction(quitAction);
 
     m_scaleGroup = new QActionGroup(this);

--- a/src/qt/MainWindow.hpp
+++ b/src/qt/MainWindow.hpp
@@ -234,6 +234,10 @@ public:
     // per cell -- rather than in physical units. The two differ only when
     // the cells are not square (see remote-fit-anisotropic-cells).
     [[nodiscard]] bool activeViewRasterHasCellAspectForTest() const;
+    // Test-only: a second independent top-level window, made exactly as the
+    // "Open New Window" menu action makes it, for the close-window test to
+    // close again.
+    MainWindow* createNewWindowForTest() { return createNewWindow(); }
     // Test-only: the Volume Rendering window -- open it as the View menu
     // action does, whether it is open, and what fraction of the last frame's
     // pixels the ray caster lit (alpha > 0); zero before any frame.

--- a/src/qt/MainWindowInteraction.cpp
+++ b/src/qt/MainWindowInteraction.cpp
@@ -353,8 +353,8 @@ void MainWindow::showKeyboardMouseReference()
     add(tr("Alt+0-9"), tr("Show one exact AMR level"));
     add(tr("Ctrl+D"), tr("Open the Dataset window (raw cell values per level)"));
     add(tr("Ctrl+W"),
-        tr("Close this window or the Volume window; closing the last "
-           "window quits"));
+        tr("Close the window in front -- this one, Volume, Dataset or Line "
+           "Plot; closing the last window quits"));
 
     QMessageBox box(this);
     box.setWindowTitle(tr("Keyboard & Mouse"));

--- a/src/qt/MainWindowInteraction.cpp
+++ b/src/qt/MainWindowInteraction.cpp
@@ -352,6 +352,7 @@ void MainWindow::showKeyboardMouseReference()
     add(tr("Ctrl+1-9"), tr("Composite levels 0 through N (Levs 0-N)"));
     add(tr("Alt+0-9"), tr("Show one exact AMR level"));
     add(tr("Ctrl+D"), tr("Open the Dataset window (raw cell values per level)"));
+    add(tr("Ctrl+W"), tr("Close this window; the other windows stay open"));
 
     QMessageBox box(this);
     box.setWindowTitle(tr("Keyboard & Mouse"));

--- a/src/qt/MainWindowInteraction.cpp
+++ b/src/qt/MainWindowInteraction.cpp
@@ -352,7 +352,9 @@ void MainWindow::showKeyboardMouseReference()
     add(tr("Ctrl+1-9"), tr("Composite levels 0 through N (Levs 0-N)"));
     add(tr("Alt+0-9"), tr("Show one exact AMR level"));
     add(tr("Ctrl+D"), tr("Open the Dataset window (raw cell values per level)"));
-    add(tr("Ctrl+W"), tr("Close this window; the other windows stay open"));
+    add(tr("Ctrl+W"),
+        tr("Close this window or the Volume window; closing the last "
+           "window quits"));
 
     QMessageBox box(this);
     box.setWindowTitle(tr("Keyboard & Mouse"));

--- a/src/qt/SmokeHarnessLifecycle.cpp
+++ b/src/qt/SmokeHarnessLifecycle.cpp
@@ -310,19 +310,19 @@ Outcome dispatchLifecycle(Context& context)
                 }
                 QObject::connect(second, &QObject::destroyed, &application,
                     [&window, &application, decided] {
-                        const bool firstSurvived = window.isVisible();
-                        // Read the verdict here, but shut down from a later
-                        // turn of the event loop: quitting from inside the
+                        // The verdict waits a turn: quitting from inside the
                         // second window's destructor races its own teardown
                         // and segfaults or hangs about half the time. Nothing
                         // in the app quits from there -- a user's Quit is
-                        // always a separate event -- so the delay is the
-                        // harness staying on a reachable path, not a
-                        // workaround for the feature.
+                        // always a separate event -- so the delay keeps the
+                        // harness on a reachable path. isVisible() is read in
+                        // that turn rather than snapshotted here, so a close
+                        // that takes the first window down one turn late is
+                        // caught too.
                         QTimer::singleShot(0, &application,
-                            [&window, &application, decided, firstSurvived] {
+                            [&window, &application, decided] {
                                 *decided = true;
-                                if (!firstSurvived) {
+                                if (!window.isVisible()) {
                                     qCritical("Close Window closed the first"
                                         " window as well");
                                     application.exit(1);

--- a/src/qt/SmokeHarnessLifecycle.cpp
+++ b/src/qt/SmokeHarnessLifecycle.cpp
@@ -269,10 +269,24 @@ Outcome dispatchLifecycle(Context& context)
         // Qt's own quit before the verdict below runs.
         const std::filesystem::path path(argv[2]);
         application.setQuitOnLastWindowClosed(false);
+        // Every exit below sets this. An action wired to quit()/exit() instead
+        // of close() unwinds exec() on the spot, so the verdict never runs and
+        // the process would otherwise exit 0 -- passing on the very
+        // regression this scenario exists to catch.
+        auto decided = std::make_shared<bool>(false);
+        QObject::connect(&application, &QCoreApplication::aboutToQuit,
+            &application, [decided] {
+                if (!*decided) {
+                    qFatal("the run ended before the Close Window verdict: "
+                        "the action quit the application instead of closing "
+                        "its own window");
+                }
+            });
         QObject::connect(&window, &amrvis::qt::MainWindow::initialSliceFinished,
-            &application, [&window, &application](bool success) {
+            &application, [&window, &application, decided](bool success) {
                 if (!success) {
                     qCritical("the initial slice failed");
+                    *decided = true;
                     application.exit(1);
                     return;
                 }
@@ -282,6 +296,7 @@ Outcome dispatchLifecycle(Context& context)
                 if (action == nullptr || !action->isEnabled()) {
                     qCritical("the Close Window menu item is missing"
                         " or disabled");
+                    *decided = true;
                     application.exit(1);
                     return;
                 }
@@ -289,11 +304,12 @@ Outcome dispatchLifecycle(Context& context)
                     != QKeySequence(Qt::CTRL | Qt::Key_W)) {
                     qCritical("Close Window carries the shortcut '%s'",
                         qUtf8Printable(action->shortcut().toString()));
+                    *decided = true;
                     application.exit(1);
                     return;
                 }
                 QObject::connect(second, &QObject::destroyed, &application,
-                    [&window, &application] {
+                    [&window, &application, decided] {
                         const bool firstSurvived = window.isVisible();
                         // Read the verdict here, but shut down from a later
                         // turn of the event loop: quitting from inside the
@@ -304,7 +320,8 @@ Outcome dispatchLifecycle(Context& context)
                         // harness staying on a reachable path, not a
                         // workaround for the feature.
                         QTimer::singleShot(0, &application,
-                            [&window, &application, firstSurvived] {
+                            [&window, &application, decided, firstSurvived] {
+                                *decided = true;
                                 if (!firstSurvived) {
                                     qCritical("Close Window closed the first"
                                         " window as well");
@@ -317,8 +334,11 @@ Outcome dispatchLifecycle(Context& context)
                     });
                 action->trigger();
             });
-        QTimer::singleShot(15000, &application,
-            [&application] { application.exit(1); });
+        QTimer::singleShot(15000, &application, [&application, decided] {
+            qCritical("the close-window scenario timed out");
+            *decided = true;
+            application.exit(1);
+        });
         QTimer::singleShot(0, &window,
             [&window, path] { window.openDataset(path); });
     } else if (argc == 3

--- a/src/qt/SmokeHarnessLifecycle.cpp
+++ b/src/qt/SmokeHarnessLifecycle.cpp
@@ -2,7 +2,9 @@
 
 #include "MainWindow.hpp"
 
+#include <QAction>
 #include <QComboBox>
+#include <QKeySequence>
 #include <QRunnable>
 #include <QThreadPool>
 #include <QTimer>
@@ -17,9 +19,9 @@
 
 // Lifecycle: the open / failure / idle-state / shutdown scenarios: plain
 // open, open failure, cache budget, idle UI state, closing with a busy pool,
-// quitting, quitting mid-export. Every branch drives MainWindow through its
-// ForTest accessors and arms connections and timers for main() to run; see
-// SmokeHarness.hpp.
+// closing one window of several, quitting, quitting mid-export. Every branch
+// drives MainWindow through its ForTest accessors and arms connections and
+// timers for main() to run; see SmokeHarness.hpp.
 
 namespace amrvis::qt::smoke {
 
@@ -258,6 +260,67 @@ Outcome dispatchLifecycle(Context& context)
             // Release the gate so the surviving worker (with the fix) can run.
             gate->store(true);
         });
+    } else if (argc == 3
+        && std::string_view(argv[1]) == "--close-window-smoke-test") {
+        // File > Close Window closes only the window it was chosen from: the
+        // second window goes away (its WA_DeleteOnClose delete is the proof)
+        // and the first one is still up afterwards. quitOnLastWindowClosed is
+        // off so that a regression closing every window cannot exit 0 through
+        // Qt's own quit before the verdict below runs.
+        const std::filesystem::path path(argv[2]);
+        application.setQuitOnLastWindowClosed(false);
+        QObject::connect(&window, &amrvis::qt::MainWindow::initialSliceFinished,
+            &application, [&window, &application](bool success) {
+                if (!success) {
+                    qCritical("the initial slice failed");
+                    application.exit(1);
+                    return;
+                }
+                auto* second = window.createNewWindowForTest();
+                auto* action = second->findChild<QAction*>(
+                    QStringLiteral("closeWindowAction"));
+                if (action == nullptr || !action->isEnabled()) {
+                    qCritical("the Close Window menu item is missing"
+                        " or disabled");
+                    application.exit(1);
+                    return;
+                }
+                if (action->shortcut()
+                    != QKeySequence(Qt::CTRL | Qt::Key_W)) {
+                    qCritical("Close Window carries the shortcut '%s'",
+                        qUtf8Printable(action->shortcut().toString()));
+                    application.exit(1);
+                    return;
+                }
+                QObject::connect(second, &QObject::destroyed, &application,
+                    [&window, &application] {
+                        const bool firstSurvived = window.isVisible();
+                        // Read the verdict here, but shut down from a later
+                        // turn of the event loop: quitting from inside the
+                        // second window's destructor races its own teardown
+                        // and segfaults or hangs about half the time. Nothing
+                        // in the app quits from there -- a user's Quit is
+                        // always a separate event -- so the delay is the
+                        // harness staying on a reachable path, not a
+                        // workaround for the feature.
+                        QTimer::singleShot(0, &application,
+                            [&window, &application, firstSurvived] {
+                                if (!firstSurvived) {
+                                    qCritical("Close Window closed the first"
+                                        " window as well");
+                                    application.exit(1);
+                                    return;
+                                }
+                                window.close();
+                                application.exit(0);
+                            });
+                    });
+                action->trigger();
+            });
+        QTimer::singleShot(15000, &application,
+            [&application] { application.exit(1); });
+        QTimer::singleShot(0, &window,
+            [&window, path] { window.openDataset(path); });
     } else if (argc == 3
         && std::string_view(argv[1]) == "--quit-smoke-test") {
         // Open a dataset, then quit through the main window once the initial

--- a/src/qt/VolumeWindow.cpp
+++ b/src/qt/VolumeWindow.cpp
@@ -1,5 +1,6 @@
 #include "VolumeWindow.hpp"
 
+#include "CloseWindowAction.hpp"
 #include "IsoWidget.hpp"
 #include "OpacityCurveWidget.hpp"
 #include "WidgetImageExport.hpp"
@@ -73,13 +74,8 @@ VolumeWindow::VolumeWindow(QWidget* parent)
     exportAction->setShortcut(QKeySequence::Save);
     connect(exportAction, &QAction::triggered, this, [this] { exportImage(); });
     fileMenu->addAction(exportAction);
-    auto* closeAction = new QAction(tr("&Close"), this);
+    auto* closeAction = addCloseWindowAction(*this, tr("&Close"));
     closeAction->setObjectName(QStringLiteral("volumeCloseAction"));
-    // Ctrl+W, matching the main window's File > Close Window. Not
-    // QKeySequence::Close, whose first binding here is Ctrl+F4; Qt::CTRL is
-    // Command on macOS, so this is Cmd+W there.
-    closeAction->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_W));
-    connect(closeAction, &QAction::triggered, this, [this] { close(); });
     fileMenu->addAction(closeAction);
 }
 

--- a/src/qt/VolumeWindow.cpp
+++ b/src/qt/VolumeWindow.cpp
@@ -74,7 +74,11 @@ VolumeWindow::VolumeWindow(QWidget* parent)
     connect(exportAction, &QAction::triggered, this, [this] { exportImage(); });
     fileMenu->addAction(exportAction);
     auto* closeAction = new QAction(tr("&Close"), this);
-    closeAction->setShortcut(QKeySequence::Close);
+    closeAction->setObjectName(QStringLiteral("volumeCloseAction"));
+    // Ctrl+W, matching the main window's File > Close Window. Not
+    // QKeySequence::Close, whose first binding here is Ctrl+F4; Qt::CTRL is
+    // Command on macOS, so this is Cmd+W there.
+    closeAction->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_W));
     connect(closeAction, &QAction::triggered, this, [this] { close(); });
     fileMenu->addAction(closeAction);
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1323,6 +1323,17 @@ if(TARGET amrexplorer_qt)
     )
     set_tests_properties(qt_window_close_pool_smoke_3d PROPERTIES TIMEOUT 30)
     add_test(
+        NAME qt_close_window_smoke_3d
+        COMMAND "${CMAKE_COMMAND}"
+            "-DMATERIALIZER=$<TARGET_FILE:fixture_materializer>"
+            "-DAMREXPLORER_QT=$<TARGET_FILE:amrexplorer_qt>"
+            "-DSOURCE=${CMAKE_CURRENT_SOURCE_DIR}/data/plotfile_3d"
+            "-DWORK=${CMAKE_CURRENT_BINARY_DIR}/fixtures_close_window_3d"
+            -DMODE=close-window
+            -P "${CMAKE_CURRENT_SOURCE_DIR}/qt_smoke_driver.cmake"
+    )
+    set_tests_properties(qt_close_window_smoke_3d PROPERTIES TIMEOUT 30)
+    add_test(
         NAME qt_quit_on_failure_smoke_3d
         COMMAND "${CMAKE_COMMAND}"
             "-DMATERIALIZER=$<TARGET_FILE:fixture_materializer>"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1044,7 +1044,7 @@ if(TARGET amrexplorer_qt)
         PRIVATE "${PROJECT_SOURCE_DIR}/src/qt"
     )
     target_link_libraries(test_line_plot_hover
-        PRIVATE amrexplorer::core amrexplorer::warnings Qt6::Widgets
+        PRIVATE amrexplorer::core amrexplorer::warnings Qt6::Test Qt6::Widgets
     )
     add_test(
         NAME line_plot_hover

--- a/tests/qt_smoke_driver.cmake
+++ b/tests/qt_smoke_driver.cmake
@@ -9,6 +9,7 @@
 #                 remote-sequence-after-fab | missing-range |
 #                 non-finite | raw-fab |
 #                 multifab-fab | quit | quit-on-failure | window-close-pool |
+#                 close-window |
 #                 export-quit |
 #                 contour-sync | raster-zoom | rubber-zoom-sync |
 #                 particle-visible-range | particle-dialog |
@@ -287,6 +288,9 @@ elseif(MODE STREQUAL "quit")
 elseif(MODE STREQUAL "window-close-pool")
     run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt")
     run_or_die("${AMREXPLORER_QT}" --window-close-pool-smoke-test "${WORK}/plt")
+elseif(MODE STREQUAL "close-window")
+    run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt")
+    run_or_die("${AMREXPLORER_QT}" --close-window-smoke-test "${WORK}/plt")
 elseif(MODE STREQUAL "quit-on-failure")
     run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt")
     # Drop the FAB payloads so the slice read fails while metadata stays valid

--- a/tests/unit/test_line_plot_hover.cpp
+++ b/tests/unit/test_line_plot_hover.cpp
@@ -2,6 +2,7 @@
 
 #include <QAction>
 #include <QApplication>
+#include <QTest>
 #include <QEvent>
 #include <QKeySequence>
 #include <QMouseEvent>
@@ -85,7 +86,12 @@ int main(int argc, char* argv[])
         "the close action is not on the window, so Ctrl+W cannot reach it");
     require(closeAction->shortcut() == QKeySequence(Qt::CTRL | Qt::Key_W),
         "the line plot close shortcut is not Ctrl+W");
-    closeAction->trigger();
+    // Pressed, not triggered: QTest::keyClick goes through the platform's key
+    // path and Qt's shortcut map, which is what a trigger() call skips -- and
+    // skipping it hides a wrong shortcut context or a missing window
+    // association, both of which leave the key dead in the app.
+    window.activateWindow();
+    QTest::keyClick(&window, Qt::Key_W, Qt::ControlModifier);
     require(!window.isVisible(), "Ctrl+W left the line plot window open");
     return 0;
 }

--- a/tests/unit/test_line_plot_hover.cpp
+++ b/tests/unit/test_line_plot_hover.cpp
@@ -1,7 +1,9 @@
 #include "LinePlotWindow.hpp"
 
+#include <QAction>
 #include <QApplication>
 #include <QEvent>
+#include <QKeySequence>
 #include <QMouseEvent>
 #include <QPointF>
 #include <QToolTip>
@@ -71,5 +73,19 @@ int main(int argc, char* argv[])
     application.processEvents();
     // QToolTip fades asynchronously and the offscreen platform keeps reporting
     // it as visible during that fade; sending Leave still exercises cleanup.
+
+    // Ctrl+W closes this window, as it does the main, volume and Dataset ones.
+    // The window carries no menu bar, so the action has to be on the window
+    // itself for the key to reach it; the sequence is spelled out here rather
+    // than read back from the action, so moving the key fails this.
+    auto* const closeAction = window.findChild<QAction*>(
+        QStringLiteral("linePlotCloseAction"));
+    require(closeAction != nullptr, "the line plot has no close action");
+    require(window.actions().contains(closeAction),
+        "the close action is not on the window, so Ctrl+W cannot reach it");
+    require(closeAction->shortcut() == QKeySequence(Qt::CTRL | Qt::Key_W),
+        "the line plot close shortcut is not Ctrl+W");
+    closeAction->trigger();
+    require(!window.isVisible(), "Ctrl+W left the line plot window open");
     return 0;
 }

--- a/tests/unit/test_volume_controller.cpp
+++ b/tests/unit/test_volume_controller.cpp
@@ -21,6 +21,7 @@
 #include <QRectF>
 #include <QCheckBox>
 #include <QEvent>
+#include <QKeySequence>
 #include <QMouseEvent>
 #include <QCoreApplication>
 #include <QStringList>
@@ -723,6 +724,28 @@ int main(int argc, char** argv)
         waitFor(application, [&] { return !controller.renderInFlight(); },
             "the drafts did not finish");
         controller.closeWindow();
+    }
+
+    // File > Close closes the window on Ctrl+W, the same shortcut the main
+    // window's Close Window carries. The sequence is spelled out here rather
+    // than read back off the action, so changing it in VolumeWindow fails.
+    {
+        VolumeController controller(hooks());
+        Observed observed;
+        observe(controller, observed);
+        controller.showWindow(nullptr);
+        waitFor(application, [&] { return observed.frames == 1; },
+            "the first frame was not displayed");
+        auto* const window = volumeWindow();
+        require(window != nullptr, "no volume window on screen");
+        auto* const closeAction = window->findChild<QAction*>(
+            QStringLiteral("volumeCloseAction"));
+        require(closeAction != nullptr, "the volume File > Close item is gone");
+        require(closeAction->shortcut() == QKeySequence(Qt::CTRL | Qt::Key_W),
+            "the volume File > Close shortcut is not Ctrl+W");
+        closeAction->trigger();
+        waitFor(application, [&] { return volumeWindow() == nullptr; },
+            "File > Close left the volume window open");
     }
 
     // cancel() disarms the settle timer. Left armed it fires after the

--- a/tests/unit/test_volume_controller.cpp
+++ b/tests/unit/test_volume_controller.cpp
@@ -759,11 +759,11 @@ int main(int argc, char** argv)
         QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
         require(volumeWindow() == nullptr,
             "File > Close left the volume window open");
-        // The delete is what tells the controller the user closed its window
-        // (the destroyed -> forgetWindow connection, which closeWindow()
-        // drops); nothing else in this file takes that branch.
-        require(!controller.windowOpen(),
-            "the controller still holds the window the user closed");
+        // The delete is what tells the controller the user closed its window,
+        // through the destroyed -> forgetWindow connection that closeWindow()
+        // drops; nothing else in this file takes that branch. The dropped
+        // frame is what shows the handler ran -- windowOpen() would report
+        // false from its QPointer nulling itself, handler or no handler.
         require(controller.lastFrame().pixels.empty(),
             "the closed window's frame was kept");
     }

--- a/tests/unit/test_volume_controller.cpp
+++ b/tests/unit/test_volume_controller.cpp
@@ -273,6 +273,12 @@ void settle(QCoreApplication& application, int milliseconds)
 int main(int argc, char** argv)
 {
     QApplication application(argc, argv);
+    // Every wait below is a real application.exec() (see waitFor) and the
+    // volume window is usually the only top-level one, so closing it would let
+    // Qt quit the application out from under the next wait. What that does to
+    // an exec() differs across the Qt versions this builds against (6.4 is the
+    // floor), so take the behaviour out of play rather than depend on it.
+    application.setQuitOnLastWindowClosed(false);
     using amrvis::qt::VolumeController;
 
     // --- the size a frame is ray-cast at -------------------------------
@@ -744,8 +750,22 @@ int main(int argc, char** argv)
         require(closeAction->shortcut() == QKeySequence(Qt::CTRL | Qt::Key_W),
             "the volume File > Close shortcut is not Ctrl+W");
         closeAction->trigger();
-        waitFor(application, [&] { return volumeWindow() == nullptr; },
+        // close() hides the window at once and leaves WA_DeleteOnClose to
+        // delete it a turn later. Flush that here instead of waiting on the
+        // event loop: when the delete lands depends on the loop level it was
+        // posted from and on the Qt version, and CI's 6.4 does not run it
+        // inside waitFor at all. Deleting it now also keeps a hidden,
+        // pending-delete window out of the next case's volumeWindow().
+        QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
+        require(volumeWindow() == nullptr,
             "File > Close left the volume window open");
+        // The delete is what tells the controller the user closed its window
+        // (the destroyed -> forgetWindow connection, which closeWindow()
+        // drops); nothing else in this file takes that branch.
+        require(!controller.windowOpen(),
+            "the controller still holds the window the user closed");
+        require(controller.lastFrame().pixels.empty(),
+            "the closed window's frame was kept");
     }
 
     // cancel() disarms the settle timer. Left armed it fires after the


### PR DESCRIPTION
File > Close Window (Ctrl+W, Cmd+W) closes the window it was chosen from; Quit still closes them all. Closing the last window exits, which is Qt's own quitOnLastWindowClosed. The shortcut is spelled out rather than taken from QKeySequence::Close, whose first binding here is Ctrl+F4, and the Volume Rendering window's existing File > Close -- which had that Ctrl+F4 -- now carries Ctrl+W too, so the same key closes whichever window is in front.