### PR TITLE
fix the opacity editor and tidy the volume window

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -323,10 +323,12 @@ match. Its own controls set the opacity:
   two end points stay at the ends of the range and move only up and down, so
   the curve always covers it.
 
-  The point you last clicked stays selected -- it is the filled one -- and the
-  arrow keys move it: one color slot sideways or one percent up and down,
-  which is finer than the mouse can place it, and ten times that with Shift
-  held. Drop a point roughly where you want it and then tune it with the keys.
+  The point you last clicked stays selected -- it is the one marked in the
+  highlight color while the plot has the keyboard focus -- and the arrow keys
+  move it in exact steps: one color slot sideways, one percent up and down,
+  and ten times either with Shift held. Drop a point roughly where you want it
+  with the mouse, then step it into place with the keys, which is easier than
+  holding a drag steady and repeatable when you want the same value twice.
 
   It starts as a straight line from transparent at the cold end to opaque at
   the hot end. Pull the low end up to see faint values, pull a stretch down to

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -323,6 +323,11 @@ match. Its own controls set the opacity:
   two end points stay at the ends of the range and move only up and down, so
   the curve always covers it.
 
+  The point you last clicked stays selected -- it is the filled one -- and the
+  arrow keys move it: one color slot sideways or one percent up and down,
+  which is finer than the mouse can place it, and ten times that with Shift
+  held. Drop a point roughly where you want it and then tune it with the keys.
+
   It starts as a straight line from transparent at the cold end to opaque at
   the hot end. Pull the low end up to see faint values, pull a stretch down to
   look through a feature that is hiding what is behind it, or pull everything

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -305,8 +305,8 @@ field: every pixel accumulates the color and opacity of the cells along its
 line of sight, so translucent structure inside the domain shows through. The
 window has its own copy of the isometric view -- drag to rotate, wheel
 to zoom, and the **XY**, **XZ**, **YZ** buttons for the axis-aligned views --
-with the domain outline, the grid boxes and the slice planes drawn over the
-rendered volume.
+with the domain outline and the slice planes drawn over the rendered volume.
+The AMR grid boxes can be drawn too, though they start off here.
 
 The window follows the main window: the field, the AMR level, the range mode
 and its User min/max, the logarithmic mapping and the palette are the ones
@@ -354,6 +354,10 @@ match. Its own controls set the opacity:
   A remote plotfile renders the same as a local one, unless the server was
   started with a tighter ceiling of its own -- in which case **High** may look
   no different from **Normal** (see [Remote datasets](#remote-datasets)).
+- **Grid boxes** and **Domain outline** draw the AMR box edges and the edge of
+  the domain over the volume. The outline is on by default and the boxes are
+  not: box edges crossing a translucent field read as structure in it, which
+  is worth asking for rather than having to switch off.
 
 While the camera moves the window shows quick half-resolution drafts and
 renders the full frame once it settles. Rotating and zooming reuse the field

--- a/include/amrexplorer/pipeline/VolumePipeline.hpp
+++ b/include/amrexplorer/pipeline/VolumePipeline.hpp
@@ -45,7 +45,11 @@ struct OpacityPoint {
 // mistakes live: a point dragged past its neighbour, an end point dragged off
 // the range, a curve left unsorted for opacityCurveValue to read.
 //
-// insert: a new point, keeping the list sorted; returns its index.
+// insert: a new point, keeping the list sorted; returns its index. On a curve
+//   with two ends it always lands between them -- its position is held to the
+//   span they cover and the returned index is never 0 or the last -- so the
+//   ends stay the ends: they are what makes the curve span the range, and an
+//   end that arrived by insertion could not be removed again.
 // move: point `index` to (position, opacity), clamped into [0, 1] and, for an
 //   interior point, between its neighbours. The two end points keep their
 //   positions -- the curve has to span the range -- and move only in opacity.

--- a/src/pipeline/VolumePipeline.cpp
+++ b/src/pipeline/VolumePipeline.cpp
@@ -58,7 +58,19 @@ std::size_t insertOpacityPoint(
 {
     const OpacityPoint point{std::clamp(position, 0.0, 1.0),
         std::clamp(opacity, 0.0, 1.0)};
-    const auto at = std::upper_bound(curve.begin(), curve.end(), point,
+    // A curve too short to have two ends has no order to keep.
+    if (curve.size() < 2) {
+        curve.push_back(point);
+        return curve.size() - 1;
+    }
+    // Between the two end points and never outside them, so only the interior
+    // is searched. They anchor the curve to the ends of the range, and a click
+    // on the right edge of the plot clamps to position 1.0, which is not less
+    // than the last point's: searching the whole curve would append past that
+    // anchor. The new point would then be the end -- which removeOpacityPoint
+    // refuses to delete, and which opacityCurveValue extends flat, so it would
+    // shape a single entry of the table and nothing else.
+    const auto at = std::upper_bound(curve.begin() + 1, curve.end() - 1, point,
         [](const OpacityPoint& left, const OpacityPoint& right) {
             return left.position < right.position;
         });

--- a/src/pipeline/VolumePipeline.cpp
+++ b/src/pipeline/VolumePipeline.cpp
@@ -56,12 +56,20 @@ double opacityCurveValue(
 std::size_t insertOpacityPoint(
     std::vector<OpacityPoint>& curve, double position, double opacity)
 {
-    const OpacityPoint point{std::clamp(position, 0.0, 1.0),
-        std::clamp(opacity, 0.0, 1.0)};
-    // A curve too short to have two ends has no order to keep.
+    const auto byPosition
+        = [](const OpacityPoint& left, const OpacityPoint& right) {
+              return left.position < right.position;
+          };
+    const auto value = std::clamp(opacity, 0.0, 1.0);
+    // Too short to have two ends: no anchors to stay inside, so this is the
+    // plain sorted insert.
     if (curve.size() < 2) {
-        curve.push_back(point);
-        return curve.size() - 1;
+        const OpacityPoint only{std::clamp(position, 0.0, 1.0), value};
+        const auto where
+            = std::upper_bound(curve.begin(), curve.end(), only, byPosition);
+        const auto at = static_cast<std::size_t>(where - curve.begin());
+        curve.insert(where, only);
+        return at;
     }
     // Between the two end points and never outside them, so only the interior
     // is searched. They anchor the curve to the ends of the range, and a click
@@ -70,10 +78,19 @@ std::size_t insertOpacityPoint(
     // anchor. The new point would then be the end -- which removeOpacityPoint
     // refuses to delete, and which opacityCurveValue extends flat, so it would
     // shape a single entry of the table and nothing else.
-    const auto at = std::upper_bound(curve.begin() + 1, curve.end() - 1, point,
-        [](const OpacityPoint& left, const OpacityPoint& right) {
-            return left.position < right.position;
-        });
+    //
+    // The position is held to the span the ends themselves cover, not just to
+    // [0, 1]: bounding the search to the interior means a position outside
+    // that span would land at the near end of the interior and leave the list
+    // unsorted, which is what opacityCurveValue reads and what moveOpacityPoint
+    // would then clamp between inverted neighbours. The list is assumed sorted
+    // on the way in, so the front is never above the back.
+    const OpacityPoint point{
+        std::clamp(std::clamp(position, 0.0, 1.0), curve.front().position,
+            curve.back().position),
+        value};
+    const auto at = std::upper_bound(
+        curve.begin() + 1, curve.end() - 1, point, byPosition);
     const auto index = static_cast<std::size_t>(at - curve.begin());
     curve.insert(at, point);
     return index;

--- a/src/pipeline/VolumePipeline.cpp
+++ b/src/pipeline/VolumePipeline.cpp
@@ -83,10 +83,13 @@ std::size_t insertOpacityPoint(
     // [0, 1]: bounding the search to the interior means a position outside
     // that span would land at the near end of the interior and leave the list
     // unsorted, which is what opacityCurveValue reads and what moveOpacityPoint
-    // would then clamp between inverted neighbours. The list is assumed sorted
-    // on the way in, so the front is never above the back.
+    // would then clamp between inverted neighbours. Written as a min of a max
+    // rather than a clamp because the list is only assumed sorted, not checked:
+    // std::clamp with a low above its high is undefined, so an unsorted curve
+    // would trade a wrong answer for undefined behaviour. This way it stays a
+    // wrong answer.
     const OpacityPoint point{
-        std::clamp(std::clamp(position, 0.0, 1.0), curve.front().position,
+        std::min(std::max(std::clamp(position, 0.0, 1.0), curve.front().position),
             curve.back().position),
         value};
     const auto at = std::upper_bound(

--- a/src/qt/IsoWidget.hpp
+++ b/src/qt/IsoWidget.hpp
@@ -61,6 +61,14 @@ public:
     // Overlay toggles for the volume view; the quadrant keeps both on.
     void setLevelBoxesVisible(bool visible);
     void setDomainOutlineVisible(bool visible);
+    [[nodiscard]] bool levelBoxesVisible() const noexcept
+    {
+        return m_levelBoxesVisible;
+    }
+    [[nodiscard]] bool domainOutlineVisible() const noexcept
+    {
+        return m_domainOutlineVisible;
+    }
 
 signals:
     void cameraChanged();

--- a/src/qt/OpacityCurveWidget.cpp
+++ b/src/qt/OpacityCurveWidget.cpp
@@ -1,5 +1,7 @@
 #include "OpacityCurveWidget.hpp"
 
+#include <QImage>
+#include <QKeyEvent>
 #include <QMouseEvent>
 #include <QPainter>
 #include <QPaintEvent>
@@ -20,6 +22,16 @@ namespace {
 constexpr double handleHalf = 3.0;
 constexpr double grabRadius = 6.0;
 
+// What one arrow key press moves the selected point by. Sideways it is one
+// palette slot, the finest step that can still change the sampled transfer
+// table; upwards one percent of opacity. Both are around a pixel on a plot
+// the width of the dock, which is the point: the mouse cannot do better than
+// a pixel, and this is what the keys are for. Shift covers ground instead.
+constexpr double positionStep
+    = 1.0 / static_cast<double>(Palette::colorSlots - 1);
+constexpr double opacityStep = 0.01;
+constexpr double coarseStep = 10.0;
+
 } // namespace
 
 OpacityCurveWidget::OpacityCurveWidget(QWidget* parent)
@@ -28,7 +40,8 @@ OpacityCurveWidget::OpacityCurveWidget(QWidget* parent)
     setMinimumHeight(96);
     setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
     setToolTip(tr("Drag a point to shape the opacity; click the curve to add "
-                  "one, right-click a point to remove it"));
+                  "one, right-click a point to remove it. Arrow keys nudge "
+                  "the selected point, with Shift for a bigger step"));
     // The plot is the whole widget, and every press inside it means something,
     // so it takes the mouse rather than passing clicks to the dock.
     setFocusPolicy(Qt::ClickFocus);
@@ -46,6 +59,8 @@ void OpacityCurveWidget::setCurve(std::vector<OpacityPoint> curve)
     // edit below assumes two ends it may not remove.
     m_curve = curve.size() >= 2 ? std::move(curve) : defaultOpacityCurve();
     m_dragging = -1;
+    // These points are not the ones that were selected, whatever the indices.
+    m_selected = -1;
     update();
 }
 
@@ -101,24 +116,22 @@ void OpacityCurveWidget::paintEvent(QPaintEvent* event)
         return;
     }
 
-    // The palette behind the curve, one band per data slot, so a point sits
-    // over the colour it is shaping. Dimmed by the curve drawn over it: the
-    // bands are the reference, not the subject.
+    // The palette behind the curve, one image column per data slot scaled to
+    // the plot, so a point sits over the colour it is shaping. A single
+    // drawImage paints every pixel once; translucent per-slot rects compound
+    // wherever they overlap and stripe the strip. Dimmed by painter opacity:
+    // the bands are the reference, not the subject.
     if (m_palette != nullptr) {
         constexpr int entries = Palette::colorSlots;
-        const auto bandWidth = plot.width() / static_cast<double>(entries);
+        QImage strip(entries, 1, QImage::Format_RGB32);
         for (int entry = 0; entry < entries; ++entry) {
-            const auto argb
-                = m_palette->slotArgb(Palette::paletteStart + entry);
-            QColor band(QRgb(argb | 0xFF000000U));
-            band.setAlpha(90);
-            const auto left
-                = plot.left() + static_cast<double>(entry) * bandWidth;
-            // A whole pixel wider than the band, so rounding cannot leave a
-            // background-coloured seam between two bands.
-            painter.fillRect(
-                QRectF(left, plot.top(), bandWidth + 1.0, plot.height()), band);
+            strip.setPixel(entry, 0,
+                m_palette->slotArgb(Palette::paletteStart + entry)
+                    | 0xFF000000U);
         }
+        painter.setOpacity(200.0 / 255.0);
+        painter.drawImage(plot, strip);
+        painter.setOpacity(1.0);
     }
 
     painter.setRenderHint(QPainter::Antialiasing, true);
@@ -144,10 +157,14 @@ void OpacityCurveWidget::paintEvent(QPaintEvent* event)
     painter.setPen(QPen(palette().color(QPalette::WindowText), 2.0));
     painter.drawPolyline(line);
 
-    // The control points last, over the curve they define.
-    painter.setBrush(palette().color(QPalette::Base));
+    // The control points last, over the curve they define. The selected one is
+    // filled, so which point the arrow keys will move is visible rather than
+    // remembered.
     for (std::size_t index = 0; index < m_curve.size(); ++index) {
         const auto at = widgetPosition(m_curve[index]);
+        painter.setBrush(palette().color(static_cast<int>(index) == m_selected
+                ? QPalette::Highlight
+                : QPalette::Base));
         painter.setPen(QPen(palette().color(QPalette::WindowText),
             static_cast<int>(index) == m_dragging ? 2.5 : 1.5));
         painter.drawRect(QRectF(at.x() - handleHalf, at.y() - handleHalf,
@@ -158,6 +175,50 @@ void OpacityCurveWidget::paintEvent(QPaintEvent* event)
     painter.setBrush(Qt::NoBrush);
     painter.setPen(palette().color(QPalette::Mid));
     painter.drawRect(plot);
+}
+
+void OpacityCurveWidget::keyPressEvent(QKeyEvent* event)
+{
+    // Arrows move the selected point, which is the last one pressed. With
+    // nothing selected they are not ours: the dock's focus chain gets them
+    // rather than a nudge landing on a point the user did not choose.
+    if (m_selected < 0
+        || static_cast<std::size_t>(m_selected) >= m_curve.size()) {
+        QWidget::keyPressEvent(event);
+        return;
+    }
+    const auto step
+        = event->modifiers().testFlag(Qt::ShiftModifier) ? coarseStep : 1.0;
+    double dx = 0.0;
+    double dy = 0.0;
+    switch (event->key()) {
+    case Qt::Key_Left:
+        dx = -positionStep * step;
+        break;
+    case Qt::Key_Right:
+        dx = positionStep * step;
+        break;
+    case Qt::Key_Down:
+        dy = -opacityStep * step;
+        break;
+    case Qt::Key_Up:
+        dy = opacityStep * step;
+        break;
+    default:
+        QWidget::keyPressEvent(event);
+        return;
+    }
+    // Through moveOpacityPoint like a drag, so a nudge obeys the same rules:
+    // the ends keep their positions, an interior point stops at its
+    // neighbours, and opacity stays on [0, 1].
+    const auto& point = m_curve[static_cast<std::size_t>(m_selected)];
+    const auto position = point.position + dx;
+    const auto opacity = point.opacity + dy;
+    moveOpacityPoint(
+        m_curve, static_cast<std::size_t>(m_selected), position, opacity);
+    update();
+    emit curveChanged();
+    event->accept();
 }
 
 void OpacityCurveWidget::mousePressEvent(QMouseEvent* event)
@@ -171,6 +232,14 @@ void OpacityCurveWidget::mousePressEvent(QMouseEvent* event)
         if (hit >= 0
             && removeOpacityPoint(m_curve, static_cast<std::size_t>(hit))) {
             m_dragging = -1;
+            // The list closed up over the gap, so an index past the removed
+            // point now names its neighbour: follow the point, and drop the
+            // selection entirely if it was the point that just went.
+            if (m_selected == hit) {
+                m_selected = -1;
+            } else if (m_selected > hit) {
+                --m_selected;
+            }
             update();
             emit curveChanged();
         }
@@ -191,6 +260,10 @@ void OpacityCurveWidget::mousePressEvent(QMouseEvent* event)
             insertOpacityPoint(m_curve, added.position, added.opacity));
         emit curveChanged();
     }
+    // Whichever point the press ended up on is the one the arrow keys take,
+    // and it stays selected after the button is released: placing a point
+    // roughly and then nudging it is the whole gesture.
+    m_selected = m_dragging;
     update();
     event->accept();
 }

--- a/src/qt/OpacityCurveWidget.cpp
+++ b/src/qt/OpacityCurveWidget.cpp
@@ -1,5 +1,6 @@
 #include "OpacityCurveWidget.hpp"
 
+#include <QFocusEvent>
 #include <QImage>
 #include <QKeyEvent>
 #include <QMouseEvent>
@@ -158,11 +159,14 @@ void OpacityCurveWidget::paintEvent(QPaintEvent* event)
     painter.drawPolyline(line);
 
     // The control points last, over the curve they define. The selected one is
-    // filled, so which point the arrow keys will move is visible rather than
-    // remembered.
+    // marked in the highlight colour, so which point the arrow keys will move
+    // is visible rather than remembered -- but only while the keys would
+    // actually come here, or the mark would advertise an edit that is going to
+    // whichever control took the focus instead.
+    const auto marked = hasFocus() ? m_selected : -1;
     for (std::size_t index = 0; index < m_curve.size(); ++index) {
         const auto at = widgetPosition(m_curve[index]);
-        painter.setBrush(palette().color(static_cast<int>(index) == m_selected
+        painter.setBrush(palette().color(static_cast<int>(index) == marked
                 ? QPalette::Highlight
                 : QPalette::Base));
         painter.setPen(QPen(palette().color(QPalette::WindowText),
@@ -175,6 +179,20 @@ void OpacityCurveWidget::paintEvent(QPaintEvent* event)
     painter.setBrush(Qt::NoBrush);
     painter.setPen(palette().color(QPalette::Mid));
     painter.drawRect(plot);
+}
+
+void OpacityCurveWidget::focusInEvent(QFocusEvent* event)
+{
+    QWidget::focusInEvent(event);
+    // The selection is kept across the focus change rather than dropped, so
+    // coming back from another window finds the same point marked again.
+    update();
+}
+
+void OpacityCurveWidget::focusOutEvent(QFocusEvent* event)
+{
+    QWidget::focusOutEvent(event);
+    update();
 }
 
 void OpacityCurveWidget::keyPressEvent(QKeyEvent* event)

--- a/src/qt/OpacityCurveWidget.cpp
+++ b/src/qt/OpacityCurveWidget.cpp
@@ -130,7 +130,12 @@ void OpacityCurveWidget::paintEvent(QPaintEvent* event)
                 m_palette->slotArgb(Palette::paletteStart + entry)
                     | 0xFF000000U);
         }
-        painter.setOpacity(200.0 / 255.0);
+        // Well back when the control is inert. Everything drawn over the strip
+        // greys out on its own, through QPalette::Disabled, but these are the
+        // palette's own colours and would keep full strength -- leaving the
+        // boldest thing on a disabled control the one part that does not say
+        // so.
+        painter.setOpacity(isEnabled() ? 200.0 / 255.0 : 60.0 / 255.0);
         painter.drawImage(plot, strip);
         painter.setOpacity(1.0);
     }

--- a/src/qt/OpacityCurveWidget.cpp
+++ b/src/qt/OpacityCurveWidget.cpp
@@ -31,7 +31,8 @@ constexpr double grabRadius = 6.0;
 constexpr double positionStep
     = 1.0 / static_cast<double>(Palette::colorSlots - 1);
 constexpr double opacityStep = 0.01;
-constexpr double coarseStep = 10.0;
+// A multiplier on either step above, not a step itself.
+constexpr double coarseMultiplier = 10.0;
 
 } // namespace
 
@@ -222,7 +223,7 @@ void OpacityCurveWidget::keyPressEvent(QKeyEvent* event)
         QWidget::keyPressEvent(event);
         return;
     }
-    const auto step = modifiers == Qt::ShiftModifier ? coarseStep : 1.0;
+    const auto step = modifiers == Qt::ShiftModifier ? coarseMultiplier : 1.0;
     double dx = 0.0;
     double dy = 0.0;
     switch (event->key()) {
@@ -318,11 +319,19 @@ void OpacityCurveWidget::mouseMoveEvent(QMouseEvent* event)
         QWidget::mouseMoveEvent(event);
         return;
     }
+    const auto index = static_cast<std::size_t>(m_dragging);
+    const auto before = m_curve[index];
     const auto moved = curvePosition(event->position());
-    moveOpacityPoint(m_curve, static_cast<std::size_t>(m_dragging),
-        moved.position, moved.opacity);
-    update();
-    emit curveChanged();
+    moveOpacityPoint(m_curve, index, moved.position, moved.opacity);
+    // Only a real move is worth a signal, for the reason keyPressEvent gives:
+    // an end dragged sideways, or an interior point dragged into a neighbour,
+    // moves nothing, and every mouse-move event would still restart the settle
+    // timer and re-render a volume that had not changed.
+    if (m_curve[index].position != before.position
+        || m_curve[index].opacity != before.opacity) {
+        update();
+        emit curveChanged();
+    }
     event->accept();
 }
 

--- a/src/qt/OpacityCurveWidget.cpp
+++ b/src/qt/OpacityCurveWidget.cpp
@@ -181,14 +181,25 @@ void OpacityCurveWidget::keyPressEvent(QKeyEvent* event)
 {
     // Arrows move the selected point, which is the last one pressed. With
     // nothing selected they are not ours: the dock's focus chain gets them
-    // rather than a nudge landing on a point the user did not choose.
-    if (m_selected < 0
+    // rather than a nudge landing on a point the user did not choose. Nor
+    // during a drag, where the next mouse move would overwrite the nudge with
+    // the cursor's own position and waste the render it asked for.
+    if (m_dragging >= 0 || m_selected < 0
         || static_cast<std::size_t>(m_selected) >= m_curve.size()) {
         QWidget::keyPressEvent(event);
         return;
     }
-    const auto step
-        = event->modifiers().testFlag(Qt::ShiftModifier) ? coarseStep : 1.0;
+    // Shift is the coarse step, and an arrow carrying anything else belongs to
+    // whatever else may want it rather than being swallowed here. Keypad is
+    // masked out rather than counted as a modifier because macOS stamps it on
+    // the arrow keys -- the same reason, and the same handling, as
+    // ImageView::keyPressEvent, which documents it at length.
+    const auto modifiers = event->modifiers() & ~Qt::KeypadModifier;
+    if (modifiers != Qt::NoModifier && modifiers != Qt::ShiftModifier) {
+        QWidget::keyPressEvent(event);
+        return;
+    }
+    const auto step = modifiers == Qt::ShiftModifier ? coarseStep : 1.0;
     double dx = 0.0;
     double dy = 0.0;
     switch (event->key()) {
@@ -211,11 +222,21 @@ void OpacityCurveWidget::keyPressEvent(QKeyEvent* event)
     // Through moveOpacityPoint like a drag, so a nudge obeys the same rules:
     // the ends keep their positions, an interior point stops at its
     // neighbours, and opacity stays on [0, 1].
-    const auto& point = m_curve[static_cast<std::size_t>(m_selected)];
-    const auto position = point.position + dx;
-    const auto opacity = point.opacity + dy;
-    moveOpacityPoint(
-        m_curve, static_cast<std::size_t>(m_selected), position, opacity);
+    const auto index = static_cast<std::size_t>(m_selected);
+    const auto before = m_curve[index];
+    moveOpacityPoint(m_curve, index, before.position + dx, before.opacity + dy);
+    // Only a real move is worth a signal. Those rules mean a key held against
+    // a limit -- an end asked to change position, a point already up against
+    // its neighbour or the top of the plot -- moves nothing, and every repeat
+    // would otherwise restart the settle timer and re-render an identical
+    // volume, so the full frame would never arrive until the key came up. The
+    // key is still ours: it is accepted either way rather than escaping to pan
+    // a panel while the curve is being edited.
+    if (m_curve[index].position == before.position
+        && m_curve[index].opacity == before.opacity) {
+        event->accept();
+        return;
+    }
     update();
     emit curveChanged();
     event->accept();

--- a/src/qt/OpacityCurveWidget.hpp
+++ b/src/qt/OpacityCurveWidget.hpp
@@ -49,6 +49,10 @@ signals:
 protected:
     void paintEvent(QPaintEvent* event) override;
     void keyPressEvent(QKeyEvent* event) override;
+    // Only to repaint: the selected point is marked while this has the focus
+    // the arrow keys follow, so gaining or losing it changes the picture.
+    void focusInEvent(QFocusEvent* event) override;
+    void focusOutEvent(QFocusEvent* event) override;
     void mousePressEvent(QMouseEvent* event) override;
     void mouseMoveEvent(QMouseEvent* event) override;
     void mouseReleaseEvent(QMouseEvent* event) override;

--- a/src/qt/OpacityCurveWidget.hpp
+++ b/src/qt/OpacityCurveWidget.hpp
@@ -48,6 +48,7 @@ signals:
 
 protected:
     void paintEvent(QPaintEvent* event) override;
+    void keyPressEvent(QKeyEvent* event) override;
     void mousePressEvent(QMouseEvent* event) override;
     void mouseMoveEvent(QMouseEvent* event) override;
     void mouseReleaseEvent(QMouseEvent* event) override;
@@ -67,6 +68,9 @@ private:
     // functions take one, and a drag cannot reorder the list -- moveOpacityPoint
     // clamps an interior point between its neighbours.
     int m_dragging = -1;
+    // The point the arrow keys nudge: the last one pressed, outliving the
+    // drag so a coarse mouse placement can be fine-tuned afterwards.
+    int m_selected = -1;
 };
 
 } // namespace amrvis::qt

--- a/src/qt/VolumeWindow.cpp
+++ b/src/qt/VolumeWindow.cpp
@@ -178,8 +178,11 @@ void VolumeWindow::buildControls()
         tr("Sample only the part of the domain the slice views are zoomed to, "
            "which spends the voxel budget on it instead of the whole field"));
     form->addRow(QString(), m_regionCheck);
+    // Unchecked by default: the boxes read as clutter over a volume. The view
+    // itself defaults to showing them (the grid page wants that), so it is
+    // told here rather than by a toggle that never fires.
     m_boxesCheck = new QCheckBox(tr("Grid boxes"), panel);
-    m_boxesCheck->setChecked(true);
+    m_view->setLevelBoxesVisible(false);
     m_outlineCheck = new QCheckBox(tr("Domain outline"), panel);
     m_outlineCheck->setChecked(true);
     form->addRow(QString(), m_boxesCheck);

--- a/src/qt/VolumeWindow.cpp
+++ b/src/qt/VolumeWindow.cpp
@@ -156,6 +156,12 @@ void VolumeWindow::buildControls()
     form->addRow(tr("Opacity:"), m_curve);
     m_paletteAlpha = new QCheckBox(tr("Use palette alpha ramp"), panel);
     m_paletteAlpha->setObjectName(QStringLiteral("volumePaletteAlphaCheck"));
+    // Whether this is available says whether the palette carries a ramp, so
+    // it starts unavailable and setPaletteHasAlpha decides: until a palette
+    // arrives there is nothing to take a ramp from. Left at the check box's
+    // own default it would read as "this palette has one" before any palette
+    // had been seen, and nothing would be asserting otherwise.
+    m_paletteAlpha->setEnabled(false);
     m_paletteAlpha->setToolTip(tr("Take each colour's opacity from the palette's "
                                   "alpha ramp (legacy .pal files carry one) "
                                   "instead of the curve above, which is "

--- a/src/qt/VolumeWindow.cpp
+++ b/src/qt/VolumeWindow.cpp
@@ -156,17 +156,16 @@ void VolumeWindow::buildControls()
     form->addRow(tr("Opacity:"), m_curve);
     m_paletteAlpha = new QCheckBox(tr("Use palette alpha ramp"), panel);
     m_paletteAlpha->setObjectName(QStringLiteral("volumePaletteAlphaCheck"));
-    // Whether this is available says whether the palette carries a ramp, so
-    // it starts unavailable and setPaletteHasAlpha decides: until a palette
-    // arrives there is nothing to take a ramp from. Left at the check box's
-    // own default it would read as "this palette has one" before any palette
-    // had been seen, and nothing would be asserting otherwise.
-    m_paletteAlpha->setEnabled(false);
-    m_paletteAlpha->setToolTip(tr("Take each colour's opacity from the palette's "
-                                  "alpha ramp (legacy .pal files carry one) "
-                                  "instead of the curve above, which is "
-                                  "disabled while this is on."));
     form->addRow(QString(), m_paletteAlpha);
+    // Whether this is available says whether the palette carries a ramp, so it
+    // starts unavailable: until a palette arrives there is nothing to take a
+    // ramp from. Left at the check box's own default it would read as "this
+    // palette has one" before any palette had been seen, and nothing would be
+    // asserting otherwise. Through setPaletteHasAlpha rather than setEnabled
+    // so the tooltip is the one that goes with the state -- the other says
+    // what the box would do, which is not the question while it cannot be
+    // ticked.
+    setPaletteHasAlpha(false);
     m_qualityCombo = new QComboBox(panel);
     m_qualityCombo->addItem(tr("Draft"), 0);
     m_qualityCombo->addItem(tr("Normal"), 1);
@@ -184,12 +183,17 @@ void VolumeWindow::buildControls()
         tr("Sample only the part of the domain the slice views are zoomed to, "
            "which spends the voxel budget on it instead of the whole field"));
     form->addRow(QString(), m_regionCheck);
-    // Unchecked by default: the boxes read as clutter over a volume. The view
-    // itself defaults to showing them (the grid page wants that), so it is
-    // told here rather than by a toggle that never fires.
+    // Grid boxes off, domain outline on: box edges crossing a translucent
+    // field read as structure in it, which is worth asking for rather than
+    // having to switch off. Both are said here and only here -- the view's own
+    // defaults suit the main window's quadrant, and the boxes below push these
+    // onto it once the toggles exist, so the check box is what the view
+    // follows rather than the two agreeing by luck.
     m_boxesCheck = new QCheckBox(tr("Grid boxes"), panel);
-    m_view->setLevelBoxesVisible(false);
+    m_boxesCheck->setObjectName(QStringLiteral("volumeGridBoxesCheck"));
+    m_boxesCheck->setChecked(false);
     m_outlineCheck = new QCheckBox(tr("Domain outline"), panel);
+    m_outlineCheck->setObjectName(QStringLiteral("volumeDomainOutlineCheck"));
     m_outlineCheck->setChecked(true);
     form->addRow(QString(), m_boxesCheck);
     form->addRow(QString(), m_outlineCheck);
@@ -223,6 +227,12 @@ void VolumeWindow::buildControls()
         [this](bool checked) { m_view->setLevelBoxesVisible(checked); });
     connect(m_outlineCheck, &QCheckBox::toggled, this,
         [this](bool checked) { m_view->setDomainOutlineVisible(checked); });
+    // The state above reaches the view once, here, because setting a box
+    // before its connect fires no toggle. Both go through the same call the
+    // toggles use, so there is one path from box to view and no dependence on
+    // what the view happened to default to.
+    m_view->setLevelBoxesVisible(m_boxesCheck->isChecked());
+    m_view->setDomainOutlineVisible(m_outlineCheck->isChecked());
 }
 
 void VolumeWindow::setDatasetGeometry(const DatasetMetadata& metadata)

--- a/src/qt/VolumeWindow.hpp
+++ b/src/qt/VolumeWindow.hpp
@@ -30,8 +30,9 @@ class OpacityCurveWidget;
 // to zoom, XY/XZ/YZ presets, the domain wireframe and the slice planes, and
 // the grid boxes when they are switched on -- with the rendered volume drawn
 // under the wireframe, and a dock of controls: the opacity curve (or the
-// palette's own alpha ramp), the render quality, and the overlay toggles. The window holds no data logic: VolumeController
-// decides when to render and pushes each frame here.
+// palette's own alpha ramp), the render quality, and the overlay toggles. The
+// window holds no data logic: VolumeController decides when to render and
+// pushes each frame here.
 class VolumeWindow final : public QMainWindow {
     Q_OBJECT
 

--- a/src/qt/VolumeWindow.hpp
+++ b/src/qt/VolumeWindow.hpp
@@ -27,11 +27,10 @@ class OpacityCurveWidget;
 
 // The Volume Rendering window: an IsoWidget in the middle -- the same
 // orthographic view as the main window's iso quadrant, drag to rotate, wheel
-// to zoom, XY/XZ/YZ presets, the domain wireframe, the grid boxes and the
-// slice planes -- with the rendered volume drawn under the wireframe, and a
-// dock of controls: the opacity ramp (a window over the colour range and a
-// maximum opacity, or the palette's own alpha ramp), the render quality, and
-// the overlay toggles. The window holds no data logic: VolumeController
+// to zoom, XY/XZ/YZ presets, the domain wireframe and the slice planes, and
+// the grid boxes when they are switched on -- with the rendered volume drawn
+// under the wireframe, and a dock of controls: the opacity curve (or the
+// palette's own alpha ramp), the render quality, and the overlay toggles. The window holds no data logic: VolumeController
 // decides when to render and pushes each frame here.
 class VolumeWindow final : public QMainWindow {
     Q_OBJECT

--- a/tests/integration/test_volume_pipeline.cpp
+++ b/tests/integration/test_volume_pipeline.cpp
@@ -297,6 +297,29 @@ int main()
                     && curve[1].opacity == 1.0,
                 "an inserted point was not sorted and clamped");
 
+            // The edges of the plot, where a press clamps to exactly 0.0 or
+            // 1.0. Both have to land inside the two anchors: a point appended
+            // past the last one would become the end, which cannot be removed
+            // and which opacityCurveValue extends flat, so it would shape one
+            // entry of the table and nothing else.
+            {
+                auto edge = amrvis::defaultOpacityCurve();
+                const auto top = amrvis::insertOpacityPoint(edge, 1.0, 0.5);
+                require(top == 1 && edge.size() == 3,
+                    "a point inserted at the top of the range did not land "
+                    "inside the curve's ends");
+                require(edge.back() == amrvis::OpacityPoint{1.0, 1.0},
+                    "inserting at the top of the range displaced the anchor");
+                require(amrvis::removeOpacityPoint(edge, top),
+                    "a point inserted at the top of the range could not be "
+                    "removed again");
+                const auto bottom = amrvis::insertOpacityPoint(edge, 0.0, 0.5);
+                require(bottom == 1
+                        && edge.front() == amrvis::OpacityPoint{0.0, 0.0},
+                    "inserting at the bottom of the range displaced the "
+                    "anchor");
+            }
+
             // An interior point cannot pass its neighbours.
             amrvis::moveOpacityPoint(curve, 2, 5.0, 0.5);
             require(curve[2].position == curve[3].position,

--- a/tests/integration/test_volume_pipeline.cpp
+++ b/tests/integration/test_volume_pipeline.cpp
@@ -320,6 +320,43 @@ int main()
                     "anchor");
             }
 
+            // Keeping the new point inside the ends must not cost the sorting
+            // that opacityCurveValue reads and that moveOpacityPoint clamps
+            // between neighbours with. Nothing says the ends are at 0 and 1 --
+            // setCurve takes any two -- so a position outside the span they
+            // cover has to come to the span's edge, not to the near end of the
+            // interior.
+            {
+                const auto isSorted = [](const std::vector<amrvis::OpacityPoint>&
+                                              points) {
+                    for (std::size_t index = 1; index < points.size(); ++index) {
+                        if (points[index - 1].position > points[index].position) {
+                            return false;
+                        }
+                    }
+                    return true;
+                };
+                const std::vector<amrvis::OpacityPoint> inset{
+                    {0.2, 0.0}, {0.5, 0.5}, {0.9, 1.0}};
+                auto below = inset;
+                const auto under = amrvis::insertOpacityPoint(below, 0.0, 0.5);
+                require(isSorted(below) && under == 1
+                        && below.front() == inset.front(),
+                    "inserting below the low end left the curve unsorted");
+                auto above = inset;
+                const auto over = amrvis::insertOpacityPoint(above, 1.0, 0.5);
+                require(isSorted(above) && over == above.size() - 2
+                        && above.back() == inset.back(),
+                    "inserting above the high end left the curve unsorted");
+
+                // And a curve too short to have two ends is still sorted, even
+                // though it has no ends to stay between.
+                std::vector<amrvis::OpacityPoint> lone{{0.8, 1.0}};
+                require(amrvis::insertOpacityPoint(lone, 0.2, 0.5) == 0
+                        && isSorted(lone),
+                    "inserting into a one-point curve did not keep it sorted");
+            }
+
             // An interior point cannot pass its neighbours.
             amrvis::moveOpacityPoint(curve, 2, 5.0, 0.5);
             require(curve[2].position == curve[3].position,

--- a/tests/integration/test_volume_pipeline.cpp
+++ b/tests/integration/test_volume_pipeline.cpp
@@ -313,11 +313,17 @@ int main()
                 require(amrvis::removeOpacityPoint(edge, top),
                     "a point inserted at the top of the range could not be "
                     "removed again");
+                // The same for the bottom, checked the same way: the index and
+                // the anchor alone would miss a point that landed as an end
+                // and could not be removed again.
                 const auto bottom = amrvis::insertOpacityPoint(edge, 0.0, 0.5);
-                require(bottom == 1
+                require(bottom == 1 && edge.size() == 3
                         && edge.front() == amrvis::OpacityPoint{0.0, 0.0},
                     "inserting at the bottom of the range displaced the "
                     "anchor");
+                require(amrvis::removeOpacityPoint(edge, bottom),
+                    "a point inserted at the bottom of the range could not be "
+                    "removed again");
             }
 
             // Keeping the new point inside the ends must not cost the sorting

--- a/tests/unit/test_volume_controller.cpp
+++ b/tests/unit/test_volume_controller.cpp
@@ -1091,11 +1091,24 @@ int main(int argc, char** argv)
         require(std::abs(static_cast<double>(dragged[midEntry]) - 0.25) <= 0.06,
             "the drag did not reach the opacities in the request");
 
-        // The arrow keys, which is what the mouse cannot do: the drag above
-        // placed the point to the nearest pixel, and these move it by less
-        // than one. The point the press took is still the selected one, so
-        // the nudge lands on it without another click.
+        // The arrow keys: exact repeatable steps, where the drag above could
+        // only leave the point wherever the cursor's pixel fell. The point the
+        // press took is still the selected one, so the nudge lands on it
+        // without another click.
+        //
+        // Quiesced first. The drag armed the settle timer and the release
+        // emits nothing to stop it, so its full frame arriving later would
+        // stand in for the render the keys are supposed to cause -- the same
+        // trap the removal check below documents, which this check was blind
+        // to until here.
+        settle(application, 500);
+        waitFor(application, [&] { return !controller.renderInFlight(); },
+            "the drag's renders did not finish");
         auto nudged = session->requests.load();
+        settle(application, 150);
+        require(session->requests == nudged,
+            "the volume was still rendering of its own accord, so the render "
+            "below could not be the keys' doing");
         const auto placed = widget->curve()[1];
         const auto sendKey = [widget](int key, Qt::KeyboardModifiers modifiers) {
             QKeyEvent pressed(QEvent::KeyPress, key, modifiers);

--- a/tests/unit/test_volume_controller.cpp
+++ b/tests/unit/test_volume_controller.cpp
@@ -1256,6 +1256,40 @@ int main(int argc, char** argv)
             "the keypad modifier stopped an arrow key from nudging, which "
             "would leave this dead on macOS");
 
+        // A drag that cannot move anything is not a render either, the same
+        // rule the keys follow. Dragging an end point sideways asks for the
+        // one move it refuses, so after the first move has settled its opacity
+        // to whatever that height means, every further move along the same
+        // height changes nothing at all. Two moves rather than one because the
+        // first still carries the cursor's own opacity onto the point.
+        const QPointF along(plotPoint(widget->curve().front()));
+        QMouseEvent takeIt(QEvent::MouseButtonPress, along,
+            widget->mapToGlobal(along), Qt::LeftButton, Qt::LeftButton,
+            Qt::NoModifier);
+        QApplication::sendEvent(widget, &takeIt);
+        const QPointF sideways(along.x() + 20.0, along.y());
+        QMouseEvent firstMove(QEvent::MouseMove, sideways,
+            widget->mapToGlobal(sideways), Qt::NoButton, Qt::LeftButton,
+            Qt::NoModifier);
+        QApplication::sendEvent(widget, &firstMove);
+        settle(application, 500);
+        waitFor(application, [&] { return !controller.renderInFlight(); },
+            "the drag's first move did not finish rendering");
+        const auto stuck = session->requests.load();
+        const QPointF further(along.x() + 40.0, along.y());
+        QMouseEvent secondMove(QEvent::MouseMove, further,
+            widget->mapToGlobal(further), Qt::NoButton, Qt::LeftButton,
+            Qt::NoModifier);
+        QApplication::sendEvent(widget, &secondMove);
+        settle(application, 200);
+        require(session->requests == stuck,
+            "dragging an end point sideways rendered a volume that could not "
+            "have changed");
+        QMouseEvent dropIt(QEvent::MouseButtonRelease, further,
+            widget->mapToGlobal(further), Qt::LeftButton, Qt::NoButton,
+            Qt::NoModifier);
+        QApplication::sendEvent(widget, &dropIt);
+
         // And not while a drag is in flight: the next mouse move would
         // overwrite the nudge with the cursor's own position, so the key would
         // cost a render and leave nothing behind.
@@ -1276,6 +1310,40 @@ int main(int argc, char** argv)
             Qt::NoModifier);
         QApplication::sendEvent(widget, &letGoEnd);
 
+        // The overlay toggles, and the volume window's own default: grid boxes
+        // off, because box edges crossing a translucent field read as
+        // structure in it. The view has to agree with the box it is labelled
+        // by -- setting a box before its connect fires no toggle, so an
+        // agreement left to the two defaults matching is one nobody checks.
+        auto* const boxesCheck = window->findChild<QCheckBox*>(
+            QStringLiteral("volumeGridBoxesCheck"));
+        auto* const outlineCheck = window->findChild<QCheckBox*>(
+            QStringLiteral("volumeDomainOutlineCheck"));
+        require(boxesCheck != nullptr && outlineCheck != nullptr,
+            "no overlay toggles in the volume window");
+        auto* const view = window->findChild<amrvis::qt::IsoWidget*>();
+        require(view != nullptr, "no iso view in the volume window");
+        require(!boxesCheck->isChecked() && !view->levelBoxesVisible(),
+            "the volume window opened drawing the grid boxes");
+        require(outlineCheck->isChecked() && view->domainOutlineVisible(),
+            "the volume window opened without the domain outline");
+        boxesCheck->setChecked(true);
+        require(view->levelBoxesVisible(),
+            "ticking the grid-boxes box did not reach the view");
+        boxesCheck->setChecked(false);
+        require(!view->levelBoxesVisible(),
+            "clearing the grid-boxes box did not reach the view");
+        // The outline the same way. Its opening state cannot be checked as
+        // sharply as the boxes' -- the box and the view's own default agree
+        // there, so nothing can tell a state that was pushed from one that was
+        // never needed -- but the toggle reaching the view can be.
+        outlineCheck->setChecked(false);
+        require(!view->domainOutlineVisible(),
+            "clearing the domain-outline box did not reach the view");
+        outlineCheck->setChecked(true);
+        require(view->domainOutlineVisible(),
+            "ticking the domain-outline box did not reach the view");
+
         // The palette's own alpha takes over from the curve, so the curve is
         // disabled: it has no say while that box is in effect, and a control
         // that looks editable and does nothing is the defect this replaced.
@@ -1291,21 +1359,30 @@ int main(int argc, char** argv)
         require(widget->isEnabled(),
             "the curve is not editable with the palette-alpha box clear");
 
-        // How much colour the widget is carrying, which is almost all the
-        // palette strip: everything else on it is the theme's own greys.
-        const auto colourfulness = [](const QImage& image) {
+        // How far the widget's pixels sit from its own background, which is
+        // almost all the palette strip: everything else on it is the theme's
+        // greys, at or near that background. Measured against the background
+        // rather than as colourfulness because fading a colour towards a dark
+        // background barely changes how saturated it is -- a saturation
+        // measure separates the two states in a light theme and not in a dark
+        // one, which is a test that passes where it is run and nowhere else.
+        const auto fromBackground = [widget](const QImage& image) {
+            const auto base = widget->palette().color(QPalette::Base);
             double total = 0.0;
             for (int y = 0; y < image.height(); ++y) {
                 for (int x = 0; x < image.width(); ++x) {
-                    total += image.pixelColor(x, y).saturation();
+                    const auto pixel = image.pixelColor(x, y);
+                    total += std::abs(pixel.red() - base.red())
+                        + std::abs(pixel.green() - base.green())
+                        + std::abs(pixel.blue() - base.blue());
                 }
             }
             return total / static_cast<double>(image.width() * image.height());
         };
-        const auto lively = colourfulness(widget->grab().toImage());
+        const auto lively = fromBackground(widget->grab().toImage());
         // Vacuity guard: with no palette there would be no strip to fade, and
         // the comparison below would hold for the wrong reason.
-        require(lively > 20.0,
+        require(lively > 60.0,
             "the curve drew no palette strip, so fading it could not be "
             "checked");
         require(alphaBox->isEnabled(),
@@ -1320,7 +1397,7 @@ int main(int argc, char** argv)
         // painted from the data palette's own colours, which know nothing of
         // the widget, so at full strength the boldest thing on an inert
         // control would be the one part not saying it was inert.
-        const auto inert = colourfulness(widget->grab().toImage());
+        const auto inert = fromBackground(widget->grab().toImage());
         require(inert < 0.6 * lively,
             "the palette strip kept its strength on a disabled curve");
         alphaBox->setChecked(false);

--- a/tests/unit/test_volume_controller.cpp
+++ b/tests/unit/test_volume_controller.cpp
@@ -21,6 +21,7 @@
 #include <QRectF>
 #include <QCheckBox>
 #include <QEvent>
+#include <QKeyEvent>
 #include <QKeySequence>
 #include <QMouseEvent>
 #include <QCoreApplication>
@@ -1090,6 +1091,46 @@ int main(int argc, char** argv)
         require(std::abs(static_cast<double>(dragged[midEntry]) - 0.25) <= 0.06,
             "the drag did not reach the opacities in the request");
 
+        // The arrow keys, which is what the mouse cannot do: the drag above
+        // placed the point to the nearest pixel, and these move it by less
+        // than one. The point the press took is still the selected one, so
+        // the nudge lands on it without another click.
+        auto nudged = session->requests.load();
+        const auto placed = widget->curve()[1];
+        const auto sendKey = [widget](int key, Qt::KeyboardModifiers modifiers) {
+            QKeyEvent pressed(QEvent::KeyPress, key, modifiers);
+            QApplication::sendEvent(widget, &pressed);
+        };
+        for (int tap = 0; tap < 3; ++tap) {
+            sendKey(Qt::Key_Up, Qt::NoModifier);
+        }
+        require(std::abs(widget->curve()[1].opacity - (placed.opacity + 0.03))
+                <= 1.0e-9,
+            "three presses of Up did not raise the point by three percent");
+        // Shift is the same key covering ground, ten steps rather than one.
+        sendKey(Qt::Key_Right, Qt::ShiftModifier);
+        const auto slot = 1.0 / static_cast<double>(amrvis::Palette::colorSlots - 1);
+        require(std::abs(widget->curve()[1].position
+                    - (placed.position + 10.0 * slot)) <= 1.0e-9,
+            "Shift+Right did not move the point ten palette slots");
+        // And a nudge renders, down the same path a drag takes.
+        waitFor(application, [&] { return session->requests > nudged; },
+            "nudging a point with the arrow keys did not render");
+        waitFor(application, [&] { return !controller.renderInFlight(); },
+            "the render after the nudge did not finish");
+
+        // Put it back where the drag left it, so the removal below still
+        // finds a point under the cursor -- and so the keys are shown to be
+        // symmetric rather than merely to move something.
+        sendKey(Qt::Key_Left, Qt::ShiftModifier);
+        for (int tap = 0; tap < 3; ++tap) {
+            sendKey(Qt::Key_Down, Qt::NoModifier);
+        }
+        require(std::abs(widget->curve()[1].position - placed.position) <= 1.0e-9
+                && std::abs(widget->curve()[1].opacity - placed.opacity)
+                    <= 1.0e-9,
+            "the opposite arrows did not return the point to where it was");
+
         // Quiesce before the next check. The drag armed the settle timer, and
         // its full frame arriving later would stand in for the render the
         // removal is supposed to cause -- which it did, until this was here.
@@ -1117,6 +1158,17 @@ int main(int argc, char** argv)
         const auto restored = session->requestsSoFar().back().transfer.opacities;
         require(std::abs(static_cast<double>(restored[midEntry]) - 0.5) <= 0.02,
             "removing the point did not put the straight ramp back");
+
+        // The point that was selected is the point that was just removed, so
+        // there is nothing to nudge: the arrows have to do nothing rather than
+        // move whichever point inherited the index. Down, because it would
+        // show on the end point the stale index names, where Up would clamp
+        // against the top and look innocent.
+        const auto untouched = widget->curve();
+        sendKey(Qt::Key_Down, Qt::NoModifier);
+        require(widget->curve().size() == untouched.size()
+                && widget->curve().back().opacity == untouched.back().opacity,
+            "an arrow key moved a point after the selected one was removed");
 
         // The palette's own alpha takes over from the curve, so the curve is
         // disabled: it has no say while that box is in effect, and a control

--- a/tests/unit/test_volume_controller.cpp
+++ b/tests/unit/test_volume_controller.cpp
@@ -1170,6 +1170,83 @@ int main(int argc, char** argv)
                 && widget->curve().back().opacity == untouched.back().opacity,
             "an arrow key moved a point after the selected one was removed");
 
+        // The end points, where the curve's rules bite: an end may change
+        // opacity but never position, so a sideways key on one asks for a move
+        // it cannot have. That must not reach the renderer -- a held key would
+        // otherwise restart the settle timer on every repeat and re-render an
+        // identical volume, so the full frame would never arrive.
+        settle(application, 500);
+        waitFor(application, [&] { return !controller.renderInFlight(); },
+            "the renders from the earlier edits did not finish");
+        auto pinned = session->requests.load();
+        settle(application, 150);
+        require(session->requests == pinned,
+            "the volume was still rendering of its own accord, so the checks "
+            "below could not be the keys' doing");
+
+        // The low end point sits in the bottom-left corner of the plot, which
+        // is inset by a control point's half-width and the border.
+        const QPointF lowEnd(4.0, widget->height() - 4.0);
+        QMouseEvent takeEnd(QEvent::MouseButtonPress, lowEnd,
+            widget->mapToGlobal(lowEnd), Qt::LeftButton, Qt::LeftButton,
+            Qt::NoModifier);
+        QApplication::sendEvent(widget, &takeEnd);
+        QMouseEvent dropEnd(QEvent::MouseButtonRelease, lowEnd,
+            widget->mapToGlobal(lowEnd), Qt::LeftButton, Qt::NoButton,
+            Qt::NoModifier);
+        QApplication::sendEvent(widget, &dropEnd);
+        require(widget->curve().size() == 2,
+            "the press missed the end point and added one instead");
+        sendKey(Qt::Key_Left, Qt::ShiftModifier);
+        sendKey(Qt::Key_Right, Qt::ShiftModifier);
+        require(widget->curve().front().position == 0.0,
+            "an arrow key moved the end point off the end of the range");
+        settle(application, 150);
+        require(session->requests == pinned,
+            "a nudge that moved nothing rendered an identical volume anyway");
+
+        // The same key up the other axis does move it, so the check above is
+        // the rule biting rather than the keys being dead on an end point.
+        sendKey(Qt::Key_Up, Qt::NoModifier);
+        require(widget->curve().front().opacity > 0.0,
+            "Up did not raise the end point, which is the one move it has");
+        waitFor(application, [&] { return session->requests > pinned; },
+            "raising the end point did not render");
+
+        // An arrow carrying any other modifier belongs to whatever else may
+        // want it -- the convention ImageView documents -- while the keypad
+        // modifier macOS stamps on the arrow keys still has to nudge.
+        // Checked one key at a time and both in the same direction: two
+        // opposite nudges would cancel and pass whether they were swallowed
+        // or not, which is how this first went in.
+        const auto held = widget->curve().front().opacity;
+        sendKey(Qt::Key_Up, Qt::ControlModifier);
+        require(widget->curve().front().opacity == held,
+            "Ctrl+arrow was swallowed as a nudge");
+        sendKey(Qt::Key_Up, Qt::AltModifier);
+        require(widget->curve().front().opacity == held,
+            "Alt+arrow was swallowed as a nudge");
+        sendKey(Qt::Key_Up, Qt::KeypadModifier);
+        require(widget->curve().front().opacity > held,
+            "the keypad modifier stopped an arrow key from nudging, which "
+            "would leave this dead on macOS");
+
+        // And not while a drag is in flight: the next mouse move would
+        // overwrite the nudge with the cursor's own position, so the key would
+        // cost a render and leave nothing behind.
+        const auto grabbed = widget->curve().front().opacity;
+        QMouseEvent holdEnd(QEvent::MouseButtonPress, lowEnd,
+            widget->mapToGlobal(lowEnd), Qt::LeftButton, Qt::LeftButton,
+            Qt::NoModifier);
+        QApplication::sendEvent(widget, &holdEnd);
+        sendKey(Qt::Key_Up, Qt::NoModifier);
+        require(widget->curve().front().opacity == grabbed,
+            "an arrow key moved a point that was being dragged");
+        QMouseEvent letGoEnd(QEvent::MouseButtonRelease, lowEnd,
+            widget->mapToGlobal(lowEnd), Qt::LeftButton, Qt::NoButton,
+            Qt::NoModifier);
+        QApplication::sendEvent(widget, &letGoEnd);
+
         // The palette's own alpha takes over from the curve, so the curve is
         // disabled: it has no say while that box is in effect, and a control
         // that looks editable and does nothing is the defect this replaced.

--- a/tests/unit/test_volume_controller.cpp
+++ b/tests/unit/test_volume_controller.cpp
@@ -21,6 +21,7 @@
 #include <QRectF>
 #include <QCheckBox>
 #include <QEvent>
+#include <QImage>
 #include <QKeyEvent>
 #include <QKeySequence>
 #include <QMouseEvent>
@@ -1197,9 +1198,20 @@ int main(int argc, char** argv)
             "the volume was still rendering of its own accord, so the checks "
             "below could not be the keys' doing");
 
-        // The low end point sits in the bottom-left corner of the plot, which
-        // is inset by a control point's half-width and the border.
-        const QPointF lowEnd(4.0, widget->height() - 4.0);
+        // Where a curve point is drawn: the plot is inset on every side by a
+        // control point's half-width and the border. Worked out from the point
+        // rather than assumed, so a press keeps landing on it wherever an edit
+        // has left it -- pressing a corner instead only works while the point
+        // is still in it, and silently hits nothing once it moves.
+        const auto plotPoint
+            = [widget](const amrvis::OpacityPoint& point) {
+                  constexpr double inset = 4.0;
+                  return QPointF(
+                      inset + point.position * (widget->width() - 2.0 * inset),
+                      widget->height() - inset
+                          - point.opacity * (widget->height() - 2.0 * inset));
+              };
+        const auto lowEnd = plotPoint(widget->curve().front());
         QMouseEvent takeEnd(QEvent::MouseButtonPress, lowEnd,
             widget->mapToGlobal(lowEnd), Qt::LeftButton, Qt::LeftButton,
             Qt::NoModifier);
@@ -1248,15 +1260,19 @@ int main(int argc, char** argv)
         // overwrite the nudge with the cursor's own position, so the key would
         // cost a render and leave nothing behind.
         const auto grabbed = widget->curve().front().opacity;
-        QMouseEvent holdEnd(QEvent::MouseButtonPress, lowEnd,
-            widget->mapToGlobal(lowEnd), Qt::LeftButton, Qt::LeftButton,
+        // Where the nudges above have left it, not where it started.
+        const auto raised = plotPoint(widget->curve().front());
+        QMouseEvent holdEnd(QEvent::MouseButtonPress, raised,
+            widget->mapToGlobal(raised), Qt::LeftButton, Qt::LeftButton,
             Qt::NoModifier);
         QApplication::sendEvent(widget, &holdEnd);
+        require(widget->curve().size() == 2,
+            "the press missed the raised end point and added one instead");
         sendKey(Qt::Key_Up, Qt::NoModifier);
         require(widget->curve().front().opacity == grabbed,
             "an arrow key moved a point that was being dragged");
-        QMouseEvent letGoEnd(QEvent::MouseButtonRelease, lowEnd,
-            widget->mapToGlobal(lowEnd), Qt::LeftButton, Qt::NoButton,
+        QMouseEvent letGoEnd(QEvent::MouseButtonRelease, raised,
+            widget->mapToGlobal(raised), Qt::LeftButton, Qt::NoButton,
             Qt::NoModifier);
         QApplication::sendEvent(widget, &letGoEnd);
 
@@ -1270,6 +1286,24 @@ int main(int argc, char** argv)
         require(alphaBox != nullptr, "no palette-alpha box in the volume window");
         require(widget->isEnabled(),
             "the curve is not editable with the palette-alpha box clear");
+
+        // How much colour the widget is carrying, which is almost all the
+        // palette strip: everything else on it is the theme's own greys.
+        const auto colourfulness = [](const QImage& image) {
+            double total = 0.0;
+            for (int y = 0; y < image.height(); ++y) {
+                for (int x = 0; x < image.width(); ++x) {
+                    total += image.pixelColor(x, y).saturation();
+                }
+            }
+            return total / static_cast<double>(image.width() * image.height());
+        };
+        const auto lively = colourfulness(widget->grab().toImage());
+        // Vacuity guard: with no palette there would be no strip to fade, and
+        // the comparison below would hold for the wrong reason.
+        require(lively > 20.0,
+            "the curve drew no palette strip, so fading it could not be "
+            "checked");
         window->setPaletteHasAlpha(true);
         require(alphaBox->isEnabled(),
             "the box did not enable for a palette with a ramp, so ticking it "
@@ -1278,6 +1312,14 @@ int main(int argc, char** argv)
         require(!widget->isEnabled(),
             "the curve stayed editable while the palette's own alpha was the "
             "opacity source");
+        // And the strip goes back with it. The line, the fill and the handles
+        // all grey out on their own, through QPalette::Disabled; the strip is
+        // painted from the data palette's own colours, which know nothing of
+        // the widget, so at full strength the boldest thing on an inert
+        // control would be the one part not saying it was inert.
+        const auto inert = colourfulness(widget->grab().toImage());
+        require(inert < 0.6 * lively,
+            "the palette strip kept its strength on a disabled curve");
         alphaBox->setChecked(false);
         require(widget->isEnabled(),
             "the curve did not become editable again when the palette's alpha "
@@ -1303,11 +1345,14 @@ int main(int argc, char** argv)
             "the renders from toggling palette alpha did not finish");
 
         // The two ends are not removable -- the curve has to span the range --
-        // and refusing must not pass for an edit either.
+        // and refusing must not pass for an edit either. Aimed at the point
+        // itself: the edits above raised it off the plot's bottom-left corner,
+        // and a press at the corner now misses it by more than the grab radius,
+        // so this check went on passing while testing nothing.
         const auto ends = session->requests.load();
-        const QPointF corner(0.0, static_cast<double>(widget->height()));
-        QMouseEvent atEnd(QEvent::MouseButtonPress, corner,
-            widget->mapToGlobal(corner), Qt::RightButton, Qt::RightButton,
+        const auto atLowEnd = plotPoint(widget->curve().front());
+        QMouseEvent atEnd(QEvent::MouseButtonPress, atLowEnd,
+            widget->mapToGlobal(atLowEnd), Qt::RightButton, Qt::RightButton,
             Qt::NoModifier);
         QApplication::sendEvent(widget, &atEnd);
         require(widget->curve().size() == 2,

--- a/tests/unit/test_volume_controller.cpp
+++ b/tests/unit/test_volume_controller.cpp
@@ -1279,8 +1279,12 @@ int main(int argc, char** argv)
         // The palette's own alpha takes over from the curve, so the curve is
         // disabled: it has no say while that box is in effect, and a control
         // that looks editable and does nothing is the defect this replaced.
-        // Driven through setPaletteHasAlpha because the palette here carries
-        // no ramp, which is what leaves the box disabled.
+        //
+        // The box being enabled is the "this palette carries a ramp" bit, and
+        // pushPalette sets it from the palette it hands over. Every builtin
+        // carries one, this one included, so the box is already enabled here
+        // and the check below is of that wiring rather than of a state the
+        // test set for itself.
         auto* const alphaBox = window->findChild<QCheckBox*>(
             QStringLiteral("volumePaletteAlphaCheck"));
         require(alphaBox != nullptr, "no palette-alpha box in the volume window");
@@ -1304,10 +1308,9 @@ int main(int argc, char** argv)
         require(lively > 20.0,
             "the curve drew no palette strip, so fading it could not be "
             "checked");
-        window->setPaletteHasAlpha(true);
         require(alphaBox->isEnabled(),
-            "the box did not enable for a palette with a ramp, so ticking it "
-            "below would not be in effect");
+            "the controller did not offer the box for a palette that carries a "
+            "ramp, so ticking it below would not be in effect");
         alphaBox->setChecked(true);
         require(!widget->isEnabled(),
             "the curve stayed editable while the palette's own alpha was the "


### PR DESCRIPTION
The palette strip behind the curve was drawn as overlapping translucent per-slot rects, which compounded unevenly wherever they overlapped and striped it; one scaled image paints every pixel once, at fuller strength. The point last pressed now stays selected, and the arrow keys nudge it more finely than a drag can place it. Grid boxes start off.