### PR TITLE
add a parser for single-line algebraic expressions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -245,6 +245,7 @@ if(AMREXPLORER_LIBFUZZER)
     amrexplorer_enable_libfuzzer_instrumentation()
 endif()
 
+add_subdirectory(src/expression)
 add_subdirectory(src/core)
 add_subdirectory(src/cache)
 add_subdirectory(src/io)

--- a/include/amrexplorer/expression/Expression.hpp
+++ b/include/amrexplorer/expression/Expression.hpp
@@ -1,0 +1,103 @@
+#pragma once
+
+#include <cstddef>
+#include <memory>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <vector>
+
+// Single-line algebraic expressions over named symbols, compiled once into a
+// flat instruction list and evaluated by a small stack machine. The grammar:
+//
+//   expression      := additive
+//   additive        := multiplicative (("+" | "-") multiplicative)*
+//   multiplicative  := unary (("*" | "/") unary)*
+//   unary           := ("+" | "-") unary | power
+//   power           := primary ("**" unary)?
+//   primary         := number | symbol | "(" expression ")"
+//                    | unary-function "(" expression ")"
+//                    | "pow" "(" expression "," expression ")"
+//   unary-function  := "abs" | "sqrt" | "exp" | "log" | "exp10" | "log10"
+//   symbol          := identifier | "${" any-but-brace+ "}"
+//
+// A symbol is a bare identifier ([A-Za-z_][A-Za-z0-9_.]*) or, for a name a
+// bare identifier cannot spell -- "x-momentum", "Y(H2)" -- the same name
+// inside ${...}, taken verbatim. Nothing here knows what a symbol *means*;
+// symbols() reports them in first-appearance order and the caller supplies a
+// value per symbol in that order.
+
+namespace amrvis {
+
+class ExpressionError : public std::invalid_argument {
+public:
+    ExpressionError(std::string message, std::size_t offset);
+
+    // Byte offset into the compiled source where the problem was found, so an
+    // editor can point at the character rather than repeat the message.
+    [[nodiscard]] std::size_t offset() const noexcept;
+
+private:
+    std::size_t m_offset;
+};
+
+// Bounds compile() enforces before it recurses. Expressions are typed by hand
+// but also arrive from files, so neither the length nor the nesting depth is
+// left to the C++ stack to discover: "((((..." nested deep enough would
+// otherwise overflow it.
+inline constexpr std::size_t maximumExpressionBytes = 4096;
+inline constexpr std::size_t maximumExpressionDepth = 64;
+
+namespace expression_detail {
+struct Program;
+}
+
+class ExpressionEvaluator;
+
+// A compiled expression: immutable, cheap to copy, and safe to share between
+// threads. Evaluation state lives in the evaluators it hands out, so each
+// thread makes its own.
+class CompiledExpression {
+public:
+    [[nodiscard]] static CompiledExpression compile(std::string_view source);
+
+    // The symbols the expression reads, in first-appearance order. This is the
+    // order every evaluate() call expects its values in.
+    [[nodiscard]] std::span<const std::string> symbols() const noexcept;
+    [[nodiscard]] ExpressionEvaluator makeEvaluator() const;
+
+private:
+    explicit CompiledExpression(
+        std::shared_ptr<const expression_detail::Program> program);
+
+    std::shared_ptr<const expression_detail::Program> m_program;
+};
+
+class ExpressionEvaluator {
+public:
+    // One point: `variables` holds one value per symbol().
+    [[nodiscard]] double evaluate(std::span<const double> variables);
+
+    // Many points at once: one column per symbol, every column and `out` the
+    // same length. Evaluated in fixed-size chunks -- one pass per instruction
+    // over a chunk rather than the whole program per point -- so the stack
+    // slots stay in cache and the per-instruction loops vectorise, without
+    // the whole-block temporaries a single pass over all points would need.
+    void evaluate(
+        std::span<const std::span<const double>> columns, std::span<double> out);
+
+private:
+    friend class CompiledExpression;
+
+    explicit ExpressionEvaluator(
+        std::shared_ptr<const expression_detail::Program> program);
+
+    std::shared_ptr<const expression_detail::Program> m_program;
+    std::vector<double> m_stack;
+    // Chunked stack slots for the batch path, allocated on first use so the
+    // scalar path pays nothing for them.
+    std::vector<double> m_slots;
+};
+
+} // namespace amrvis

--- a/include/amrexplorer/expression/Expression.hpp
+++ b/include/amrexplorer/expression/Expression.hpp
@@ -20,7 +20,7 @@
 //                    | unary-function "(" expression ")"
 //                    | "pow" "(" expression "," expression ")"
 //   unary-function  := "abs" | "sqrt" | "exp" | "log" | "exp10" | "log10"
-//   symbol          := identifier | "${" any-but-brace+ "}"
+//   symbol          := identifier | "${" any-but-brace-or-newline+ "}"
 //
 // A symbol is a bare identifier ([A-Za-z_][A-Za-z0-9_.]*) or, for a name a
 // bare identifier cannot spell -- "x-momentum", "Y(H2)" -- the same name

--- a/src/expression/CMakeLists.txt
+++ b/src/expression/CMakeLists.txt
@@ -1,0 +1,14 @@
+add_library(amrexplorer_expression
+    Expression.cpp
+)
+add_library(amrexplorer::expression ALIAS amrexplorer_expression)
+
+target_include_directories(amrexplorer_expression
+    PUBLIC
+        $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+        $<INSTALL_INTERFACE:include>
+)
+target_link_libraries(amrexplorer_expression
+    PRIVATE amrexplorer::warnings
+)
+target_compile_features(amrexplorer_expression PUBLIC cxx_std_20)

--- a/src/expression/Expression.cpp
+++ b/src/expression/Expression.cpp
@@ -4,10 +4,9 @@
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
-#include <locale>
+#include <cstdlib>
 #include <memory>
 #include <optional>
-#include <sstream>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -61,24 +60,34 @@ std::string errorMessage(std::string message, std::size_t offset)
     return std::move(message) + " at byte " + std::to_string(offset);
 }
 
-// One source byte as it can safely appear in a message: printable ASCII as
-// itself, anything else as \xNN. Messages reach a Qt label as UTF-8, and a
-// byte spliced straight out of the source is not a character -- a pasted
-// U+2212 minus or U+00D7 times, which is what copying a formula out of a paper
-// gives you, is two or three bytes and each one alone is invalid UTF-8 that
-// renders as U+FFFD.
-std::string quotedByte(char value)
+// Source bytes as they can safely appear in a message: printable ASCII as
+// itself, anything else as \xNN. Messages reach a Qt label as UTF-8, and bytes
+// spliced straight out of the source are not characters -- a pasted U+2212
+// minus or U+00D7 times, which is what copying a formula out of a paper gives
+// you, is two or three bytes, and each one alone is invalid UTF-8 that renders
+// as U+FFFD. Whole tokens go through this too, not just the lexer's stray
+// byte: a ${...} name is taken verbatim, so a token can carry anything.
+std::string quotedText(std::string_view text)
 {
-    const auto byte = static_cast<unsigned char>(value);
-    if (byte >= 0x20 && byte < 0x7F) {
-        return "'" + std::string(1, value) + "'";
-    }
     constexpr std::string_view digits = "0123456789abcdef";
-    std::string quoted = "'\\x";
-    quoted += digits[byte >> 4U];
-    quoted += digits[byte & 0x0FU];
+    std::string quoted = "'";
+    for (const auto value : text) {
+        const auto byte = static_cast<unsigned char>(value);
+        if (byte >= 0x20 && byte < 0x7F) {
+            quoted += value;
+            continue;
+        }
+        quoted += "\\x";
+        quoted += digits[byte >> 4U];
+        quoted += digits[byte & 0x0FU];
+    }
     quoted += "'";
     return quoted;
+}
+
+std::string quotedByte(char value)
+{
+    return quotedText(std::string_view(&value, 1));
 }
 
 enum class TokenKind : std::uint8_t {
@@ -225,7 +234,7 @@ private:
         const auto start = m_position;
         while (m_position < m_source.size() && m_source[m_position] != '}') {
             if (m_source[m_position] == '\n' || m_source[m_position] == '\r') {
-                throw ExpressionError("newlines are not allowed", m_position);
+                throw ExpressionError("newlines are not allowed", offset);
             }
             // Refused rather than taken as part of the name, so a mistyped
             // nested reference ("${a${b}}") is a syntax error here instead of
@@ -283,35 +292,36 @@ private:
         }
 
         const auto text = m_source.substr(offset, m_position - offset);
-        // A literal whose significand is zero *is* zero, whatever its exponent
-        // says: "0e-9999" is 0.0 and not an error. Settled here, before the
-        // conversion, because the libraries disagree about how they report an
-        // out-of-range exponent -- some return zero with no error, others set
-        // the failbit -- and on the latter a verdict-driven check would reject
-        // this. The significand is the one thing that does not vary.
-        if (!hasNonzeroSignificand(text)) {
-            return {
-                .kind = TokenKind::Number,
-                .offset = offset,
-                .text = text,
-                .number = 0.0
-            };
-        }
-        double result = 0.0;
-        // The classic locale, not the process one: a decimal point must mean a
-        // decimal point wherever the viewer runs.
-        std::istringstream conversion(std::string{text});
-        conversion.imbue(std::locale::classic());
-        conversion >> result;
-        // The three ways a nonzero significand leaves the representable range,
-        // which the libraries also disagree about: a failbit, an infinity, and
-        // a silent zero from an underflowing exponent. Rejecting all three
-        // keeps the same source an error everywhere.
-        if (conversion.fail() || !std::isfinite(result) || result == 0.0) {
-            throw ExpressionError("numeric literal is out of range", offset);
-        }
-        if (!conversion.eof()) {
+        // strtod rather than an imbued istringstream, which is what this used
+        // to be. A stream's only signal for an overflowing literal is its
+        // failbit -- libstdc++ clamps the value to DBL_MAX rather than handing
+        // back an infinity -- and that same failbit is how libc++ and MSVC
+        // report the ERANGE a *legitimate* denormal raises. So no stream-based
+        // rule tells "1e9999" from "1e-320" the same way on every library, and
+        // the one written here accepted a denormal on Linux and would have
+        // refused it on macOS. strtod's contract separates them: an overflow
+        // is an infinity, a denormal is a finite nonzero. The plotfile reader
+        // settled on the same thing for the same reason (readStatisticValue,
+        // which spells out the ERANGE half). It reads LC_NUMERIC, which main()
+        // pins to "C" once, deliberately, for every call site like this one.
+        const std::string token{text};
+        const char* begin = token.c_str();
+        char* end = nullptr;
+        const double result = std::strtod(begin, &end);
+        if (end != begin + token.size()) {
+            // Unreachable through this lexer, whose numeric grammar is a
+            // subset of strtod's. Kept because that subset relationship is the
+            // assumption this conversion rests on, and the two grammars are
+            // under no obligation to stay in step.
             throw ExpressionError("invalid numeric literal", offset);
+        }
+        // Out of range two ways, neither of them a library's verdict: an
+        // overflow is an infinity, and an underflow is a zero whose digits
+        // were not. A significand that is itself zero is simply zero, whatever
+        // its exponent says, so "0e-9999" is 0.0 and not an error.
+        if (!std::isfinite(result)
+            || (result == 0.0 && hasNonzeroSignificand(text))) {
+            throw ExpressionError("numeric literal is out of range", offset);
         }
         return {
             .kind = TokenKind::Number,
@@ -391,7 +401,7 @@ private:
         if (m_current.kind == TokenKind::End) {
             fail("unexpected end of expression");
         }
-        fail("unexpected token '" + std::string(m_current.text) + "'");
+        fail("unexpected token " + quotedText(m_current.text));
     }
 
     void expect(TokenKind kind, std::string message)

--- a/src/expression/Expression.cpp
+++ b/src/expression/Expression.cpp
@@ -1,0 +1,785 @@
+#include <amrexplorer/expression/Expression.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <locale>
+#include <memory>
+#include <optional>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace amrvis {
+namespace expression_detail {
+
+enum class Opcode : std::uint8_t {
+    PushConstant,
+    PushVariable,
+    Negate,
+    Add,
+    Subtract,
+    Multiply,
+    Divide,
+    Abs,
+    Sqrt,
+    Pow,
+    Exp,
+    Log,
+    Exp10,
+    Log10
+};
+
+struct Instruction {
+    Opcode opcode;
+    double constant = 0.0;
+    std::size_t index = 0;
+};
+
+struct Program {
+    std::vector<Instruction> instructions;
+    std::vector<std::string> symbols;
+    std::size_t stackDepth = 0;
+};
+
+} // namespace expression_detail
+namespace {
+
+using expression_detail::Instruction;
+using expression_detail::Opcode;
+using expression_detail::Program;
+
+// Points per batch pass. Small enough that stackDepth slots stay in L1 and
+// large enough to amortise the per-instruction dispatch.
+constexpr std::size_t batchPoints = 512;
+
+std::string errorMessage(std::string message, std::size_t offset)
+{
+    return std::move(message) + " at byte " + std::to_string(offset);
+}
+
+enum class TokenKind : std::uint8_t {
+    End,
+    Number,
+    Identifier,
+    // A ${...} field reference: never a function call, whatever it spells.
+    Symbol,
+    Plus,
+    Minus,
+    Star,
+    Slash,
+    Power,
+    LeftParen,
+    RightParen,
+    Comma
+};
+
+struct Token {
+    TokenKind kind = TokenKind::End;
+    std::size_t offset = 0;
+    std::string_view text{};
+    double number = 0.0;
+};
+
+bool isIdentifierStart(char value)
+{
+    return (value >= 'a' && value <= 'z')
+        || (value >= 'A' && value <= 'Z') || value == '_';
+}
+
+bool isIdentifierContinuation(char value)
+{
+    return isIdentifierStart(value) || (value >= '0' && value <= '9')
+        || value == '.';
+}
+
+bool hasNonzeroSignificand(std::string_view text)
+{
+    for (const auto value : text) {
+        if (value == 'e' || value == 'E') {
+            break;
+        }
+        if (value >= '1' && value <= '9') {
+            return true;
+        }
+    }
+    return false;
+}
+
+class Lexer {
+public:
+    explicit Lexer(std::string_view source)
+        : m_source(source)
+    {
+    }
+
+    Token next()
+    {
+        skipHorizontalWhitespace();
+        if (m_position == m_source.size()) {
+            return {.kind = TokenKind::End, .offset = m_position};
+        }
+
+        const auto offset = m_position;
+        const auto value = m_source[m_position];
+        if (value == '\n' || value == '\r') {
+            throw ExpressionError("newlines are not allowed", offset);
+        }
+        if ((value >= '0' && value <= '9')
+            || (value == '.' && m_position + 1 < m_source.size()
+                && m_source[m_position + 1] >= '0'
+                && m_source[m_position + 1] <= '9')) {
+            return number();
+        }
+        if (value == '$') {
+            return braced();
+        }
+        if (isIdentifierStart(value)) {
+            ++m_position;
+            while (m_position < m_source.size()
+                && isIdentifierContinuation(m_source[m_position])) {
+                ++m_position;
+            }
+            return {
+                .kind = TokenKind::Identifier,
+                .offset = offset,
+                .text = m_source.substr(offset, m_position - offset)
+            };
+        }
+
+        ++m_position;
+        switch (value) {
+        case '+':
+            return {.kind = TokenKind::Plus, .offset = offset, .text = "+"};
+        case '-':
+            return {.kind = TokenKind::Minus, .offset = offset, .text = "-"};
+        case '*':
+            if (m_position < m_source.size()
+                && m_source[m_position] == '*') {
+                ++m_position;
+                return {
+                    .kind = TokenKind::Power, .offset = offset, .text = "**"};
+            }
+            return {.kind = TokenKind::Star, .offset = offset, .text = "*"};
+        case '/':
+            return {.kind = TokenKind::Slash, .offset = offset, .text = "/"};
+        case '(':
+            return {
+                .kind = TokenKind::LeftParen, .offset = offset, .text = "("};
+        case ')':
+            return {
+                .kind = TokenKind::RightParen, .offset = offset, .text = ")"};
+        case ',':
+            return {.kind = TokenKind::Comma, .offset = offset, .text = ","};
+        default:
+            throw ExpressionError(
+                "unexpected token '" + std::string(1, value) + "'", offset);
+        }
+    }
+
+private:
+    void skipHorizontalWhitespace()
+    {
+        while (m_position < m_source.size()
+            && (m_source[m_position] == ' '
+                || m_source[m_position] == '\t')) {
+            ++m_position;
+        }
+    }
+
+    // ${name}: everything between the braces is one symbol, verbatim, so a
+    // field name with dashes, parentheses or spaces needs no escaping. The
+    // whole token is reported at the '$' -- the offset a reader would point
+    // at -- rather than at whichever inner byte the scan stopped on.
+    Token braced()
+    {
+        const auto offset = m_position;
+        ++m_position;
+        if (m_position == m_source.size() || m_source[m_position] != '{') {
+            throw ExpressionError("expected '{' after '$'", offset);
+        }
+        ++m_position;
+        const auto start = m_position;
+        while (m_position < m_source.size() && m_source[m_position] != '}') {
+            if (m_source[m_position] == '\n' || m_source[m_position] == '\r') {
+                throw ExpressionError("newlines are not allowed", m_position);
+            }
+            ++m_position;
+        }
+        if (m_position == m_source.size()) {
+            throw ExpressionError("unterminated '${'", offset);
+        }
+        const auto text = m_source.substr(start, m_position - start);
+        ++m_position;
+        if (text.empty()) {
+            throw ExpressionError("'${}' names no field", offset);
+        }
+        return {.kind = TokenKind::Symbol, .offset = offset, .text = text};
+    }
+
+    Token number()
+    {
+        const auto offset = m_position;
+        while (m_position < m_source.size()
+            && m_source[m_position] >= '0' && m_source[m_position] <= '9') {
+            ++m_position;
+        }
+        if (m_position < m_source.size() && m_source[m_position] == '.') {
+            ++m_position;
+            while (m_position < m_source.size()
+                && m_source[m_position] >= '0'
+                && m_source[m_position] <= '9') {
+                ++m_position;
+            }
+        }
+        if (m_position < m_source.size()
+            && (m_source[m_position] == 'e'
+                || m_source[m_position] == 'E')) {
+            ++m_position;
+            if (m_position < m_source.size()
+                && (m_source[m_position] == '+'
+                    || m_source[m_position] == '-')) {
+                ++m_position;
+            }
+            const auto exponentStart = m_position;
+            while (m_position < m_source.size()
+                && m_source[m_position] >= '0'
+                && m_source[m_position] <= '9') {
+                ++m_position;
+            }
+            if (m_position == exponentStart) {
+                throw ExpressionError("invalid numeric exponent", m_position);
+            }
+        }
+
+        const auto text = m_source.substr(offset, m_position - offset);
+        double result = 0.0;
+        // The classic locale, not the process one: a decimal point must mean a
+        // decimal point wherever the viewer runs.
+        std::istringstream conversion(std::string{text});
+        conversion.imbue(std::locale::classic());
+        conversion >> result;
+        // The three ways a literal leaves the representable range, which the
+        // standard libraries disagree about: a failbit, an infinity, and a
+        // silent zero for an underflowing exponent ("1e-9999"). Rejecting all
+        // three keeps the same source an error everywhere.
+        if (conversion.fail() || !std::isfinite(result)
+            || (result == 0.0 && hasNonzeroSignificand(text))) {
+            throw ExpressionError("numeric literal is out of range", offset);
+        }
+        if (!conversion.eof()) {
+            throw ExpressionError("invalid numeric literal", offset);
+        }
+        return {
+            .kind = TokenKind::Number,
+            .offset = offset,
+            .text = text,
+            .number = result
+        };
+    }
+
+    std::string_view m_source;
+    std::size_t m_position = 0;
+};
+
+class Parser {
+public:
+    explicit Parser(std::string_view source)
+        : m_lexer(source)
+        , m_current(m_lexer.next())
+    {
+    }
+
+    std::shared_ptr<const Program> parse()
+    {
+        parseExpression();
+        if (m_current.kind != TokenKind::End) {
+            failUnexpected();
+        }
+        validateStack();
+        return std::make_shared<const Program>(std::move(m_program));
+    }
+
+private:
+    // Bounds both recursive descents below on the one counter: parenthesis and
+    // call nesting through parseExpression, and sign chains ("---x") through
+    // parseUnary. Without it a deep enough source overflows the C++ stack.
+    class DepthGuard {
+    public:
+        explicit DepthGuard(Parser& parser)
+            : m_parser(parser)
+        {
+            if (++m_parser.m_depth > maximumExpressionDepth) {
+                m_parser.fail("expression nests too deeply");
+            }
+        }
+        DepthGuard(const DepthGuard&) = delete;
+        DepthGuard& operator=(const DepthGuard&) = delete;
+        DepthGuard(DepthGuard&&) = delete;
+        DepthGuard& operator=(DepthGuard&&) = delete;
+        ~DepthGuard() { --m_parser.m_depth; }
+
+    private:
+        Parser& m_parser;
+    };
+
+    void advance()
+    {
+        m_current = m_lexer.next();
+    }
+
+    [[noreturn]] void fail(std::string message) const
+    {
+        throw ExpressionError(std::move(message), m_current.offset);
+    }
+
+    [[noreturn]] void failUnexpected() const
+    {
+        if (m_current.kind == TokenKind::End) {
+            fail("unexpected end of expression");
+        }
+        fail("unexpected token '" + std::string(m_current.text) + "'");
+    }
+
+    void expect(TokenKind kind, std::string message)
+    {
+        if (m_current.kind != kind) {
+            fail(std::move(message));
+        }
+        advance();
+    }
+
+    void emit(Opcode opcode)
+    {
+        m_program.instructions.push_back({.opcode = opcode});
+    }
+
+    void parseExpression()
+    {
+        const DepthGuard guard(*this);
+        parseAdditive();
+    }
+
+    void parseAdditive()
+    {
+        parseMultiplicative();
+        while (m_current.kind == TokenKind::Plus
+            || m_current.kind == TokenKind::Minus) {
+            const auto operation = m_current.kind;
+            advance();
+            parseMultiplicative();
+            emit(operation == TokenKind::Plus ? Opcode::Add : Opcode::Subtract);
+        }
+    }
+
+    void parseMultiplicative()
+    {
+        parseUnary();
+        while (m_current.kind == TokenKind::Star
+            || m_current.kind == TokenKind::Slash) {
+            const auto operation = m_current.kind;
+            advance();
+            parseUnary();
+            emit(operation == TokenKind::Star ? Opcode::Multiply : Opcode::Divide);
+        }
+    }
+
+    void parseUnary()
+    {
+        // Guarded only where it recurses into itself -- a sign chain. Taking
+        // the guard on the way down to parsePower as well would charge two
+        // levels for every parenthesis, halving the limit the constant states.
+        if (m_current.kind == TokenKind::Plus
+            || m_current.kind == TokenKind::Minus) {
+            const DepthGuard guard(*this);
+            const auto negate = m_current.kind == TokenKind::Minus;
+            advance();
+            parseUnary();
+            if (negate) {
+                emit(Opcode::Negate);
+            }
+            return;
+        }
+        parsePower();
+    }
+
+    void parsePower()
+    {
+        parsePrimary();
+        if (m_current.kind == TokenKind::Power) {
+            advance();
+            parseUnary();
+            emit(Opcode::Pow);
+        }
+    }
+
+    void parsePrimary()
+    {
+        if (m_current.kind == TokenKind::Number) {
+            m_program.instructions.push_back({
+                .opcode = Opcode::PushConstant,
+                .constant = m_current.number
+            });
+            advance();
+            return;
+        }
+        if (m_current.kind == TokenKind::Symbol) {
+            pushVariable(std::string(m_current.text));
+            advance();
+            return;
+        }
+        if (m_current.kind == TokenKind::Identifier) {
+            parseIdentifier();
+            return;
+        }
+        if (m_current.kind == TokenKind::LeftParen) {
+            advance();
+            parseExpression();
+            expect(TokenKind::RightParen, "expected ')'");
+            return;
+        }
+        if (m_current.kind == TokenKind::End) {
+            fail("expected expression");
+        }
+        failUnexpected();
+    }
+
+    void parseIdentifier()
+    {
+        const auto name = std::string(m_current.text);
+        const auto nameOffset = m_current.offset;
+        advance();
+        if (m_current.kind != TokenKind::LeftParen) {
+            pushVariable(name);
+            return;
+        }
+
+        advance();
+        if (name == "pow") {
+            parseExpression();
+            expect(TokenKind::Comma, "expected ',' after first argument to pow");
+            parseExpression();
+            expect(TokenKind::RightParen, "expected ')' after arguments to pow");
+            emit(Opcode::Pow);
+            return;
+        }
+
+        const auto operation = unaryFunction(name);
+        if (!operation.has_value()) {
+            throw ExpressionError("unknown function '" + name + "'", nameOffset);
+        }
+        parseExpression();
+        expect(
+            TokenKind::RightParen, "expected ')' after argument to " + name);
+        emit(*operation);
+    }
+
+    static std::optional<Opcode> unaryFunction(const std::string& name)
+    {
+        if (name == "abs") {
+            return Opcode::Abs;
+        }
+        if (name == "sqrt") {
+            return Opcode::Sqrt;
+        }
+        if (name == "exp") {
+            return Opcode::Exp;
+        }
+        if (name == "log") {
+            return Opcode::Log;
+        }
+        if (name == "exp10") {
+            return Opcode::Exp10;
+        }
+        if (name == "log10") {
+            return Opcode::Log10;
+        }
+        return std::nullopt;
+    }
+
+    void pushVariable(const std::string& name)
+    {
+        m_program.instructions.push_back({
+            .opcode = Opcode::PushVariable,
+            .index = symbolIndex(name)
+        });
+    }
+
+    std::size_t symbolIndex(const std::string& name)
+    {
+        for (std::size_t index = 0; index < m_program.symbols.size(); ++index) {
+            if (m_program.symbols[index] == name) {
+                return index;
+            }
+        }
+        m_program.symbols.push_back(name);
+        return m_program.symbols.size() - 1;
+    }
+
+    void validateStack()
+    {
+        std::size_t depth = 0;
+        std::size_t maximum = 0;
+        for (const auto& instruction : m_program.instructions) {
+            switch (instruction.opcode) {
+            case Opcode::PushConstant:
+            case Opcode::PushVariable:
+                ++depth;
+                maximum = std::max(maximum, depth);
+                break;
+            case Opcode::Negate:
+            case Opcode::Abs:
+            case Opcode::Sqrt:
+            case Opcode::Exp:
+            case Opcode::Log:
+            case Opcode::Exp10:
+            case Opcode::Log10:
+                if (depth < 1) {
+                    throw std::logic_error(
+                        "expression compiler produced an invalid unary operation");
+                }
+                break;
+            case Opcode::Add:
+            case Opcode::Subtract:
+            case Opcode::Multiply:
+            case Opcode::Divide:
+            case Opcode::Pow:
+                if (depth < 2) {
+                    throw std::logic_error(
+                        "expression compiler produced an invalid binary operation");
+                }
+                --depth;
+                break;
+            }
+        }
+        if (depth != 1) {
+            throw std::logic_error(
+                "expression compiler produced an invalid final stack");
+        }
+        m_program.stackDepth = maximum;
+    }
+
+    Lexer m_lexer;
+    Token m_current;
+    Program m_program;
+    std::size_t m_depth = 0;
+};
+
+} // namespace
+
+ExpressionError::ExpressionError(std::string message, std::size_t offset)
+    : std::invalid_argument(errorMessage(std::move(message), offset))
+    , m_offset(offset)
+{
+}
+
+std::size_t ExpressionError::offset() const noexcept
+{
+    return m_offset;
+}
+
+CompiledExpression::CompiledExpression(
+    std::shared_ptr<const expression_detail::Program> program)
+    : m_program(std::move(program))
+{
+}
+
+CompiledExpression CompiledExpression::compile(std::string_view source)
+{
+    if (source.size() > maximumExpressionBytes) {
+        throw ExpressionError(
+            "expression exceeds " + std::to_string(maximumExpressionBytes)
+                + " bytes",
+            maximumExpressionBytes);
+    }
+    return CompiledExpression(Parser(source).parse());
+}
+
+std::span<const std::string> CompiledExpression::symbols() const noexcept
+{
+    return m_program->symbols;
+}
+
+ExpressionEvaluator CompiledExpression::makeEvaluator() const
+{
+    return ExpressionEvaluator(m_program);
+}
+
+ExpressionEvaluator::ExpressionEvaluator(
+    std::shared_ptr<const expression_detail::Program> program)
+    : m_program(std::move(program))
+    , m_stack(m_program->stackDepth)
+{
+}
+
+double ExpressionEvaluator::evaluate(std::span<const double> variables)
+{
+    if (variables.size() != m_program->symbols.size()) {
+        throw std::invalid_argument(
+            "expression evaluator received "
+            + std::to_string(variables.size()) + " variables; expected "
+            + std::to_string(m_program->symbols.size()));
+    }
+
+    std::size_t depth = 0;
+    for (const auto& instruction : m_program->instructions) {
+        switch (instruction.opcode) {
+        case Opcode::PushConstant:
+            m_stack[depth++] = instruction.constant;
+            break;
+        case Opcode::PushVariable:
+            m_stack[depth++] = variables[instruction.index];
+            break;
+        case Opcode::Negate:
+            m_stack[depth - 1] = -m_stack[depth - 1];
+            break;
+        case Opcode::Add:
+            --depth;
+            m_stack[depth - 1] += m_stack[depth];
+            break;
+        case Opcode::Subtract:
+            --depth;
+            m_stack[depth - 1] -= m_stack[depth];
+            break;
+        case Opcode::Multiply:
+            --depth;
+            m_stack[depth - 1] *= m_stack[depth];
+            break;
+        case Opcode::Divide:
+            --depth;
+            m_stack[depth - 1] /= m_stack[depth];
+            break;
+        case Opcode::Abs:
+            m_stack[depth - 1] = std::abs(m_stack[depth - 1]);
+            break;
+        case Opcode::Sqrt:
+            m_stack[depth - 1] = std::sqrt(m_stack[depth - 1]);
+            break;
+        case Opcode::Pow:
+            --depth;
+            m_stack[depth - 1] = std::pow(m_stack[depth - 1], m_stack[depth]);
+            break;
+        case Opcode::Exp:
+            m_stack[depth - 1] = std::exp(m_stack[depth - 1]);
+            break;
+        case Opcode::Log:
+            m_stack[depth - 1] = std::log(m_stack[depth - 1]);
+            break;
+        case Opcode::Exp10:
+            m_stack[depth - 1] = std::pow(10.0, m_stack[depth - 1]);
+            break;
+        case Opcode::Log10:
+            m_stack[depth - 1] = std::log10(m_stack[depth - 1]);
+            break;
+        }
+    }
+    return m_stack.front();
+}
+
+void ExpressionEvaluator::evaluate(
+    std::span<const std::span<const double>> columns, std::span<double> out)
+{
+    if (columns.size() != m_program->symbols.size()) {
+        throw std::invalid_argument(
+            "expression evaluator received " + std::to_string(columns.size())
+            + " columns; expected "
+            + std::to_string(m_program->symbols.size()));
+    }
+    for (const auto& column : columns) {
+        if (column.size() != out.size()) {
+            throw std::invalid_argument(
+                "expression evaluator columns must be as long as its output");
+        }
+    }
+    if (out.empty()) {
+        return;
+    }
+
+    m_slots.resize(m_program->stackDepth * batchPoints);
+    for (std::size_t start = 0; start < out.size(); start += batchPoints) {
+        const auto points = std::min(batchPoints, out.size() - start);
+        std::size_t depth = 0;
+        const auto slot = [this](std::size_t index) {
+            return m_slots.data() + index * batchPoints;
+        };
+        // Each instruction is one pass over the chunk. depth indexes the stack
+        // of chunk-wide slots exactly as it indexes the scalar stack above.
+        const auto push = [&](const double* source, bool constant) {
+            auto* target = slot(depth++);
+            if (constant) {
+                std::fill(target, target + points, *source);
+            } else {
+                std::copy(source + start, source + start + points, target);
+            }
+        };
+        const auto unary = [&](auto operation) {
+            auto* target = slot(depth - 1);
+            for (std::size_t i = 0; i < points; ++i) {
+                target[i] = operation(target[i]);
+            }
+        };
+        const auto binary = [&](auto operation) {
+            --depth;
+            auto* target = slot(depth - 1);
+            const auto* source = slot(depth);
+            for (std::size_t i = 0; i < points; ++i) {
+                target[i] = operation(target[i], source[i]);
+            }
+        };
+        for (const auto& instruction : m_program->instructions) {
+            switch (instruction.opcode) {
+            case Opcode::PushConstant:
+                push(&instruction.constant, true);
+                break;
+            case Opcode::PushVariable:
+                push(columns[instruction.index].data(), false);
+                break;
+            case Opcode::Negate:
+                unary([](double value) { return -value; });
+                break;
+            case Opcode::Add:
+                binary([](double left, double right) { return left + right; });
+                break;
+            case Opcode::Subtract:
+                binary([](double left, double right) { return left - right; });
+                break;
+            case Opcode::Multiply:
+                binary([](double left, double right) { return left * right; });
+                break;
+            case Opcode::Divide:
+                binary([](double left, double right) { return left / right; });
+                break;
+            case Opcode::Abs:
+                unary([](double value) { return std::abs(value); });
+                break;
+            case Opcode::Sqrt:
+                unary([](double value) { return std::sqrt(value); });
+                break;
+            case Opcode::Pow:
+                binary([](double left, double right) {
+                    return std::pow(left, right);
+                });
+                break;
+            case Opcode::Exp:
+                unary([](double value) { return std::exp(value); });
+                break;
+            case Opcode::Log:
+                unary([](double value) { return std::log(value); });
+                break;
+            case Opcode::Exp10:
+                unary([](double value) { return std::pow(10.0, value); });
+                break;
+            case Opcode::Log10:
+                unary([](double value) { return std::log10(value); });
+                break;
+            }
+        }
+        const auto* result = m_slots.data();
+        std::copy(result, result + points,
+            out.begin() + static_cast<std::ptrdiff_t>(start));
+    }
+}
+
+} // namespace amrvis

--- a/src/expression/Expression.cpp
+++ b/src/expression/Expression.cpp
@@ -9,6 +9,7 @@
 #include <optional>
 #include <sstream>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -58,6 +59,26 @@ constexpr std::size_t batchPoints = 512;
 std::string errorMessage(std::string message, std::size_t offset)
 {
     return std::move(message) + " at byte " + std::to_string(offset);
+}
+
+// One source byte as it can safely appear in a message: printable ASCII as
+// itself, anything else as \xNN. Messages reach a Qt label as UTF-8, and a
+// byte spliced straight out of the source is not a character -- a pasted
+// U+2212 minus or U+00D7 times, which is what copying a formula out of a paper
+// gives you, is two or three bytes and each one alone is invalid UTF-8 that
+// renders as U+FFFD.
+std::string quotedByte(char value)
+{
+    const auto byte = static_cast<unsigned char>(value);
+    if (byte >= 0x20 && byte < 0x7F) {
+        return "'" + std::string(1, value) + "'";
+    }
+    constexpr std::string_view digits = "0123456789abcdef";
+    std::string quoted = "'\\x";
+    quoted += digits[byte >> 4U];
+    quoted += digits[byte & 0x0FU];
+    quoted += "'";
+    return quoted;
 }
 
 enum class TokenKind : std::uint8_t {
@@ -175,7 +196,7 @@ public:
             return {.kind = TokenKind::Comma, .offset = offset, .text = ","};
         default:
             throw ExpressionError(
-                "unexpected token '" + std::string(1, value) + "'", offset);
+                "unexpected token " + quotedByte(value), offset);
         }
     }
 
@@ -205,6 +226,13 @@ private:
         while (m_position < m_source.size() && m_source[m_position] != '}') {
             if (m_source[m_position] == '\n' || m_source[m_position] == '\r') {
                 throw ExpressionError("newlines are not allowed", m_position);
+            }
+            // Refused rather than taken as part of the name, so a mistyped
+            // nested reference ("${a${b}}") is a syntax error here instead of
+            // a symbol named "a${b" that fails much later as an unknown field.
+            if (m_source[m_position] == '{') {
+                throw ExpressionError("'{' is not allowed in a '${...}' name",
+                    offset);
             }
             ++m_position;
         }
@@ -255,18 +283,31 @@ private:
         }
 
         const auto text = m_source.substr(offset, m_position - offset);
+        // A literal whose significand is zero *is* zero, whatever its exponent
+        // says: "0e-9999" is 0.0 and not an error. Settled here, before the
+        // conversion, because the libraries disagree about how they report an
+        // out-of-range exponent -- some return zero with no error, others set
+        // the failbit -- and on the latter a verdict-driven check would reject
+        // this. The significand is the one thing that does not vary.
+        if (!hasNonzeroSignificand(text)) {
+            return {
+                .kind = TokenKind::Number,
+                .offset = offset,
+                .text = text,
+                .number = 0.0
+            };
+        }
         double result = 0.0;
         // The classic locale, not the process one: a decimal point must mean a
         // decimal point wherever the viewer runs.
         std::istringstream conversion(std::string{text});
         conversion.imbue(std::locale::classic());
         conversion >> result;
-        // The three ways a literal leaves the representable range, which the
-        // standard libraries disagree about: a failbit, an infinity, and a
-        // silent zero for an underflowing exponent ("1e-9999"). Rejecting all
-        // three keeps the same source an error everywhere.
-        if (conversion.fail() || !std::isfinite(result)
-            || (result == 0.0 && hasNonzeroSignificand(text))) {
+        // The three ways a nonzero significand leaves the representable range,
+        // which the libraries also disagree about: a failbit, an infinity, and
+        // a silent zero from an underflowing exponent. Rejecting all three
+        // keeps the same source an error everywhere.
+        if (conversion.fail() || !std::isfinite(result) || result == 0.0) {
             throw ExpressionError("numeric literal is out of range", offset);
         }
         if (!conversion.eof()) {
@@ -303,17 +344,27 @@ public:
     }
 
 private:
-    // Bounds both recursive descents below on the one counter: parenthesis and
-    // call nesting through parseExpression, and sign chains ("---x") through
-    // parseUnary. Without it a deep enough source overflows the C++ stack.
+    // Bounds every recursive descent below on the one counter: parenthesis and
+    // call nesting through parseExpression, sign chains ("---x") through
+    // parseUnary, and power chains ("a**a**a") through parsePower. Without it
+    // a deep enough source overflows the C++ stack. Each construct costs
+    // exactly one level, so the limit means the same thing whichever of the
+    // three does the nesting.
     class DepthGuard {
     public:
         explicit DepthGuard(Parser& parser)
             : m_parser(parser)
         {
-            if (++m_parser.m_depth > maximumExpressionDepth) {
+            // Checked before the increment, not after: a constructor that
+            // throws does not run its own destructor, so incrementing first
+            // would leave the counter permanently high -- invisible today,
+            // because the throw always leaves compile() and the parser is
+            // single-use, but a trap for anyone who later catches inside the
+            // parse to collect more than one diagnostic.
+            if (m_parser.m_depth >= maximumExpressionDepth) {
                 m_parser.fail("expression nests too deeply");
             }
+            ++m_parser.m_depth;
         }
         DepthGuard(const DepthGuard&) = delete;
         DepthGuard& operator=(const DepthGuard&) = delete;
@@ -409,6 +460,15 @@ private:
     {
         parsePrimary();
         if (m_current.kind == TokenKind::Power) {
+            // The third recursion the depth limit has to bound, and the one
+            // that is easiest to miss: the right operand of ** is a unary, so
+            // "a**a**a..." descends once per operator without passing through
+            // a parenthesis or a sign. Unguarded it overflowed the C++ stack
+            // on a thread with a small stack (a 1000-term chain, well inside
+            // the byte limit, faulted on 128 KiB) and drove the compiled
+            // stack depth -- and so the batch evaluator's slot buffer -- up
+            // with the chain's length.
+            const DepthGuard guard(*this);
             advance();
             parseUnary();
             emit(Opcode::Pow);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,6 +18,13 @@ function(amrexplorer_add_fuzz_target target)
     endif()
 endfunction()
 
+add_executable(test_expression unit/test_expression.cpp)
+target_link_libraries(
+    test_expression PRIVATE amrexplorer::expression amrexplorer::warnings
+    Threads::Threads
+)
+add_test(NAME expression COMMAND test_expression)
+
 add_executable(test_core_metadata unit/test_core_metadata.cpp)
 target_link_libraries(test_core_metadata PRIVATE amrexplorer::core amrexplorer::warnings)
 add_test(NAME core_metadata COMMAND test_core_metadata)
@@ -1850,3 +1857,14 @@ target_include_directories(fuzz_header_parsing PRIVATE
 target_link_libraries(
     fuzz_header_parsing PRIVATE amrexplorer::io amrexplorer::warnings)
 amrexplorer_add_fuzz_target(fuzz_header_parsing)
+
+# Fuzz/property harness for the expression parser. Expression text is typed by
+# hand but also imported from files, so it gets the same treatment as the other
+# untrusted-input parsers. Deterministic + bounded; see the file header for
+# libFuzzer use.
+add_executable(fuzz_expression fuzz/fuzz_expression.cpp)
+target_include_directories(fuzz_expression PRIVATE
+    "${CMAKE_CURRENT_SOURCE_DIR}/fuzz")
+target_link_libraries(
+    fuzz_expression PRIVATE amrexplorer::expression amrexplorer::warnings)
+amrexplorer_add_fuzz_target(fuzz_expression)

--- a/tests/fuzz/fuzz_expression.cpp
+++ b/tests/fuzz/fuzz_expression.cpp
@@ -1,0 +1,192 @@
+// Property/fuzz harness for the expression parser. Contract: compile() of
+// arbitrary or near-valid text either returns a program or throws
+// ExpressionError -- never another exception type (a std::logic_error would
+// mean the compiler emitted a program its own stack check rejects), never a
+// crash, and never unbounded recursion; and an accepted program evaluates
+// without throwing, with the batch path agreeing with the scalar path bit for
+// bit. Expression text is typed by hand but also imported from files, which
+// is what puts it on this side of the trust boundary. Deterministic and
+// bounded so it runs as a normal ctest; configure with
+// -DAMREXPLORER_LIBFUZZER=ON (Clang), together with
+// AMREXPLORER_ENABLE_SANITIZERS=ON so the fuzzer sees UB/OOB and not only
+// hard crashes, to build it instead as a coverage-guided libFuzzer driver.
+#include "fuzz_util.hpp"
+
+#include <amrexplorer/expression/Expression.hpp>
+
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <exception>
+#include <span>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace {
+
+using amrvis::fuzz::fail;
+
+// How many inputs got past compile() and were actually evaluated. Random bytes
+// practically never compile, so without this the whole evaluation half of the
+// contract could stop being exercised -- by a mutation set that never produces
+// a valid expression, or by a parser change -- and the harness would still
+// report success.
+long accepted = 0;
+
+bool sameValue(double left, double right)
+{
+    return left == right || (std::isnan(left) && std::isnan(right));
+}
+
+void exerciseExpression(std::string_view source)
+{
+    amrvis::CompiledExpression compiled = [&source] {
+        try {
+            return amrvis::CompiledExpression::compile(source);
+        } catch (const amrvis::ExpressionError&) {
+            // The one rejection the parser promises.
+            throw;
+        } catch (const std::exception& error) {
+            std::fprintf(stderr, "fuzz: unexpected exception: %s\n",
+                error.what());
+            fail("compile threw something other than ExpressionError");
+        } catch (...) {
+            fail("compile threw a non-std::exception");
+        }
+    }();
+
+    const auto symbols = compiled.symbols();
+    // Values chosen to reach the domain edges of the functions the grammar
+    // offers: a negative (log, sqrt), a zero (division, log), and a large
+    // magnitude (exp, pow). More points than the batch path's chunk holds, so
+    // the batch/scalar agreement below is checked across a chunk seam and not
+    // only within one pass.
+    static constexpr std::array<double, 5> pattern{
+        1.5, -2.0, 0.0, 1.0e300, -0.25};
+    static constexpr std::size_t points = 520;
+    std::vector<std::vector<double>> columns(symbols.size());
+    for (std::size_t symbol = 0; symbol < symbols.size(); ++symbol) {
+        columns[symbol].reserve(points);
+        for (std::size_t point = 0; point < points; ++point) {
+            columns[symbol].push_back(
+                pattern[(symbol + point) % pattern.size()]);
+        }
+    }
+    ++accepted;
+    std::vector<std::span<const double>> views;
+    views.reserve(columns.size());
+    for (const auto& column : columns) {
+        views.emplace_back(column);
+    }
+
+    try {
+        std::vector<double> batch(points, 0.0);
+        auto batchEvaluator = compiled.makeEvaluator();
+        batchEvaluator.evaluate(views, batch);
+
+        auto scalarEvaluator = compiled.makeEvaluator();
+        std::vector<double> point(columns.size(), 0.0);
+        for (std::size_t index = 0; index < points; ++index) {
+            for (std::size_t symbol = 0; symbol < columns.size(); ++symbol) {
+                point[symbol] = columns[symbol][index];
+            }
+            if (!sameValue(scalarEvaluator.evaluate(point), batch[index])) {
+                fail("batch evaluation disagrees with scalar evaluation");
+            }
+        }
+    } catch (const std::exception& error) {
+        std::fprintf(stderr, "fuzz: unexpected exception: %s\n", error.what());
+        fail("evaluating an accepted expression threw");
+    } catch (...) {
+        fail("evaluating an accepted expression threw a non-std::exception");
+    }
+}
+
+// Swallows the promised rejection so the callers below can feed anything.
+void exercise(std::string_view source)
+{
+    try {
+        exerciseExpression(source);
+    } catch (const amrvis::ExpressionError&) {
+    }
+}
+
+const std::vector<std::string>& expressionSeeds()
+{
+    static const std::vector<std::string> seeds{
+        "density",
+        "sqrt(u**2 + v**2)",
+        "pressure/density - 1.0",
+        "log10(abs(${x-momentum}))",
+        "pow(${Y(H2)}, 2) + exp10(-3)",
+        "-2**-3.5e2",
+        "abs(x)/(y*z) + exp(log(1.5))",
+        "${a}+${b}*(${c}-${d})/2",
+    };
+    return seeds;
+}
+
+} // namespace
+
+#if defined(AMREXPLORER_LIBFUZZER)
+extern "C" int LLVMFuzzerTestOneInput(const std::uint8_t* data, std::size_t size)
+{
+    amrvis::fuzz::setCurrentInput(0, data, size);
+    exercise(size == 0
+            ? std::string_view{}
+            : std::string_view(reinterpret_cast<const char*>(data), size));
+    return 0;
+}
+#else
+int main()
+{
+    constexpr int iterations = 40000;
+    std::uint64_t rng = 0x51ed'270b'7dea'0b6dULL;
+    const auto& seeds = expressionSeeds();
+    long iteration = 0;
+
+    // The two ceilings, at and just past their constants: a source that long,
+    // and nesting that deep. Random text never reaches either, and each is
+    // what stands between an imported file and an overflowed C++ stack.
+    for (const std::size_t n : {amrvis::maximumExpressionBytes - 1,
+             amrvis::maximumExpressionBytes,
+             amrvis::maximumExpressionBytes + 1}) {
+        const std::string text(n, '1');
+        amrvis::fuzz::setCurrentInput(iteration++, text.data(), text.size());
+        exercise(text);
+    }
+    for (const std::size_t n : {amrvis::maximumExpressionDepth - 1,
+             amrvis::maximumExpressionDepth,
+             amrvis::maximumExpressionDepth + 1,
+             amrvis::maximumExpressionBytes / 2}) {
+        for (const std::string& text :
+            {std::string(n, '(') + "1" + std::string(n, ')'),
+                std::string(n, '-') + "1",
+                std::string(n, '(') + "1"}) {
+            amrvis::fuzz::setCurrentInput(
+                iteration++, text.data(), text.size());
+            exercise(text);
+        }
+    }
+
+    for (int i = 0; i < iterations; ++i) {
+        const auto bytes = amrvis::fuzz::randomBytes(rng, 96);
+        amrvis::fuzz::setCurrentInput(iteration++, bytes.data(), bytes.size());
+        exercise(amrvis::fuzz::viewOf(bytes));
+        const auto mutated = amrvis::fuzz::mutateText(
+            rng, seeds[amrvis::fuzz::nextRandom(rng) % seeds.size()]);
+        amrvis::fuzz::setCurrentInput(
+            iteration++, mutated.data(), mutated.size());
+        exercise(mutated);
+    }
+    if (accepted < iterations / 100) {
+        fail("too few inputs compiled: the evaluation contract went untested");
+    }
+    std::printf("fuzz_expression: %d iterations, %ld compiled, no crash\n",
+        iterations, accepted);
+    return 0;
+}
+#endif

--- a/tests/fuzz/fuzz_expression.cpp
+++ b/tests/fuzz/fuzz_expression.cpp
@@ -114,6 +114,29 @@ void exercise(std::string_view source)
     }
 }
 
+// A valid expression of exactly `bytes` bytes, so the length ceiling is probed
+// with something that would be *accepted* but for its length. A run of digits
+// is not: it is one enormous numeric literal, rejected as out of range however
+// short it is, which makes the just-inside probe say nothing.
+std::string additiveChain(std::size_t bytes)
+{
+    std::string source = bytes % 2 == 0 ? "11" : "1";
+    while (source.size() < bytes) {
+        source += "+1";
+    }
+    return source;
+}
+
+// "1**1**...", the recursion that a parenthesis or sign chain does not reach.
+std::string powerChain(std::size_t operators)
+{
+    std::string source = "1";
+    for (std::size_t index = 0; index < operators; ++index) {
+        source += "**1";
+    }
+    return source;
+}
+
 const std::vector<std::string>& expressionSeeds()
 {
     static const std::vector<std::string> seeds{
@@ -154,18 +177,24 @@ int main()
     for (const std::size_t n : {amrvis::maximumExpressionBytes - 1,
              amrvis::maximumExpressionBytes,
              amrvis::maximumExpressionBytes + 1}) {
-        const std::string text(n, '1');
-        amrvis::fuzz::setCurrentInput(iteration++, text.data(), text.size());
-        exercise(text);
+        for (const std::string& text : {additiveChain(n), std::string(n, '1')}) {
+            amrvis::fuzz::setCurrentInput(
+                iteration++, text.data(), text.size());
+            exercise(text);
+        }
     }
     for (const std::size_t n : {amrvis::maximumExpressionDepth - 1,
              amrvis::maximumExpressionDepth,
              amrvis::maximumExpressionDepth + 1,
-             amrvis::maximumExpressionBytes / 2}) {
+             amrvis::maximumExpressionBytes / 4}) {
+        // All three recursions, at and around the bound. The power chain is
+        // here because it was the one the bound did not cover, and a chain long
+        // enough to matter is well inside the byte limit.
         for (const std::string& text :
             {std::string(n, '(') + "1" + std::string(n, ')'),
                 std::string(n, '-') + "1",
-                std::string(n, '(') + "1"}) {
+                std::string(n, '(') + "1",
+                powerChain(n)}) {
             amrvis::fuzz::setCurrentInput(
                 iteration++, text.data(), text.size());
             exercise(text);

--- a/tests/unit/test_expression.cpp
+++ b/tests/unit/test_expression.cpp
@@ -110,6 +110,29 @@ void requireBatchMatchesScalar(
     }
 }
 
+// A power chain of `operators` operators: "1**1**...". Right-associative and
+// all ones, so the value is 1 however deep it goes.
+std::string powerChain(std::size_t operators)
+{
+    std::string source = "1";
+    for (std::size_t index = 0; index < operators; ++index) {
+        source += "**1";
+    }
+    return source;
+}
+
+// A valid expression of exactly `bytes` bytes. Additive, because parseAdditive
+// iterates rather than recursing, so length can be probed without also hitting
+// the depth limit. Its value is the number of terms plus ten.
+std::string additiveChain(std::size_t bytes)
+{
+    std::string source = bytes % 2 == 0 ? "11" : "1";
+    while (source.size() < bytes) {
+        source += "+1";
+    }
+    return source;
+}
+
 std::vector<double> ramp(std::size_t count, double first, double step)
 {
     std::vector<double> values;
@@ -267,6 +290,12 @@ int main()
         requireError("1\n+2", 1, "newlines are not allowed");
         requireError("1\r+2", 1, "newlines are not allowed");
         requireError("2^3", 1, "unexpected token");
+        // A byte that is not a character is quoted as hex, never spliced into
+        // the message: the message is UTF-8 by the time a label shows it, and
+        // one byte of a pasted U+2212 minus is not valid UTF-8 on its own.
+        requireError("a \xe2\x88\x92 b", 2, "unexpected token '\\xe2'");
+        requireError("a\x0b+b", 1, "unexpected token '\\x0b'");
+        requireError(std::string("a\0+b", 4), 1, "unexpected token '\\x00'");
         requireError("x=1", 1, "unexpected token");
         requireError("1;2", 1, "unexpected token");
         requireError("sin(1)", 0, "unknown function");
@@ -278,6 +307,11 @@ int main()
         requireError("1e-9999", 0, "out of range");
         requireError(".1e-9999", 0, "out of range");
         requireError("$density", 0, "expected '{'");
+        // A brace inside the name is refused rather than taken as part of it,
+        // which is what the documented grammar says and what turns a mistyped
+        // "${a${b}}" into a syntax error instead of a symbol named "a${b".
+        requireError("${a{b}", 0, "not allowed in a '${...}' name");
+        requireError("${a${b}}", 0, "not allowed in a '${...}' name");
         requireError("1 + ${", 4, "unterminated");
         requireError("1 + ${density", 4, "unterminated");
         requireError("${}", 0, "names no field");
@@ -293,6 +327,13 @@ int main()
                 "nests too deeply");
             requireErrorMessage(
                 std::string(depth, '-') + "1", "nests too deeply");
+            // Power chains are the third recursion, and the one that went
+            // unbounded: the right operand of ** is a unary, so a chain
+            // descends once per operator without a parenthesis or a sign in
+            // sight. Both sides of the bound, as for the other two.
+            requireErrorMessage(powerChain(depth), "nests too deeply");
+            require(close(evaluate(powerChain(depth - 1)), 1.0),
+                "a power chain within the depth limit was rejected");
             // One parenthesis short of the limit still compiles, so the limit
             // bounds the recursion rather than the whole grammar.
             const auto allowed = std::string(depth - 1, '(') + "2"
@@ -304,9 +345,18 @@ int main()
                 "a sign chain within the depth limit was rejected");
         }
         {
-            const auto tooLong =
-                std::string(amrvis::maximumExpressionBytes + 1, '1');
-            requireError(tooLong, amrvis::maximumExpressionBytes, "exceeds");
+            const auto limit = amrvis::maximumExpressionBytes;
+            const auto tooLong = std::string(limit + 1, '1');
+            requireError(tooLong, limit, "exceeds");
+            // And the accepted side of the same bound. Without it the length
+            // check can be off by one -- ">" for ">=" -- with nothing to
+            // notice: every other length case here is a rejection.
+            const auto atLimit = additiveChain(limit);
+            require(atLimit.size() == limit, "the length fixture is the wrong "
+                                             "size");
+            require(close(evaluate(atLimit),
+                        10.0 + static_cast<double>(limit / 2)),
+                "an expression of exactly the maximum length was rejected");
         }
 
         std::cout << "expression parser tests passed\n";

--- a/tests/unit/test_expression.cpp
+++ b/tests/unit/test_expression.cpp
@@ -82,6 +82,13 @@ void requireBatchMatchesScalar(
         "test supplied the wrong column count for '" + std::string(source)
             + "'");
     const auto points = columns.empty() ? std::size_t{0} : columns[0].size();
+    // Or it would run the batch evaluator over a zero-length output, skip the
+    // comparison loop and report success having compared nothing. The
+    // constant-program case is covered by its own block below, deliberately,
+    // because this helper cannot express it.
+    require(!columns.empty() && points > 0,
+        "requireBatchMatchesScalar was given nothing to compare for '"
+            + std::string(source) + "'");
 
     std::vector<std::span<const double>> views;
     views.reserve(columns.size());
@@ -306,6 +313,18 @@ int main()
         requireError("1e9999", 0, "out of range");
         requireError("1e-9999", 0, "out of range");
         requireError(".1e-9999", 0, "out of range");
+        // The accepted edge of the range, which is where the libraries
+        // disagree: a denormal is finite and nonzero, so it is a number, and
+        // only a rule that consults the library's error flag calls it out of
+        // range (strtod raises ERANGE for one). Exact comparisons: the same
+        // digits, converted by the same correctly-rounded conversion.
+        require(evaluate("1e-310") == 1e-310, "a denormal literal was rejected");
+        require(evaluate("4.9e-324") == 4.9e-324
+                && evaluate("4.9e-324") > 0.0,
+            "the smallest denormal was rejected");
+        // ...and the other end of the zero-significand shortcut.
+        require(evaluate("0e9999") == 0.0,
+            "a zero significand with a huge exponent was rejected");
         requireError("$density", 0, "expected '{'");
         // A brace inside the name is refused rather than taken as part of it,
         // which is what the documented grammar says and what turns a mistyped
@@ -315,8 +334,13 @@ int main()
         requireError("1 + ${", 4, "unterminated");
         requireError("1 + ${density", 4, "unterminated");
         requireError("${}", 0, "names no field");
-        requireError("${a\nb}", 3, "newlines are not allowed");
-        requireError("${a}${b}", 4, "unexpected token");
+        // At the '$', like every other failure inside a braced name -- the
+        // offset names the token, not the byte the scan happened to stop on.
+        requireError("${a\nb}", 0, "newlines are not allowed");
+        // A token's own text is escaped as well: a ${...} name is verbatim, so
+        // it can carry bytes that are not characters.
+        requireError("${a}${b}", 4, "unexpected token 'b'");
+        requireError("${a}${\xe2}", 4, "unexpected token '\\xe2'");
 
         // Deep nesting is bounded rather than left to the C++ stack: both the
         // parenthesis descent and a sign chain.

--- a/tests/unit/test_expression.cpp
+++ b/tests/unit/test_expression.cpp
@@ -1,0 +1,318 @@
+#include <amrexplorer/expression/Expression.hpp>
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstdlib>
+#include <future>
+#include <iostream>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace {
+
+void require(bool condition, const std::string& message)
+{
+    if (!condition) {
+        throw std::runtime_error(message);
+    }
+}
+
+bool close(double left, double right)
+{
+    const auto scale = std::max({1.0, std::abs(left), std::abs(right)});
+    return std::abs(left - right) <= 1.0e-12 * scale;
+}
+
+double evaluate(
+    std::string_view source, std::span<const double> variables = {})
+{
+    auto compiled = amrvis::CompiledExpression::compile(source);
+    auto evaluator = compiled.makeEvaluator();
+    return evaluator.evaluate(variables);
+}
+
+void requireError(
+    std::string_view source, std::size_t offset, std::string_view message)
+{
+    try {
+        [[maybe_unused]] const auto compiled =
+            amrvis::CompiledExpression::compile(source);
+    } catch (const amrvis::ExpressionError& error) {
+        require(error.offset() == offset,
+            "wrong error offset for '" + std::string(source) + "': "
+                + std::to_string(error.offset()));
+        require(std::string_view(error.what()).find(message)
+                != std::string_view::npos,
+            "wrong error message for '" + std::string(source) + "': "
+                + error.what());
+        return;
+    }
+    throw std::runtime_error(
+        "expression was unexpectedly accepted: " + std::string(source));
+}
+
+// A rejection whose offset is not part of the contract: the depth and length
+// limits are about what the parser refuses, not where.
+void requireErrorMessage(std::string_view source, std::string_view message)
+{
+    try {
+        [[maybe_unused]] const auto compiled =
+            amrvis::CompiledExpression::compile(source);
+    } catch (const amrvis::ExpressionError& error) {
+        require(std::string_view(error.what()).find(message)
+                != std::string_view::npos,
+            std::string("wrong error message: ") + error.what());
+        return;
+    }
+    throw std::runtime_error("expression was unexpectedly accepted");
+}
+
+// The batch evaluator must agree with the scalar one point for point; this is
+// the only thing that makes the chunked stack slots interchangeable with the
+// scalar stack.
+void requireBatchMatchesScalar(
+    std::string_view source, const std::vector<std::vector<double>>& columns)
+{
+    const auto compiled = amrvis::CompiledExpression::compile(source);
+    require(compiled.symbols().size() == columns.size(),
+        "test supplied the wrong column count for '" + std::string(source)
+            + "'");
+    const auto points = columns.empty() ? std::size_t{0} : columns[0].size();
+
+    std::vector<std::span<const double>> views;
+    views.reserve(columns.size());
+    for (const auto& column : columns) {
+        require(column.size() == points, "test columns differ in length");
+        views.emplace_back(column);
+    }
+    std::vector<double> batch(points, 0.0);
+    auto batchEvaluator = compiled.makeEvaluator();
+    batchEvaluator.evaluate(views, batch);
+
+    auto scalarEvaluator = compiled.makeEvaluator();
+    std::vector<double> point(columns.size(), 0.0);
+    for (std::size_t index = 0; index < points; ++index) {
+        for (std::size_t column = 0; column < columns.size(); ++column) {
+            point[column] = columns[column][index];
+        }
+        const auto expected = scalarEvaluator.evaluate(point);
+        const auto actual = batch[index];
+        const auto agree = close(expected, actual)
+            || (std::isnan(expected) && std::isnan(actual))
+            || expected == actual;
+        require(agree,
+            "batch and scalar evaluation differ for '" + std::string(source)
+                + "' at point " + std::to_string(index));
+    }
+}
+
+std::vector<double> ramp(std::size_t count, double first, double step)
+{
+    std::vector<double> values;
+    values.reserve(count);
+    for (std::size_t index = 0; index < count; ++index) {
+        values.push_back(first + step * static_cast<double>(index));
+    }
+    return values;
+}
+
+} // namespace
+
+int main()
+{
+    try {
+        require(close(evaluate("1"), 1.0), "integer literal failed");
+        require(close(evaluate("1."), 1.0), "trailing decimal failed");
+        require(close(evaluate(".5"), 0.5), "leading decimal failed");
+        require(close(evaluate("2.5E-3"), 0.0025), "exponent literal failed");
+        require(close(evaluate("0e-9999"), 0.0),
+            "zero with extreme exponent failed");
+        require(close(evaluate(" 1 + 2 * 3 \t"), 7.0), "precedence failed");
+        require(close(evaluate("8 / 2 - 1"), 3.0),
+            "division or subtraction failed");
+        require(close(evaluate("(1 + 2) * 3"), 9.0), "parentheses failed");
+        require(close(evaluate("+3 + -2"), 1.0), "unary signs failed");
+        require(close(evaluate("2**3**2"), 512.0),
+            "power is not right-associative");
+        require(close(evaluate("2**-2"), 0.25), "signed exponent failed");
+        require(close(evaluate("-2**2"), -4.0),
+            "power did not bind more tightly than unary minus");
+        require(close(evaluate("2**3"), evaluate("pow(2,3)")),
+            "power syntaxes differ");
+
+        require(close(evaluate("abs(2.0)"), 2.0),
+            "abs changed a positive value");
+        require(close(evaluate("abs(-2.0)"), 2.0),
+            "abs failed for a negative value");
+        require(close(evaluate("sqrt(9)"), 3.0), "sqrt failed");
+        require(close(evaluate("exp(1)"), std::exp(1.0)), "exp failed");
+        require(close(evaluate("log(exp(2))"), 2.0), "log failed");
+        require(close(evaluate("exp10(3)"), 1000.0), "exp10 failed");
+        require(close(evaluate("log10(1000)"), 3.0), "log10 failed");
+
+        const auto absolute =
+            amrvis::CompiledExpression::compile("abs(x)");
+        auto absoluteEvaluator = absolute.makeEvaluator();
+        const std::array negativeValue{-4.5};
+        require(close(absoluteEvaluator.evaluate(negativeValue), 4.5),
+            "abs of a variable failed");
+
+        const auto expression =
+            amrvis::CompiledExpression::compile("z + x*z + log");
+        const auto symbols = expression.symbols();
+        require(symbols.size() == 3 && symbols[0] == "z"
+                && symbols[1] == "x" && symbols[2] == "log",
+            "symbols are not ordered by first appearance");
+        auto evaluator = expression.makeEvaluator();
+        const std::array variables{2.0, 3.0, 4.0};
+        require(close(evaluator.evaluate(variables), 12.0),
+            "variable evaluation failed");
+
+        // ${...} names a symbol a bare identifier cannot spell, verbatim, and
+        // is never read as a function call.
+        {
+            const auto braced = amrvis::CompiledExpression::compile(
+                "sqrt(${x-momentum}**2 + ${Y(H2)}**2)");
+            const auto names = braced.symbols();
+            require(names.size() == 2 && names[0] == "x-momentum"
+                    && names[1] == "Y(H2)",
+                "braced symbols were not taken verbatim");
+            auto bracedEvaluator = braced.makeEvaluator();
+            const std::array components{3.0, 4.0};
+            require(close(bracedEvaluator.evaluate(components), 5.0),
+                "braced symbol evaluation failed");
+        }
+        {
+            // The same name braced and bare is the same symbol, and a name
+            // with a space or a leading digit is reachable only braced.
+            const auto mixed = amrvis::CompiledExpression::compile(
+                "density + ${density} + ${2nd moment} + ${ x }");
+            const auto names = mixed.symbols();
+            require(names.size() == 3 && names[0] == "density"
+                    && names[1] == "2nd moment" && names[2] == " x ",
+                "braced and bare spellings did not share one symbol");
+        }
+
+        // Non-finite results are values, not errors: the display layer already
+        // treats them as invalid samples.
+        require(std::isnan(evaluate("log(0-1)")), "log of a negative was not NaN");
+        require(std::isinf(evaluate("1/(1-1)")), "division by zero was not inf");
+        require(std::isnan(evaluate("(1-1)/(1-1)")), "0/0 was not NaN");
+
+        bool wrongCountRejected = false;
+        try {
+            [[maybe_unused]] const auto ignored =
+                evaluator.evaluate(std::span<const double>{});
+        } catch (const std::invalid_argument&) {
+            wrongCountRejected = true;
+        }
+        require(wrongCountRejected, "wrong variable count was accepted");
+
+        // The batch path: more points than one chunk holds, so the chunk seam
+        // is exercised, plus a constant-only and a single-symbol program.
+        requireBatchMatchesScalar("2*a + b/a - sqrt(abs(b))",
+            {ramp(1300, -3.0, 0.5), ramp(1300, 7.0, -0.25)});
+        requireBatchMatchesScalar("log10(${x-momentum}) + 3**2",
+            {ramp(700, -2.0, 1.0)});
+        requireBatchMatchesScalar("density", {ramp(5, 1.0, 1.0)});
+        {
+            const auto constant = amrvis::CompiledExpression::compile("1+2");
+            auto constantEvaluator = constant.makeEvaluator();
+            std::vector<double> out(3, 0.0);
+            constantEvaluator.evaluate({}, out);
+            require(close(out[0], 3.0) && close(out[2], 3.0),
+                "constant batch evaluation failed");
+            // An empty output is a no-op, not an error.
+            constantEvaluator.evaluate({}, std::span<double>{});
+        }
+        {
+            const auto program = amrvis::CompiledExpression::compile("a+b");
+            auto batchEvaluator = program.makeEvaluator();
+            const std::array<double, 2> first{1.0, 2.0};
+            const std::array<double, 3> second{1.0, 2.0, 3.0};
+            std::vector<double> out(3, 0.0);
+            bool raggedRejected = false;
+            try {
+                const std::array<std::span<const double>, 2> columns{
+                    std::span<const double>{first},
+                    std::span<const double>{second}};
+                batchEvaluator.evaluate(columns, out);
+            } catch (const std::invalid_argument&) {
+                raggedRejected = true;
+            }
+            require(raggedRejected, "ragged batch columns were accepted");
+        }
+
+        std::vector<std::future<double>> results;
+        for (int index = 0; index < 16; ++index) {
+            results.push_back(std::async(
+                std::launch::async, [&expression, index] {
+                    auto local = expression.makeEvaluator();
+                    const std::array values{
+                        static_cast<double>(index), 2.0, 1.0};
+                    return local.evaluate(values);
+                }));
+        }
+        for (int index = 0; index < 16; ++index) {
+            require(close(results[static_cast<std::size_t>(index)].get(),
+                        3.0 * static_cast<double>(index) + 1.0),
+                "concurrent evaluation failed");
+        }
+
+        requireError("", 0, "expected expression");
+        requireError("1\n+2", 1, "newlines are not allowed");
+        requireError("1\r+2", 1, "newlines are not allowed");
+        requireError("2^3", 1, "unexpected token");
+        requireError("x=1", 1, "unexpected token");
+        requireError("1;2", 1, "unexpected token");
+        requireError("sin(1)", 0, "unknown function");
+        requireError("pow(1)", 5, "expected ','");
+        requireError("pow(1,2,3)", 7, "expected ')'");
+        requireError("2(3)", 1, "unexpected token");
+        requireError("1e+", 3, "invalid numeric exponent");
+        requireError("1e9999", 0, "out of range");
+        requireError("1e-9999", 0, "out of range");
+        requireError(".1e-9999", 0, "out of range");
+        requireError("$density", 0, "expected '{'");
+        requireError("1 + ${", 4, "unterminated");
+        requireError("1 + ${density", 4, "unterminated");
+        requireError("${}", 0, "names no field");
+        requireError("${a\nb}", 3, "newlines are not allowed");
+        requireError("${a}${b}", 4, "unexpected token");
+
+        // Deep nesting is bounded rather than left to the C++ stack: both the
+        // parenthesis descent and a sign chain.
+        {
+            const auto depth = amrvis::maximumExpressionDepth;
+            requireErrorMessage(
+                std::string(depth, '(') + "1" + std::string(depth, ')'),
+                "nests too deeply");
+            requireErrorMessage(
+                std::string(depth, '-') + "1", "nests too deeply");
+            // One parenthesis short of the limit still compiles, so the limit
+            // bounds the recursion rather than the whole grammar.
+            const auto allowed = std::string(depth - 1, '(') + "2"
+                + std::string(depth - 1, ')');
+            require(close(evaluate(allowed), 2.0),
+                "an expression within the depth limit was rejected");
+            require(close(evaluate(std::string(depth - 1, '-') + "1"),
+                        (depth - 1) % 2 == 0 ? 1.0 : -1.0),
+                "a sign chain within the depth limit was rejected");
+        }
+        {
+            const auto tooLong =
+                std::string(amrvis::maximumExpressionBytes + 1, '1');
+            requireError(tooLong, amrvis::maximumExpressionBytes, "exceeds");
+        }
+
+        std::cout << "expression parser tests passed\n";
+        return EXIT_SUCCESS;
+    } catch (const std::exception& error) {
+        std::cerr << "test_expression failed: " << error.what() << '\n';
+        return EXIT_FAILURE;
+    }
+}


### PR DESCRIPTION
The front end for derived fields: a recursive-descent parse of one line of algebra into a flat instruction list, evaluated by a small stack machine. Compiled once, shared between threads, evaluated through per-thread evaluators.

Symbols are bare identifiers or ${name} for a name a bare identifier cannot spell -- "x-momentum", "Y(H2)" -- taken verbatim, which is what keeps a field name out of the operator alphabet without rewriting the source and mapping error offsets back through it.

Bounded before it recurses: 4096 bytes and 64 levels of nesting. Expressions are typed by hand but also imported from files, and "((((..." nested deeply enough is otherwise a stack overflow. A numeric literal out of range is an error whichever way the standard library reports it, so "1e-9999" does not silently become zero on one platform and fail on another.

Evaluation comes two ways: one point, and many through chunk-wide passes over the stack slots, which is what a whole block of samples wants without block-sized temporaries.