### PR TITLE
read volume samples between the voxel centres

### DIFF
--- a/docs/remote-client-server-plan.md
+++ b/docs/remote-client-server-plan.md
@@ -335,7 +335,7 @@ The production schema will cover:
 | `CancelRequest` | `CancelAcknowledged` | Request cancellation by request ID |
 | `PingRequest` | `PongResponse` | Explicit health check |
 | `ListDirectoryRequest` (1.1) | `DirectoryListing` | List a server directory's subdirectories, marking plotfiles |
-| `RenderedFrameRequest` (1.2) | `RenderedFrameResponse` | Render one volume frame on the server: camera, range, transfer lookup and voxel budget in; premultiplied pixels, the range used and sampling metrics out |
+| `RenderedFrameRequest` (1.2; sampling policy 1.3) | `RenderedFrameResponse` | Render one volume frame on the server: camera, range, transfer lookup, voxel budget and sampling policy in; premultiplied pixels, the range used and sampling metrics out |
 | any request | `ErrorResponse` | Typed terminal failure |
 
 Every ordinary request has exactly one terminal response with the same
@@ -415,7 +415,8 @@ query APIs.
 orthographic camera, the physical region, the output size, an optional
 explicit range (or the request that the server resolve the "Visible" range
 from the sampled grid), the transfer function as an explicit colour/opacity
-lookup, the samples per voxel and a voxel budget; the response carries the
+lookup, the samples per voxel, a voxel budget and -- from 1.3 -- the march's
+sampling policy (nearest or trilinear, field id 20); the response carries the
 viewport-sized premultiplied image, the range used, and the sampling metrics.
 The server bounds every field before allocating -- output size against the
 negotiated frame, the voxel budget against its own `--max-volume-voxels`

--- a/docs/remote-client-server-plan.md
+++ b/docs/remote-client-server-plan.md
@@ -294,6 +294,29 @@ Protocol policy:
 Packed messages are transient network data, not files. No persistence or
 cross-major migration path is promised.
 
+Verifying a version gate. A client-side capability gate -- the pattern
+protocol 1.3 uses for the volume march's sampling policy, where the client
+asks `supportsVolumeSampling()` before offering the control -- cannot be
+reached by an in-process test. `Connection` always negotiates the highest
+minor version both peers support, and neither `ConnectionOptions` nor
+`ServerOptions` exposes a cap, so a test cannot fabricate an older peer. The
+raw-socket tests in `test_remote_volume.cpp` drive a hand-written hello at a
+pinned version and so cover the *server's* refusal, but not the client's.
+
+What covers the client half is a real pair of binaries: build the server from
+a commit before the bump, and point a current client at it over ssh.
+
+```text
+(laptop) $ amrexplorer --ssh HOST --server /path/to/older/amrexplorer-server \
+    /path/to/plt3d
+```
+
+The client offers 0 through its own maximum, the older server answers with
+its own, and the capability query then reports false against a peer that
+really is older rather than one a test pretended was. Protocol 1.3's gate was
+checked this way: the control is greyed out and cleared, the volume still
+renders nearest, and returning to a session that can sample restores it.
+
 ### 5.3 Handshake and capabilities
 
 The first request must be `HelloRequest`. It will carry:

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -360,10 +360,10 @@ match. Its own controls set the opacity:
   around it instead of the one it happens to land in. It is on by default:
   reading a single voxel makes a ray fetch the same value several times over
   and renders the field as terraced blocks, which is the coarser look this
-  replaces. Clear it to see the sampled voxels as they are. It costs roughly
-  twice the render time at the same number of samples per voxel -- though it
-  buys more per sample, so a smooth **Draft** frame is not much dearer than a
-  terraced **Normal** one.
+  replaces. Clear it to see the sampled voxels as they are. It costs about
+  twice the march at the same number of samples per voxel -- though it buys
+  more per sample, so a smooth frame at half the samples beats a terraced one
+  at full, for less time than either.
 
   It shapes only how the volume is drawn from the grid, not how the grid is
   built from the AMR data. Where the voxel budget forces a grid coarser than
@@ -386,8 +386,10 @@ sends back the picture, never the field. It needs an `amrexplorer-server`
 that speaks protocol 1.2; against an older server the menu item stays
 disabled. **Smooth sampling** needs protocol 1.3, since the server is what
 does the sampling; against a 1.2 server the box is greyed out and says so,
-and the volume is rendered from the nearest voxel. The server's `--max-volume-voxels` and `--volume-cache-mib` options
-set how large one volume and one dataset's cache may get. They are per volume
+and the volume is rendered from the nearest voxel.
+
+The server's `--max-volume-voxels` and `--volume-cache-mib` options set how
+large one volume and one dataset's cache may get. They are per volume
 and per dataset, not a total for the server, so sizing a host means multiplying
 them by how many datasets and connections you allow. `--max-volume-voxels`
 starts at the largest a client may ask for, so it is there to tighten a server

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -356,6 +356,18 @@ match. Its own controls set the opacity:
   A remote plotfile renders the same as a local one, unless the server was
   started with a tighter ceiling of its own -- in which case **High** may look
   no different from **Normal** (see [Remote datasets](#remote-datasets)).
+- **Smooth sampling** reads each point along a ray from the eight voxels
+  around it instead of the one it happens to land in. It is on by default:
+  reading a single voxel makes a ray fetch the same value several times over
+  and renders the field as terraced blocks, which is the coarser look this
+  replaces. Clear it to see the sampled voxels as they are. It costs roughly
+  twice the render time at the same number of samples per voxel -- though it
+  buys more per sample, so a smooth **Draft** frame is not much dearer than a
+  terraced **Normal** one.
+
+  It shapes only how the volume is drawn from the grid, not how the grid is
+  built from the AMR data. Where the voxel budget forces a grid coarser than
+  the finest level, the detail is already gone before this applies.
 - **Grid boxes** and **Domain outline** draw the AMR box edges and the edge of
   the domain over the volume. The outline is on by default and the boxes are
   not: box edges crossing a translucent field read as structure in it, which
@@ -372,7 +384,9 @@ Volume rendering works for remote plotfiles too (see [Remote
 datasets](#remote-datasets)): the server samples and renders the frame and
 sends back the picture, never the field. It needs an `amrexplorer-server`
 that speaks protocol 1.2; against an older server the menu item stays
-disabled. The server's `--max-volume-voxels` and `--volume-cache-mib` options
+disabled. **Smooth sampling** needs protocol 1.3, since the server is what
+does the sampling; against a 1.2 server the box is greyed out and says so,
+and the volume is rendered from the nearest voxel. The server's `--max-volume-voxels` and `--volume-cache-mib` options
 set how large one volume and one dataset's cache may get. They are per volume
 and per dataset, not a total for the server, so sizing a host means multiplying
 them by how many datasets and connections you allow. `--max-volume-voxels`

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -362,8 +362,8 @@ match. Its own controls set the opacity:
   and renders the field as terraced blocks, which is the coarser look this
   replaces. Clear it to see the sampled voxels as they are. It costs about
   twice the march at the same number of samples per voxel -- though it buys
-  more per sample, so a smooth frame at half the samples beats a terraced one
-  at full, for less time than either.
+  more per sample, so a smooth frame at half the samples costs roughly what a
+  terraced one at full does, and shows more.
 
   It shapes only how the volume is drawn from the grid, not how the grid is
   built from the AMR data. Where the voxel budget forces a grid coarser than

--- a/docs/volume-rendering-plan.md
+++ b/docs/volume-rendering-plan.md
@@ -379,8 +379,13 @@ row, threading note; `docs/building.md` unchanged.
 - **Isosurfaces** — extracted and shaded iso-value surfaces alongside the
   translucent volume; needs a marching-cubes pass over the sampled grid and
   a depth-composited draw.
-- **Trilinear sampling** — a request/wire field and the High quality preset;
-  nearest-voxel today.
+- ~~**Trilinear sampling**~~ — done: a request/wire field (protocol 1.3) and a
+  **Smooth sampling** box, on by default rather than tied to the High preset,
+  since terracing shows most while rotating and that is when Draft is in use.
+  It costs about 2.4x the march at equal samples per voxel, so lowering the
+  presets' samples now that each one carries more is a follow-up worth
+  measuring: linear at 1 sample/voxel already beats nearest at 2 for 18% more
+  time.
 - **Box-averaged downsampling** — when the voxel budget forces a coarser
   pitch than the finest level, average the cells under a voxel instead of
   taking the one at its centre.

--- a/docs/volume-rendering-plan.md
+++ b/docs/volume-rendering-plan.md
@@ -382,10 +382,10 @@ row, threading note; `docs/building.md` unchanged.
 - ~~**Trilinear sampling**~~ — done: a request/wire field (protocol 1.3) and a
   **Smooth sampling** box, on by default rather than tied to the High preset,
   since terracing shows most while rotating and that is when Draft is in use.
-  It costs about 2.4x the march at equal samples per voxel, so lowering the
-  presets' samples now that each one carries more is a follow-up worth
-  measuring: linear at 1 sample/voxel already beats nearest at 2 for 18% more
-  time.
+  It costs about twice the march at equal samples per voxel (900^2 over 256^3,
+  24 threads: 129 ms against 65 ms), so lowering the presets' samples now that
+  each carries more is a follow-up worth measuring -- linear at 2 samples/voxel
+  is 76 ms, well under nearest at 4.
 - **Box-averaged downsampling** — when the voxel budget forces a coarser
   pitch than the finest level, average the cells under a voxel instead of
   taking the one at its centre.

--- a/docs/volume-rendering-plan.md
+++ b/docs/volume-rendering-plan.md
@@ -382,12 +382,19 @@ row, threading note; `docs/building.md` unchanged.
 - ~~**Trilinear sampling**~~ — done: a request/wire field (protocol 1.3) and a
   **Smooth sampling** box, on by default rather than tied to the High preset,
   since terracing shows most while rotating and that is when Draft is in use.
-  It costs about twice the march at equal samples per voxel (900^2 over 256^3,
-  24 threads: 129 ms against 66 ms), so lowering the presets' samples now that
-  each carries more is a follow-up worth measuring -- linear at 2 samples/voxel
-  is 75 ms, about what nearest at 4 costs (67 ms), for a better picture. Not
-  cheaper than it: an earlier note here said "well under", which compared 2
-  samples against the wrong column.
+  It costs about twice the march at equal samples per voxel. One run of
+  `bench_volume_render 256 900 <spv> 3 0 <linear>`, 900^2 over 256^3 on 24
+  threads:
+
+  | samples/voxel | nearest | linear |
+  | --- | --- | --- |
+  | 4 | 65 ms | 127 ms |
+  | 2 | -- | 77 ms |
+
+  So lowering the presets' samples now that each carries more is a follow-up
+  worth measuring: linear at 2 costs about what nearest at 4 does, for a better
+  picture. Not less than it -- an earlier note here said "well under", which
+  compared against the wrong column.
 - **Box-averaged downsampling** — when the voxel budget forces a coarser
   pitch than the finest level, average the cells under a voxel instead of
   taking the one at its centre.

--- a/docs/volume-rendering-plan.md
+++ b/docs/volume-rendering-plan.md
@@ -383,9 +383,11 @@ row, threading note; `docs/building.md` unchanged.
   **Smooth sampling** box, on by default rather than tied to the High preset,
   since terracing shows most while rotating and that is when Draft is in use.
   It costs about twice the march at equal samples per voxel (900^2 over 256^3,
-  24 threads: 129 ms against 65 ms), so lowering the presets' samples now that
+  24 threads: 129 ms against 66 ms), so lowering the presets' samples now that
   each carries more is a follow-up worth measuring -- linear at 2 samples/voxel
-  is 76 ms, well under nearest at 4.
+  is 75 ms, about what nearest at 4 costs (67 ms), for a better picture. Not
+  cheaper than it: an earlier note here said "well under", which compared 2
+  samples against the wrong column.
 - **Box-averaged downsampling** — when the voxel budget forces a coarser
   pitch than the finest level, average the cells under a voxel instead of
   taking the one at its centre.

--- a/include/amrexplorer/core/OrthoProjection.hpp
+++ b/include/amrexplorer/core/OrthoProjection.hpp
@@ -35,6 +35,18 @@ inline constexpr OrthoCamera orthoPresetYZ{
 inline constexpr OrthoCamera orthoDefaultView{
     0.5235987755982988, -0.5235987755982988, 1.0};
 
+// Which way a direction in domain space points on screen, in screen sense
+// (y down), as a unit-ish vector a caller scales for itself. The same rotation
+// projectPoint applies, without the domain normalisation or the viewport
+// scale: an axis indicator drawn from this agrees with the picture because it
+// is the same arithmetic, not because someone transcribed it correctly.
+struct ViewDirection {
+    double x = 0.0;
+    double y = 0.0;
+};
+[[nodiscard]] ViewDirection projectDirection(
+    const OrthoCamera& camera, const Real3& direction) noexcept;
+
 // Where the projection lands in a viewport of the given pixel size: the
 // centre, and the pixel scale of one normalised unit (the normalised domain
 // spans [-0.5, 0.5], so a scale of half the shorter side minus the margin

--- a/include/amrexplorer/core/OrthoProjection.hpp
+++ b/include/amrexplorer/core/OrthoProjection.hpp
@@ -26,7 +26,7 @@ inline constexpr OrthoCamera orthoPresetXZ{0.0, -1.5707963267948966, 1.0};
 inline constexpr OrthoCamera orthoPresetYZ{
     -1.5707963267948966, -1.5707963267948966, 1.0};
 
-// The angle the 3-D views open at: a fifth of a turn around the domain and
+// The angle the 3-D views open at: a twelfth of a turn around the domain and
 // tilted onto it from above. The elevation is negative for the same reason
 // the presets above are -- that is the sign that puts +z up. A positive one
 // looks at the domain from underneath, so a plume hangs from the ceiling

--- a/include/amrexplorer/core/OrthoProjection.hpp
+++ b/include/amrexplorer/core/OrthoProjection.hpp
@@ -26,6 +26,15 @@ inline constexpr OrthoCamera orthoPresetXZ{0.0, -1.5707963267948966, 1.0};
 inline constexpr OrthoCamera orthoPresetYZ{
     -1.5707963267948966, -1.5707963267948966, 1.0};
 
+// The angle the 3-D views open at: a fifth of a turn around the domain and
+// tilted onto it from above. The elevation is negative for the same reason
+// the presets above are -- that is the sign that puts +z up. A positive one
+// looks at the domain from underneath, so a plume hangs from the ceiling
+// instead of rising from the floor, and the axis indicator, which shares
+// these angles, agrees with it and looks equally wrong.
+inline constexpr OrthoCamera orthoDefaultView{
+    0.5235987755982988, -0.5235987755982988, 1.0};
+
 // Where the projection lands in a viewport of the given pixel size: the
 // centre, and the pixel scale of one normalised unit (the normalised domain
 // spans [-0.5, 0.5], so a scale of half the shorter side minus the margin

--- a/include/amrexplorer/core/Volume.hpp
+++ b/include/amrexplorer/core/Volume.hpp
@@ -111,6 +111,12 @@ struct VolumeRenderRequest {
     // Ray samples per voxel along the ray (the step is the mean distance a
     // view ray spends crossing one voxel divided by this).
     int samplesPerVoxel = 2;
+    // How each sample reads the sampled grid: Linear interpolates over the
+    // eight voxel centres around it, Nearest and PiecewiseConstant take the
+    // voxel it lands in. A march property, not a sampling one -- it does not
+    // change the grid, so it is deliberately absent from VolumeSampleRequest
+    // and from the grid cache key, and one cached grid serves both.
+    SamplingPolicy sampling = SamplingPolicy::Linear;
     std::uint64_t maximumVoxels = defaultVolumeVoxelBudget;
     friend bool operator==(const VolumeRenderRequest&,
         const VolumeRenderRequest&) = default;

--- a/include/amrexplorer/data/DatasetSession.hpp
+++ b/include/amrexplorer/data/DatasetSession.hpp
@@ -75,6 +75,14 @@ public:
     {
         return false;
     }
+    // Whether the march's sampling policy can be chosen. Separate from
+    // rendering itself because a peer speaking 1.2 renders volumes perfectly
+    // well and simply cannot be asked how to sample them; a session that
+    // renders at all can, unless it says otherwise.
+    [[nodiscard]] virtual bool supportsVolumeSampling() const noexcept
+    {
+        return supportsVolumeRendering();
+    }
     [[nodiscard]] virtual VolumeFrame renderVolume(
         const VolumeRenderRequest& request, StopToken cancellation = {})
     {

--- a/include/amrexplorer/data/DatasetSession.hpp
+++ b/include/amrexplorer/data/DatasetSession.hpp
@@ -79,9 +79,13 @@ public:
     // rendering itself because a peer speaking 1.2 renders volumes perfectly
     // well and simply cannot be asked how to sample them; a session that
     // renders at all can, unless it says otherwise.
+    // False, not supportsVolumeRendering(): a session that renders volumes
+    // but cannot be told how to sample them is exactly what this exists to
+    // find, so inheriting "yes" would hand the choice to the one kind of
+    // session that cannot honour it. An implementation that can says so.
     [[nodiscard]] virtual bool supportsVolumeSampling() const noexcept
     {
-        return supportsVolumeRendering();
+        return false;
     }
     [[nodiscard]] virtual VolumeFrame renderVolume(
         const VolumeRenderRequest& request, StopToken cancellation = {})

--- a/include/amrexplorer/data/LocalDatasetSession.hpp
+++ b/include/amrexplorer/data/LocalDatasetSession.hpp
@@ -82,6 +82,12 @@ public:
 
     // A 3-D plotfile with physical geometry can be volume-rendered.
     [[nodiscard]] bool supportsVolumeRendering() const noexcept override;
+    // Whatever this can render, it can sample either way: the choice only
+    // ever fails to reach a peer, and there is no peer here.
+    [[nodiscard]] bool supportsVolumeSampling() const noexcept override
+    {
+        return supportsVolumeRendering();
+    }
     [[nodiscard]] VolumeFrame renderVolume(const VolumeRenderRequest& request,
         StopToken cancellation = {}) override;
     // The same render with a bound on the threads it may use, or 0 to leave

--- a/include/amrexplorer/remote/Connection.hpp
+++ b/include/amrexplorer/remote/Connection.hpp
@@ -36,6 +36,12 @@ struct ConnectionOptions {
 inline constexpr const char* volumeRenderingUnsupportedMessage
     = "the remote server predates volume rendering (protocol 1.2); install a "
       "current amrexplorer-server";
+// Its narrower sibling: the server renders volumes but always sampled
+// nearest, so smooth sampling is the one thing it cannot be asked for.
+inline constexpr const char* volumeSamplingUnsupportedMessage
+    = "the remote server predates smooth volume sampling (protocol 1.3) and "
+      "samples each ray at the nearest voxel; install a current "
+      "amrexplorer-server";
 
 class Connection : public std::enable_shared_from_this<Connection> {
 public:
@@ -67,6 +73,9 @@ public:
     // before the call so a caller can refuse the capability without the
     // failure looking like a misbehaving peer.
     [[nodiscard]] bool supportsVolumeRendering() const noexcept;
+    // Whether the negotiated protocol carries the volume march's sampling
+    // policy (1.3). A 1.2 peer renders volumes but always sampled nearest.
+    [[nodiscard]] bool supportsVolumeSampling() const noexcept;
     // Renders a volume on the server and returns the frame (protocol 1.2).
     // Ask supportsVolumeRendering() first: this throws when the server
     // negotiated an older protocol.

--- a/include/amrexplorer/remote/Protocol.hpp
+++ b/include/amrexplorer/remote/Protocol.hpp
@@ -18,8 +18,15 @@
 namespace amrvis::remote {
 
 inline constexpr std::uint16_t protocolMajor = 1;
-// 1.1 added directory browsing; 1.2 adds volume rendering (RenderedFrame*).
-inline constexpr std::uint16_t protocolMinorVersion = 2;
+// 1.1 added directory browsing; 1.2 adds volume rendering (RenderedFrame*);
+// 1.3 adds the volume march's sampling policy (RenderedFrameRequest.sampling).
+//
+// 1.3 is a version rather than a bare appended field because the field changes
+// the picture. A 1.2 server ignores what it cannot read and renders nearest,
+// so a client that simply sent it would offer a control that silently did
+// nothing there -- the defect this codebase keeps designing against. The
+// version lets the client ask first and say so instead.
+inline constexpr std::uint16_t protocolMinorVersion = 3;
 
 enum class PayloadKind : std::uint8_t {
     None = 0,

--- a/include/amrexplorer/remote/RemoteDatasetSession.hpp
+++ b/include/amrexplorer/remote/RemoteDatasetSession.hpp
@@ -37,6 +37,7 @@ public:
     // True when the server speaks protocol 1.2 and the dataset is a 3-D
     // plotfile; the frame comes back rendered, validated against the request.
     [[nodiscard]] bool supportsVolumeRendering() const noexcept override;
+    [[nodiscard]] bool supportsVolumeSampling() const noexcept override;
     [[nodiscard]] VolumeFrame renderVolume(const VolumeRenderRequest& request,
         StopToken cancellation = {}) override;
     [[nodiscard]] DatasetPage requestDatasetPage(

--- a/include/amrexplorer/render3d/VolumeRaycaster.hpp
+++ b/include/amrexplorer/render3d/VolumeRaycaster.hpp
@@ -40,6 +40,13 @@ struct RaycastSettings {
     // axis would otherwise be sampled many times per voxel and come out far
     // more opaque than its entry asks for.
     int samplesPerVoxel = 2;
+    // How a sample reads the grid. Linear is trilinear over the eight voxel
+    // centres bracketing the sample, which is what stops a ray from fetching
+    // one voxel repeatedly and terracing the picture; Nearest and
+    // PiecewiseConstant both take the voxel the sample lands in, the rule the
+    // 2-D slice shows cells with. The names are the slice's, so one vocabulary
+    // covers both -- see SamplingPolicy in core/Request.hpp.
+    SamplingPolicy sampling = SamplingPolicy::Linear;
     // 0 = std::thread::hardware_concurrency(); bounded above by the row count
     // and by a small multiple of the hardware's, so an outsized request costs
     // no more than a sensible one.

--- a/schemas/amrexplorer_wire.fbs
+++ b/schemas/amrexplorer_wire.fbs
@@ -367,6 +367,12 @@ table RenderedFrameRequest {
   samples_per_voxel:int (id: 17);
   maximum_voxels:ulong (id: 18);
   range_logarithmic:bool (id: 19);
+  // Protocol 1.3. Appended with the next free id rather than placed beside
+  // samples_per_voxel, the way range_logarithmic was: renumbering an id would
+  // make every older peer read the wrong field. The default is Nearest -- what
+  // a server that predates 1.3 does -- but a 1.3 client never relies on that,
+  // because the version gate stops it asking such a server for Linear at all.
+  sampling:SamplingPolicy (id: 20);
 }
 
 // Premultiplied 0xAARRGGBB pixels, row 0 at the top, exactly width x height.

--- a/src/core/OrthoProjection.cpp
+++ b/src/core/OrthoProjection.cpp
@@ -156,4 +156,12 @@ Ray pixelRay(const OrthoCamera& camera, const ViewportFrame& frame,
     return rayAt(rayField(camera, frame, domain), pixelX, pixelY);
 }
 
+ViewDirection projectDirection(
+    const OrthoCamera& camera, const Real3& direction) noexcept
+{
+    const auto view = toView(rotationOf(camera), direction);
+    // Negated the way projectPoint negates it: screen y counts downward.
+    return {view.x1, -view.y2};
+}
+
 } // namespace amrvis

--- a/src/data/LocalDatasetSession.cpp
+++ b/src/data/LocalDatasetSession.cpp
@@ -404,6 +404,9 @@ VolumeFrame LocalDatasetSession::renderVolume(const VolumeRenderRequest& request
     }
     settings.transfer = request.transfer;
     settings.samplesPerVoxel = request.samplesPerVoxel;
+    // Not part of VolumeGridKey: this shapes the march, not the grid, so both
+    // modes read the same cached grid.
+    settings.sampling = request.sampling;
     auto frame = raycastVolume(*grid, settings, cancellation);
     const auto renderMicroseconds = frame.metrics.renderMicroseconds;
     frame.metrics = metrics;

--- a/src/qt/IsoWidget.cpp
+++ b/src/qt/IsoWidget.cpp
@@ -35,7 +35,7 @@ constexpr std::array<std::array<int, 2>, 12> boxEdges{{
 
 IsoWidget::IsoWidget(QWidget* parent)
     : QWidget(parent)
-    , m_camera{30.0 * pi / 180.0, 30.0 * pi / 180.0, 1.0}
+    , m_camera(orthoDefaultView)
 {
     setMinimumSize(200, 150);
     setMouseTracking(true);

--- a/src/qt/IsoWidget.cpp
+++ b/src/qt/IsoWidget.cpp
@@ -300,7 +300,13 @@ void IsoWidget::mouseMoveEvent(QMouseEvent* event)
         const auto delta = event->pos() - m_lastMousePos;
         m_lastMousePos = event->pos();
         constexpr double sensitivity = 0.008;
-        m_camera.azimuth -= static_cast<double>(delta.x()) * sensitivity;
+        // Both signs turn the domain with the drag rather than walking the
+        // camera around it: the surface under the cursor follows the cursor.
+        // The two disagreed once -- a drag down tipped the top toward you
+        // while a drag right slid the near face left -- which reads as the
+        // horizontal being backwards, since the vertical is what everything
+        // else does too.
+        m_camera.azimuth += static_cast<double>(delta.x()) * sensitivity;
         m_camera.elevation += static_cast<double>(delta.y()) * sensitivity;
         m_camera.elevation = std::clamp(
             m_camera.elevation, -pi / 2.0 + 0.01, pi / 2.0 - 0.01);

--- a/src/qt/IsoWidget.cpp
+++ b/src/qt/IsoWidget.cpp
@@ -359,17 +359,17 @@ void IsoWidget::drawAxisIndicator(QPainter& painter) const
     const QPointF origin(static_cast<qreal>(originX),
         static_cast<qreal>(h - originY));
 
-    const auto cosAz = std::cos(m_camera.azimuth);
-    const auto sinAz = std::sin(m_camera.azimuth);
-    const auto cosEl = std::cos(m_camera.elevation);
-    const auto sinEl = std::sin(m_camera.elevation);
-
-    auto projectDir = [&](double dx, double dy, double dz) -> QPointF {
-        const auto x1 = dx * cosAz - dy * sinAz;
-        const auto y1 = dx * sinAz + dy * cosAz;
-        const auto y2 = y1 * cosEl - dz * sinEl;
-        return QPointF(static_cast<double>(armLen) * x1,
-            -static_cast<double>(armLen) * y2);
+    // Through the shared projection rather than a second copy of its
+    // rotation: the arms have to agree with the wireframe about which way is
+    // up, and a transcription agrees only until one of the two is edited.
+    const auto projectDir = [this](double dx, double dy, double dz) {
+        Real3 direction;
+        direction[0] = dx;
+        direction[1] = dy;
+        direction[2] = dz;
+        const auto view = projectDirection(m_camera, direction);
+        return QPointF(
+            static_cast<double>(armLen) * view.x, static_cast<double>(armLen) * view.y);
     };
 
     const auto xTip = origin + projectDir(1.0, 0.0, 0.0);

--- a/src/qt/VolumeController.cpp
+++ b/src/qt/VolumeController.cpp
@@ -587,9 +587,14 @@ QString VolumeController::describe(
     const auto milliseconds = static_cast<double>(frame.metrics.renderMicroseconds
                                   + frame.metrics.sampleMicroseconds)
         / 1000.0;
-    const auto elapsed = milliseconds >= 1000.0
-        ? tr("%1 s").arg(milliseconds / 1000.0, 0, 'f', 2)
-        : tr("%1 ms").arg(milliseconds, 0, 'f', milliseconds >= 100.0 ? 0 : 1);
+    // Rounded before the threshold is tested, not after: 999.6 ms prints as
+    // a whole number, and testing the unrounded value would let it print
+    // "1000 ms" -- the second this switch exists to avoid claiming.
+    const auto whole = milliseconds >= 100.0;
+    const auto shown = whole ? std::round(milliseconds) : milliseconds;
+    const auto elapsed = shown >= 1000.0
+        ? tr("%1 s").arg(shown / 1000.0, 0, 'f', 2)
+        : tr("%1 ms").arg(shown, 0, 'f', whole ? 0 : 1);
     return tr("%1  level %2  range [%3, %4]%5\ngrid %6 x %7 x %8 (%9)  %10")
         .arg(fieldName)
         .arg(result.request.maximumLevel)

--- a/src/qt/VolumeController.cpp
+++ b/src/qt/VolumeController.cpp
@@ -577,7 +577,20 @@ QString VolumeController::describe(
 {
     const auto& frame = result.frame;
     const auto& range = frame.usedRange;
-    return tr("%1  level %2  range [%3, %4]%5\ngrid %6 x %7 x %8 (%9)  %10 ms")
+    // The metrics are microseconds (Volume.hpp says why), shown in whichever
+    // unit carries the digits that mean something. A draft is tens of
+    // milliseconds and its tenth is the difference between instant and not; a
+    // hundred milliseconds up, the tenth is noise on a line that changes every
+    // frame; past a second, four digits of milliseconds is not a number anyone
+    // reads. The switch to seconds waits for a whole one, so nothing ever
+    // rounds up into a second it has not reached.
+    const auto milliseconds = static_cast<double>(frame.metrics.renderMicroseconds
+                                  + frame.metrics.sampleMicroseconds)
+        / 1000.0;
+    const auto elapsed = milliseconds >= 1000.0
+        ? tr("%1 s").arg(milliseconds / 1000.0, 0, 'f', 2)
+        : tr("%1 ms").arg(milliseconds, 0, 'f', milliseconds >= 100.0 ? 0 : 1);
+    return tr("%1  level %2  range [%3, %4]%5\ngrid %6 x %7 x %8 (%9)  %10")
         .arg(fieldName)
         .arg(result.request.maximumLevel)
         .arg(range.minimum)
@@ -587,12 +600,7 @@ QString VolumeController::describe(
         .arg(frame.metrics.gridDims[1])
         .arg(frame.metrics.gridDims[2])
         .arg(frame.metrics.gridFromCache ? tr("cached") : tr("sampled"))
-        // The metrics are microseconds (Volume.hpp says why); one decimal
-        // place so a sub-millisecond render reads as fast rather than as 0.
-        .arg(static_cast<double>(frame.metrics.renderMicroseconds
-                 + frame.metrics.sampleMicroseconds)
-                / 1000.0,
-            0, 'f', 1);
+        .arg(elapsed);
 }
 
 } // namespace amrvis::qt

--- a/src/qt/VolumeController.cpp
+++ b/src/qt/VolumeController.cpp
@@ -582,8 +582,9 @@ QString VolumeController::describe(
     // milliseconds and its tenth is the difference between instant and not; a
     // hundred milliseconds up, the tenth is noise on a line that changes every
     // frame; past a second, four digits of milliseconds is not a number anyone
-    // reads. The switch to seconds waits for a whole one, so nothing ever
-    // rounds up into a second it has not reached.
+    // reads. Something just short of a second has to round somewhere -- 999.6
+    // is either "1000 ms" or "1.00 s" -- and it reads better as the second,
+    // which is why the rounding happens before the unit is chosen below.
     const auto milliseconds = static_cast<double>(frame.metrics.renderMicroseconds
                                   + frame.metrics.sampleMicroseconds)
         / 1000.0;

--- a/src/qt/VolumeController.cpp
+++ b/src/qt/VolumeController.cpp
@@ -182,6 +182,7 @@ void VolumeController::showWindow(QWidget* parent)
     // Toggling the region limit moves the box in one step, in both
     // directions, so it renders at once rather than drafting.
     connect(window, &VolumeWindow::regionLimitChanged, this, endInteraction);
+    connect(window, &VolumeWindow::samplingChanged, this, endInteraction);
     connect(window, &VolumeWindow::paletteAlphaChanged, this, endInteraction);
     // A close from the title bar: closeWindow drops this connection before
     // closing, so reaching here means the user closed the window and nothing
@@ -246,6 +247,10 @@ void VolumeController::pushGeometry()
     const auto dataset = m_hooks.dataset ? m_hooks.dataset() : nullptr;
     if (dataset) {
         m_window->setDatasetGeometry(dataset->metadata());
+        // Whether this session can be asked how to sample: a local one always
+        // can, a server speaking an older protocol cannot. Pushed here so it
+        // follows the dataset, the way the palette's alpha ramp does.
+        m_window->setSamplingSelectable(dataset->supportsVolumeSampling());
     }
     pushPalette();
     slicePositionsChanged();
@@ -468,6 +473,9 @@ void VolumeController::startRender()
         m_hooks.palette ? m_hooks.palette() : builtinPalette(BuiltinPalette::Rainbow),
         m_window->ramp());
     request.samplesPerVoxel = draft ? 1 : quality.samplesPerVoxel;
+    // Drafts too: with fewer samples per voxel there is more distance between
+    // them, which is exactly where reading one voxel per sample terraces.
+    request.sampling = m_window->sampling();
     request.maximumVoxels = quality.maximumVoxels;
 
     const auto generation = ++m_generation;

--- a/src/qt/VolumeWindow.cpp
+++ b/src/qt/VolumeWindow.cpp
@@ -207,6 +207,10 @@ void VolumeWindow::buildControls()
     form->addRow(QString(), m_outlineCheck);
     layout->addLayout(form);
     m_status = new QLabel(panel);
+    // Named for the same reason the check boxes are: neither label is the one
+    // an unqualified findChild would return twice running, and the order they
+    // are built in is a layout decision, not an identity.
+    m_status->setObjectName(QStringLiteral("volumeStatusLabel"));
     m_status->setWordWrap(true);
     m_status->setTextInteractionFlags(Qt::TextSelectableByMouse);
     layout->addWidget(m_status);
@@ -215,6 +219,7 @@ void VolumeWindow::buildControls()
     // each time; below, the numbers it belongs to hold still and the weight is
     // what catches the eye instead of the movement.
     m_rendering = new QLabel(panel);
+    m_rendering->setObjectName(QStringLiteral("volumeRenderingLabel"));
     auto renderingFont = m_rendering->font();
     renderingFont.setBold(true);
     m_rendering->setFont(renderingFont);
@@ -238,8 +243,12 @@ void VolumeWindow::buildControls()
         [this](int) { emit qualityChanged(); });
     connect(m_regionCheck, &QCheckBox::toggled, this,
         [this] { emit regionLimitChanged(); });
-    connect(m_smoothCheck, &QCheckBox::toggled, this,
-        [this] { emit samplingChanged(); });
+    connect(m_smoothCheck, &QCheckBox::toggled, this, [this](bool on) {
+        // Only what the user asked for: the tick setSamplingSelectable takes
+        // away and puts back is blocked, so it never overwrites this.
+        m_smoothWanted = on;
+        emit samplingChanged();
+    });
     connect(m_boxesCheck, &QCheckBox::toggled, this,
         [this](bool checked) { m_view->setLevelBoxesVisible(checked); });
     connect(m_outlineCheck, &QCheckBox::toggled, this,
@@ -362,15 +371,16 @@ SamplingPolicy VolumeWindow::sampling() const
 void VolumeWindow::setSamplingSelectable(bool selectable)
 {
     m_smoothCheck->setEnabled(selectable);
-    // Unticked as well as disabled, for the reason setPaletteHasAlpha gives:
-    // sampling() already reads a disabled box as Nearest, so a box left
-    // ticked would sit there claiming a smoothness the picture does not have,
-    // and re-arm itself the moment a session that can sample arrives.
-    // Silently, since whatever changed the session is already rendering.
-    if (!selectable && m_smoothCheck->isChecked()) {
-        const QSignalBlocker blocker(m_smoothCheck);
-        m_smoothCheck->setChecked(false);
-    }
+    // Unticked while unavailable, so it does not sit there claiming a
+    // smoothness the picture does not have -- and ticked again from what was
+    // last asked of it when it comes back. This is where it parts company
+    // with the palette-alpha box it otherwise copies: that one is off by
+    // default and has nothing to restore, while this one is on, so leaving it
+    // clear after one older server would turn the default off for the rest of
+    // the session. Silently either way, since whatever changed the session is
+    // already rendering.
+    const QSignalBlocker blocker(m_smoothCheck);
+    m_smoothCheck->setChecked(selectable && m_smoothWanted);
     m_smoothCheck->setToolTip(selectable
             ? tr("Read each ray sample from the eight voxels around it "
                  "instead of the one it lands in, which is what stops a "

--- a/src/qt/VolumeWindow.cpp
+++ b/src/qt/VolumeWindow.cpp
@@ -183,6 +183,14 @@ void VolumeWindow::buildControls()
         tr("Sample only the part of the domain the slice views are zoomed to, "
            "which spends the voxel budget on it instead of the whole field"));
     form->addRow(QString(), m_regionCheck);
+    m_smoothCheck = new QCheckBox(tr("Smooth sampling"), panel);
+    m_smoothCheck->setObjectName(QStringLiteral("volumeSmoothSamplingCheck"));
+    m_smoothCheck->setChecked(true);
+    form->addRow(QString(), m_smoothCheck);
+    // Available until a session says otherwise, the way the palette-alpha box
+    // is: this is a local render's answer, and setSamplingSelectable revises
+    // it for a server that cannot be asked.
+    setSamplingSelectable(true);
     // Grid boxes off, domain outline on: box edges crossing a translucent
     // field read as structure in it, which is worth asking for rather than
     // having to switch off. Both are said here and only here -- the view's own
@@ -223,6 +231,8 @@ void VolumeWindow::buildControls()
         [this](int) { emit qualityChanged(); });
     connect(m_regionCheck, &QCheckBox::toggled, this,
         [this] { emit regionLimitChanged(); });
+    connect(m_smoothCheck, &QCheckBox::toggled, this,
+        [this] { emit samplingChanged(); });
     connect(m_boxesCheck, &QCheckBox::toggled, this,
         [this](bool checked) { m_view->setLevelBoxesVisible(checked); });
     connect(m_outlineCheck, &QCheckBox::toggled, this,
@@ -330,6 +340,28 @@ QSize VolumeWindow::viewSize() const
 bool VolumeWindow::limitToVisibleRegion() const
 {
     return m_regionCheck->isChecked();
+}
+
+SamplingPolicy VolumeWindow::sampling() const
+{
+    // The same shape as the palette-alpha box: a ticked box that is not
+    // available is not in effect, so what the control offers and what the
+    // render does cannot disagree.
+    return m_smoothCheck->isEnabled() && m_smoothCheck->isChecked()
+        ? SamplingPolicy::Linear
+        : SamplingPolicy::Nearest;
+}
+
+void VolumeWindow::setSamplingSelectable(bool selectable)
+{
+    m_smoothCheck->setEnabled(selectable);
+    m_smoothCheck->setToolTip(selectable
+            ? tr("Read each ray sample from the eight voxels around it "
+                 "instead of the one it lands in, which is what stops a "
+                 "coarse volume looking terraced")
+            : tr("This server predates smooth sampling (protocol 1.3) and "
+                 "always reads the nearest voxel; install a current "
+                 "amrexplorer-server"));
 }
 
 qreal VolumeWindow::viewDevicePixelRatio() const

--- a/src/qt/VolumeWindow.cpp
+++ b/src/qt/VolumeWindow.cpp
@@ -362,6 +362,15 @@ SamplingPolicy VolumeWindow::sampling() const
 void VolumeWindow::setSamplingSelectable(bool selectable)
 {
     m_smoothCheck->setEnabled(selectable);
+    // Unticked as well as disabled, for the reason setPaletteHasAlpha gives:
+    // sampling() already reads a disabled box as Nearest, so a box left
+    // ticked would sit there claiming a smoothness the picture does not have,
+    // and re-arm itself the moment a session that can sample arrives.
+    // Silently, since whatever changed the session is already rendering.
+    if (!selectable && m_smoothCheck->isChecked()) {
+        const QSignalBlocker blocker(m_smoothCheck);
+        m_smoothCheck->setChecked(false);
+    }
     m_smoothCheck->setToolTip(selectable
             ? tr("Read each ray sample from the eight voxels around it "
                  "instead of the one it lands in, which is what stops a "

--- a/src/qt/VolumeWindow.cpp
+++ b/src/qt/VolumeWindow.cpp
@@ -206,13 +206,20 @@ void VolumeWindow::buildControls()
     form->addRow(QString(), m_boxesCheck);
     form->addRow(QString(), m_outlineCheck);
     layout->addLayout(form);
-    m_rendering = new QLabel(panel);
-    m_rendering->setVisible(false);
-    layout->addWidget(m_rendering);
     m_status = new QLabel(panel);
     m_status->setWordWrap(true);
     m_status->setTextInteractionFlags(Qt::TextSelectableByMouse);
     layout->addWidget(m_status);
+    // Under the status rather than over it, and bold. It comes and goes with
+    // every render, so above the status it pushed those lines down and back
+    // each time; below, the numbers it belongs to hold still and the weight is
+    // what catches the eye instead of the movement.
+    m_rendering = new QLabel(panel);
+    auto renderingFont = m_rendering->font();
+    renderingFont.setBold(true);
+    m_rendering->setFont(renderingFont);
+    m_rendering->setVisible(false);
+    layout->addWidget(m_rendering);
     layout->addStretch(1);
     dock->setWidget(panel);
     addDockWidget(Qt::RightDockWidgetArea, dock);

--- a/src/qt/VolumeWindow.cpp
+++ b/src/qt/VolumeWindow.cpp
@@ -185,7 +185,6 @@ void VolumeWindow::buildControls()
     form->addRow(QString(), m_regionCheck);
     m_smoothCheck = new QCheckBox(tr("Smooth sampling"), panel);
     m_smoothCheck->setObjectName(QStringLiteral("volumeSmoothSamplingCheck"));
-    m_smoothCheck->setChecked(true);
     form->addRow(QString(), m_smoothCheck);
     // Available until a session says otherwise, the way the palette-alpha box
     // is: this is a local render's answer, and setSamplingSelectable revises

--- a/src/qt/VolumeWindow.hpp
+++ b/src/qt/VolumeWindow.hpp
@@ -51,6 +51,10 @@ public:
     void setColorPalette(const Palette* palette);
     // Enables the "use palette alpha" control (the palette carries a ramp).
     void setPaletteHasAlpha(bool hasAlpha);
+    // Whether the session can be asked how to sample. A server speaking an
+    // older protocol renders volumes but always at the nearest voxel, so the
+    // control is offered only when asking for anything else would be heard.
+    void setSamplingSelectable(bool selectable);
 
     // The frame to draw, the camera it was rendered with (so a camera moved
     // since can be corrected for), and a line of status text; and whether a
@@ -70,6 +74,9 @@ public:
     [[nodiscard]] OpacityRamp ramp() const;
     // Whether the render should cover only what the slice views show.
     [[nodiscard]] bool limitToVisibleRegion() const;
+    // The march's sampling policy: Linear while the box is ticked and in
+    // effect, Nearest otherwise.
+    [[nodiscard]] SamplingPolicy sampling() const;
     [[nodiscard]] Quality quality() const;
 
 signals:
@@ -86,6 +93,7 @@ signals:
     void paletteAlphaChanged();
     void qualityChanged();
     void regionLimitChanged();
+    void samplingChanged();
     void viewResized();
     void viewScaleChanged();
 
@@ -101,6 +109,7 @@ private:
     QCheckBox* m_paletteAlpha = nullptr;
     QComboBox* m_qualityCombo = nullptr;
     QCheckBox* m_regionCheck = nullptr;
+    QCheckBox* m_smoothCheck = nullptr;
     QCheckBox* m_boxesCheck = nullptr;
     QCheckBox* m_outlineCheck = nullptr;
     QLabel* m_status = nullptr;

--- a/src/qt/VolumeWindow.hpp
+++ b/src/qt/VolumeWindow.hpp
@@ -110,6 +110,11 @@ private:
     QComboBox* m_qualityCombo = nullptr;
     QCheckBox* m_regionCheck = nullptr;
     QCheckBox* m_smoothCheck = nullptr;
+    // What was last asked of the smooth-sampling box while it was available.
+    // The box itself cannot hold it: it is unticked while unavailable so it
+    // does not claim a smoothness the render lacks, and something has to
+    // remember what to put back.
+    bool m_smoothWanted = true;
     QCheckBox* m_boxesCheck = nullptr;
     QCheckBox* m_outlineCheck = nullptr;
     QLabel* m_status = nullptr;

--- a/src/remote/Codec.cpp
+++ b/src/remote/Codec.cpp
@@ -947,6 +947,7 @@ fb::RenderedFrameRequestT toWire(const VolumeRenderRequest& value)
     wire.transfer_opacities = value.transfer.opacities;
     wire.samples_per_voxel = value.samplesPerVoxel;
     wire.maximum_voxels = value.maximumVoxels;
+    wire.sampling = toWireSampling(value.sampling);
     return wire;
 }
 
@@ -985,6 +986,7 @@ VolumeRenderRequest fromWire(const fb::RenderedFrameRequestT& value)
     result.transfer.opacities = value.transfer_opacities;
     result.samplesPerVoxel = value.samples_per_voxel;
     result.maximumVoxels = value.maximum_voxels;
+    result.sampling = fromWireSampling(value.sampling);
     return result;
 }
 

--- a/src/remote/Connection.cpp
+++ b/src/remote/Connection.cpp
@@ -279,6 +279,13 @@ public:
         return m_selectedMinorVersion >= 2;
     }
 
+    // Separately from rendering itself: a 1.2 server volume-renders perfectly
+    // well, it just cannot be asked how to sample.
+    [[nodiscard]] bool supportsVolumeSampling() const noexcept
+    {
+        return m_selectedMinorVersion >= 3;
+    }
+
     VolumeFrame renderVolume(
         const VolumeRenderRequest& request, StopToken cancellation)
     {
@@ -769,6 +776,11 @@ RemoteDirectoryListing Connection::listDirectory(
 bool Connection::supportsVolumeRendering() const noexcept
 {
     return m_impl->supportsVolumeRendering();
+}
+
+bool Connection::supportsVolumeSampling() const noexcept
+{
+    return m_impl->supportsVolumeSampling();
 }
 
 VolumeFrame Connection::renderVolume(

--- a/src/remote/Connection.cpp
+++ b/src/remote/Connection.cpp
@@ -292,6 +292,14 @@ public:
         // Still refused here for a caller that did not ask first -- but the
         // wrapper that closes the connection on an unexpected exception has
         // supportsVolumeRendering() to test, so it never has to reach this.
+        // Both refusals here as well as in RemoteDatasetSession: this class
+        // is public, this is where the negotiated version lives, and a caller
+        // that did not ask first would otherwise have its request quietly
+        // answered by a different rule than the one it named.
+        if (request.sampling == SamplingPolicy::Linear
+            && !supportsVolumeSampling()) {
+            throw std::runtime_error(volumeSamplingUnsupportedMessage);
+        }
         if (!supportsVolumeRendering()) {
             throw std::runtime_error(volumeRenderingUnsupportedMessage);
         }

--- a/src/remote/Connection.cpp
+++ b/src/remote/Connection.cpp
@@ -295,13 +295,20 @@ public:
         // Both refusals here as well as in RemoteDatasetSession: this class
         // is public, this is where the negotiated version lives, and a caller
         // that did not ask first would otherwise have its request quietly
-        // answered by a different rule than the one it named.
-        if (request.sampling == SamplingPolicy::Linear
-            && !supportsVolumeSampling()) {
-            throw std::runtime_error(volumeSamplingUnsupportedMessage);
-        }
+        // answered by a different rule than the one it named. Rendering
+        // first, because sampling defaults to Linear: a peer too old to render
+        // volumes at all would otherwise be reported as merely too old to
+        // smooth them, which is advice about the wrong problem.
         if (!supportsVolumeRendering()) {
             throw std::runtime_error(volumeRenderingUnsupportedMessage);
+        }
+        // Then anything the wire default cannot express. Tested against
+        // Nearest rather than for Linear: a peer older than 1.3 drops the
+        // field and renders nearest whatever it held, so Nearest is the only
+        // value that may travel there -- and the enum has a third.
+        if (request.sampling != SamplingPolicy::Nearest
+            && !supportsVolumeSampling()) {
+            throw std::runtime_error(volumeSamplingUnsupportedMessage);
         }
         // Indefinite: the first render of a field samples the plotfile,
         // which can outlast the request timeout; the token still cancels it.

--- a/src/remote/Connection.cpp
+++ b/src/remote/Connection.cpp
@@ -302,11 +302,13 @@ public:
         if (!supportsVolumeRendering()) {
             throw std::runtime_error(volumeRenderingUnsupportedMessage);
         }
-        // Then anything the wire default cannot express. Tested against
-        // Nearest rather than for Linear: a peer older than 1.3 drops the
-        // field and renders nearest whatever it held, so Nearest is the only
-        // value that may travel there -- and the enum has a third.
-        if (request.sampling != SamplingPolicy::Nearest
+        // Then a sampling policy the peer cannot honour. Tested for Linear
+        // specifically, because that is the one the march itself distinguishes
+        // (VolumeRaycaster reads anything else as nearest): refusing
+        // PiecewiseConstant would refuse a request whose picture an older peer
+        // would have produced correctly. If that policy ever grows a march of
+        // its own, this has to widen with it.
+        if (request.sampling == SamplingPolicy::Linear
             && !supportsVolumeSampling()) {
             throw std::runtime_error(volumeSamplingUnsupportedMessage);
         }

--- a/src/remote/RemoteDatasetSession.cpp
+++ b/src/remote/RemoteDatasetSession.cpp
@@ -163,7 +163,7 @@ VolumeFrame RemoteDatasetSession::renderVolume(
     // different question from the one asked -- and nothing downstream could
     // tell. The window asks supportsVolumeSampling() first and offers no such
     // request, so reaching this means a caller that did not.
-    if (request.sampling != SamplingPolicy::Nearest
+    if (request.sampling == SamplingPolicy::Linear
         && !m_connection->supportsVolumeSampling()) {
         throw std::runtime_error(volumeSamplingUnsupportedMessage);
     }

--- a/src/remote/RemoteDatasetSession.cpp
+++ b/src/remote/RemoteDatasetSession.cpp
@@ -163,7 +163,7 @@ VolumeFrame RemoteDatasetSession::renderVolume(
     // different question from the one asked -- and nothing downstream could
     // tell. The window asks supportsVolumeSampling() first and offers no such
     // request, so reaching this means a caller that did not.
-    if (request.sampling == SamplingPolicy::Linear
+    if (request.sampling != SamplingPolicy::Nearest
         && !m_connection->supportsVolumeSampling()) {
         throw std::runtime_error(volumeSamplingUnsupportedMessage);
     }

--- a/src/remote/RemoteDatasetSession.cpp
+++ b/src/remote/RemoteDatasetSession.cpp
@@ -137,6 +137,11 @@ bool RemoteDatasetSession::supportsVolumeRendering() const noexcept
         && datasetSupportsVolumeRendering(m_metadata);
 }
 
+bool RemoteDatasetSession::supportsVolumeSampling() const noexcept
+{
+    return supportsVolumeRendering() && m_connection->supportsVolumeSampling();
+}
+
 VolumeFrame RemoteDatasetSession::renderVolume(
     const VolumeRenderRequest& request, StopToken cancellation)
 {
@@ -152,6 +157,15 @@ VolumeFrame RemoteDatasetSession::renderVolume(
     if (!datasetSupportsVolumeRendering(m_metadata)) {
         throw std::invalid_argument(
             "volume rendering requires a 3-D plotfile with physical geometry");
+    }
+    // Refused rather than sent and quietly ignored. A 1.2 server cannot read
+    // the field, so it would render nearest and return a frame that answers a
+    // different question from the one asked -- and nothing downstream could
+    // tell. The window asks supportsVolumeSampling() first and offers no such
+    // request, so reaching this means a caller that did not.
+    if (request.sampling == SamplingPolicy::Linear
+        && !m_connection->supportsVolumeSampling()) {
+        throw std::runtime_error(volumeSamplingUnsupportedMessage);
     }
     validateSessionVolumeRequest(m_metadata, m_id, request);
     return refusingInvalidResponses(*m_connection, [&] {

--- a/src/remote/Server.cpp
+++ b/src/remote/Server.cpp
@@ -806,7 +806,7 @@ private:
         // can only be a peer claiming one version and speaking another. Say so
         // rather than rendering by a rule it did not ask for -- a refusal the
         // client can read, and one that leaves the connection up.
-        if (request.sampling != SamplingPolicy::Nearest
+        if (request.sampling == SamplingPolicy::Linear
             && m_selectedMinorVersion < 3) {
             throw RemoteError(ErrorCode::UnsupportedProtocol,
                 "smooth volume sampling requires protocol 1.3");

--- a/src/remote/Server.cpp
+++ b/src/remote/Server.cpp
@@ -802,6 +802,15 @@ private:
                 "volume rendering requires protocol 1.2");
         }
         auto request = codec::fromWire(*payload);
+        // A client that negotiated 1.2 has no sampling field to send, so this
+        // can only be a peer claiming one version and speaking another. Say so
+        // rather than rendering by a rule it did not ask for -- a refusal the
+        // client can read, and one that leaves the connection up.
+        if (request.sampling == SamplingPolicy::Linear
+            && m_selectedMinorVersion < 3) {
+            throw RemoteError(ErrorCode::UnsupportedProtocol,
+                "smooth volume sampling requires protocol 1.3");
+        }
         validateVolumeBound(request);
         // The server's own voxel cap applies on top of the client's budget.
         request.maximumVoxels = std::min<std::uint64_t>(

--- a/src/remote/Server.cpp
+++ b/src/remote/Server.cpp
@@ -806,7 +806,7 @@ private:
         // can only be a peer claiming one version and speaking another. Say so
         // rather than rendering by a rule it did not ask for -- a refusal the
         // client can read, and one that leaves the connection up.
-        if (request.sampling == SamplingPolicy::Linear
+        if (request.sampling != SamplingPolicy::Nearest
             && m_selectedMinorVersion < 3) {
             throw RemoteError(ErrorCode::UnsupportedProtocol,
                 "smooth volume sampling requires protocol 1.3");

--- a/src/render3d/VolumeRaycaster.cpp
+++ b/src/render3d/VolumeRaycaster.cpp
@@ -517,8 +517,11 @@ VolumeFrame raycastVolume(const VolumeGrid& grid,
               // Seven interpolations along the axes in turn rather than
               // eight corners each weighted by a product: the same value, and
               // the weight products are what this loop spends its time on.
+              // std::lerp rather than from + where * (to - from): it is
+              // specified to return the endpoints exactly, which is what the
+              // clamped shell above leans on when it claims to read flat.
               const auto between = [](double from, double to, double where) {
-                  return from + where * (to - from);
+                  return std::lerp(from, to, where);
               };
               const auto blend = [&](const std::array<double, 8>& corner) {
                   const auto lowY

--- a/src/render3d/VolumeRaycaster.cpp
+++ b/src/render3d/VolumeRaycaster.cpp
@@ -517,11 +517,17 @@ VolumeFrame raycastVolume(const VolumeGrid& grid,
               // Seven interpolations along the axes in turn rather than
               // eight corners each weighted by a product: the same value, and
               // the weight products are what this loop spends its time on.
-              // std::lerp rather than from + where * (to - from): it is
-              // specified to return the endpoints exactly, which is what the
-              // clamped shell above leans on when it claims to read flat.
+              // Not std::lerp, which costs about a quarter of the frame here
+              // (160 ms against 129 at 900 square over 256 cubed): it carries
+              // guarantees about infinities and monotonicity that this does
+              // not need, and does not fold to the same arithmetic. The one
+              // guarantee that would matter -- returning the endpoints
+              // exactly -- is already had: the weight is exactly zero in the
+              // clamped shell, where this returns `from` unchanged, and the
+              // bracket only produces a fraction in [0, 1) elsewhere, so the
+              // far endpoint is never asked for.
               const auto between = [](double from, double to, double where) {
-                  return std::lerp(from, to, where);
+                  return from + where * (to - from);
               };
               const auto blend = [&](const std::array<double, 8>& corner) {
                   const auto lowY

--- a/src/render3d/VolumeRaycaster.cpp
+++ b/src/render3d/VolumeRaycaster.cpp
@@ -438,9 +438,28 @@ VolumeFrame raycastVolume(const VolumeGrid& grid,
     // than invent data, and never let one NaN erode a voxel-wide rind. Every
     // corner is then mappable, so the result is a convex combination of
     // mappable values and is mappable itself.
+    // The eight corner values a sample interpolates, kept from one sample to
+    // the next. At two or more samples per voxel a ray takes several steps
+    // inside one cell -- four of them at the High preset -- and the corners do
+    // not change while it does, so the fetches and the coverage tests are the
+    // same work repeated. One of these lives per ray, not per frame, so the
+    // march stays a pure function of the sample's index.
+    //
+    // Corners are kept as the grid holds them, uncovered ones included, with a
+    // bit per corner saying which those were. Substitution happens on the way
+    // out instead: what stands in for an uncovered corner is the value of the
+    // voxel the sample landed in, and that changes within a cell, so a cell
+    // stored already-substituted could not be reused across the sample that
+    // changed it. This way every cell is reusable, boundaries included.
+    struct CellCache {
+        std::array<std::size_t, 3> low{};
+        std::array<double, 8> corner{};
+        unsigned uncovered = 0;
+        bool loaded = false;
+    };
     const auto linearValue
         = [&grid, &mappedRange, gridRowStride, slabStride](
-              const std::array<double, 3>& at, double landed) {
+              const std::array<double, 3>& at, double landed, CellCache& cache) {
               // Per axis: the two bracketing voxel indices and how far the
               // sample sits between them.
               std::array<std::array<std::size_t, 2>, 3> bracket{};
@@ -467,25 +486,61 @@ VolumeFrame raycastVolume(const VolumeGrid& grid,
                       = static_cast<std::size_t>(low < limit ? low + 1.0 : limit);
                   weight[axis] = fraction;
               }
-              double result = 0.0;
-              for (std::size_t k = 0; k < 2; ++k) {
-                  const auto wz = k == 1 ? weight[2] : 1.0 - weight[2];
-                  for (std::size_t j = 0; j < 2; ++j) {
-                      const auto wy = j == 1 ? weight[1] : 1.0 - weight[1];
-                      for (std::size_t i = 0; i < 2; ++i) {
-                          const auto wx = i == 1 ? weight[0] : 1.0 - weight[0];
-                          const auto corner = bracket[0][i]
-                              + gridRowStride * bracket[1][j]
-                              + slabStride * bracket[2][k];
-                          auto value = static_cast<double>(grid.values[corner]);
-                          if (!mappableValue(value, mappedRange)) {
-                              value = landed;
+              // The same cell as the last sample on this ray, and that one
+              // needed no substitution: its corners still hold.
+              // Read straight into the cache and interpolate out of it, so a
+              // reused cell costs three comparisons and a fresh one costs no
+              // copy on top of its fetches.
+              if (!cache.loaded || cache.low[0] != bracket[0][0]
+                  || cache.low[1] != bracket[1][0]
+                  || cache.low[2] != bracket[2][0]) {
+                  cache.uncovered = 0;
+                  for (std::size_t k = 0; k < 2; ++k) {
+                      for (std::size_t j = 0; j < 2; ++j) {
+                          for (std::size_t i = 0; i < 2; ++i) {
+                              const auto corner = i + 2 * j + 4 * k;
+                              const auto offset = bracket[0][i]
+                                  + gridRowStride * bracket[1][j]
+                                  + slabStride * bracket[2][k];
+                              const auto value
+                                  = static_cast<double>(grid.values[offset]);
+                              if (!mappableValue(value, mappedRange)) {
+                                  cache.uncovered |= 1U << corner;
+                              }
+                              cache.corner[corner] = value;
                           }
-                          result += wx * wy * wz * value;
                       }
                   }
+                  cache.loaded = true;
+                  cache.low = {bracket[0][0], bracket[1][0], bracket[2][0]};
               }
-              return result;
+              // Seven interpolations along the axes in turn rather than
+              // eight corners each weighted by a product: the same value, and
+              // the weight products are what this loop spends its time on.
+              const auto between = [](double from, double to, double where) {
+                  return from + where * (to - from);
+              };
+              const auto blend = [&](const std::array<double, 8>& corner) {
+                  const auto lowY
+                      = between(between(corner[0], corner[1], weight[0]),
+                          between(corner[2], corner[3], weight[0]), weight[1]);
+                  const auto highY
+                      = between(between(corner[4], corner[5], weight[0]),
+                          between(corner[6], corner[7], weight[0]), weight[1]);
+                  return between(lowY, highY, weight[2]);
+              };
+              if (cache.uncovered == 0) {
+                  return blend(cache.corner);
+              }
+              // The uncommon path: a cell at the edge of what the levels
+              // cover. The landed voxel stands in for the corners they do not.
+              auto covered = cache.corner;
+              for (std::size_t corner = 0; corner < 8; ++corner) {
+                  if ((cache.uncovered & (1U << corner)) != 0) {
+                      covered[corner] = landed;
+                  }
+              }
+              return blend(covered);
           };
 
     const auto renderRow = [&](int row) {
@@ -537,6 +592,8 @@ VolumeFrame raycastVolume(const VolumeGrid& grid,
                 voxelStart[axis] = (ray.origin[axis] + tEnter * ray.direction[axis]
                     - lower[axis]) * inversePitch[axis];
             }
+            // Per ray: what the previous sample on this ray read.
+            CellCache cell;
             double alpha = 0.0;
             double red = 0.0;
             double green = 0.0;
@@ -574,7 +631,8 @@ VolumeFrame raycastVolume(const VolumeGrid& grid,
                 if (!mappableValue(nearest, mappedRange)) {
                     continue;
                 }
-                const auto value = linear ? linearValue(at, nearest) : nearest;
+                const auto value
+                    = linear ? linearValue(at, nearest, cell) : nearest;
                 const auto& entry = entries[static_cast<std::size_t>(
                     valueSlot(value, mappedRange, entryCount))];
                 if (!(entry.stepOpacity > 0.0)) {

--- a/src/render3d/VolumeRaycaster.cpp
+++ b/src/render3d/VolumeRaycaster.cpp
@@ -255,9 +255,13 @@ VolumeFrame raycastVolume(const VolumeGrid& grid,
     const auto& lower = grid.region.lower;
     // The reciprocal, because the march divides by the pitch three times per
     // sample and the pitch is fixed for the frame. Unlike the range mapping,
-    // where the reciprocal costs the exact palette-slot ties, this quotient
-    // only feeds std::floor: the sole values it can move are samples landing
-    // exactly on a voxel plane, an arbitrary tie either way.
+    // where the reciprocal costs the exact palette-slot ties, what this
+    // quotient can move is bounded: under Nearest it only feeds std::floor, so
+    // the sole values it moves are samples landing exactly on a voxel plane,
+    // an arbitrary tie either way. Under Linear it also feeds an interpolation
+    // weight, where the rounding is no longer confined to ties -- but it is an
+    // ulp of a weight, three orders below the 8-bit channel the weight ends up
+    // in, so it cannot move a rendered pixel.
     std::array<double, 3> inversePitch{};
     for (std::size_t axis = 0; axis < 3; ++axis) {
         const auto pitch = (grid.region.upper[axis] - grid.region.lower[axis])
@@ -414,6 +418,76 @@ VolumeFrame raycastVolume(const VolumeGrid& grid,
     for (std::size_t axis = 0; axis < 3; ++axis) {
         voxelStep[axis] = rays.direction[axis] * step * inversePitch[axis];
     }
+    // Hoisted: one loop-invariant branch per sample rather than a policy read.
+    const auto linear = settings.sampling == SamplingPolicy::Linear;
+    // Trilinear over the eight voxel centres bracketing the sample.
+    //
+    // Voxel i is centred at i + 0.5 in this coordinate (Volume.hpp says so),
+    // which is why the nearest rule above can just take the floor -- the half
+    // voxel cancels. Interpolating has to put it back, or the picture moves
+    // half a voxel and still looks entirely plausible.
+    //
+    // Outside the outermost centres the bracket collapses onto the edge voxel
+    // and the weight goes to zero, so the outer half-voxel shell reads flat --
+    // the same value the nearest rule gives there, which is what keeps a
+    // uniform slab compositing to its analytic opacity rather than fading at
+    // the boundary. A corner the range cannot map -- uncovered, or
+    // non-positive under a logarithmic range -- takes the landed voxel's value
+    // instead, the 3-D form of what the slice's bilinear sampler does at a
+    // domain edge (SliceQuery.cpp): clamp the field to its coverage rather
+    // than invent data, and never let one NaN erode a voxel-wide rind. Every
+    // corner is then mappable, so the result is a convex combination of
+    // mappable values and is mappable itself.
+    const auto linearValue
+        = [&grid, &mappedRange, gridRowStride, slabStride](
+              const std::array<double, 3>& at, double landed) {
+              // Per axis: the two bracketing voxel indices and how far the
+              // sample sits between them.
+              std::array<std::array<std::size_t, 2>, 3> bracket{};
+              std::array<double, 3> weight{};
+              for (std::size_t axis = 0; axis < 3; ++axis) {
+                  const auto centred = at[axis] - 0.5;
+                  const auto limit = static_cast<double>(grid.dims[axis] - 1);
+                  double low = 0.0;
+                  double fraction = 0.0;
+                  // Ordered so NaN takes the first branch's false arm, the way
+                  // the clamp above does: it reads voxel zero rather than
+                  // casting something undefined. A single-voxel axis has
+                  // limit 0 and lands here too, with both ends on voxel zero.
+                  if (centred > 0.0) {
+                      if (centred < limit) {
+                          low = std::floor(centred);
+                          fraction = centred - low;
+                      } else {
+                          low = limit;
+                      }
+                  }
+                  bracket[axis][0] = static_cast<std::size_t>(low);
+                  bracket[axis][1]
+                      = static_cast<std::size_t>(low < limit ? low + 1.0 : limit);
+                  weight[axis] = fraction;
+              }
+              double result = 0.0;
+              for (std::size_t k = 0; k < 2; ++k) {
+                  const auto wz = k == 1 ? weight[2] : 1.0 - weight[2];
+                  for (std::size_t j = 0; j < 2; ++j) {
+                      const auto wy = j == 1 ? weight[1] : 1.0 - weight[1];
+                      for (std::size_t i = 0; i < 2; ++i) {
+                          const auto wx = i == 1 ? weight[0] : 1.0 - weight[0];
+                          const auto corner = bracket[0][i]
+                              + gridRowStride * bracket[1][j]
+                              + slabStride * bracket[2][k];
+                          auto value = static_cast<double>(grid.values[corner]);
+                          if (!mappableValue(value, mappedRange)) {
+                              value = landed;
+                          }
+                          result += wx * wy * wz * value;
+                      }
+                  }
+              }
+              return result;
+          };
+
     const auto renderRow = [&](int row) {
         auto* pixels = frame.pixels.data() + rowStride * static_cast<std::size_t>(row);
         const auto pixelY = static_cast<double>(row) + 0.5;
@@ -475,10 +549,11 @@ VolumeFrame raycastVolume(const VolumeGrid& grid,
                     return;
                 }
                 const auto offsetInSamples = static_cast<double>(sample) + 0.5;
+                std::array<double, 3> at{};
                 std::array<std::size_t, 3> index{};
                 for (std::size_t axis = 0; axis < 3; ++axis) {
-                    const auto voxel = std::floor(
-                        voxelStart[axis] + offsetInSamples * voxelStep[axis]);
+                    at[axis] = voxelStart[axis] + offsetInSamples * voxelStep[axis];
+                    const auto voxel = std::floor(at[axis]);
                     // Clamped as a double, before the cast: casting a value
                     // past the int range is undefined, and std::clamp passes
                     // a NaN straight through to it. Both are reachable from a
@@ -490,10 +565,16 @@ VolumeFrame raycastVolume(const VolumeGrid& grid,
                 }
                 const auto offset = index[0] + gridRowStride * index[1]
                     + slabStride * index[2];
-                const auto value = static_cast<double>(grid.values[offset]);
-                if (!mappableValue(value, mappedRange)) {
+                // The voxel the sample lands in decides whether there is a
+                // sample at all. An uncovered one is not the field's to give
+                // whatever its neighbours hold, so interpolation never fills
+                // a hole in -- which is also what keeps an all-NaN grid
+                // completely transparent.
+                const auto nearest = static_cast<double>(grid.values[offset]);
+                if (!mappableValue(nearest, mappedRange)) {
                     continue;
                 }
+                const auto value = linear ? linearValue(at, nearest) : nearest;
                 const auto& entry = entries[static_cast<std::size_t>(
                     valueSlot(value, mappedRange, entryCount))];
                 if (!(entry.stepOpacity > 0.0)) {

--- a/src/render3d/VolumeRaycaster.cpp
+++ b/src/render3d/VolumeRaycaster.cpp
@@ -418,7 +418,9 @@ VolumeFrame raycastVolume(const VolumeGrid& grid,
     for (std::size_t axis = 0; axis < 3; ++axis) {
         voxelStep[axis] = rays.direction[axis] * step * inversePitch[axis];
     }
-    // Hoisted: one loop-invariant branch per sample rather than a policy read.
+    // The policy folded to a bool once per frame. The branch itself is still
+    // per sample -- specialising the row renderer on it would remove that, and
+    // has not been measured.
     const auto linear = settings.sampling == SamplingPolicy::Linear;
     // Trilinear over the eight voxel centres bracketing the sample.
     //
@@ -486,8 +488,9 @@ VolumeFrame raycastVolume(const VolumeGrid& grid,
                       = static_cast<std::size_t>(low < limit ? low + 1.0 : limit);
                   weight[axis] = fraction;
               }
-              // The same cell as the last sample on this ray, and that one
-              // needed no substitution: its corners still hold.
+              // The same cell as the last sample on this ray: its corners
+              // still hold, uncovered ones included, because they are stored
+              // as the grid has them and substituted on the way out.
               // Read straight into the cache and interpolate out of it, so a
               // reused cell costs three comparisons and a fresh one costs no
               // copy on top of its fetches.
@@ -711,7 +714,7 @@ VolumeFrame raycastVolume(const VolumeGrid& grid,
                 threads.emplace_back(renderShare);
             }
         } catch (...) {
-            // std::thread construction can fail once earlier bands are
+            // std::thread construction can fail once earlier workers are
             // already running -- a process thread limit, a loaded machine.
             // Stopping and joining them here is what keeps ~vector<thread>
             // from meeting a joinable thread and calling std::terminate.

--- a/src/render3d/VolumeRaycaster.cpp
+++ b/src/render3d/VolumeRaycaster.cpp
@@ -655,14 +655,30 @@ VolumeFrame raycastVolume(const VolumeGrid& grid,
     };
 
     const auto threadCount = raycastThreadCount(settings.threadCount, height);
-    const auto rowsPerThread = (height + threadCount - 1) / threadCount;
     std::exception_ptr failure;
     std::mutex failureMutex;
-    const auto renderBand = [&](int begin, int end) {
+    // Rows are taken one at a time from a shared counter rather than dealt
+    // out in contiguous bands. What a row costs varies enormously down the
+    // frame -- rows that miss the domain return at clipToBox, rows through
+    // the middle march the full depth, and an early-out ends a ray as soon as
+    // it is opaque -- so a band of neighbouring rows is a band of similar
+    // cost, and the thread holding the middle of the picture finishes long
+    // after the ones holding the top and bottom. Handing out rows on demand
+    // costs one relaxed increment each and lets every worker keep going until
+    // the frame is done.
+    //
+    // The picture cannot change: renderRow is a pure function of its index
+    // and writes only that row, so which worker takes it is not observable.
+    std::atomic<int> nextRow{0};
+    const auto renderShare = [&] {
         try {
-            // No separate per-row poll: renderRow checks at column 0 of
-            // every row and every stride within it, which subsumes one.
-            for (int row = begin; row < end; ++row) {
+            for (;;) {
+                const auto row = nextRow.fetch_add(1, std::memory_order_relaxed);
+                if (row >= height) {
+                    return;
+                }
+                // No separate per-row poll: renderRow checks at column 0 of
+                // every row and every stride within it, which subsumes one.
                 renderRow(row);
                 if (cancelled.load(std::memory_order_relaxed)) {
                     return;
@@ -677,18 +693,13 @@ VolumeFrame raycastVolume(const VolumeGrid& grid,
         }
     };
     if (threadCount == 1) {
-        renderBand(0, height);
+        renderShare();
     } else {
         std::vector<std::thread> threads;
         threads.reserve(static_cast<std::size_t>(threadCount));
         try {
-            for (int band = 0; band < threadCount; ++band) {
-                const auto begin = band * rowsPerThread;
-                const auto end = std::min(height, begin + rowsPerThread);
-                if (begin >= end) {
-                    break;
-                }
-                threads.emplace_back(renderBand, begin, end);
+            for (int worker = 0; worker < threadCount; ++worker) {
+                threads.emplace_back(renderShare);
             }
         } catch (...) {
             // std::thread construction can fail once earlier bands are

--- a/tests/benchmark/bench_volume_render.cpp
+++ b/tests/benchmark/bench_volume_render.cpp
@@ -6,7 +6,13 @@
 // scale the workload via argv for real numbers:
 //
 //   bench_volume_render [gridDim] [outputDim] [samplesPerVoxel] [iterations]
-//                       [threads]
+//                       [threads] [linear]
+//
+// `linear` is 1 for trilinear sampling (the renderer's default) and 0 for
+// nearest, so the eight-fetch and one-fetch costs can be compared directly.
+// Measure at a grid that does not fit in cache -- 64^3 of float is 1 MiB and
+// sits in L2, where the seven extra fetches look free -- and pin the thread
+// count so two runs are comparable.
 //
 // The grid is a smooth radial field with an opaque core, so the rays do real
 // compositing work and the early-out fires for the central pixels as it does
@@ -61,6 +67,7 @@ int main(int argc, char** argv)
     const int samplesPerVoxel = argument(argc, argv, 3, 2);
     const int iterations = argument(argc, argv, 4, 2);
     const int threads = argument(argc, argv, 5, 0);
+    const int linear = argument(argc, argv, 6, 1);
     // Bounded as the renderer bounds them, so an out-of-range argument is
     // this file's own message rather than an uncaught std::invalid_argument
     // escaping main and aborting through std::terminate.
@@ -76,6 +83,7 @@ int main(int argc, char** argv)
         "the output dimension is too small for the check below to mean anything");
     require(samplesPerVoxel <= amrvis::maxVolumeSamplesPerVoxel,
         "samples per voxel exceeds the renderer's limit");
+    require(linear == 0 || linear == 1, "linear must be 0 or 1");
     require(amrvis::volumeVoxelCount({gridDim, gridDim, gridDim})
             <= amrvis::maxVolumeVoxelBudget,
         "the grid exceeds the renderer's voxel budget");
@@ -111,6 +119,8 @@ int main(int argc, char** argv)
     settings.range = {0.0, 1.0, false};
     settings.samplesPerVoxel = samplesPerVoxel;
     settings.threadCount = static_cast<unsigned>(std::max(0, threads));
+    settings.sampling = linear == 1 ? amrvis::SamplingPolicy::Linear
+                                    : amrvis::SamplingPolicy::Nearest;
     // A ramp that is transparent below 0.4 and opaque white above 0.9, so
     // the core stops rays and the halo composites.
     for (int entry = 0; entry < 253; ++entry) {
@@ -141,7 +151,8 @@ int main(int argc, char** argv)
               << samplesPerVoxel << " samples/voxel, "
               << amrvis::raycastThreadCount(
                      settings.threadCount, settings.outputSize[1])
-              << " threads: " << perFrame * 1000.0 << " ms/frame, "
+              << " threads, " << (linear == 1 ? "linear" : "nearest")
+              << ": " << perFrame * 1000.0 << " ms/frame, "
               << pixels / elapsed / 1.0e6 << " Mpx/s\n";
     return 0;
 }

--- a/tests/fuzz/fuzz_wire_codec.cpp
+++ b/tests/fuzz/fuzz_wire_codec.cpp
@@ -158,7 +158,10 @@ void checkConverted(const fb::RenderedFrameRequestT& wire,
     const amrvis::VolumeRenderRequest& result)
 {
     // fromWire promises finite camera and range values and a consistent,
-    // finite, bounded transfer function; the enum round-trips.
+    // finite, bounded transfer function; the enums round-trip. Converted once
+    // -- each call rebuilds the transfer vectors, and this runs every
+    // iteration that reaches it.
+    const auto roundTripped = codec::toWire(result);
     if (!finite(result.camera.azimuth) || !finite(result.camera.elevation)
         || !finite(result.camera.zoom) || !finite(result.region)
         || result.range.has_value() != wire.has_range
@@ -169,12 +172,12 @@ void checkConverted(const fb::RenderedFrameRequestT& wire,
         || !std::all_of(result.transfer.opacities.begin(),
             result.transfer.opacities.end(),
             [](float opacity) { return std::isfinite(opacity); })
-        || codec::toWire(result).composition != wire.composition
+        || roundTripped.composition != wire.composition
         // The same round-trip check for the second enum on this table: a
         // transposed mapping converts cleanly in both directions and shows up
         // only against a peer that disagrees, which is what the composition
         // check above exists to catch.
-        || codec::toWire(result).sampling != wire.sampling
+        || roundTripped.sampling != wire.sampling
         || result.outputSize[0] != wire.width || result.outputSize[1] != wire.height) {
         fail("RenderedFrameRequest converter accepted a bad request");
     }

--- a/tests/fuzz/fuzz_wire_codec.cpp
+++ b/tests/fuzz/fuzz_wire_codec.cpp
@@ -718,10 +718,11 @@ std::vector<std::vector<std::uint8_t>> wireSeeds()
         request.camera = {0.5, -0.25, 1.5};
         request.outputSize = {64, 48};
         request.range = amrvis::VolumeRange{0.5, 2.0, true};
-        // Not the struct's default, so the corpus carries a buffer whose
-        // sampling field has to survive the trip rather than one that happens
-        // to match whatever it decodes to.
-        request.sampling = amrvis::SamplingPolicy::Nearest;
+        // Not the *wire* default: Nearest is the schema's zero, which
+        // flatbuffers omits from the buffer entirely, so a seed carrying it
+        // would be byte-identical to a pre-1.3 request and would exercise
+        // nothing. This one has to be written and read back.
+        request.sampling = amrvis::SamplingPolicy::Linear;
         request.transfer.colors = {0x0000FFU, 0x00FF00U, 0xFFFF00U, 0xFF0000U};
         request.transfer.opacities = {0.0F, 0.25F, 0.5F, 1.0F};
         request.samplesPerVoxel = 3;

--- a/tests/fuzz/fuzz_wire_codec.cpp
+++ b/tests/fuzz/fuzz_wire_codec.cpp
@@ -170,6 +170,11 @@ void checkConverted(const fb::RenderedFrameRequestT& wire,
             result.transfer.opacities.end(),
             [](float opacity) { return std::isfinite(opacity); })
         || codec::toWire(result).composition != wire.composition
+        // The same round-trip check for the second enum on this table: a
+        // transposed mapping converts cleanly in both directions and shows up
+        // only against a peer that disagrees, which is what the composition
+        // check above exists to catch.
+        || codec::toWire(result).sampling != wire.sampling
         || result.outputSize[0] != wire.width || result.outputSize[1] != wire.height) {
         fail("RenderedFrameRequest converter accepted a bad request");
     }
@@ -710,6 +715,10 @@ std::vector<std::vector<std::uint8_t>> wireSeeds()
         request.camera = {0.5, -0.25, 1.5};
         request.outputSize = {64, 48};
         request.range = amrvis::VolumeRange{0.5, 2.0, true};
+        // Not the struct's default, so the corpus carries a buffer whose
+        // sampling field has to survive the trip rather than one that happens
+        // to match whatever it decodes to.
+        request.sampling = amrvis::SamplingPolicy::Nearest;
         request.transfer.colors = {0x0000FFU, 0x00FF00U, 0xFFFF00U, 0xFF0000U};
         request.transfer.opacities = {0.0F, 0.25F, 0.5F, 1.0F};
         request.samplesPerVoxel = 3;

--- a/tests/integration/test_remote_volume.cpp
+++ b/tests/integration/test_remote_volume.cpp
@@ -290,6 +290,57 @@ int main(int argc, char* argv[])
                         == ErrorCode::UnsupportedProtocol,
                 "a 1.1 client's volume request was not refused as unsupported");
         }
+
+        // --- a 1.2 client is told smooth sampling needs 1.3 -------------
+        //
+        // The narrower gate: 1.2 renders volumes perfectly well and simply
+        // has no field to ask how they are sampled. A real 1.2 client cannot
+        // send one, so reaching the server with Linear means a peer claiming
+        // one version and speaking another -- and the answer has to be a
+        // refusal it can read rather than a frame sampled by another rule.
+        // The connection has to survive it: nothing about this says the peer
+        // misbehaved badly enough to lose every other dataset on it.
+        {
+            auto socket = connectTo("127.0.0.1", server.port());
+            HelloRequestData hello{"volume test", "test", 0, 2,
+                defaultMaximumFrameBytes, server.token(), {}};
+            writeFrame(socket, codec::encode(1, codec::toWire(hello), 2),
+                defaultMaximumFrameBytes);
+            auto response = readFrame(socket, defaultMaximumFrameBytes);
+            require(response.has_value(), "the server closed on a 1.2 hello");
+            auto envelope = codec::decode(*response);
+            require(codec::inspect(*envelope).payload == PayloadKind::HelloResponse
+                    && codec::fromWire(*envelope->payload.AsHelloResponse())
+                            .selectedMinorVersion == 2,
+                "the server did not negotiate 1.2 with a 1.2 client");
+            auto request = requestFor(*remote);
+            request.sampling = SamplingPolicy::Linear;
+            writeFrame(socket, codec::encode(2, codec::toWire(request), 2),
+                defaultMaximumFrameBytes);
+            response = readFrame(socket, defaultMaximumFrameBytes);
+            require(response.has_value(),
+                "the server closed on a 1.2 client asking for smooth sampling");
+            envelope = codec::decode(*response);
+            require(codec::inspect(*envelope).payload == PayloadKind::ErrorResponse
+                    && codec::fromWire(*envelope->payload.AsErrorResponse()).code
+                        == ErrorCode::UnsupportedProtocol,
+                "a 1.2 client's smooth-sampling request was not refused");
+
+            // And the connection is still there to be asked again. A
+            // refusal over a capability is not misbehaviour, and losing the
+            // session -- with every other dataset open on it -- would be a far
+            // larger answer than the question deserves.
+            writeFrame(socket, codec::encode(3, codec::toWire(request), 2),
+                defaultMaximumFrameBytes);
+            response = readFrame(socket, defaultMaximumFrameBytes);
+            require(response.has_value(),
+                "the refusal closed the connection instead of answering");
+            envelope = codec::decode(*response);
+            require(codec::inspect(*envelope).payload == PayloadKind::ErrorResponse
+                    && codec::fromWire(*envelope->payload.AsErrorResponse()).code
+                        == ErrorCode::UnsupportedProtocol,
+                "the connection stopped answering after one refusal");
+        }
         remote->close();
         local->close();
     } catch (const std::exception& error) {

--- a/tests/integration/test_volume_pipeline.cpp
+++ b/tests/integration/test_volume_pipeline.cpp
@@ -189,6 +189,13 @@ public:
     {
         return m_inner->supportsVolumeRendering();
     }
+    // Forwarded like everything else: the base class answers false, so a
+    // wrapper that forgot this would report a session that samples in
+    // process as one that cannot.
+    [[nodiscard]] bool supportsVolumeSampling() const noexcept override
+    {
+        return m_inner->supportsVolumeSampling();
+    }
     // The one that matters: render at one level coarser than asked and say
     // so, without ever throwing CacheBudgetExceeded at the pipeline.
     [[nodiscard]] amrvis::VolumeFrame renderVolume(

--- a/tests/unit/test_ortho_projection.cpp
+++ b/tests/unit/test_ortho_projection.cpp
@@ -54,6 +54,22 @@ int main()
     require(near(amrvis::viewportFrame(10, 10).scale, 1.0),
         "a tiny viewport did not clamp the scale to one pixel");
 
+    // The 3-D views open with +z drawn upward, like the two presets that show
+    // that axis. The sign of the elevation is what decides it, and getting it
+    // wrong is not obvious in the numbers -- the view simply shows the domain
+    // from underneath, so a plume hangs from the ceiling instead of rising
+    // from the floor. Checked against the presets, which promise it outright.
+    for (const auto& view : {amrvis::orthoDefaultView, amrvis::orthoPresetXZ,
+             amrvis::orthoPresetYZ}) {
+        const auto floorAt
+            = amrvis::projectPoint(view, frame, domain, point(1.0, 0.5, 0.0));
+        const auto ceilingAt
+            = amrvis::projectPoint(view, frame, domain, point(1.0, 0.5, 1.0));
+        require(ceilingAt.y < floorAt.y,
+            "a 3-D view draws +z downward, so it looks at the domain from "
+            "underneath");
+    }
+
     // Pinned from the iso view's projection formula: the upper corner under
     // azimuth 30 deg, elevation 30 deg, zoom 1.
     const amrvis::OrthoCamera oblique{30.0 * pi / 180.0, 30.0 * pi / 180.0, 1.0};

--- a/tests/unit/test_ortho_projection.cpp
+++ b/tests/unit/test_ortho_projection.cpp
@@ -68,6 +68,13 @@ int main()
         require(ceilingAt.y < floorAt.y,
             "a 3-D view draws +z downward, so it looks at the domain from "
             "underneath");
+        // And the axis indicator agrees, because it is drawn from the same
+        // rotation. This is the pair the default-view comment promises: an
+        // arrow pointing one way over a domain drawn the other would be worse
+        // than either alone.
+        const auto upward = amrvis::projectDirection(view, point(0.0, 0.0, 1.0));
+        require(upward.y < 0.0,
+            "the axis indicator draws +z downward while the view draws it up");
     }
 
     // Pinned from the iso view's projection formula: the upper corner under

--- a/tests/unit/test_remote_codec.cpp
+++ b/tests/unit/test_remote_codec.cpp
@@ -498,6 +498,21 @@ int main()
     volume.maximumVoxels = 1 << 20;
     require(codec::fromWire(codec::toWire(volume)) == volume,
         "a volume request with a range did not round-trip");
+    // The value on the wire, not just that it survives a round trip. Two
+    // transposed mappings are inverses of each other, so every round-trip
+    // check in the suite passes while a peer on the other side of a real
+    // socket reads the wrong policy -- which is the only situation protocol
+    // 1.3 exists for, and the one no round trip can see.
+    volume.sampling = SamplingPolicy::Linear;
+    require(codec::toWire(volume).sampling == amrexplorer::wire::SamplingPolicy::Linear,
+        "Linear does not encode as Linear on the wire");
+    volume.sampling = SamplingPolicy::Nearest;
+    require(codec::toWire(volume).sampling == amrexplorer::wire::SamplingPolicy::Nearest,
+        "Nearest does not encode as Nearest on the wire");
+    volume.sampling = SamplingPolicy::PiecewiseConstant;
+    require(codec::toWire(volume).sampling == amrexplorer::wire::SamplingPolicy::PiecewiseConstant,
+        "PiecewiseConstant does not encode as PiecewiseConstant on the wire");
+    volume.sampling = SamplingPolicy::Linear;
     // The two logarithmic flags, against the wire rather than through a
     // round trip. They are both bools and mean opposite cases -- one is the
     // explicit range's mapping, the other the mapping asked for when there is

--- a/tests/unit/test_volume_controller.cpp
+++ b/tests/unit/test_volume_controller.cpp
@@ -1371,8 +1371,32 @@ int main(int argc, char** argv)
         session->samplingSupported = true;
         controller.configureForDataset();
         application.processEvents();
-        require(smoothCheck->isEnabled(),
-            "the box did not come back for a session that can sample");
+        // Ticked again, not merely available: it is on by default, so a box
+        // left clear after one session that could not sample would turn that
+        // default off for the rest of the run, and every later render would
+        // quietly be nearest.
+        require(smoothCheck->isEnabled() && smoothCheck->isChecked(),
+            "the box did not come back ticked for a session that can sample, "
+            "so one older server turned smooth sampling off for good");
+        require(window->sampling() == amrvis::SamplingPolicy::Linear,
+            "smooth sampling did not resume once it was available again");
+
+        // And a deliberate clearing is not undone by the same round trip: the
+        // box comes back to what was asked of it, not to the default.
+        QMetaObject::invokeMethod(
+            window, [smoothCheck] { smoothCheck->setChecked(false); });
+        application.processEvents();
+        session->samplingSupported = false;
+        controller.configureForDataset();
+        session->samplingSupported = true;
+        controller.configureForDataset();
+        application.processEvents();
+        require(smoothCheck->isEnabled() && !smoothCheck->isChecked(),
+            "a session that could not sample re-ticked a box the user had "
+            "deliberately cleared");
+        QMetaObject::invokeMethod(
+            window, [smoothCheck] { smoothCheck->setChecked(true); });
+        application.processEvents();
 
         // The overlay toggles, and the volume window's own default: grid boxes
         // off, because box edges crossing a translucent field read as

--- a/tests/unit/test_volume_controller.cpp
+++ b/tests/unit/test_volume_controller.cpp
@@ -147,6 +147,14 @@ public:
     {
         return m_metadata.dimension == 3;
     }
+    // A local-shaped session: it renders in process, so it can be told how to
+    // sample. `samplingSupported` turns that off to stand in for a peer
+    // speaking a protocol that has no sampling field.
+    std::atomic<bool> samplingSupported{true};
+    [[nodiscard]] bool supportsVolumeSampling() const noexcept override
+    {
+        return supportsVolumeRendering() && samplingSupported;
+    }
     [[nodiscard]] amrvis::VolumeFrame renderVolume(
         const amrvis::VolumeRenderRequest& request,
         amrvis::StopToken cancellation) override
@@ -1309,6 +1317,62 @@ int main(int argc, char** argv)
             widget->mapToGlobal(raised), Qt::LeftButton, Qt::NoButton,
             Qt::NoModifier);
         QApplication::sendEvent(widget, &letGoEnd);
+
+        // Smooth sampling: on by default, and a full frame rather than a
+        // draft when it changes, since it is a deliberate edit and not a
+        // camera in motion.
+        auto* const smoothCheck = window->findChild<QCheckBox*>(
+            QStringLiteral("volumeSmoothSamplingCheck"));
+        require(smoothCheck != nullptr,
+            "no smooth-sampling box in the volume window");
+        settle(application, 500);
+        waitFor(application, [&] { return !controller.renderInFlight(); },
+            "the earlier renders did not finish");
+        require(smoothCheck->isEnabled() && smoothCheck->isChecked(),
+            "the volume window did not offer smooth sampling for a session "
+            "that can be told how to sample");
+        require(session->requestsSoFar().back().sampling
+                == amrvis::SamplingPolicy::Linear,
+            "a ticked smooth-sampling box did not reach the request");
+        auto smoothed = session->requests.load();
+        QMetaObject::invokeMethod(
+            window, [smoothCheck] { smoothCheck->setChecked(false); });
+        application.processEvents();
+        waitFor(application, [&] { return session->requests > smoothed; },
+            "clearing smooth sampling did not render");
+        require(session->requestsSoFar().back().sampling
+                == amrvis::SamplingPolicy::Nearest,
+            "clearing the box did not reach the request");
+        require(session->requestsSoFar().back().samplesPerVoxel == 2,
+            "the render after the toggle was a draft rather than a full frame");
+        waitFor(application, [&] { return !controller.renderInFlight(); },
+            "the render after clearing smooth sampling did not finish");
+        QMetaObject::invokeMethod(
+            window, [smoothCheck] { smoothCheck->setChecked(true); });
+        application.processEvents();
+
+        // A session that cannot be told how to sample takes the choice away,
+        // and takes the tick with it: a box left ticked but greyed would claim
+        // a smoothness the picture does not have, and would re-arm itself the
+        // moment a session that can sample arrived.
+        settle(application, 500);
+        waitFor(application, [&] { return !controller.renderInFlight(); },
+            "the renders from re-ticking did not finish");
+        session->samplingSupported = false;
+        controller.configureForDataset();
+        application.processEvents();
+        require(!smoothCheck->isEnabled(),
+            "the box stayed available for a session that cannot sample");
+        require(!smoothCheck->isChecked(),
+            "the box stayed ticked while unavailable, claiming a smoothness "
+            "the render does not have");
+        require(window->sampling() == amrvis::SamplingPolicy::Nearest,
+            "an unavailable box still asked for smooth sampling");
+        session->samplingSupported = true;
+        controller.configureForDataset();
+        application.processEvents();
+        require(smoothCheck->isEnabled(),
+            "the box did not come back for a session that can sample");
 
         // The overlay toggles, and the volume window's own default: grid boxes
         // off, because box edges crossing a translucent field read as

--- a/tests/unit/test_volume_controller.cpp
+++ b/tests/unit/test_volume_controller.cpp
@@ -1528,6 +1528,87 @@ int main(int argc, char** argv)
         settle(application, 200);
         require(session->requests == ends,
             "refusing to remove an end point rendered anyway");
+
+        // Dragging turns the domain rather than walking the camera around it:
+        // whichever face is nearest follows the cursor, on both axes. The two
+        // disagreed once -- a drag down tipped the top toward you while a drag
+        // right slid the near face the other way -- and one axis obeying the
+        // hand while the other opposes it reads as the second being backwards.
+        // Written against the projection rather than against the angles, since
+        // which way an angle turns the picture is the thing that was wrong.
+        {
+            const auto domain = amrvis::datasetSampleBounds(session->metadata());
+            const auto frame
+                = amrvis::viewportFrame(view->width(), view->height());
+            const std::array<amrvis::Real3, 6> faces{
+                amrvis::Real3{{1.0, 0.5, 0.5}}, amrvis::Real3{{0.0, 0.5, 0.5}},
+                amrvis::Real3{{0.5, 1.0, 0.5}}, amrvis::Real3{{0.5, 0.0, 0.5}},
+                amrvis::Real3{{0.5, 0.5, 1.0}}, amrvis::Real3{{0.5, 0.5, 0.0}}};
+            // In the domain's own coordinates, and the nearest of them:
+            // depth increases toward the viewer. A horizontal drag turns the
+            // domain about z, so the z faces sit on that axis and do not move
+            // sideways however far it turns -- picking one of those to follow
+            // would compare zero against zero. They are left out when the
+            // drag is horizontal.
+            const auto nearestFace = [&](const amrvis::OrthoCamera& camera,
+                                         bool aboutZ) {
+                amrvis::Real3 best{};
+                auto bestDepth = -std::numeric_limits<double>::infinity();
+                for (std::size_t index = 0; index < faces.size(); ++index) {
+                    if (aboutZ && index >= 4) {
+                        continue;
+                    }
+                    const auto& unit = faces[index];
+                    amrvis::Real3 point;
+                    for (std::size_t axis = 0; axis < 3; ++axis) {
+                        point[axis] = domain.lower[axis]
+                            + unit[axis] * (domain.upper[axis] - domain.lower[axis]);
+                    }
+                    const auto at
+                        = amrvis::projectPoint(camera, frame, domain, point);
+                    if (at.depth > bestDepth) {
+                        bestDepth = at.depth;
+                        best = point;
+                    }
+                }
+                return best;
+            };
+            const auto dragBy = [&](int dx, int dy) {
+                const QPointF from(0.5 * view->width(), 0.5 * view->height());
+                const QPointF to(from.x() + dx, from.y() + dy);
+                QMouseEvent orbitPress(QEvent::MouseButtonPress, from,
+                    view->mapToGlobal(from), Qt::LeftButton, Qt::LeftButton,
+                    Qt::NoModifier);
+                QApplication::sendEvent(view, &orbitPress);
+                QMouseEvent orbitMove(QEvent::MouseMove, to, view->mapToGlobal(to),
+                    Qt::NoButton, Qt::LeftButton, Qt::NoModifier);
+                QApplication::sendEvent(view, &orbitMove);
+                QMouseEvent orbitRelease(QEvent::MouseButtonRelease, to,
+                    view->mapToGlobal(to), Qt::LeftButton, Qt::NoButton,
+                    Qt::NoModifier);
+                QApplication::sendEvent(view, &orbitRelease);
+            };
+            const std::array<std::array<int, 2>, 4> drags{
+                {{{40, 0}}, {{-40, 0}}, {{0, 40}}, {{0, -40}}}};
+            for (const auto& pull : drags) {
+                const auto start = view->camera();
+                const auto face = nearestFace(start, pull[0] != 0);
+                const auto was
+                    = amrvis::projectPoint(start, frame, domain, face);
+                dragBy(pull[0], pull[1]);
+                const auto now = amrvis::projectPoint(
+                    view->camera(), frame, domain, face);
+                const auto shift = pull[0] != 0 ? now.x - was.x : now.y - was.y;
+                const auto asked = pull[0] != 0 ? pull[0] : pull[1];
+                require(shift * asked > 0.0,
+                    "the face under the cursor moved against the drag, so the "
+                    "view walks the camera around the domain on that axis "
+                    "instead of turning it");
+            }
+            settle(application, 500);
+            waitFor(application, [&] { return !controller.renderInFlight(); },
+                "the renders from the drags did not finish");
+        }
         controller.closeWindow();
     }
 

--- a/tests/unit/test_volume_raycaster.cpp
+++ b/tests/unit/test_volume_raycaster.cpp
@@ -7,6 +7,8 @@
 
 #include <amrexplorer/render3d/VolumeRaycaster.hpp>
 
+#include <amrexplorer/core/ValueMapping.hpp>
+
 #include <algorithm>
 #include <chrono>
 #include <cmath>
@@ -80,6 +82,11 @@ amrvis::RaycastSettings settingsFor(const amrvis::OrthoCamera& camera,
     settings.transfer = transfer;
     settings.samplesPerVoxel = samplesPerVoxel;
     settings.threadCount = 1;
+    // Nearest unless a case asks otherwise. Most of what is checked below is
+    // the march -- step length, opacity correction, path length, threading --
+    // and reading one voxel per sample keeps a case's expected value the
+    // voxel's own, so those checks stay about the thing they name.
+    settings.sampling = amrvis::SamplingPolicy::Nearest;
     return settings;
 }
 
@@ -99,6 +106,12 @@ std::uint32_t pixelAt(const amrvis::VolumeFrame& frame, int x, int y)
 int main()
 {
     // --- a lone opaque voxel projects to its footprint and nowhere else -----
+    //
+    // Nearest sampling, which this pins: the footprint is exactly the voxel's
+    // own projection, with nothing outside it. Linear deliberately breaks
+    // both halves -- it spreads the voxel half a voxel further and drops the
+    // value below the entry threshold inside -- and is checked on its own
+    // terms further down.
     {
         auto grid = uniformGrid(8, 0.0F);
         // Voxel (5, 2, 6): x in [0.625, 0.75), y in [0.25, 0.375), z in
@@ -415,6 +428,197 @@ int main()
         require(std::all_of(frame.pixels.begin(), frame.pixels.end(),
                     [](std::uint32_t pixel) { return pixel == 0U; }),
             "uncovered voxels were painted");
+    }
+
+    // --- linear sampling reads between the voxel centres --------------------
+    //
+    // A step from 0 to 1 between voxels 3 and 4 of an 8-voxel axis. Nearest
+    // jumps at the face they share, x = 0.5. Linear ramps between their
+    // centres, x = 0.4375 to x = 0.5625, and with two entries over [0, 1] only
+    // the very top of that ramp selects the opaque entry -- so the picture
+    // starts at the far centre, x = 0.5625, not at the face.
+    //
+    // This is the half-voxel offset, and it is the whole reason to write the
+    // case: voxel i is centred at i + 0.5, so interpolating without shifting
+    // by half a voxel moves the field half a voxel through the grid. That
+    // renders perfectly plausibly -- it just shows the wrong place, and every
+    // other check here would still pass.
+    {
+        constexpr int n = 8;
+        auto grid = uniformGrid(n, 0.0F);
+        for (int k = 0; k < n; ++k) {
+            for (int j = 0; j < n; ++j) {
+                for (int i = n / 2; i < n; ++i) {
+                    grid.values[voxel(grid, i, j, k)] = 1.0F;
+                }
+            }
+        }
+        auto settings = settingsFor(
+            amrvis::orthoPresetXY, 256, twoEntries(0x0000FFU, 1.0F), 4);
+        const auto viewport = amrvis::viewportFrame(256, 256);
+        const auto columnOf = [&](double worldX) {
+            amrvis::Real3 point;
+            point[0] = worldX;
+            point[1] = 0.5;
+            point[2] = 0.5;
+            return amrvis::projectPoint(
+                settings.camera, viewport, settings.domain, point)
+                .x;
+        };
+        const auto firstLit = [&](const amrvis::VolumeFrame& frame) {
+            for (int x = 0; x < 256; ++x) {
+                if (alphaOf(pixelAt(frame, x, 128)) > 0U) {
+                    return x;
+                }
+            }
+            return -1;
+        };
+
+        settings.sampling = amrvis::SamplingPolicy::Nearest;
+        const auto nearestFrame = amrvis::raycastVolume(grid, settings);
+        require(std::abs(static_cast<double>(firstLit(nearestFrame))
+                    - columnOf(0.5))
+                <= 1.0,
+            "nearest sampling did not step at the face between the voxels");
+
+        settings.sampling = amrvis::SamplingPolicy::Linear;
+        const auto linearFrame = amrvis::raycastVolume(grid, settings);
+        require(std::abs(static_cast<double>(firstLit(linearFrame))
+                    - columnOf(0.5625))
+                <= 1.0,
+            "linear sampling did not reach the top of its ramp at the far "
+            "voxel centre, so the half-voxel offset is wrong");
+    }
+
+    // --- linear sampling reproduces a linear field --------------------------
+    //
+    // The property that says the weights are right rather than merely smooth:
+    // over a field linear in the grid's own coordinates, interpolating between
+    // the centres returns the field itself. Read through the transfer
+    // function, which is the only way a value leaves a render: 253 entries,
+    // each painting its own index into the blue channel, so the pixel names
+    // the entry the sample chose and through valueSlot the value it read.
+    //
+    // The field varies along x and y, not one axis: with a single axis every
+    // per-axis weight could be swapped for another and nothing would show it,
+    // because the other axes' fractions never matter. It stays constant along
+    // z so that a ray down z crosses one value and the pixel is unambiguous.
+    {
+        constexpr int n = 16;
+        constexpr int entryCount = 253;
+        auto grid = uniformGrid(n, 0.0F);
+        for (int k = 0; k < n; ++k) {
+            for (int j = 0; j < n; ++j) {
+                for (int i = 0; i < n; ++i) {
+                    grid.values[voxel(grid, i, j, k)]
+                        = static_cast<float>(i + j)
+                        / static_cast<float>(2 * (n - 1));
+                }
+            }
+        }
+        amrvis::VolumeTransferFunction transfer;
+        for (int entry = 0; entry < entryCount; ++entry) {
+            transfer.colors.push_back(static_cast<std::uint32_t>(entry));
+            transfer.opacities.push_back(1.0F);
+        }
+        auto settings = settingsFor(amrvis::orthoPresetXY, 128, transfer, 1);
+        settings.sampling = amrvis::SamplingPolicy::Linear;
+        const auto frame = amrvis::raycastVolume(grid, settings);
+        const auto viewport = amrvis::viewportFrame(128, 128);
+        // Bisect the projection the renderer used rather than reinventing it,
+        // so this cannot drift from the camera. The XY preset maps world x to
+        // screen x and world y to screen y, so each axis inverts on its own.
+        const auto worldOn = [&](std::size_t axis, double screen) {
+            double low = 0.0;
+            double high = 1.0;
+            for (int step = 0; step < 60; ++step) {
+                const auto mid = 0.5 * (low + high);
+                amrvis::Real3 point;
+                point[0] = 0.5;
+                point[1] = 0.5;
+                point[2] = 0.5;
+                point[axis] = mid;
+                const auto projected = amrvis::projectPoint(
+                    settings.camera, viewport, settings.domain, point);
+                const auto at = axis == 0 ? projected.x : projected.y;
+                const auto rising = axis == 0;
+                if ((at < screen) == rising) {
+                    low = mid;
+                } else {
+                    high = mid;
+                }
+            }
+            return 0.5 * (low + high);
+        };
+        // Down the diagonal, so both fractions vary and neither can stand in
+        // for the other. Only pixels the domain actually covers: the camera
+        // fits the whole box, so the outer ones render nothing at all.
+        auto checked = 0;
+        for (int step = 24; step < 104; ++step) {
+            if (alphaOf(pixelAt(frame, step, step)) == 0U) {
+                continue;
+            }
+            ++checked;
+            // Voxel i is centred at i + 0.5 voxels, so this is the field the
+            // grid holds, evaluated where the ray actually goes.
+            const auto centreX
+                = worldOn(0, static_cast<double>(step) + 0.5)
+                    * static_cast<double>(n) - 0.5;
+            const auto centreY
+                = worldOn(1, static_cast<double>(step) + 0.5)
+                    * static_cast<double>(n) - 0.5;
+            const auto expected
+                = (centreX + centreY) / static_cast<double>(2 * (n - 1));
+            const auto slot = amrvis::valueSlot(
+                expected, amrvis::ResolvedValueRange{0.0, 1.0, false},
+                entryCount);
+            const auto seen
+                = static_cast<int>(blueOf(pixelAt(frame, step, step)));
+            require(std::abs(seen - slot) <= 1,
+                "linear sampling did not reproduce a field linear in the "
+                "grid's own coordinates");
+        }
+        require(checked > 40,
+            "too few pixels landed on the domain to have checked the field");
+    }
+
+    // --- linear sampling does not erode a coverage boundary -----------------
+    //
+    // The rule a plain eight-corner average gets wrong: a stencil touching an
+    // uncovered voxel would average NaN and drop the sample, eating a
+    // voxel-wide transparent rind inward from every boundary. A covered voxel
+    // beside NaN keeps its own value instead, which is what the slice's
+    // bilinear sampler does at a domain edge.
+    {
+        constexpr int n = 8;
+        auto grid = uniformGrid(n, 1.0F);
+        // Uncover the whole upper half in x, leaving a boundary mid-grid.
+        for (int k = 0; k < n; ++k) {
+            for (int j = 0; j < n; ++j) {
+                for (int i = n / 2; i < n; ++i) {
+                    grid.values[voxel(grid, i, j, k)]
+                        = std::numeric_limits<float>::quiet_NaN();
+                }
+            }
+        }
+        grid.coveredVoxels = grid.values.size() / 2;
+        auto settings = settingsFor(
+            amrvis::orthoPresetXY, 128, twoEntries(0xFFFFFFU, 1.0F), 4);
+        const auto countLit = [&](amrvis::SamplingPolicy policy) {
+            settings.sampling = policy;
+            const auto frame = amrvis::raycastVolume(grid, settings);
+            auto lit = 0;
+            for (int x = 0; x < 128; ++x) {
+                if (alphaOf(pixelAt(frame, x, 64)) > 0U) {
+                    ++lit;
+                }
+            }
+            return lit;
+        };
+        require(countLit(amrvis::SamplingPolicy::Linear)
+                == countLit(amrvis::SamplingPolicy::Nearest),
+            "linear sampling lit a different width than nearest at a coverage "
+            "boundary, so the stencil ate into the covered side");
     }
 
     // --- volumeGridRange ---------------------------------------------------

--- a/tests/unit/test_volume_raycaster.cpp
+++ b/tests/unit/test_volume_raycaster.cpp
@@ -511,8 +511,8 @@ int main()
             for (int j = 0; j < n; ++j) {
                 for (int i = 0; i < n; ++i) {
                     grid.values[voxel(grid, i, j, k)]
-                        = static_cast<float>(i + j)
-                        / static_cast<float>(2 * (n - 1));
+                        = static_cast<float>(i + 3 * j)
+                        / static_cast<float>(4 * (n - 1));
                 }
             }
         }
@@ -561,14 +561,21 @@ int main()
             ++checked;
             // Voxel i is centred at i + 0.5 voxels, so this is the field the
             // grid holds, evaluated where the ray actually goes.
-            const auto centreX
-                = worldOn(0, static_cast<double>(step) + 0.5)
-                    * static_cast<double>(n) - 0.5;
-            const auto centreY
-                = worldOn(1, static_cast<double>(step) + 0.5)
-                    * static_cast<double>(n) - 0.5;
+            // Clamped the way the sampler clamps: outside the outermost
+            // centres the bracket collapses onto the edge voxel and the field
+            // reads flat, so the half voxel at each end is not the linear
+            // extrapolation of it.
+            const auto onCentres = [](double world) {
+                const auto centres = world * static_cast<double>(n) - 0.5;
+                return std::clamp(centres, 0.0, static_cast<double>(n - 1));
+            };
+            const auto centreX = onCentres(worldOn(0, static_cast<double>(step) + 0.5));
+            const auto centreY = onCentres(worldOn(1, static_cast<double>(step) + 0.5));
+            // Weighted unequally on purpose: a field symmetric in x and y
+            // reads the same with the two weights exchanged, so it cannot
+            // tell a correct interpolation from one that swaps them.
             const auto expected
-                = (centreX + centreY) / static_cast<double>(2 * (n - 1));
+                = (centreX + 3.0 * centreY) / static_cast<double>(4 * (n - 1));
             const auto slot = amrvis::valueSlot(
                 expected, amrvis::ResolvedValueRange{0.0, 1.0, false},
                 entryCount);
@@ -580,6 +587,100 @@ int main()
         }
         require(checked > 40,
             "too few pixels landed on the domain to have checked the field");
+    }
+
+    // --- linear sampling interpolates along the ray as well -----------------
+    //
+    // Everything above varies across the ray, not along it, so a ray sees one
+    // value the whole way and nothing checks the axis it travels down. That
+    // axis is the one a per-ray cache can get wrong -- reuse the cell a ray
+    // started in and the field looks constant along it, which those cases
+    // cannot see -- and it is also where a mixed-up z weight hides.
+    //
+    // A step along z instead, read through the accumulated opacity. Nearest
+    // turns opaque at the face between voxels 3 and 4 (z = 0.5, four voxels of
+    // it); linear only where the ramp between their centres reaches the top
+    // entry, at z = 0.5625, which is three and a half voxels. The opacity
+    // correction makes a voxel contribute its entry's opacity once, so those
+    // are 1 - 0.7^4 and 1 - 0.7^3.5 -- far enough apart to tell, and both far
+    // from the 1 - 0.7^8 a ray would accumulate if it read one cell all the
+    // way down.
+    {
+        constexpr int n = 8;
+        auto grid = uniformGrid(n, 0.0F);
+        for (int k = n / 2; k < n; ++k) {
+            for (int j = 0; j < n; ++j) {
+                for (int i = 0; i < n; ++i) {
+                    grid.values[voxel(grid, i, j, k)] = 1.0F;
+                }
+            }
+        }
+        auto settings = settingsFor(
+            amrvis::orthoPresetXY, 64, twoEntries(0x0000FFU, 0.3F), 4);
+        settings.sampling = amrvis::SamplingPolicy::Linear;
+        const auto linearFrame = amrvis::raycastVolume(grid, settings);
+        settings.sampling = amrvis::SamplingPolicy::Nearest;
+        const auto nearestFrame = amrvis::raycastVolume(grid, settings);
+        const auto centreAlpha = [](const amrvis::VolumeFrame& frame) {
+            return static_cast<double>(alphaOf(pixelAt(frame, 32, 32))) / 255.0;
+        };
+        require(std::abs(centreAlpha(nearestFrame) - (1.0 - std::pow(0.7, 4.0)))
+                <= 4.0 / 255.0,
+            "nearest sampling did not turn opaque at the face along the ray");
+        require(std::abs(centreAlpha(linearFrame) - (1.0 - std::pow(0.7, 3.5)))
+                <= 4.0 / 255.0,
+            "linear sampling did not interpolate along the ray, which is the "
+            "axis a reused cell would freeze");
+    }
+
+    // --- the ray's own axis is interpolated, whichever axis that is ---------
+    //
+    // The step case above proves the axis a ray travels down is interpolated;
+    // it does not prove the right weight reaches it, because a step's corners
+    // are 0 and 1 and any weight short of 1 leaves the value below the top
+    // entry, so a substituted weight lands the transition in the same place.
+    // A ramp exposes it: the value inside a cell then depends on the fraction,
+    // and a wrong one -- another axis's, or a frozen one from a cell held over
+    // from the previous sample -- moves where the ramp crosses the entry
+    // threshold.
+    //
+    // Once per preset, since each looks down a different axis: the XY view
+    // travels z, XZ travels y, YZ travels x. A cache that compares only some
+    // of the three indices, or a weight taken from the wrong axis, survives
+    // every check that exercises one axis alone.
+    {
+        constexpr int n = 8;
+        const std::array<std::pair<amrvis::OrthoCamera, std::size_t>, 3> views{
+            {{amrvis::orthoPresetXY, 2}, {amrvis::orthoPresetXZ, 1},
+                {amrvis::orthoPresetYZ, 0}}};
+        for (const auto& [camera, axis] : views) {
+            auto grid = uniformGrid(n, 0.0F);
+            for (int k = 0; k < n; ++k) {
+                for (int j = 0; j < n; ++j) {
+                    for (int i = 0; i < n; ++i) {
+                        const std::array<int, 3> at{i, j, k};
+                        grid.values[voxel(grid, i, j, k)]
+                            = static_cast<float>(at[axis])
+                            / static_cast<float>(n - 1);
+                    }
+                }
+            }
+            auto settings = settingsFor(
+                camera, 64, twoEntries(0x0000FFU, 0.3F), 4);
+            // Half the field's span, so the top entry begins halfway up the
+            // ramp -- at the centre of voxel 3.5, which is the middle of the
+            // grid -- instead of only at its very top.
+            settings.range = {0.0, 0.5, false};
+            settings.sampling = amrvis::SamplingPolicy::Linear;
+            const auto frame = amrvis::raycastVolume(grid, settings);
+            const auto alpha
+                = static_cast<double>(alphaOf(pixelAt(frame, 32, 32))) / 255.0;
+            // The ramp reaches the threshold at the middle of the grid, so
+            // four of the eight voxels along the ray are opaque.
+            require(std::abs(alpha - (1.0 - std::pow(0.7, 4.0))) <= 4.0 / 255.0,
+                "linear sampling did not interpolate correctly along the axis "
+                "the ray travels down");
+        }
     }
 
     // --- linear sampling does not erode a coverage boundary -----------------

--- a/tests/unit/test_volume_raycaster.cpp
+++ b/tests/unit/test_volume_raycaster.cpp
@@ -357,21 +357,29 @@ int main()
             transfer.opacities.push_back(static_cast<float>(entry) / 40.0F);
         }
         const amrvis::OrthoCamera oblique{0.7, -0.4, 1.3};
-        auto single = settingsFor(oblique, 97, transfer, 3);
-        auto many = single;
-        many.threadCount = 7;
-        auto oversubscribed = single;
-        oversubscribed.threadCount = 500;   // more threads than rows: clamped
-        const auto one = amrvis::raycastVolume(grid, single);
-        const auto seven = amrvis::raycastVolume(grid, many);
-        const auto clamped = amrvis::raycastVolume(grid, oversubscribed);
-        require(one.pixels == seven.pixels && one.pixels == clamped.pixels,
-            "the thread split changed the picture");
-        std::size_t lit = 0;
-        for (const auto pixel : one.pixels) {
-            lit += pixel != 0U;
+        // Both policies, because rows are handed out on demand and Linear
+        // carries a cache that lives for one ray: a cache that outlived its
+        // ray would make a pixel depend on which worker reached it and in
+        // what order, and Nearest touches neither piece of machinery.
+        for (const auto policy : {amrvis::SamplingPolicy::Nearest,
+                 amrvis::SamplingPolicy::Linear}) {
+            auto single = settingsFor(oblique, 97, transfer, 3);
+            single.sampling = policy;
+            auto many = single;
+            many.threadCount = 7;
+            auto oversubscribed = single;
+            oversubscribed.threadCount = 500;   // more threads than rows
+            const auto one = amrvis::raycastVolume(grid, single);
+            const auto seven = amrvis::raycastVolume(grid, many);
+            const auto clamped = amrvis::raycastVolume(grid, oversubscribed);
+            require(one.pixels == seven.pixels && one.pixels == clamped.pixels,
+                "the thread split changed the picture");
+            std::size_t lit = 0;
+            for (const auto pixel : one.pixels) {
+                lit += pixel != 0U;
+            }
+            require(lit > 0, "the oblique render lit nothing");
         }
-        require(lit > 0, "the oblique render lit nothing");
     }
 
     // --- the value mapping is the 2-D renderer's --------------------------


### PR DESCRIPTION
The march took the voxel each sample landed in, so at two samples per voxel a ray fetched the same value twice and the field came out terraced. Trilinear now, over the eight centres bracketing the sample, behind a Smooth sampling box that is on by default.

The half voxel matters: voxel i is centred at i + 0.5, so interpolating without shifting moves the field through the grid and still looks plausible. A corner the range cannot map takes the landed voxel's value, which clamps the field to its coverage instead of letting one NaN eat a voxel-wide rind, and an uncovered landing voxel skips as before.

Protocol 1.3: the server does the sampling, so a 1.2 server would have ignored the field and rendered nearest while the box claimed otherwise. It is greyed out against one instead.