### PR TITLE
compute fields from expressions over the ones a plotfile stores

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -22,11 +22,13 @@ whole compute path can run — and be tested — headless.
   io            core         SessionValidation, ...)   render3d: VolumeRaycaster (data links it:
    |             |             |             |                    a session samples and renders)
   core         cache         core          remote      query:   SliceQuery, LineQuery, VolumeQuery
-                                                        io:      plotfile readers, FitsWriter
-                                                        core:    Geometry, Metadata, Request, Result,
-                                                                 Volume, OrthoProjection
+   |                          |                         io:      plotfile readers, FitsWriter
+expression               expression                     core:    Geometry, Metadata, Request, Result,
+                                                                 Volume, OrthoProjection, DerivedField
                                                         cache:   ByteLruCache
                                                         remote:  Frame/Channel, Codec, Connection, Server
+                                                        expression: the algebraic expressions behind
+                                                                 derived fields; depends on nothing
 ```
 
 The guiding split: **the GUI orchestrates, the pipeline computes.** `MainWindow`
@@ -142,6 +144,7 @@ either should preserve its invariants.
 | A slice request end to end | `src/pipeline/SlicePipeline.cpp` → `src/query/SliceQuery.cpp` |
 | A volume frame end to end | `src/pipeline/VolumePipeline.cpp` → `src/data/LocalDatasetSession.cpp` (`renderVolume`) → `src/query/VolumeQuery.cpp` → `src/render3d/VolumeRaycaster.cpp`; the camera math both the view and the caster use is `include/amrexplorer/core/OrthoProjection.hpp` |
 | Plotfile reading / hardening | `src/io/plotfile/`, `include/amrexplorer/io/detail/FabHeaderParsing.hpp` |
+| A derived field end to end | `include/amrexplorer/core/DerivedField.hpp` (resolve a definition against a dataset) → `src/io/plotfile/PlotfileDataset.cpp` (`readDerivedBlock`) → `src/expression/Expression.cpp`. Installed when the dataset is opened, so above `PlotfileDataset` a derived field is an ordinary `FieldId` |
 | The remote protocol | `src/remote/Codec.hpp`, `Frame.cpp` (Channel/Socket), `Server.cpp`, `Connection.cpp` |
 | Response validation | `src/data/SessionValidation.cpp` |
 | The GUI ↔ worker handoff | `src/qt/MainWindowSlice.cpp` (request/arrival), `SequenceController` |

--- a/include/amrexplorer/core/DerivedField.hpp
+++ b/include/amrexplorer/core/DerivedField.hpp
@@ -96,9 +96,20 @@ private:
     std::optional<std::size_t> m_sourceOffset;
 };
 
-// Symbols one derived field may read. The cap bounds how many blocks
-// evaluating one derived block has to hold pinned at once.
+// Fields one derived field may read. The cap bounds how many blocks evaluating
+// one derived block has to hold pinned at once, so it counts fields alone --
+// a coordinate is computed, not read, and pins nothing.
 inline constexpr std::size_t maximumDerivedFieldInputs = 16;
+
+// How long a chain of derived fields may depend on one another: a definition
+// reading a definition reading a definition. Evaluating a derived block
+// recurses once per link (PlotfileDataset::readDerivedBlock requests its
+// inputs, which may themselves be derived), and a definition list is as long
+// as its author cares to make it -- an imported one especially -- so without a
+// bound a long enough chain overflows the C++ stack of whichever worker
+// evaluates it. Bounded here, at installation, because that is where the chain
+// is known and where saying so can name the definition.
+inline constexpr std::size_t maximumDerivedFieldDepth = 16;
 
 // Appends one FieldMetadata per installed definition to metadata.fields, in
 // order, and returns the programs that produce them. Definitions are resolved

--- a/include/amrexplorer/core/DerivedField.hpp
+++ b/include/amrexplorer/core/DerivedField.hpp
@@ -1,0 +1,124 @@
+#pragma once
+
+#include <amrexplorer/core/Metadata.hpp>
+#include <amrexplorer/core/Request.hpp>
+#include <amrexplorer/expression/Expression.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+// Fields the viewer computes rather than reads: a name and an algebraic
+// expression over the fields a dataset does store (expression/Expression.hpp
+// for the grammar). Resolving a definition against a dataset turns its symbols
+// into field ids and coordinate axes and appends a FieldMetadata for it, after
+// which it is an ordinary field to everything above -- one FieldId that the
+// slice, line, page, volume and range paths all treat like any other.
+
+namespace amrvis {
+
+// What the user typed. This is also what a settings file or an exported
+// expression list carries, so it stays plain data.
+struct DerivedFieldDefinition {
+    std::string name;
+    std::string expression;
+
+    friend bool operator==(
+        const DerivedFieldDefinition&, const DerivedFieldDefinition&) = default;
+};
+
+// Where one symbol of a resolved expression takes its value from: a field of
+// the dataset, or a coordinate axis.
+struct DerivedFieldInput {
+    // The field to read, when axis is negative.
+    FieldId field;
+    // 0, 1, 2 for the x, y, z sample coordinate; -1 for a field input.
+    int axis = -1;
+
+    [[nodiscard]] bool isCoordinate() const noexcept { return axis >= 0; }
+};
+
+// A definition resolved against one dataset: the compiled expression plus, in
+// expression.symbols() order, where each symbol's values come from.
+struct DerivedFieldProgram {
+    CompiledExpression expression;
+    std::vector<DerivedFieldInput> inputs;
+};
+
+// What to do with a definition that does not resolve.
+enum class DerivedFieldPolicy : std::uint8_t {
+    // Throw DerivedFieldError on the first one. What an editor validating a
+    // list the user just typed wants: the reason, and the definition it
+    // belongs to.
+    Strict,
+    // Leave it out and record why. What opening a dataset wants: a definition
+    // written for another plotfile must not stop this one from opening, and a
+    // sequence frame that happens to lack a field must still load.
+    Skip
+};
+
+// A definition that was left out under DerivedFieldPolicy::Skip.
+struct DerivedFieldSkip {
+    std::size_t definitionIndex = 0;
+    std::string name;
+    // The same text DerivedFieldError would have carried.
+    std::string reason;
+};
+
+struct DerivedFieldInstallation {
+    // One per *installed* definition, in the order their fields were appended
+    // -- which is the definition order with the skipped ones removed.
+    std::vector<DerivedFieldProgram> programs;
+    // Empty under Strict, which throws instead.
+    std::vector<DerivedFieldSkip> skipped;
+};
+
+class DerivedFieldError : public std::invalid_argument {
+public:
+    DerivedFieldError(std::size_t definitionIndex, const std::string& name,
+        const std::string& message,
+        std::optional<std::size_t> sourceOffset = std::nullopt);
+
+    // Which definition of the installed list failed, so an editor can select
+    // the row it belongs to.
+    [[nodiscard]] std::size_t definitionIndex() const noexcept;
+    // Byte offset into that definition's expression, set only when the problem
+    // was inside the expression itself.
+    [[nodiscard]] const std::optional<std::size_t>& sourceOffset()
+        const noexcept;
+
+private:
+    std::size_t m_definitionIndex;
+    std::optional<std::size_t> m_sourceOffset;
+};
+
+// Symbols one derived field may read. The cap bounds how many blocks
+// evaluating one derived block has to hold pinned at once.
+inline constexpr std::size_t maximumDerivedFieldInputs = 16;
+
+// Appends one FieldMetadata per installed definition to metadata.fields, in
+// order, and returns the programs that produce them. Definitions are resolved
+// in order, so one may read the fields of any definition before it -- and only
+// those, which makes the dependency graph acyclic by construction. A
+// definition that is skipped is therefore also unavailable to the ones after
+// it, which are then skipped for naming a field that is not there.
+//
+// A symbol names a stored field, then an earlier derived field, then a
+// coordinate axis ("x", "y", "z"): a dataset with a field named x therefore
+// shadows the coordinate, which is the only rule that stays predictable when
+// the two collide.
+//
+// Under Strict the first problem throws and the caller is expected to discard
+// the metadata it passed in; under Skip the metadata is always left usable.
+// Either way the caller passes a copy, since a dataset's stored metadata is
+// shared.
+[[nodiscard]] DerivedFieldInstallation installDerivedFields(
+    DatasetMetadata& metadata,
+    std::span<const DerivedFieldDefinition> definitions,
+    DerivedFieldPolicy policy = DerivedFieldPolicy::Strict);
+
+} // namespace amrvis

--- a/include/amrexplorer/core/DerivedField.hpp
+++ b/include/amrexplorer/core/DerivedField.hpp
@@ -90,10 +90,15 @@ public:
     // was inside the expression itself.
     [[nodiscard]] const std::optional<std::size_t>& sourceOffset()
         const noexcept;
+    // The problem alone, without the "derived field 'x':" that what() prefixes
+    // it with. A DerivedFieldSkip carries the name in a field of its own, so
+    // anything composing the two would otherwise say it twice.
+    [[nodiscard]] const std::string& message() const noexcept;
 
 private:
     std::size_t m_definitionIndex;
     std::optional<std::size_t> m_sourceOffset;
+    std::string m_message;
 };
 
 // Fields one derived field may read. The cap bounds how many blocks *one level*

--- a/include/amrexplorer/core/DerivedField.hpp
+++ b/include/amrexplorer/core/DerivedField.hpp
@@ -96,10 +96,19 @@ private:
     std::optional<std::size_t> m_sourceOffset;
 };
 
-// Fields one derived field may read. The cap bounds how many blocks evaluating
-// one derived block has to hold pinned at once, so it counts fields alone --
-// a coordinate is computed, not read, and pins nothing.
+// Fields one derived field may read. The cap bounds how many blocks *one level*
+// of an evaluation holds pinned, and it counts fields alone -- a coordinate is
+// computed, not read, and pins nothing. A chain pins that many per link while
+// it recurses, so the whole of one request can hold up to this times
+// maximumDerivedFieldDepth.
 inline constexpr std::size_t maximumDerivedFieldInputs = 16;
+
+// How many derived fields a dataset may have. Installation resolves each
+// definition against the fields installed before it, so a list costs time in
+// its own length squared, and it is reinstalled for every frame of a sequence.
+// Bounded for the same reason the chain is: an imported list is as long as its
+// author cared to make it.
+inline constexpr std::size_t maximumDerivedFieldCount = 256;
 
 // How long a chain of derived fields may depend on one another: a definition
 // reading a definition reading a definition. Evaluating a derived block

--- a/include/amrexplorer/data/DatasetSession.hpp
+++ b/include/amrexplorer/data/DatasetSession.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <amrexplorer/cache/CacheMetrics.hpp>
+#include <amrexplorer/core/DerivedField.hpp>
 #include <amrexplorer/core/Metadata.hpp>
 #include <amrexplorer/core/Request.hpp>
 #include <amrexplorer/core/Statistics.hpp>
@@ -11,6 +12,7 @@
 #include <amrexplorer/io/ParticleReader.hpp>
 #include <amrexplorer/io/PlotfileMetadataReader.hpp>
 
+#include <cstddef>
 #include <cstdint>
 #include <optional>
 #include <stdexcept>
@@ -94,6 +96,33 @@ public:
         static_cast<void>(cancellation);
         throw std::runtime_error(
             "volume rendering is not supported by this session");
+    }
+
+    // How many of metadata().fields the dataset stores rather than computes;
+    // any derived fields follow them. Everything, unless the session installed
+    // derived fields.
+    [[nodiscard]] virtual std::size_t storedFieldCount() const noexcept
+    {
+        return metadata().fields.size();
+    }
+    // The derived-field definitions this session was opened with and could not
+    // install, with the reason for each (core/DerivedField.hpp). Empty for a
+    // session that installs none.
+    [[nodiscard]] virtual std::vector<DerivedFieldSkip> skippedDerivedFields()
+        const
+    {
+        return {};
+    }
+
+    // Whether this session can present fields computed from expressions over
+    // the stored ones (core/DerivedField.hpp). They are installed when the
+    // dataset is opened, so a session that can offer them is one the GUI can
+    // reopen with a new definition list -- which a remote session cannot until
+    // the protocol carries them. False by default so no implementation, and no
+    // test fake, claims it by accident.
+    [[nodiscard]] virtual bool supportsDerivedFields() const noexcept
+    {
+        return false;
     }
 
     [[nodiscard]] virtual CacheMetrics cacheMetrics() const = 0;

--- a/include/amrexplorer/data/LocalDatasetSession.hpp
+++ b/include/amrexplorer/data/LocalDatasetSession.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <amrexplorer/cache/ByteLruCache.hpp>
+#include <amrexplorer/core/DerivedField.hpp>
 #include <amrexplorer/data/DatasetSession.hpp>
 
 #include <array>
@@ -12,6 +13,7 @@
 #include <memory>
 #include <mutex>
 #include <optional>
+#include <vector>
 
 namespace amrvis {
 
@@ -50,12 +52,17 @@ class LocalDatasetSession final : public DatasetSession {
 public:
     // The file version comes from the dataset's own metadata read; nothing
     // re-opens the Header for it.
+    // `derivedFields` are passed straight to the dataset, which resolves them
+    // against its stored field list and fails the open if one does not
+    // resolve (see PlotfileDataset).
     explicit LocalDatasetSession(std::shared_ptr<PlotfileDataset> dataset);
     LocalDatasetSession(const std::filesystem::path& path, DatasetId id,
-        std::uint64_t cacheBudgetBytes, StopToken cancellation = {});
+        std::uint64_t cacheBudgetBytes, StopToken cancellation = {},
+        std::vector<DerivedFieldDefinition> derivedFields = {});
     LocalDatasetSession(std::filesystem::path dataRoot, DatasetId id,
         std::uint64_t cacheBudgetBytes, PlotfileMetadataResult metadata,
-        StopToken cancellation = {});
+        StopToken cancellation = {},
+        std::vector<DerivedFieldDefinition> derivedFields = {});
 
     [[nodiscard]] DatasetId id() const noexcept override;
     [[nodiscard]] const DatasetMetadata& metadata() const noexcept override;
@@ -104,6 +111,16 @@ public:
     // it is false only while a pinned grid still exceeds it.
     [[nodiscard]] bool setVolumeGridCacheBudget(std::uint64_t bytes);
 
+    // Locally there is nothing between the definitions and the dataset that
+    // opens with them.
+    [[nodiscard]] bool supportsDerivedFields() const noexcept override
+    {
+        return true;
+    }
+    [[nodiscard]] std::size_t storedFieldCount() const noexcept override;
+    [[nodiscard]] std::vector<DerivedFieldSkip> skippedDerivedFields()
+        const override;
+
     // The block pool alone. setCacheBudget deliberately moves both pools,
     // which is what a user setting one number wants -- but a server applying
     // a *client's* requested budget must not let it raise the sampled-grid
@@ -128,6 +145,8 @@ private:
     MetadataReadMetrics m_metadataMetrics;
     std::string m_fileVersion;
     std::vector<ParticleSpeciesMetadata> m_particleSpecies;
+    std::size_t m_storedFieldCount = 0;
+    std::vector<DerivedFieldSkip> m_skippedDerivedFields;
     mutable std::mutex m_mutex;
     std::shared_ptr<PlotfileDataset> m_dataset;
     // File-scope ranges for a standalone FAB, by field. These are scanned out

--- a/include/amrexplorer/data/LocalDatasetSession.hpp
+++ b/include/amrexplorer/data/LocalDatasetSession.hpp
@@ -53,8 +53,9 @@ public:
     // The file version comes from the dataset's own metadata read; nothing
     // re-opens the Header for it.
     // `derivedFields` are passed straight to the dataset, which resolves them
-    // against its stored field list and fails the open if one does not
-    // resolve (see PlotfileDataset).
+    // against its stored field list and leaves out any that do not resolve,
+    // reporting them through skippedDerivedFields() rather than failing the
+    // open (see PlotfileDataset).
     explicit LocalDatasetSession(std::shared_ptr<PlotfileDataset> dataset);
     LocalDatasetSession(const std::filesystem::path& path, DatasetId id,
         std::uint64_t cacheBudgetBytes, StopToken cancellation = {},

--- a/include/amrexplorer/io/PlotfileBlockReader.hpp
+++ b/include/amrexplorer/io/PlotfileBlockReader.hpp
@@ -62,6 +62,13 @@ public:
     using std::runtime_error::runtime_error;
 };
 
+// The number of samples a FAB box holds: the product of its extents,
+// overflow-checked, throwing BlockReadError on a non-positive extent or a
+// product that does not fit. Shared because the reader sizes a payload with it
+// and PlotfileDataset sizes a derived block with it, and the two must agree
+// about what a box holds.
+[[nodiscard]] std::uint64_t fabPointCount(const IntBox& box, int dimension);
+
 class PlotfileBlockReader {
 public:
     PlotfileBlockReader(

--- a/include/amrexplorer/io/PlotfileDataset.hpp
+++ b/include/amrexplorer/io/PlotfileDataset.hpp
@@ -2,14 +2,19 @@
 
 #include <amrexplorer/cache/BlockKey.hpp>
 #include <amrexplorer/cache/ByteLruCache.hpp>
+#include <amrexplorer/core/DerivedField.hpp>
 #include <amrexplorer/core/StopToken.hpp>
 #include <amrexplorer/io/PlotfileBlockReader.hpp>
 #include <amrexplorer/io/PlotfileMetadataReader.hpp>
 #include <amrexplorer/io/ParticleReader.hpp>
 
+#include <cstddef>
 #include <cstdint>
 #include <filesystem>
+#include <memory>
 #include <mutex>
+#include <span>
+#include <vector>
 
 namespace amrvis {
 
@@ -23,12 +28,24 @@ public:
         BlockReadMetrics io;
     };
 
+    // `derivedFields` are resolved against the plotfile's own field list once,
+    // here, and appended to the metadata this dataset presents (see
+    // core/DerivedField.hpp); one that does not resolve is left out and
+    // reported by skippedDerivedFields() rather than failing the open, so a
+    // definition written for another plotfile -- or a sequence frame that
+    // happens to lack a field -- still opens. Installing at construction rather than later is what
+    // lets the field list be shared without a lock: the block reader and every
+    // caller of metadata() see one list that never changes. Editing the
+    // definitions therefore means opening a new dataset, which is what the GUI
+    // does.
     PlotfileDataset(
         std::filesystem::path plotfile, DatasetId id,
-        std::uint64_t cacheBudgetBytes, StopToken cancellation = {});
+        std::uint64_t cacheBudgetBytes, StopToken cancellation = {},
+        std::vector<DerivedFieldDefinition> derivedFields = {});
     PlotfileDataset(std::filesystem::path dataRoot, DatasetId id,
         std::uint64_t cacheBudgetBytes, PlotfileMetadataResult metadata,
-        StopToken cancellation = {});
+        StopToken cancellation = {},
+        std::vector<DerivedFieldDefinition> derivedFields = {});
 
     [[nodiscard]] const DatasetMetadata& metadata() const noexcept;
     [[nodiscard]] const MetadataReadMetrics& metadataReadMetrics() const noexcept;
@@ -51,6 +68,21 @@ public:
         std::size_t maximumPoints = std::numeric_limits<std::size_t>::max()) const;
     [[nodiscard]] const std::filesystem::path& dataRoot() const noexcept;
 
+    // Whether this field is computed from others rather than read.
+    [[nodiscard]] bool isDerivedField(FieldId field) const noexcept;
+    // How many of metadata().fields this dataset stores; the derived ones
+    // follow them, in the order their definitions were given.
+    [[nodiscard]] std::size_t storedFieldCount() const noexcept;
+    // The definitions this dataset could not install, with the reason. A
+    // definition written for another plotfile does not stop this one from
+    // opening (DerivedFieldPolicy::Skip); it lands here instead, for whoever
+    // asked for it to say so.
+    [[nodiscard]] const std::vector<DerivedFieldSkip>& skippedDerivedFields()
+        const noexcept;
+
+    // A block of any field the metadata lists. A derived field's block is
+    // evaluated from its inputs' blocks (recursively, so one derived field may
+    // read another) and cached like any other, under its own field id.
     [[nodiscard]] BlockAccess requestBlock(
         const BlockRequest& request, StopToken cancellation = {});
 
@@ -59,9 +91,28 @@ public:
     void clearUnpinnedCache();
 
 private:
+    // The field list this dataset presents: the stored metadata with one field
+    // appended per derived definition, the programs that produce them, and
+    // where the stored fields end (so a field id says which it is). Built once,
+    // before the block reader is handed the metadata; the plain metadata is
+    // shared as-is when there are no derived fields, so the common path copies
+    // nothing.
+    struct Fields {
+        std::shared_ptr<const DatasetMetadata> metadata;
+        std::vector<DerivedFieldProgram> programs;
+        std::size_t storedCount = 0;
+        std::vector<DerivedFieldSkip> skipped;
+    };
+    [[nodiscard]] static Fields installFields(
+        const PlotfileMetadataResult& source,
+        std::span<const DerivedFieldDefinition> definitions);
+    [[nodiscard]] BlockReadResult readDerivedBlock(const BlockRequest& request,
+        const DerivedFieldProgram& program, StopToken cancellation);
+
     std::filesystem::path m_plotfile;
     DatasetId m_id;
     PlotfileMetadataResult m_metadataResult;
+    Fields m_fields;
     std::vector<ParticleSpeciesMetadata> m_particleSpecies;
     PlotfileBlockReader m_blockReader;
     BlockCache m_cache;

--- a/include/amrexplorer/pipeline/SlicePipeline.hpp
+++ b/include/amrexplorer/pipeline/SlicePipeline.hpp
@@ -128,6 +128,17 @@ struct InitialSliceResult {
 struct FrameSliceSpec {
     DisplayMode displayMode = DisplayMode::Raster;
     std::uint32_t field = 0;
+    // The same selections by name, which is what actually carries them from
+    // one frame to the next. An index is only meaningful in the field list it
+    // came from: frames need not agree on their stored fields, and a derived
+    // definition that one frame cannot resolve is left out of that frame's
+    // list (DerivedFieldPolicy::Skip), which compacts every id after it. An
+    // index alone then lands on whatever now occupies that slot, silently.
+    // Empty means "no name to go on", and the index is used as it was.
+    std::string fieldName;
+    std::string vectorUFieldName;
+    std::string vectorVFieldName;
+    std::string vectorWFieldName;
     int levelSelection = -1;  // level combo data: -1 = finest available
     RangeMode rangeMode = RangeMode::File;
     std::optional<std::pair<double, double>> userRange;
@@ -155,15 +166,17 @@ struct FrameSliceSpec {
     std::vector<std::string> particleSpecies;
     double particleFraction = 1.0;
     std::uint64_t particleSeed = 0;
-    // Fields to compute rather than read (core/DerivedField.hpp). Installed by
-    // the session executeFrameLoad opens, so they follow the user's field
-    // selection across frames; a definition that does not resolve against a
-    // frame fails that frame's load with a named reason.
+    // Fields to compute rather than read (core/DerivedField.hpp), installed by
+    // the session executeFrameLoad opens. A definition this frame cannot
+    // resolve is left out of it rather than failing the load, and the session
+    // says which through DatasetSession::skippedDerivedFields().
     //
-    // Only executeFrameLoad can honour these -- it is what opens the session.
-    // A spec handed to executeSessionFrameLoad must leave them empty: that
-    // session is already open, and its field list is fixed. Callers gate on
-    // DatasetSession::supportsDerivedFields() rather than guessing.
+    // Only executeFrameLoad can act on these, because it is what opens the
+    // session. Passing a spec that carries them to executeSessionFrameLoad is
+    // not an error -- executeFrameLoad does exactly that, having already
+    // installed them -- but for a session opened elsewhere they are inert:
+    // its field list was fixed when it opened. Callers with a session in hand
+    // gate on DatasetSession::supportsDerivedFields().
     std::vector<DerivedFieldDefinition> derivedFields;
 };
 
@@ -179,6 +192,16 @@ struct LevelSelection {
 // Decodes the level combo's data encoding: -1 = finest available, N = level N
 // only, kUpdateToLevelOffset + N = composite levels 0..N.
 [[nodiscard]] LevelSelection decodeLevelData(int data, int finestLevel);
+
+// The field a carried selection means in *this* dataset: the one named, if it
+// is here, and otherwise the index clamped into range. Names are how a
+// selection survives a frame switch -- see FrameSliceSpec::fieldName for why
+// an index does not -- and the clamp is what happens when the frame simply
+// does not have the field any more. An empty name goes straight to the index,
+// which is the behaviour of every caller that has no name to give.
+[[nodiscard]] std::uint32_t resolveSpecField(
+    const DatasetMetadata& metadata, const std::string& name,
+    std::uint32_t index);
 
 // Upper bound on slice output dimensions. One pixel per finest cell is the
 // ideal, but a plane costs on the order of 10 bytes per pixel (float value,

--- a/include/amrexplorer/pipeline/SlicePipeline.hpp
+++ b/include/amrexplorer/pipeline/SlicePipeline.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <amrexplorer/core/DerivedField.hpp>
 #include <amrexplorer/core/Metadata.hpp>
 #include <amrexplorer/core/Request.hpp>
 #include <amrexplorer/core/Result.hpp>
@@ -154,6 +155,16 @@ struct FrameSliceSpec {
     std::vector<std::string> particleSpecies;
     double particleFraction = 1.0;
     std::uint64_t particleSeed = 0;
+    // Fields to compute rather than read (core/DerivedField.hpp). Installed by
+    // the session executeFrameLoad opens, so they follow the user's field
+    // selection across frames; a definition that does not resolve against a
+    // frame fails that frame's load with a named reason.
+    //
+    // Only executeFrameLoad can honour these -- it is what opens the session.
+    // A spec handed to executeSessionFrameLoad must leave them empty: that
+    // session is already open, and its field list is fixed. Callers gate on
+    // DatasetSession::supportsDerivedFields() rather than guessing.
+    std::vector<DerivedFieldDefinition> derivedFields;
 };
 
 // Combo data sentinel for "Update to Level N" entries, which composite

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library(amrexplorer_core
     CoordinateSystem.cpp
+    DerivedField.cpp
     Metadata.cpp
     OrthoProjection.cpp
     Request.cpp
@@ -13,7 +14,10 @@ target_include_directories(amrexplorer_core
         $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
         $<INSTALL_INTERFACE:include>
 )
-target_link_libraries(amrexplorer_core PRIVATE amrexplorer::warnings)
+# expression is PUBLIC: DerivedField.hpp exposes CompiledExpression.
+target_link_libraries(amrexplorer_core
+    PUBLIC amrexplorer::expression
+    PRIVATE amrexplorer::warnings)
 target_compile_features(amrexplorer_core PUBLIC cxx_std_20)
 
 # Version.cpp is deliberately not part of amrexplorer_core. It is the one file

--- a/src/core/DerivedField.cpp
+++ b/src/core/DerivedField.cpp
@@ -1,0 +1,177 @@
+#include <amrexplorer/core/DerivedField.hpp>
+
+#include <array>
+#include <cstdint>
+#include <limits>
+#include <string>
+#include <string_view>
+#include <utility>
+
+namespace amrvis {
+namespace {
+
+// The coordinate symbols, indexed by axis.
+constexpr std::array<std::string_view, 3> coordinateNames{"x", "y", "z"};
+
+std::string describe(std::size_t definitionIndex, const std::string& name,
+    const std::string& message)
+{
+    const auto subject = name.empty()
+        ? "derived field " + std::to_string(definitionIndex + 1)
+        : "derived field '" + name + "'";
+    return subject + ": " + message;
+}
+
+// The index of `name` in the fields installed so far, which is also its
+// FieldId: stored fields keep the order the plotfile lists them in and each
+// derived field is appended as it is resolved.
+std::optional<std::size_t> fieldIndex(
+    const DatasetMetadata& metadata, std::string_view name)
+{
+    for (std::size_t index = 0; index < metadata.fields.size(); ++index) {
+        if (metadata.fields[index].name == name) {
+            return index;
+        }
+    }
+    return std::nullopt;
+}
+
+std::optional<int> coordinateAxis(std::string_view name)
+{
+    for (int axis = 0; axis < 3; ++axis) {
+        if (coordinateNames[static_cast<std::size_t>(axis)] == name) {
+            return axis;
+        }
+    }
+    return std::nullopt;
+}
+
+} // namespace
+
+DerivedFieldError::DerivedFieldError(std::size_t definitionIndex,
+    const std::string& name, const std::string& message,
+    std::optional<std::size_t> sourceOffset)
+    : std::invalid_argument(describe(definitionIndex, name, message))
+    , m_definitionIndex(definitionIndex)
+    , m_sourceOffset(sourceOffset)
+{
+}
+
+std::size_t DerivedFieldError::definitionIndex() const noexcept
+{
+    return m_definitionIndex;
+}
+
+const std::optional<std::size_t>& DerivedFieldError::sourceOffset()
+    const noexcept
+{
+    return m_sourceOffset;
+}
+
+DerivedFieldInstallation installDerivedFields(DatasetMetadata& metadata,
+    std::span<const DerivedFieldDefinition> definitions,
+    DerivedFieldPolicy policy)
+{
+    DerivedFieldInstallation installation;
+    installation.programs.reserve(definitions.size());
+    for (std::size_t index = 0; index < definitions.size(); ++index) {
+        const auto& definition = definitions[index];
+        const auto fail = [index, &definition](const std::string& message,
+                              std::optional<std::size_t> offset = std::nullopt) {
+            return DerivedFieldError(index, definition.name, message, offset);
+        };
+        // Under Skip the loop body's throws are caught per definition, so one
+        // that does not resolve leaves the metadata as it was before it and the
+        // ones after it are still tried. Written as a try around the body
+        // rather than as a return at every check so the two policies cannot
+        // drift apart on which problems they report.
+        try {
+            if (definition.name.empty()) {
+                throw fail("a derived field needs a name");
+            }
+            if (fieldIndex(metadata, definition.name)) {
+                // Both a stored field and an earlier definition:
+                // field names are the namespace expressions resolve in,
+                // and validateMetadata requires them unique.
+                throw fail("the name is already in use by another field");
+            }
+            if (definition.expression.empty()) {
+                throw fail("a derived field needs an expression");
+            }
+
+            DerivedFieldProgram program{
+                [&] {
+                    try {
+                        return CompiledExpression::compile(
+                            definition.expression);
+                    } catch (const ExpressionError& error) {
+                        // The offset is into what the user typed: symbols
+                        // come from the source as written, so nothing has
+                        // to be mapped back through a rewrite.
+                        throw fail(error.what(), error.offset());
+                    }
+                }(),
+                {}};
+
+            const auto symbols = program.expression.symbols();
+            if (symbols.size() > maximumDerivedFieldInputs) {
+                throw fail("an expression may read at most "
+                    + std::to_string(maximumDerivedFieldInputs) + " fields");
+            }
+            program.inputs.reserve(symbols.size());
+            // Every field an expression reads must share one centering, because
+            // its values are combined sample for sample; the derived field then
+            // has that centering. A coordinates-only expression is cell-centered.
+            std::optional<Centering> centering;
+            for (const auto& symbol : symbols) {
+                if (const auto input = fieldIndex(metadata, symbol)) {
+                    if (*input > std::numeric_limits<std::uint32_t>::max()) {
+                        throw fail("the dataset has more fields than a field id "
+                                   "can name");
+                    }
+                    const auto& field = metadata.fields[*input];
+                    if (centering && *centering != field.centering) {
+                        throw fail("'" + symbol
+                            + "' is not centered like the other fields the "
+                              "expression reads");
+                    }
+                    centering = field.centering;
+                    program.inputs.push_back(
+                        {.field = FieldId{static_cast<std::uint32_t>(*input)},
+                            .axis = -1});
+                    continue;
+                }
+                if (const auto axis = coordinateAxis(symbol)) {
+                    if (!metadata.hasPhysicalGeometry) {
+                        throw fail("'" + symbol
+                            + "' needs physical coordinates, which this dataset "
+                              "does not carry");
+                    }
+                    if (*axis >= metadata.dimension) {
+                        throw fail("'" + symbol + "' is not an axis of a "
+                            + std::to_string(metadata.dimension)
+                            + "-D dataset");
+                    }
+                    program.inputs.push_back({.field = {}, .axis = *axis});
+                    continue;
+                }
+                throw fail("no field or coordinate is named '" + symbol + "'");
+            }
+
+            metadata.fields.push_back(FieldMetadata{
+                .name = definition.name,
+                .centering = centering.value_or(Centering::Cell),
+                .componentNames = {}});
+            installation.programs.push_back(std::move(program));
+        } catch (const DerivedFieldError& error) {
+            if (policy == DerivedFieldPolicy::Strict) {
+                throw;
+            }
+            installation.skipped.push_back(
+                {index, definition.name, error.what()});
+        }
+    }
+    return installation;
+}
+
+} // namespace amrvis

--- a/src/core/DerivedField.cpp
+++ b/src/core/DerivedField.cpp
@@ -94,6 +94,14 @@ DerivedFieldInstallation installDerivedFields(DatasetMetadata& metadata,
         // rather than as a return at every check so the two policies cannot
         // drift apart on which problems they report.
         try {
+            // Thrown per definition rather than up front so Skip keeps its
+            // promise: the ones that fit are installed and the rest are
+            // reported, instead of the whole list failing.
+            if (index >= maximumDerivedFieldCount) {
+                throw fail("a dataset may have at most "
+                    + std::to_string(maximumDerivedFieldCount)
+                    + " derived fields");
+            }
             if (definition.name.empty()) {
                 throw fail("a derived field needs a name");
             }

--- a/src/core/DerivedField.cpp
+++ b/src/core/DerivedField.cpp
@@ -1,5 +1,6 @@
 #include <amrexplorer/core/DerivedField.hpp>
 
+#include <algorithm>
 #include <array>
 #include <cstdint>
 #include <limits>
@@ -74,6 +75,13 @@ DerivedFieldInstallation installDerivedFields(DatasetMetadata& metadata,
 {
     DerivedFieldInstallation installation;
     installation.programs.reserve(definitions.size());
+    // Where the stored fields end, so a resolved input can be recognised as
+    // derived (its id is storedCount + its program's index, which is how
+    // PlotfileDataset finds the program again), and the depth of each
+    // installed program, for the chain bound below.
+    const auto storedCount = metadata.fields.size();
+    std::vector<std::size_t> depths;
+    depths.reserve(definitions.size());
     for (std::size_t index = 0; index < definitions.size(); ++index) {
         const auto& definition = definitions[index];
         const auto fail = [index, &definition](const std::string& message,
@@ -114,10 +122,6 @@ DerivedFieldInstallation installDerivedFields(DatasetMetadata& metadata,
                 {}};
 
             const auto symbols = program.expression.symbols();
-            if (symbols.size() > maximumDerivedFieldInputs) {
-                throw fail("an expression may read at most "
-                    + std::to_string(maximumDerivedFieldInputs) + " fields");
-            }
             program.inputs.reserve(symbols.size());
             // Every field an expression reads must share one centering, because
             // its values are combined sample for sample; the derived field then
@@ -158,11 +162,43 @@ DerivedFieldInstallation installDerivedFields(DatasetMetadata& metadata,
                 throw fail("no field or coordinate is named '" + symbol + "'");
             }
 
+            // Counted over the fields, not the symbols: this bounds the
+            // blocks one evaluation holds pinned, and a coordinate is
+            // computed rather than read.
+            const auto fieldInputs = static_cast<std::size_t>(
+                std::count_if(program.inputs.begin(), program.inputs.end(),
+                    [](const DerivedFieldInput& input) {
+                        return !input.isCoordinate();
+                    }));
+            if (fieldInputs > maximumDerivedFieldInputs) {
+                throw fail("an expression may read at most "
+                    + std::to_string(maximumDerivedFieldInputs) + " fields");
+            }
+            // One deeper than the deepest derived field it reads. Evaluation
+            // recurses once per link, so this is what keeps that recursion off
+            // the end of the stack.
+            std::size_t depth = 1;
+            for (const auto& input : program.inputs) {
+                if (input.isCoordinate()) {
+                    continue;
+                }
+                const auto id = static_cast<std::size_t>(input.field.value);
+                if (id >= storedCount) {
+                    depth = std::max(depth, depths[id - storedCount] + 1);
+                }
+            }
+            if (depth > maximumDerivedFieldDepth) {
+                throw fail("a derived field may not read a chain of more than "
+                    + std::to_string(maximumDerivedFieldDepth)
+                    + " derived fields");
+            }
+
             metadata.fields.push_back(FieldMetadata{
                 .name = definition.name,
                 .centering = centering.value_or(Centering::Cell),
                 .componentNames = {}});
             installation.programs.push_back(std::move(program));
+            depths.push_back(depth);
         } catch (const DerivedFieldError& error) {
             if (policy == DerivedFieldPolicy::Strict) {
                 throw;

--- a/src/core/DerivedField.cpp
+++ b/src/core/DerivedField.cpp
@@ -55,6 +55,7 @@ DerivedFieldError::DerivedFieldError(std::size_t definitionIndex,
     : std::invalid_argument(describe(definitionIndex, name, message))
     , m_definitionIndex(definitionIndex)
     , m_sourceOffset(sourceOffset)
+    , m_message(message)
 {
 }
 
@@ -67,6 +68,11 @@ const std::optional<std::size_t>& DerivedFieldError::sourceOffset()
     const noexcept
 {
     return m_sourceOffset;
+}
+
+const std::string& DerivedFieldError::message() const noexcept
+{
+    return m_message;
 }
 
 DerivedFieldInstallation installDerivedFields(DatasetMetadata& metadata,
@@ -97,7 +103,7 @@ DerivedFieldInstallation installDerivedFields(DatasetMetadata& metadata,
             // Thrown per definition rather than up front so Skip keeps its
             // promise: the ones that fit are installed and the rest are
             // reported, instead of the whole list failing.
-            if (index >= maximumDerivedFieldCount) {
+            if (installation.programs.size() >= maximumDerivedFieldCount) {
                 throw fail("a dataset may have at most "
                     + std::to_string(maximumDerivedFieldCount)
                     + " derived fields");
@@ -212,7 +218,7 @@ DerivedFieldInstallation installDerivedFields(DatasetMetadata& metadata,
                 throw;
             }
             installation.skipped.push_back(
-                {index, definition.name, error.what()});
+                {index, definition.name, error.message()});
         }
     }
     return installation;

--- a/src/data/LocalDatasetSession.cpp
+++ b/src/data/LocalDatasetSession.cpp
@@ -105,6 +105,10 @@ LocalDatasetSession::LocalDatasetSession(
     , m_particleSpecies(
           dataset ? dataset->particleSpecies()
                   : std::vector<ParticleSpeciesMetadata>{})
+    , m_storedFieldCount(dataset ? dataset->storedFieldCount() : 0)
+    , m_skippedDerivedFields(
+          dataset ? dataset->skippedDerivedFields()
+                  : std::vector<DerivedFieldSkip>{})
     , m_dataset(std::move(dataset))
 {
     if (!m_dataset) {
@@ -120,17 +124,20 @@ LocalDatasetSession::LocalDatasetSession(
 }
 
 LocalDatasetSession::LocalDatasetSession(const std::filesystem::path& path,
-    DatasetId id, std::uint64_t cacheBudgetBytes, StopToken cancellation)
+    DatasetId id, std::uint64_t cacheBudgetBytes, StopToken cancellation,
+    std::vector<DerivedFieldDefinition> derivedFields)
     : LocalDatasetSession(std::make_shared<PlotfileDataset>(
-          path, id, cacheBudgetBytes, cancellation))
+          path, id, cacheBudgetBytes, cancellation, std::move(derivedFields)))
 {
 }
 
 LocalDatasetSession::LocalDatasetSession(std::filesystem::path dataRoot,
     DatasetId id, std::uint64_t cacheBudgetBytes,
-    PlotfileMetadataResult metadata, StopToken cancellation)
+    PlotfileMetadataResult metadata, StopToken cancellation,
+    std::vector<DerivedFieldDefinition> derivedFields)
     : LocalDatasetSession(std::make_shared<PlotfileDataset>(dataRoot, id,
-          cacheBudgetBytes, std::move(metadata), cancellation))
+          cacheBudgetBytes, std::move(metadata), cancellation,
+          std::move(derivedFields)))
 {
 }
 
@@ -282,6 +289,18 @@ ParticleSample LocalDatasetSession::requestParticleSample(
         m_metadata, m_particleSpecies, species, fraction);
     return requireDataset()->requestParticleSample(
         species, fraction, seed, cancellation, maximumPoints);
+}
+
+std::size_t LocalDatasetSession::storedFieldCount() const noexcept
+{
+    // Recorded at construction, like the metadata copy above it: the dataset
+    // may be closed by the time anything asks.
+    return m_storedFieldCount;
+}
+
+std::vector<DerivedFieldSkip> LocalDatasetSession::skippedDerivedFields() const
+{
+    return m_skippedDerivedFields;
 }
 
 bool LocalDatasetSession::supportsVolumeRendering() const noexcept

--- a/src/io/plotfile/PlotfileBlockReader.cpp
+++ b/src/io/plotfile/PlotfileBlockReader.cpp
@@ -88,7 +88,9 @@ IntBox grownBox(const IntBox& source, const Int3& ghost, int dimension)
     return detail::grownBox<BlockReadError>(source, ghost, dimension);
 }
 
-std::uint64_t pointCount(const IntBox& box, int dimension)
+} // namespace
+
+std::uint64_t fabPointCount(const IntBox& box, int dimension)
 {
     std::uint64_t result = 1;
     for (int axis = 0; axis < dimension; ++axis) {
@@ -106,8 +108,6 @@ std::uint64_t pointCount(const IntBox& box, int dimension)
     }
     return result;
 }
-
-} // namespace
 
 FabValues::FabValues(std::vector<float> values) noexcept
     : m_storage(std::move(values))
@@ -211,7 +211,7 @@ BlockReadResult PlotfileBlockReader::readBlock(
         throw BlockReadError("FAB and VisMF component counts disagree");
     }
 
-    const auto valuesPerComponent = pointCount(header.box, m_metadata->dimension);
+    const auto valuesPerComponent = fabPointCount(header.box, m_metadata->dimension);
     if (valuesPerComponent > std::numeric_limits<std::uint64_t>::max() / header.encoding.bytes) {
         throw BlockReadError("FAB component byte count overflows");
     }

--- a/src/io/plotfile/PlotfileDataset.cpp
+++ b/src/io/plotfile/PlotfileDataset.cpp
@@ -268,9 +268,17 @@ BlockReadResult PlotfileDataset::readDerivedBlock(const BlockRequest& request,
     // by a claimed count. A box array claiming 10^10 cells is an 80 GB request
     // otherwise. The budget is the bound the block would have been held to a
     // moment later anyway, when it was offered to the cache, so the failure is
-    // one callers already handle -- and passing it is what makes the narrowing
-    // below safe on any width of size_t.
+    // one callers already handle.
     const auto points = fabPointCount(derived->box, metadata.dimension);
+    // The budget does not bound this: it is a uint64 read from the
+    // environment and clamped to nothing, so where size_t is narrower than it
+    // a budget large enough leaves points past what the cast below can hold,
+    // and the block would then advertise a box its payload does not fill. A
+    // no-op the compiler folds away wherever size_t is 64 bits, which is every
+    // target we build -- and the whole guard where it is not.
+    if (points > std::numeric_limits<std::size_t>::max()) {
+        throw BlockReadError("derived block exceeds addressable memory");
+    }
     constexpr std::uint64_t blockBytes = sizeof(FabBlock);
     if (points
         > (std::numeric_limits<std::uint64_t>::max() - blockBytes)

--- a/src/io/plotfile/PlotfileDataset.cpp
+++ b/src/io/plotfile/PlotfileDataset.cpp
@@ -5,6 +5,7 @@
 #include <array>
 #include <chrono>
 #include <cstddef>
+#include <cstdint>
 #include <limits>
 #include <mutex>
 #include <optional>
@@ -62,8 +63,7 @@ PlotfileDataset::Fields PlotfileDataset::installFields(
     std::span<const DerivedFieldDefinition> definitions)
 {
     if (!source.metadata) {
-        throw std::invalid_argument(
-            "selected FAB dataset requires metadata and an id");
+        throw std::invalid_argument("dataset metadata is unavailable");
     }
     if (definitions.empty()) {
         return {source.metadata, {}, source.metadata->fields.size(), {}};
@@ -111,7 +111,7 @@ PlotfileDataset::PlotfileDataset(std::filesystem::path root, DatasetId id,
     , m_cache(cacheBudgetBytes)
 {
     if (m_id.value == 0) {
-        throw std::invalid_argument("selected FAB dataset requires metadata and an id");
+        throw std::invalid_argument("selected FAB dataset requires an id");
     }
 }
 
@@ -261,30 +261,28 @@ BlockReadResult PlotfileDataset::readDerivedBlock(const BlockRequest& request,
     derived->box = level.blocks[static_cast<std::size_t>(request.gridIndex)].box;
     derived->field = request.field;
     derived->component = 0;
+    // What this block would occupy, decided in 64 bits and before it is
+    // allocated. An expression over coordinates alone reads no file, so
+    // nothing else here bounds the size by anything but what the metadata
+    // claimed -- and src/io bounds its allocations by real file evidence, not
+    // by a claimed count. A box array claiming 10^10 cells is an 80 GB request
+    // otherwise. The budget is the bound the block would have been held to a
+    // moment later anyway, when it was offered to the cache, so the failure is
+    // one callers already handle -- and passing it is what makes the narrowing
+    // below safe on any width of size_t.
     const auto points = fabPointCount(derived->box, metadata.dimension);
-    if (points > std::numeric_limits<std::size_t>::max()) {
-        throw BlockReadError("derived block exceeds addressable memory");
-    }
-    const auto count = static_cast<std::size_t>(points);
-    // What this block will occupy, checked against the budget before it is
-    // allocated rather than after. An expression over coordinates alone reads
-    // no file, so nothing else here bounds `count` by anything but what the
-    // metadata claimed -- and src/io bounds its allocations by real file
-    // evidence, not by a claimed count. A box array claiming 10^10 cells is
-    // an 80 GB request otherwise. The budget is the same bound the block
-    // would have been held to a moment later, when it was offered to the
-    // cache, so the failure is one callers already handle.
     constexpr std::uint64_t blockBytes = sizeof(FabBlock);
-    if (count
+    if (points
         > (std::numeric_limits<std::uint64_t>::max() - blockBytes)
             / sizeof(double)) {
         throw BlockReadError("derived block exceeds addressable memory");
     }
-    const auto resident = blockBytes + count * sizeof(double);
+    const auto resident = blockBytes + points * sizeof(double);
     if (resident > m_cache.metrics().budgetBytes) {
         throw CacheBudgetExceeded(
             "a derived field's block exceeds the entire byte budget");
     }
+    const auto count = static_cast<std::size_t>(points);
 
     // Every input block, pinned for as long as the evaluation reads it, with
     // the arithmetic that turns a sample of the derived box into an offset
@@ -344,7 +342,11 @@ BlockReadResult PlotfileDataset::readDerivedBlock(const BlockRequest& request,
             } else if (axis == 2) {
                 source.planeStride = stride;
             }
-            stride *= static_cast<std::size_t>(box.upper[i] - box.lower[i] + 1);
+            // Widened before the subtraction, as fabPointCount and
+            // valueOffset are: these are the same box bounds, and int
+            // arithmetic on them overflows for a crafted box.
+            stride *= static_cast<std::size_t>(
+                static_cast<std::int64_t>(box.upper[i]) - box.lower[i] + 1);
         }
         sourceOf[input] = sources.size();
         sources.push_back(std::move(source));
@@ -362,7 +364,12 @@ BlockReadResult PlotfileDataset::readDerivedBlock(const BlockRequest& request,
     std::array<int, 3> extent{1, 1, 1};
     for (int axis = 0; axis < metadata.dimension; ++axis) {
         const auto i = static_cast<std::size_t>(axis);
-        extent[i] = derived->box.upper[i] - derived->box.lower[i] + 1;
+        const auto length = static_cast<std::int64_t>(derived->box.upper[i])
+            - derived->box.lower[i] + 1;
+        if (length > std::numeric_limits<int>::max()) {
+            throw BlockReadError("derived block extent exceeds an index");
+        }
+        extent[i] = static_cast<int>(length);
     }
     auto evaluator = program.expression.makeEvaluator();
     for (std::size_t start = 0; start < count; start += derivedChunkPoints) {

--- a/src/io/plotfile/PlotfileDataset.cpp
+++ b/src/io/plotfile/PlotfileDataset.cpp
@@ -1,12 +1,18 @@
 #include <amrexplorer/io/PlotfileDataset.hpp>
 #include <amrexplorer/io/StandaloneMetadataReader.hpp>
 
+#include <algorithm>
+#include <array>
 #include <chrono>
 #include <cstddef>
+#include <limits>
 #include <mutex>
+#include <optional>
+#include <span>
 #include <stdexcept>
 #include <thread>
 #include <utility>
+#include <vector>
 
 namespace amrvis {
 namespace {
@@ -42,18 +48,46 @@ std::vector<ParticleSpeciesMetadata> discoverParticlesForPlotfileRoot(
     return {};
 }
 
+// Points evaluated per pass when a derived block is computed. The inputs are
+// gathered into double columns a chunk at a time rather than a block at a time:
+// a chunk of columns is a few kilobytes whatever the block's size, and the
+// stored payload may be single precision, so it cannot be handed to the
+// evaluator directly.
+constexpr std::size_t derivedChunkPoints = 512;
+
 } // namespace
+
+PlotfileDataset::Fields PlotfileDataset::installFields(
+    const PlotfileMetadataResult& source,
+    std::span<const DerivedFieldDefinition> definitions)
+{
+    if (!source.metadata) {
+        throw std::invalid_argument(
+            "selected FAB dataset requires metadata and an id");
+    }
+    if (definitions.empty()) {
+        return {source.metadata, {}, source.metadata->fields.size(), {}};
+    }
+    auto metadata = std::make_shared<DatasetMetadata>(*source.metadata);
+    const auto storedCount = metadata->fields.size();
+    auto installation = installDerivedFields(
+        *metadata, definitions, DerivedFieldPolicy::Skip);
+    return {std::move(metadata), std::move(installation.programs), storedCount,
+        std::move(installation.skipped)};
+}
 
 PlotfileDataset::PlotfileDataset(
     std::filesystem::path plotfile, DatasetId id,
-    std::uint64_t cacheBudgetBytes, StopToken cancellation)
+    std::uint64_t cacheBudgetBytes, StopToken cancellation,
+    std::vector<DerivedFieldDefinition> derivedFields)
     : m_plotfile(sourceDataRoot(plotfile))
     , m_id(id)
     , m_metadataResult(readDatasetMetadata(plotfile, cancellation))
+    , m_fields(installFields(m_metadataResult, derivedFields))
     , m_particleSpecies(std::filesystem::is_directory(plotfile)
             ? discoverParticleSpecies(m_plotfile, cancellation)
             : std::vector<ParticleSpeciesMetadata>{})
-    , m_blockReader(m_plotfile, m_metadataResult.metadata)
+    , m_blockReader(m_plotfile, m_fields.metadata)
     , m_cache(cacheBudgetBytes)
 {
     if (m_id.value == 0) {
@@ -63,23 +97,44 @@ PlotfileDataset::PlotfileDataset(
 
 PlotfileDataset::PlotfileDataset(std::filesystem::path root, DatasetId id,
     std::uint64_t cacheBudgetBytes, PlotfileMetadataResult metadata,
-    StopToken cancellation)
+    StopToken cancellation, std::vector<DerivedFieldDefinition> derivedFields)
     : m_plotfile(std::move(root))
     , m_id(id)
     , m_metadataResult(std::move(metadata))
+    // Rejects a missing metadata result, which used to be the constructor
+    // body's job -- the field list has to be built before the block reader is
+    // constructed, so the check has to happen there too.
+    , m_fields(installFields(m_metadataResult, derivedFields))
     , m_particleSpecies(
           discoverParticlesForPlotfileRoot(m_plotfile, cancellation))
-    , m_blockReader(m_plotfile, m_metadataResult.metadata)
+    , m_blockReader(m_plotfile, m_fields.metadata)
     , m_cache(cacheBudgetBytes)
 {
-    if (m_id.value == 0 || !m_metadataResult.metadata) {
+    if (m_id.value == 0) {
         throw std::invalid_argument("selected FAB dataset requires metadata and an id");
     }
 }
 
 const DatasetMetadata& PlotfileDataset::metadata() const noexcept
 {
-    return *m_metadataResult.metadata;
+    return *m_fields.metadata;
+}
+
+bool PlotfileDataset::isDerivedField(FieldId field) const noexcept
+{
+    return field.value >= m_fields.storedCount
+        && static_cast<std::size_t>(field.value) < m_fields.metadata->fields.size();
+}
+
+std::size_t PlotfileDataset::storedFieldCount() const noexcept
+{
+    return m_fields.storedCount;
+}
+
+const std::vector<DerivedFieldSkip>& PlotfileDataset::skippedDerivedFields()
+    const noexcept
+{
+    return m_fields.skipped;
 }
 
 const MetadataReadMetrics& PlotfileDataset::metadataReadMetrics() const noexcept
@@ -127,6 +182,27 @@ PlotfileDataset::BlockAccess PlotfileDataset::requestBlock(
         return {std::move(cached), true, {}};
     }
 
+    // isDerivedField bounds the field id at both ends, so a request past the
+    // field list falls through to the reader and is refused there, as it was
+    // before derived fields existed.
+    if (isDerivedField(request.field)) {
+        // No IO lock: this reads no file of its own, and the recursive
+        // requests for its inputs take the lock individually for whichever of
+        // them actually miss the cache. Holding it across an evaluation would
+        // stall every unrelated read on this dataset behind it -- and the
+        // recursion below would deadlock on it. Two threads racing on the same
+        // derived block therefore both evaluate it, and the loser's insert
+        // finds the winner's entry and hands that back (insertAndPin), so the
+        // race costs one duplicate evaluation and counts one extra cache hit.
+        auto read = readDerivedBlock(request,
+            m_fields.programs[static_cast<std::size_t>(request.field.value)
+                - m_fields.storedCount],
+            cancellation);
+        auto handle = m_cache.insertAndPin(
+            key, read.block, residentBytes(*read.block));
+        return {std::move(handle), false, read.metrics};
+    }
+
     // Acquire the per-dataset IO lock, polling the cancellation token while we
     // wait so a request can bail promptly instead of being stuck behind a
     // long in-progress read on this dataset. try_lock + sleep rather than a
@@ -155,6 +231,160 @@ PlotfileDataset::BlockAccess PlotfileDataset::requestBlock(
     auto handle = m_cache.insertAndPin(
         key, read.block, residentBytes(*read.block));
     return {std::move(handle), false, read.metrics};
+}
+
+BlockReadResult PlotfileDataset::readDerivedBlock(const BlockRequest& request,
+    const DerivedFieldProgram& program, StopToken cancellation)
+{
+    if (request.componentCount != 1 || request.firstComponent != 0) {
+        throw BlockReadError("a derived field has one component");
+    }
+    const auto& metadata = *m_fields.metadata;
+    if (request.level < 0
+        || static_cast<std::size_t>(request.level) >= metadata.levels.size()) {
+        throw BlockReadError("requested level is unavailable");
+    }
+    const auto& level = metadata.levels[static_cast<std::size_t>(request.level)];
+    if (request.gridIndex < 0
+        || static_cast<std::size_t>(request.gridIndex) >= level.blocks.size()) {
+        throw BlockReadError("requested grid is unavailable");
+    }
+
+    auto derived = std::make_shared<FabBlock>();
+    // The grid's valid box, which is the box every reader of a block requires
+    // it to cover -- deliberately not whatever box the inputs came back with.
+    // A stored block's box is the valid box grown by the level's ghost width,
+    // and a block computed from coordinates alone has no input to inherit a
+    // box from at all, so taking the inputs' box would make the two disagree
+    // and turn an expression mixing them into an error. The valid box is the
+    // one thing they all cover.
+    derived->box = level.blocks[static_cast<std::size_t>(request.gridIndex)].box;
+    derived->field = request.field;
+    derived->component = 0;
+    const auto points = fabPointCount(derived->box, metadata.dimension);
+    if (points > std::numeric_limits<std::size_t>::max()) {
+        throw BlockReadError("derived block exceeds addressable memory");
+    }
+    const auto count = static_cast<std::size_t>(points);
+
+    // Every input block, pinned for as long as the evaluation reads it, with
+    // the arithmetic that turns a sample of the derived box into an offset
+    // into that block's own (possibly ghost-grown) box. The recursion is
+    // bounded by the definition order installDerivedFields enforces: an
+    // expression reads only fields resolved before it.
+    struct Source {
+        BlockCache::Handle block;
+        // Offset of the derived box's first sample in this block.
+        std::size_t origin = 0;
+        // Samples between consecutive j and k of this block.
+        std::size_t rowStride = 1;
+        std::size_t planeStride = 1;
+    };
+    const auto& inputs = program.inputs;
+    std::vector<Source> sources;
+    sources.reserve(inputs.size());
+    // Where in `sources` each input's block is; unused for a coordinate.
+    std::vector<std::size_t> sourceOf(inputs.size(), 0);
+    BlockReadMetrics metrics;
+    for (std::size_t input = 0; input < inputs.size(); ++input) {
+        if (inputs[input].isCoordinate()) {
+            continue;
+        }
+        auto inputRequest = request;
+        inputRequest.field = inputs[input].field;
+        auto access = requestBlock(inputRequest, cancellation);
+        metrics.filesRead += access.io.filesRead;
+        metrics.bytesRead += access.io.bytesRead;
+        metrics.valuesRead += access.io.valuesRead;
+
+        const auto& box = access.handle->box;
+        // First, before any offset into this block is computed from its box:
+        // fabPointCount is overflow-checked and is what the reader sized the
+        // payload with, so a box this payload cannot hold -- or one whose
+        // extents do not multiply -- is refused before the strides below
+        // multiply them.
+        if (access.handle->values.size()
+            < fabPointCount(box, metadata.dimension)) {
+            throw BlockReadError(
+                "a derived field's input payload is smaller than its box");
+        }
+        Source source{std::move(access.handle), 0, 1, 1};
+        std::size_t stride = 1;
+        for (int axis = 0; axis < metadata.dimension; ++axis) {
+            const auto i = static_cast<std::size_t>(axis);
+            if (derived->box.lower[i] < box.lower[i]
+                || derived->box.upper[i] > box.upper[i]) {
+                throw BlockReadError(
+                    "a derived field's input does not cover its box");
+            }
+            source.origin += stride
+                * static_cast<std::size_t>(
+                    derived->box.lower[i] - box.lower[i]);
+            if (axis == 1) {
+                source.rowStride = stride;
+            } else if (axis == 2) {
+                source.planeStride = stride;
+            }
+            stride *= static_cast<std::size_t>(box.upper[i] - box.lower[i] + 1);
+        }
+        sourceOf[input] = sources.size();
+        sources.push_back(std::move(source));
+    }
+
+    std::vector<double> values(count);
+    // One column per symbol, a chunk long, and the spans handed to the
+    // evaluator each pass (shorter on the last chunk).
+    std::vector<std::vector<double>> columns(
+        inputs.size(), std::vector<double>(derivedChunkPoints));
+    std::vector<std::span<const double>> reads(inputs.size());
+    // The sample index within the box, first axis fastest, which is the order
+    // a FAB's values are laid out in (see valueOffset).
+    std::array<int, 3> offset{0, 0, 0};
+    std::array<int, 3> extent{1, 1, 1};
+    for (int axis = 0; axis < metadata.dimension; ++axis) {
+        const auto i = static_cast<std::size_t>(axis);
+        extent[i] = derived->box.upper[i] - derived->box.lower[i] + 1;
+    }
+    auto evaluator = program.expression.makeEvaluator();
+    for (std::size_t start = 0; start < count; start += derivedChunkPoints) {
+        if (cancellation.stop_requested()) {
+            throw ReadCancelled();
+        }
+        const auto chunk = std::min(derivedChunkPoints, count - start);
+        for (std::size_t point = 0; point < chunk; ++point) {
+            for (std::size_t input = 0; input < inputs.size(); ++input) {
+                if (inputs[input].isCoordinate()) {
+                    const auto axis =
+                        static_cast<std::size_t>(inputs[input].axis);
+                    columns[input][point] = samplePosition(level,
+                        inputs[input].axis,
+                        derived->box.lower[axis] + offset[axis]);
+                } else {
+                    const auto& source = sources[sourceOf[input]];
+                    columns[input][point] = source.block->values[source.origin
+                        + static_cast<std::size_t>(offset[0])
+                        + source.rowStride
+                            * static_cast<std::size_t>(offset[1])
+                        + source.planeStride
+                            * static_cast<std::size_t>(offset[2])];
+                }
+            }
+            // Advance the sample index with the walk rather than dividing it
+            // out of the linear one per point.
+            for (std::size_t axis = 0; axis < 3; ++axis) {
+                if (++offset[axis] < extent[axis]) {
+                    break;
+                }
+                offset[axis] = 0;
+            }
+        }
+        for (std::size_t input = 0; input < inputs.size(); ++input) {
+            reads[input] = std::span<const double>(columns[input].data(), chunk);
+        }
+        evaluator.evaluate(reads, std::span<double>(values.data() + start, chunk));
+    }
+    derived->values = FabValues{std::move(values)};
+    return {std::shared_ptr<const FabBlock>(std::move(derived)), metrics};
 }
 
 CacheMetrics PlotfileDataset::cacheMetrics() const

--- a/src/io/plotfile/PlotfileDataset.cpp
+++ b/src/io/plotfile/PlotfileDataset.cpp
@@ -266,6 +266,25 @@ BlockReadResult PlotfileDataset::readDerivedBlock(const BlockRequest& request,
         throw BlockReadError("derived block exceeds addressable memory");
     }
     const auto count = static_cast<std::size_t>(points);
+    // What this block will occupy, checked against the budget before it is
+    // allocated rather than after. An expression over coordinates alone reads
+    // no file, so nothing else here bounds `count` by anything but what the
+    // metadata claimed -- and src/io bounds its allocations by real file
+    // evidence, not by a claimed count. A box array claiming 10^10 cells is
+    // an 80 GB request otherwise. The budget is the same bound the block
+    // would have been held to a moment later, when it was offered to the
+    // cache, so the failure is one callers already handle.
+    constexpr std::uint64_t blockBytes = sizeof(FabBlock);
+    if (count
+        > (std::numeric_limits<std::uint64_t>::max() - blockBytes)
+            / sizeof(double)) {
+        throw BlockReadError("derived block exceeds addressable memory");
+    }
+    const auto resident = blockBytes + count * sizeof(double);
+    if (resident > m_cache.metrics().budgetBytes) {
+        throw CacheBudgetExceeded(
+            "a derived field's block exceeds the entire byte budget");
+    }
 
     // Every input block, pinned for as long as the evaluation reads it, with
     // the arithmetic that turns a sample of the derived box into an offset

--- a/src/pipeline/SlicePipeline.cpp
+++ b/src/pipeline/SlicePipeline.cpp
@@ -571,6 +571,23 @@ std::vector<ParticleSample> loadParticleSamples(
     return samples;
 }
 
+std::uint32_t resolveSpecField(const DatasetMetadata& metadata,
+    const std::string& name, std::uint32_t index)
+{
+    if (metadata.fields.empty()) {
+        return 0;
+    }
+    if (!name.empty()) {
+        for (std::size_t field = 0; field < metadata.fields.size(); ++field) {
+            if (metadata.fields[field].name == name) {
+                return static_cast<std::uint32_t>(field);
+            }
+        }
+    }
+    return std::min(index,
+        static_cast<std::uint32_t>(metadata.fields.size() - 1));
+}
+
 InitialSliceResult executeSessionFrameLoad(
     std::shared_ptr<DatasetSession> dataset, const FrameSliceSpec& spec,
     StopToken cancellation)
@@ -589,8 +606,7 @@ InitialSliceResult executeSessionFrameLoad(
     }
     result.fileVersion = result.dataset->fileVersion();
 
-    const auto fieldCount = static_cast<std::uint32_t>(metadata.fields.size());
-    const auto field = std::min(spec.field, fieldCount - 1);
+    const auto field = resolveSpecField(metadata, spec.fieldName, spec.field);
     // An out-of-range exact level falls back to finest-available, matching
     // the level combo's behavior when a frame has fewer levels.
     // Combo data encoding: -1=finest, N=level N only, 1000+N=update to N.
@@ -689,9 +705,12 @@ InitialSliceResult executeSessionFrameLoad(
                         cancellation, display);
                 }
                 if (spec.displayMode == DisplayMode::VelocityVectors) {
-                    const auto u = std::min(spec.vectorUField, fieldCount - 1);
-                    const auto v = std::min(spec.vectorVField, fieldCount - 1);
-                    const auto w = std::min(spec.vectorWField, fieldCount - 1);
+                    const auto u = resolveSpecField(
+                        metadata, spec.vectorUFieldName, spec.vectorUField);
+                    const auto v = resolveSpecField(
+                        metadata, spec.vectorVFieldName, spec.vectorVField);
+                    const auto w = resolveSpecField(
+                        metadata, spec.vectorWFieldName, spec.vectorWField);
                     auto [f1, f2] = (metadata.dimension == 3)
                         ? (normal == 0 ? std::pair{v, w}
                            : normal == 1 ? std::pair{u, w}

--- a/src/pipeline/SlicePipeline.cpp
+++ b/src/pipeline/SlicePipeline.cpp
@@ -787,10 +787,11 @@ InitialSliceResult executeFrameLoad(const std::filesystem::path& path,
     if (preparedMetadata) {
         dataset = std::make_shared<LocalDatasetSession>(
             std::move(dataRoot), datasetId, cacheBudgetBytes,
-            std::move(*preparedMetadata), cancellation);
+            std::move(*preparedMetadata), cancellation, spec.derivedFields);
     } else {
         dataset = std::make_shared<LocalDatasetSession>(
-            path, datasetId, cacheBudgetBytes, cancellation);
+            path, datasetId, cacheBudgetBytes, cancellation,
+            spec.derivedFields);
     }
     return executeSessionFrameLoad(
         std::move(dataset), spec, cancellation);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -25,6 +25,11 @@ target_link_libraries(
 )
 add_test(NAME expression COMMAND test_expression)
 
+add_executable(test_derived_field unit/test_derived_field.cpp)
+target_link_libraries(
+    test_derived_field PRIVATE amrexplorer::core amrexplorer::warnings)
+add_test(NAME derived_field COMMAND test_derived_field)
+
 add_executable(test_core_metadata unit/test_core_metadata.cpp)
 target_link_libraries(test_core_metadata PRIVATE amrexplorer::core amrexplorer::warnings)
 add_test(NAME core_metadata COMMAND test_core_metadata)
@@ -475,6 +480,12 @@ target_link_libraries(
     PRIVATE amrexplorer::pipeline amrexplorer::warnings
 )
 add_test(NAME display_transitions COMMAND test_display_transitions)
+
+add_executable(test_derived_field_query integration/test_derived_field_query.cpp)
+target_link_libraries(
+    test_derived_field_query PRIVATE amrexplorer::data amrexplorer::query
+    amrexplorer::warnings)
+add_test(NAME derived_field_query COMMAND test_derived_field_query)
 
 add_executable(test_slice_query integration/test_slice_query.cpp)
 target_link_libraries(test_slice_query PRIVATE amrexplorer::query amrexplorer::warnings)

--- a/tests/integration/test_derived_field_query.cpp
+++ b/tests/integration/test_derived_field_query.cpp
@@ -505,6 +505,143 @@ int main()
         std::filesystem::remove_all(ghostRoot);
     }
 
+    // A crafted box array, claiming a grid far larger than the payload behind
+    // it. The stored reader bounds its buffer by the data file; a derived
+    // field over coordinates alone reads no file at all, so nothing else here
+    // bounds the allocation by anything but the claim. It has to be refused
+    // before it is made, not discovered afterwards.
+    {
+        const auto craftedRoot = std::filesystem::temp_directory_path()
+            / ("amrexplorer-derived-crafted-" + std::to_string(unique));
+        std::filesystem::create_directories(craftedRoot / "Level_0");
+        // 10^10 cells claimed; four on disk. At eight bytes a cell the
+        // allocation this guards would be 800 GB.
+        const std::string claimed = "((0,0) (99999,99999) (0,0))";
+        writeText(craftedRoot / "Header",
+            "HyperCLaw-V1.1\n"
+            "1\ndensity\n"
+            "2\n0.0\n0\n"
+            "0.0 0.0\n1.0 1.0\n"
+            "\n"
+            + claimed + "\n"
+            "0\n"
+            "0.5 0.5\n"
+            "0\n0\n"
+            "0 1 0.0\n0\n"
+            "0.0 1.0\n0.0 1.0\n"
+            "Level_0/Cell\n");
+        writeText(craftedRoot / "Level_0" / "Cell_H",
+            "1\n1\n1\n0\n(1 0\n" + claimed + "\n)\n"
+            "1\nFabOnDisk: Cell_D_00000 0\n\n"
+            "1,1\n0.0,\n\n1,1\n1.0,\n\n");
+        writeFab(craftedRoot / "Level_0" / "Cell_D_00000",
+            "((0,0) (1,1) (0,0))", {std::vector<double>(4, 1.0)});
+
+        amrvis::PlotfileDataset crafted(craftedRoot, amrvis::DatasetId{17},
+            8 * 1024 * 1024, {},
+            {{"here", "x + y"}, {"scaled", "density * 2"}});
+        for (const std::uint32_t field : {1U, 2U}) {
+            amrvis::BlockRequest request;
+            request.dataset.value = 17;
+            request.field.value = field;
+            bool refused = false;
+            try {
+                static_cast<void>(crafted.requestBlock(request));
+            } catch (const amrvis::CacheBudgetExceeded&) {
+                refused = true;
+            }
+            require(refused,
+                "a derived block larger than the whole cache budget was not "
+                "refused before it was allocated");
+        }
+        std::filesystem::remove_all(craftedRoot);
+    }
+
+    // Three dimensions, with ghosts: the k-direction stride and the third
+    // digit of the sample odometer are the one part of the derived gather that
+    // a 2-D fixture cannot reach, so everything above says nothing about them.
+    // Ghost cells hold a value no expectation can produce, as in the 2-D case.
+    {
+        constexpr int cells = 4;
+        constexpr double poison = -999.0;
+        const auto solidRoot = std::filesystem::temp_directory_path()
+            / ("amrexplorer-derived-3d-" + std::to_string(unique));
+        std::filesystem::create_directories(solidRoot / "Level_0");
+        writeText(solidRoot / "Header",
+            "HyperCLaw-V1.1\n"
+            "2\ndensity\ntemperature\n"
+            "3\n0.0\n0\n"
+            "0.0 0.0 0.0\n1.0 1.0 1.0\n"
+            "\n"
+            "((0,0,0) (3,3,3) (0,0,0))\n"
+            "0\n"
+            "0.25 0.25 0.25\n"
+            "0\n0\n"
+            "0 1 0.0\n0\n"
+            "0.0 1.0\n0.0 1.0\n0.0 1.0\n"
+            "Level_0/Cell\n");
+        writeText(solidRoot / "Level_0" / "Cell_H",
+            "1\n1\n2\n1\n(1 0\n((0,0,0) (3,3,3) (0,0,0))\n)\n"
+            "1\nFabOnDisk: Cell_D_00000 0\n\n"
+            "1,2\n-10000.0,-10000.0,\n\n"
+            "1,2\n10000.0,10000.0,\n\n");
+        std::vector<std::vector<double>> components(2);
+        for (int k = -1; k <= cells; ++k) {
+            for (int j = -1; j <= cells; ++j) {
+                for (int i = -1; i <= cells; ++i) {
+                    const auto ghost = i < 0 || j < 0 || k < 0 || i >= cells
+                        || j >= cells || k >= cells;
+                    // Distinct along every axis, k included, so a stride that
+                    // is wrong in the third direction cannot coincide.
+                    const auto value = 1.0 + static_cast<double>(i)
+                        + 10.0 * static_cast<double>(j)
+                        + 100.0 * static_cast<double>(k);
+                    components[0].push_back(ghost ? poison : value);
+                    components[1].push_back(ghost ? poison : 2.0 * value);
+                }
+            }
+        }
+        writeFab(solidRoot / "Level_0" / "Cell_D_00000",
+            "((-1,-1,-1) (4,4,4) (0,0,0))", components);
+
+        amrvis::PlotfileDataset solid(solidRoot, amrvis::DatasetId{13},
+            8 * 1024 * 1024, {},
+            {{"sum", "density + temperature"}, {"lifted", "density*z"}});
+        const auto& level = solid.metadata().levels[0];
+        for (const std::uint32_t field : {2U, 3U}) {
+            amrvis::BlockRequest request;
+            request.dataset.value = 13;
+            request.field.value = field;
+            const auto access = solid.requestBlock(request);
+            const auto& blockBox = access.handle->box;
+            require(blockBox.lower[2] == 0 && blockBox.upper[2] == cells - 1,
+                "the 3-D derived block does not span the valid box in k");
+            std::size_t compared = 0;
+            for (int k = 0; k < cells; ++k) {
+                for (int j = 0; j < cells; ++j) {
+                    for (int i = 0; i < cells; ++i) {
+                        const auto offset = static_cast<std::size_t>(
+                            i + cells * (j + cells * k));
+                        const auto density = 1.0 + static_cast<double>(i)
+                            + 10.0 * static_cast<double>(j)
+                            + 100.0 * static_cast<double>(k);
+                        const auto expected = field == 2
+                            ? 3.0 * density
+                            : density * amrvis::samplePosition(level, 2, k);
+                        require(close(access.handle->values[offset], expected),
+                            "a 3-D derived block read the wrong samples");
+                        ++compared;
+                    }
+                }
+            }
+            require(compared
+                    == static_cast<std::size_t>(cells * cells * cells),
+                "the 3-D derived block was not fully compared");
+        }
+        std::filesystem::remove_all(solidRoot);
+    }
+
+    std::filesystem::remove_all(root);
     std::cout << "derived field query tests passed\n";
     return EXIT_SUCCESS;
 }

--- a/tests/integration/test_derived_field_query.cpp
+++ b/tests/integration/test_derived_field_query.cpp
@@ -1,0 +1,510 @@
+// A derived field end to end: installed by the dataset, evaluated per block,
+// and read back through the ordinary slice, line and range paths. The point of
+// the whole design is that nothing above PlotfileDataset knows the difference,
+// so the assertions compare a derived field's results against the same query
+// run on the fields it is computed from.
+#include <amrexplorer/data/LocalDatasetSession.hpp>
+#include <amrexplorer/query/LineQuery.hpp>
+#include <amrexplorer/query/SliceQuery.hpp>
+
+#include <array>
+#include <chrono>
+#include <memory>
+#include <cmath>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <span>
+#include <string>
+#include <string_view>
+#include <variant>
+#include <vector>
+
+namespace {
+
+constexpr std::string_view realDescriptor =
+    "((8, (64 11 52 0 1 12 0 1023)),(8, (8 7 6 5 4 3 2 1)))";
+
+void require(bool condition, const char* message)
+{
+    if (!condition) {
+        std::cerr << "FAILED: " << message << '\n';
+        std::exit(1);
+    }
+}
+
+// Samples travel as float, and the derived field evaluates in double before
+// narrowing, so an expectation rebuilt from the narrowed inputs agrees only to
+// float precision. Everything compared here has been through a plane or a line
+// result, so this is the tolerance throughout.
+bool close(double left, double right)
+{
+    const auto scale = std::max({1.0, std::abs(left), std::abs(right)});
+    return std::abs(left - right) <= 1.0e-6 * scale;
+}
+
+void writeText(const std::filesystem::path& path, const std::string& text)
+{
+    std::ofstream output(path, std::ios::binary);
+    require(static_cast<bool>(output), "could not create fixture text");
+    output << text;
+}
+
+// One multi-component FAB: the components follow one another, each laid out
+// i-fastest over the box.
+void writeFab(const std::filesystem::path& path, std::string_view box,
+    const std::vector<std::vector<double>>& components)
+{
+    std::ofstream output(path, std::ios::binary);
+    require(static_cast<bool>(output), "could not create fixture FAB");
+    output << "FAB " << realDescriptor << box << " " << components.size()
+           << '\n';
+    for (const auto& values : components) {
+        output.write(reinterpret_cast<const char*>(values.data()),
+            static_cast<std::streamsize>(values.size() * sizeof(double)));
+    }
+}
+
+// Cells per axis on the coarse level. Deliberately more than one evaluation
+// chunk holds (derivedChunkPoints in PlotfileDataset.cpp), so a derived block
+// is computed over several passes and the seams between them are covered; a
+// block that fits in one pass hides every indexing mistake across them. The
+// count keeps both levels' cell sizes exact in binary.
+constexpr int coarseCells = 32;
+
+// The fixture's three stored fields, as functions of the cell index, so the
+// expectations below are written in the same terms.
+double densityAt(int i, int j)
+{
+    return 1.0 + static_cast<double>(i)
+        + static_cast<double>(coarseCells) * static_cast<double>(j);
+}
+double temperatureAt(int i, int j)
+{
+    return 10.0 + static_cast<double>(i) - static_cast<double>(j);
+}
+double momentumAt(int i, int j)
+{
+    return -(static_cast<double>(i) + static_cast<double>(j)) - 0.5;
+}
+
+std::vector<std::vector<double>> fabComponents(
+    int lowI, int lowJ, double offset)
+{
+    std::vector<std::vector<double>> components(3);
+    for (int j = lowJ; j < lowJ + coarseCells; ++j) {
+        for (int i = lowI; i < lowI + coarseCells; ++i) {
+            components[0].push_back(densityAt(i, j) + offset);
+            components[1].push_back(temperatureAt(i, j) + offset);
+            components[2].push_back(momentumAt(i, j) + offset);
+        }
+    }
+    return components;
+}
+
+std::string visMfHeader(std::string_view box)
+{
+    return std::string("1\n1\n3\n0\n(1 0\n") + std::string(box)
+        + "\n)\n1\nFabOnDisk: Cell_D_00000 0\n\n"
+        // Statistics for the three stored components. Deliberately wide
+        // enough to cover the payload; the derived fields have none, which is
+        // what makes their File range unavailable.
+        "1,3\n-10000.0,-10000.0,-10000.0,\n\n"
+        "1,3\n10000.0,10000.0,10000.0,\n\n";
+}
+
+amrvis::SliceRequest sliceRequest(std::uint32_t field, int maximumLevel)
+{
+    amrvis::SliceRequest request;
+    request.dataset.value = 7;
+    request.field.value = field;
+    request.normalDirection = 1;
+    request.visibleRegion = {{{0.0, 0.0, 0.0}}, {{1.0, 1.0, 0.0}}};
+    request.maximumLevel = maximumLevel;
+    // One output sample per coarse cell, so a level-0 plane index maps
+    // straight onto a cell index (which the coordinate check below relies on).
+    request.outputSize = {coarseCells, coarseCells};
+    return request;
+}
+
+// The derived-field definitions the fixture is opened with. Their ids follow
+// the three stored fields, in this order.
+const std::vector<amrvis::DerivedFieldDefinition>& definitions()
+{
+    static const std::vector<amrvis::DerivedFieldDefinition> list{
+        {"speed", "sqrt(density**2 + temperature**2)"},
+        {"drag", "-${x-momentum} / density"},
+        {"doubled", "2*speed"},
+        {"radius", "sqrt(x**2 + y**2)"},
+    };
+    return list;
+}
+
+constexpr std::uint32_t speedField = 3;
+constexpr std::uint32_t dragField = 4;
+constexpr std::uint32_t doubledField = 5;
+constexpr std::uint32_t radiusField = 6;
+
+} // namespace
+
+int main()
+{
+    const auto unique =
+        std::chrono::steady_clock::now().time_since_epoch().count();
+    const auto root = std::filesystem::temp_directory_path()
+        / ("amrexplorer-derived-field-" + std::to_string(unique));
+    std::filesystem::create_directories(root / "Level_0");
+    std::filesystem::create_directories(root / "Level_1");
+
+    // Two levels over the unit square: level 0 is one grid of coarseCells^2
+    // cells, level 1 one grid of the same count over the middle quarter, so a
+    // composite slice mixes both and every block spans several evaluation
+    // chunks. The fine level's values are offset so which level a sample came
+    // from is visible in the value itself.
+    const auto box = [](int low, int high) {
+        return "((" + std::to_string(low) + "," + std::to_string(low) + ") ("
+            + std::to_string(high) + "," + std::to_string(high) + ") (0,0))";
+    };
+    const auto coarseBox = box(0, coarseCells - 1);
+    const auto fineBox = box(coarseCells / 2, 3 * coarseCells / 2 - 1);
+    const auto coarseCellSize = 1.0 / static_cast<double>(coarseCells);
+    const auto cellSizeLine = [](double size) {
+        return std::to_string(size) + " " + std::to_string(size) + "\n";
+    };
+    writeText(root / "Header",
+        "HyperCLaw-V1.1\n"
+        "3\ndensity\ntemperature\nx-momentum\n"
+        "2\n0.0\n1\n"
+        "0.0 0.0\n1.0 1.0\n2\n"
+        + coarseBox + "\n"
+        + box(0, 2 * coarseCells - 1) + "\n"
+        "0 0\n"
+        + cellSizeLine(coarseCellSize) + cellSizeLine(0.5 * coarseCellSize)
+        + "0\n0\n"
+        "0 1 0.0\n0\n"
+        "0.0 1.0\n0.0 1.0\n"
+        "Level_0/Cell\n"
+        "1 1 0.0\n0\n"
+        "0.25 0.75\n0.25 0.75\n"
+        "Level_1/Cell\n");
+    writeText(root / "Level_0" / "Cell_H", visMfHeader(coarseBox));
+    writeText(root / "Level_1" / "Cell_H", visMfHeader(fineBox));
+    writeFab(root / "Level_0" / "Cell_D_00000", coarseBox,
+        fabComponents(0, 0, 0.0));
+    writeFab(root / "Level_1" / "Cell_D_00000", fineBox,
+        fabComponents(coarseCells / 2, coarseCells / 2, 1000.0));
+
+    // A definition that does not resolve is left out and reported, and the
+    // dataset opens: a definition written for another plotfile must not be
+    // able to stop this one from opening.
+    {
+        amrvis::PlotfileDataset partial(root, amrvis::DatasetId{7},
+            1024 * 1024, {},
+            {{"speed", "sqrt(dens**2)"}, {"twice", "2*density"}});
+        require(partial.metadata().fields.size() == 4,
+            "the resolvable definition was not installed");
+        require(partial.metadata().fields[3].name == "twice",
+            "the installed definition is not the resolvable one");
+        require(partial.storedFieldCount() == 3,
+            "the stored field count moved");
+        const auto& skipped = partial.skippedDerivedFields();
+        require(skipped.size() == 1 && skipped[0].definitionIndex == 0
+                && skipped[0].name == "speed"
+                && skipped[0].reason.find("dens") != std::string::npos,
+            "the skipped definition was not reported with its reason");
+    }
+
+    amrvis::PlotfileDataset dataset(
+        root, amrvis::DatasetId{7}, 8 * 1024 * 1024, {}, definitions());
+    const auto& metadata = dataset.metadata();
+    require(metadata.fields.size() == 7, "derived fields were not appended");
+    require(metadata.fields[speedField].name == "speed"
+            && metadata.fields[radiusField].name == "radius",
+        "derived fields are not in definition order");
+    require(!dataset.isDerivedField(amrvis::FieldId{2})
+            && dataset.isDerivedField(amrvis::FieldId{speedField}),
+        "isDerivedField does not separate stored from derived");
+
+    amrvis::SliceQuery query(dataset);
+
+    // The whole contract, on the composite path that mixes both levels: the
+    // derived plane is the expression applied to the stored planes, sample for
+    // sample, including where the fine level covers the coarse one.
+    {
+        const auto density = query.execute(sliceRequest(0, 1));
+        const auto temperature = query.execute(sliceRequest(1, 1));
+        const auto momentum = query.execute(sliceRequest(2, 1));
+        const auto speed = query.execute(sliceRequest(speedField, 1));
+        const auto drag = query.execute(sliceRequest(dragField, 1));
+        const auto doubled = query.execute(sliceRequest(doubledField, 1));
+        require(speed.plane.values.size() == density.plane.values.size(),
+            "a derived plane is not the size of a stored one");
+        bool sawFineLevel = false;
+        bool sawCoarseLevel = false;
+        std::size_t compared = 0;
+        for (std::size_t index = 0; index < speed.plane.values.size(); ++index) {
+            require(speed.plane.valid[index] == density.plane.valid[index],
+                "a derived plane's coverage differs from its inputs'");
+            require(speed.plane.sourceLevel[index]
+                    == density.plane.sourceLevel[index],
+                "a derived plane's source levels differ from its inputs'");
+            if (speed.plane.valid[index] == 0) {
+                continue;
+            }
+            sawFineLevel = sawFineLevel || speed.plane.sourceLevel[index] == 1;
+            sawCoarseLevel
+                = sawCoarseLevel || speed.plane.sourceLevel[index] == 0;
+            const auto d = static_cast<double>(density.plane.values[index]);
+            const auto t = static_cast<double>(temperature.plane.values[index]);
+            const auto m = static_cast<double>(momentum.plane.values[index]);
+            require(close(static_cast<double>(speed.plane.values[index]),
+                        std::sqrt(d * d + t * t)),
+                "derived slice does not match its expression");
+            require(close(static_cast<double>(drag.plane.values[index]),
+                        -m / d),
+                "derived slice with a braced field name does not match");
+            require(close(static_cast<double>(doubled.plane.values[index]),
+                        2.0 * std::sqrt(d * d + t * t)),
+                "a derived field reading another derived field does not match");
+            ++compared;
+        }
+        require(compared > 0, "no covered samples were compared");
+        require(sawFineLevel && sawCoarseLevel,
+            "the comparison did not cover both levels");
+    }
+
+    // Coordinates come from the level the sample was taken on, which is what
+    // samplePosition answers for a cell-centered axis.
+    {
+        auto request = sliceRequest(radiusField, 0);
+        request.composition = amrvis::CompositionPolicy::ExactLevel;
+        const auto radius = query.execute(request);
+        const auto& level = metadata.levels[0];
+        std::size_t compared = 0;
+        for (int j = 0; j < coarseCells; ++j) {
+            for (int i = 0; i < coarseCells; ++i) {
+                const auto index =
+                    static_cast<std::size_t>(i + coarseCells * j);
+                if (radius.plane.valid[index] == 0) {
+                    continue;
+                }
+                const auto x = amrvis::samplePosition(level, 0, i);
+                const auto y = amrvis::samplePosition(level, 1, j);
+                require(close(static_cast<double>(radius.plane.values[index]),
+                            std::sqrt(x * x + y * y)),
+                    "a coordinate expression does not match samplePosition");
+                ++compared;
+            }
+        }
+        require(compared == static_cast<std::size_t>(coarseCells)
+                    * static_cast<std::size_t>(coarseCells),
+            "the coordinate plane was not fully covered");
+    }
+
+    // A derived block is cached like any other: the second identical slice
+    // reads nothing. On its own dataset, so the queries above have not already
+    // warmed the block this measures.
+    {
+        amrvis::PlotfileDataset cold(
+            root, amrvis::DatasetId{7}, 8 * 1024 * 1024, {}, definitions());
+        amrvis::SliceQuery coldQuery(cold);
+        const auto first = coldQuery.execute(sliceRequest(speedField, 0));
+        const auto again = coldQuery.execute(sliceRequest(speedField, 0));
+        require(first.metrics.blocksRead >= 1,
+            "the first derived slice read no block");
+        require(again.metrics.blocksRead == 0
+                && again.metrics.cacheHits == first.metrics.blocksRead,
+            "a repeated derived slice did not reuse the cached block");
+        require(again.metrics.payloadBytesRead == 0,
+            "a cached derived slice performed payload I/O");
+    }
+
+    // The line path, which composites blocks of its own.
+    {
+        amrvis::LineQuery line(dataset);
+        amrvis::LineRequest request;
+        request.dataset.value = 7;
+        request.axis = 0;
+        request.maximumLevel = 0;
+        request.composition = amrvis::CompositionPolicy::ExactLevel;
+        request.fixedCoordinates = {0.0, 0.375, 0.0};
+        request.field.value = 0;
+        const auto density = line.execute(request);
+        request.field.value = 1;
+        const auto temperature = line.execute(request);
+        request.field.value = speedField;
+        const auto speed = line.execute(request);
+        require(speed.line.values.size() == density.line.values.size()
+                && !speed.line.values.empty(),
+            "a derived line is not the shape of a stored one");
+        for (std::size_t index = 0; index < speed.line.values.size(); ++index) {
+            const auto d = density.line.values[index];
+            const auto t = temperature.line.values[index];
+            require(close(speed.line.values[index], std::sqrt(d * d + t * t)),
+                "derived line does not match its expression");
+        }
+    }
+
+    // Cancellation is observed while evaluating, not only while reading. Its
+    // own dataset, with the inputs warmed and the derived block not: a cold
+    // input would report the cancellation from the read below it and leave the
+    // evaluation loop's own check untested, while a warm derived block would
+    // be served from the cache without reaching either.
+    {
+        amrvis::PlotfileDataset warm(
+            root, amrvis::DatasetId{7}, 8 * 1024 * 1024, {}, definitions());
+        amrvis::SliceQuery warmQuery(warm);
+        for (const std::uint32_t field : {0U, 1U}) {
+            auto request = sliceRequest(field, 0);
+            request.composition = amrvis::CompositionPolicy::ExactLevel;
+            static_cast<void>(warmQuery.execute(request));
+        }
+        amrvis::StopSource stop;
+        stop.request_stop();
+        bool cancelled = false;
+        try {
+            amrvis::BlockRequest request;
+            request.dataset.value = 7;
+            request.field.value = speedField;
+            static_cast<void>(warm.requestBlock(request, stop.get_token()));
+        } catch (const amrvis::ReadCancelled&) {
+            cancelled = true;
+        }
+        require(cancelled, "a cancelled derived block read was not abandoned");
+    }
+
+    // Ranges: a derived field has no stored statistic, so the File and Level
+    // scopes cannot answer for it while they still answer for stored fields.
+    // (The resolver's fallback to Visible is what the GUI then shows.)
+    {
+        amrvis::LocalDatasetSession session(
+            root, amrvis::DatasetId{7}, 8 * 1024 * 1024, {}, definitions());
+        require(session.supportsDerivedFields(),
+            "a local session does not offer derived fields");
+        require(session.metadata().fields.size() == 7,
+            "the session does not see the derived fields");
+        require(session.storedFieldCount() == 3
+                && session.skippedDerivedFields().empty(),
+            "the session misreports which fields are stored");
+        const auto available = [&session](std::uint32_t field,
+                                   amrvis::RangeScope scope) {
+            return session.rangeAvailable(
+                amrvis::RangeRequest{amrvis::FieldId{field}, 0,
+                    amrvis::CompositionPolicy::ExactLevel, scope});
+        };
+        require(available(0, amrvis::RangeScope::File)
+                && available(0, amrvis::RangeScope::Level),
+            "a stored field's metadata ranges went missing");
+        require(!available(speedField, amrvis::RangeScope::File)
+                && !available(speedField, amrvis::RangeScope::Level),
+            "a derived field claimed a range no statistic can answer");
+        require(!session.requestRange(
+                        amrvis::RangeRequest{amrvis::FieldId{speedField}, 0,
+                            amrvis::CompositionPolicy::ExactLevel,
+                            amrvis::RangeScope::File})
+                     .has_value(),
+            "a derived field returned a File range");
+
+        // The session's own read path (what the slice pipeline calls) sees the
+        // derived field as an ordinary one.
+        auto slice = sliceRequest(speedField, 0);
+        slice.composition = amrvis::CompositionPolicy::ExactLevel;
+        const auto result = session.requestView(amrvis::ViewDataRequest{slice});
+        require(!std::get<amrvis::SliceQueryResult>(result)
+                     .plane.values.empty(),
+            "a session view of a derived field produced no samples");
+    }
+
+    // Ghost cells: a stored block's box is the valid box grown by the level's
+    // ghost width, so a derived field has to read its inputs through their own
+    // boxes rather than assume they are laid out like its own. The ghost cells
+    // here hold a value no expectation below can produce, so an offset that
+    // slips into them is not a near miss but an obvious wrong answer -- and an
+    // expression mixing a stored field with a coordinate, whose block has no
+    // ghosts to inherit, is exactly what used to disagree.
+    {
+        constexpr int cells = 8;
+        constexpr double poison = -999.0;
+        const auto ghostRoot = std::filesystem::temp_directory_path()
+            / ("amrexplorer-derived-ghost-" + std::to_string(unique));
+        std::filesystem::create_directories(ghostRoot / "Level_0");
+        writeText(ghostRoot / "Header",
+            "HyperCLaw-V1.1\n"
+            "2\ndensity\ntemperature\n"
+            "2\n0.0\n0\n"
+            "0.0 0.0\n1.0 1.0\n"
+            "\n"
+            "((0,0) (7,7) (0,0))\n"
+            "0\n"
+            "0.125 0.125\n"
+            "0\n0\n"
+            "0 1 0.0\n0\n"
+            "0.0 1.0\n0.0 1.0\n"
+            "Level_0/Cell\n");
+        // One ghost cell all round: the box array carries the valid box, the
+        // FAB its own grown one.
+        writeText(ghostRoot / "Level_0" / "Cell_H",
+            "1\n1\n2\n1\n(1 0\n((0,0) (7,7) (0,0))\n)\n"
+            "1\nFabOnDisk: Cell_D_00000 0\n\n"
+            "1,2\n-10000.0,-10000.0,\n\n"
+            "1,2\n10000.0,10000.0,\n\n");
+        std::vector<std::vector<double>> components(2);
+        for (int j = -1; j <= cells; ++j) {
+            for (int i = -1; i <= cells; ++i) {
+                const auto ghost =
+                    i < 0 || j < 0 || i >= cells || j >= cells;
+                components[0].push_back(ghost ? poison : densityAt(i, j));
+                components[1].push_back(ghost ? poison : temperatureAt(i, j));
+            }
+        }
+        writeFab(ghostRoot / "Level_0" / "Cell_D_00000",
+            "((-1,-1) (8,8) (0,0))", components);
+
+        amrvis::PlotfileDataset ghosted(ghostRoot, amrvis::DatasetId{11},
+            8 * 1024 * 1024, {},
+            {{"sum", "density + temperature"}, {"weighted", "density*x"}});
+        require(ghosted.metadata().fields.size() == 4,
+            "the ghosted fixture did not install both derived fields");
+        amrvis::SliceQuery ghostQuery(ghosted);
+        const auto sliceOf = [&ghostQuery](std::uint32_t field) {
+            amrvis::SliceRequest request;
+            request.dataset.value = 11;
+            request.field.value = field;
+            request.normalDirection = 1;
+            request.visibleRegion = {{{0.0, 0.0, 0.0}}, {{1.0, 1.0, 0.0}}};
+            request.maximumLevel = 0;
+            request.composition = amrvis::CompositionPolicy::ExactLevel;
+            request.outputSize = {cells, cells};
+            return ghostQuery.execute(request);
+        };
+        const auto sum = sliceOf(2);
+        const auto weighted = sliceOf(3);
+        const auto& level = ghosted.metadata().levels[0];
+        std::size_t compared = 0;
+        for (int j = 0; j < cells; ++j) {
+            for (int i = 0; i < cells; ++i) {
+                const auto index = static_cast<std::size_t>(i + cells * j);
+                require(sum.plane.valid[index] == 1
+                        && weighted.plane.valid[index] == 1,
+                    "a ghosted derived plane left a hole");
+                require(close(static_cast<double>(sum.plane.values[index]),
+                            densityAt(i, j) + temperatureAt(i, j)),
+                    "a derived field over ghost-grown blocks read the wrong "
+                    "samples");
+                require(close(static_cast<double>(weighted.plane.values[index]),
+                            densityAt(i, j)
+                                * amrvis::samplePosition(level, 0, i)),
+                    "a stored field and a coordinate did not line up over "
+                    "ghost-grown blocks");
+                ++compared;
+            }
+        }
+        require(compared == static_cast<std::size_t>(cells * cells),
+            "the ghosted planes were not fully covered");
+        std::filesystem::remove_all(ghostRoot);
+    }
+
+    std::cout << "derived field query tests passed\n";
+    return EXIT_SUCCESS;
+}

--- a/tests/unit/test_derived_field.cpp
+++ b/tests/unit/test_derived_field.cpp
@@ -226,6 +226,29 @@ int main()
                         != std::string::npos,
                 "the definition past the cap was not reported");
             requireRejected(many, limit, "at most");
+
+            // The cap counts what was installed, not how far down the list we
+            // are: definitions the dataset cannot resolve take no slot, so the
+            // ones after them still fit.
+            std::vector<DerivedFieldDefinition> mixed;
+            for (std::size_t index = 0; index < 8; ++index) {
+                mixed.push_back({"skip" + std::to_string(index), "absent"});
+            }
+            for (std::size_t index = 0; index < limit; ++index) {
+                mixed.push_back({"keep" + std::to_string(index), "density"});
+            }
+            auto second = makeMetadata();
+            const auto capped = amrvis::installDerivedFields(
+                second, mixed, amrvis::DerivedFieldPolicy::Skip);
+            require(capped.programs.size() == limit,
+                "unresolvable definitions consumed slots from the cap");
+            require(capped.skipped.size() == 8,
+                "the cap rejected definitions that had room");
+            // The reason is the problem alone; the name lives beside it, and a
+            // caller composing the two should not say it twice.
+            require(capped.skipped[0].name == "skip0"
+                    && capped.skipped[0].reason.rfind("derived field", 0) != 0,
+                "the skip reason repeats the name it is stored with");
         }
         {
             // A chain of derived fields, each reading the one before it.

--- a/tests/unit/test_derived_field.cpp
+++ b/tests/unit/test_derived_field.cpp
@@ -206,6 +206,28 @@ int main()
                 "not centered like", metadata);
         }
         {
+            // The list length is bounded too, and past the bound the ones that
+            // fit are still installed -- Skip's promise -- while the rest are
+            // reported.
+            const auto limit = amrvis::maximumDerivedFieldCount;
+            std::vector<DerivedFieldDefinition> many;
+            for (std::size_t index = 0; index <= limit; ++index) {
+                many.push_back(
+                    {"f" + std::to_string(index), "density + 1"});
+            }
+            auto metadata = makeMetadata();
+            const auto installation = amrvis::installDerivedFields(
+                metadata, many, amrvis::DerivedFieldPolicy::Skip);
+            require(installation.programs.size() == limit,
+                "the definition cap installed the wrong number");
+            require(installation.skipped.size() == 1
+                    && installation.skipped[0].definitionIndex == limit
+                    && installation.skipped[0].reason.find("at most")
+                        != std::string::npos,
+                "the definition past the cap was not reported");
+            requireRejected(many, limit, "at most");
+        }
+        {
             // A chain of derived fields, each reading the one before it.
             // Evaluating the last one recurses once per link, so the chain is
             // bounded at installation; without that a long enough list is a

--- a/tests/unit/test_derived_field.cpp
+++ b/tests/unit/test_derived_field.cpp
@@ -206,7 +206,63 @@ int main()
                 "not centered like", metadata);
         }
         {
-            // One symbol past the input cap.
+            // A chain of derived fields, each reading the one before it.
+            // Evaluating the last one recurses once per link, so the chain is
+            // bounded at installation; without that a long enough list is a
+            // stack overflow in whichever worker evaluates it.
+            const auto depth = amrvis::maximumDerivedFieldDepth;
+            const auto chain = [](std::size_t links) {
+                std::vector<DerivedFieldDefinition> definitions{
+                    {"d0", "density"}};
+                for (std::size_t index = 1; index < links; ++index) {
+                    definitions.push_back({"d" + std::to_string(index),
+                        "d" + std::to_string(index - 1) + " + 1"});
+                }
+                return definitions;
+            };
+            {
+                auto metadata = makeMetadata();
+                const auto programs = install(metadata, chain(depth));
+                require(programs.size() == depth,
+                    "a chain at the depth limit was not installed");
+            }
+            // ...and one link too many, which names the definition that
+            // crossed the line rather than the whole list.
+            requireRejected(chain(depth + 1), depth, "chain of more than");
+            // Depth is the longest path, not the count: a definition may read
+            // any number of shallow ones.
+            {
+                auto metadata = makeMetadata();
+                std::vector<DerivedFieldDefinition> wide{{"a", "density"},
+                    {"b", "temperature"}, {"c", "a + b"}};
+                require(install(metadata, wide).size() == 3,
+                    "a wide but shallow list was rejected");
+            }
+        }
+        {
+            // Coordinates are computed rather than read, so they do not count
+            // against the cap that bounds how many blocks one evaluation
+            // holds pinned -- and the message says "fields" because that is
+            // what it counts.
+            std::string expression = "x + y + z";
+            auto metadata = makeMetadata();
+            for (std::size_t index = 0; index < amrvis::maximumDerivedFieldInputs;
+                ++index) {
+                const auto name = "f" + std::to_string(index);
+                expression += " + " + name;
+                metadata.fields.push_back(FieldMetadata{
+                    .name = name, .centering = Centering::Cell,
+                    .componentNames = {}});
+            }
+            const auto programs = install(metadata, {{"a", expression}});
+            require(programs.size() == 1,
+                "three coordinates and the maximum fields were rejected");
+            require(programs[0].inputs.size()
+                    == amrvis::maximumDerivedFieldInputs + 3,
+                "the coordinates did not resolve alongside the fields");
+        }
+        {
+            // One field past the input cap.
             std::string expression = "density";
             for (std::size_t index = 0; index <= amrvis::maximumDerivedFieldInputs;
                 ++index) {

--- a/tests/unit/test_derived_field.cpp
+++ b/tests/unit/test_derived_field.cpp
@@ -1,0 +1,272 @@
+#include <amrexplorer/core/DerivedField.hpp>
+
+#include <cstdlib>
+#include <iostream>
+#include <optional>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace {
+
+using amrvis::Centering;
+using amrvis::DatasetMetadata;
+using amrvis::DerivedFieldDefinition;
+using amrvis::DerivedFieldError;
+using amrvis::FieldMetadata;
+
+void require(bool condition, const std::string& message)
+{
+    if (!condition) {
+        throw std::runtime_error(message);
+    }
+}
+
+// A 3-D dataset with physical geometry and three cell-centered fields, one of
+// them named so that only ${...} can spell it.
+DatasetMetadata makeMetadata(int dimension = 3)
+{
+    DatasetMetadata metadata;
+    metadata.dimension = dimension;
+    metadata.hasPhysicalGeometry = true;
+    metadata.finestLevel = 0;
+    // A whole, valid single-level dataset, so the validateMetadata assertion
+    // below is about what installing did and not about a half-built fixture.
+    for (std::size_t axis = 0; axis < 3; ++axis) {
+        metadata.physicalDomain.lower[axis] = 0.0;
+        metadata.physicalDomain.upper[axis] = 1.0;
+    }
+    amrvis::LevelMetadata level;
+    level.level = 0;
+    level.cellSize = amrvis::Real3{{0.25, 0.25, 0.25}};
+    level.domain.upper = amrvis::Int3{{3, 3, 3}};
+    level.storedComponents = 3;
+    metadata.levels.push_back(level);
+    metadata.fields = {
+        FieldMetadata{.name = "density", .centering = Centering::Cell, .componentNames = {}},
+        FieldMetadata{.name = "temperature", .centering = Centering::Cell, .componentNames = {}},
+        FieldMetadata{.name = "x-momentum", .centering = Centering::Cell, .componentNames = {}},
+    };
+    return metadata;
+}
+
+// Strict is the default and what every assertion below except the Skip
+// section expects.
+std::vector<amrvis::DerivedFieldProgram> install(DatasetMetadata& metadata,
+    const std::vector<DerivedFieldDefinition>& definitions)
+{
+    auto installation = amrvis::installDerivedFields(metadata, definitions);
+    require(installation.skipped.empty(),
+        "a strict install reported a skipped definition");
+    return std::move(installation.programs);
+}
+
+// The rejection, with the definition it belongs to and a fragment of the
+// reason. Asserting the index matters: an editor selects the failing row by it.
+void requireRejected(const std::vector<DerivedFieldDefinition>& definitions,
+    std::size_t definitionIndex, std::string_view message,
+    DatasetMetadata metadata = makeMetadata())
+{
+    const auto fieldsBefore = metadata.fields.size();
+    try {
+        static_cast<void>(install(metadata, definitions));
+    } catch (const DerivedFieldError& error) {
+        require(error.definitionIndex() == definitionIndex,
+            std::string("wrong definition index for '") + std::string(message)
+                + "': " + std::to_string(error.definitionIndex()));
+        require(std::string_view(error.what()).find(message)
+                != std::string_view::npos,
+            std::string("wrong message: ") + error.what());
+        require(metadata.fields.size() == fieldsBefore + definitionIndex,
+            "a rejected install kept more or fewer fields than the "
+            "definitions before it");
+        return;
+    }
+    throw std::runtime_error(
+        "definitions were unexpectedly accepted: " + std::string(message));
+}
+
+} // namespace
+
+int main()
+{
+    try {
+        {
+            // The ordinary case: two derived fields, the second reading the
+            // first, both appended after the stored fields in list order.
+            auto metadata = makeMetadata();
+            const auto programs = install(metadata,
+                {{"speed", "sqrt(density**2 + temperature**2)"},
+                    {"scaled", "2*speed + ${x-momentum}"}});
+            require(programs.size() == 2, "wrong program count");
+            require(metadata.fields.size() == 5, "fields were not appended");
+            require(metadata.fields[3].name == "speed"
+                    && metadata.fields[4].name == "scaled",
+                "derived fields are not in definition order");
+            require(metadata.fields[3].centering == Centering::Cell,
+                "derived centering was not taken from its inputs");
+            require(amrvis::validateMetadata(metadata).empty(),
+                "installed metadata no longer validates");
+
+            const auto& first = programs[0].inputs;
+            require(first.size() == 2 && first[0].field.value == 0
+                    && first[1].field.value == 1
+                    && !first[0].isCoordinate() && !first[1].isCoordinate(),
+                "stored inputs did not resolve in symbol order");
+            // The second reads the first derived field by its new id (3), and
+            // the braced name resolves to the same field a bare name would.
+            const auto& second = programs[1].inputs;
+            require(second.size() == 2 && second[0].field.value == 3
+                    && second[1].field.value == 2,
+                "a derived field did not resolve as an input");
+        }
+        {
+            // Coordinates: resolved by axis, and mixable with fields.
+            auto metadata = makeMetadata();
+            const auto programs = install(metadata,
+                {{"radius", "sqrt(x**2 + y**2 + z**2)"},
+                    {"column", "density*z"}});
+            const auto& radius = programs[0].inputs;
+            require(radius.size() == 3 && radius[0].isCoordinate()
+                    && radius[0].axis == 0 && radius[1].axis == 1
+                    && radius[2].axis == 2,
+                "coordinate symbols did not resolve to axes");
+            require(metadata.fields[3].centering == Centering::Cell,
+                "a coordinates-only field is not cell-centered");
+            const auto& column = programs[1].inputs;
+            require(column.size() == 2 && !column[0].isCoordinate()
+                    && column[1].isCoordinate() && column[1].axis == 2,
+                "a mixed field/coordinate expression did not resolve");
+        }
+        {
+            // A field named like a coordinate shadows it.
+            auto metadata = makeMetadata();
+            metadata.fields.push_back(
+                FieldMetadata{.name = "x", .centering = Centering::Cell, .componentNames = {}});
+            const auto programs = install(metadata, {{"shadowed", "x + 1"}});
+            require(programs[0].inputs[0].isCoordinate() == false
+                    && programs[0].inputs[0].field.value == 3,
+                "a field named x did not shadow the coordinate");
+        }
+        {
+            // Non-cell inputs are fine as long as they agree, and the derived
+            // field inherits their centering.
+            auto metadata = makeMetadata();
+            metadata.fields = {
+                FieldMetadata{.name = "bx", .centering = Centering::FaceX, .componentNames = {}},
+                FieldMetadata{.name = "cx", .centering = Centering::FaceX, .componentNames = {}},
+            };
+            const auto programs = install(metadata, {{"sum", "bx + cx"}});
+            require(programs.size() == 1, "a non-cell install failed");
+            require(metadata.fields[2].centering == Centering::FaceX,
+                "derived centering was not inherited from face-centered "
+                "inputs");
+        }
+        {
+            // An expression reporting a parse error carries the offset into
+            // what the user typed, unmapped.
+            auto metadata = makeMetadata();
+            try {
+                static_cast<void>(
+                    install(metadata, {{"bad", "density + sin(1)"}}));
+                throw std::runtime_error("a bad expression was accepted");
+            } catch (const DerivedFieldError& error) {
+                require(error.sourceOffset().has_value()
+                        && *error.sourceOffset() == 10,
+                    "the parse error offset does not point at the source");
+            }
+        }
+
+        requireRejected({{"", "density"}}, 0, "needs a name");
+        requireRejected({{"speed", ""}}, 0, "needs an expression");
+        requireRejected({{"density", "1"}}, 0, "already in use");
+        requireRejected({{"a", "1"}, {"a", "2"}}, 1, "already in use");
+        requireRejected({{"a", "b"}}, 0, "no field or coordinate is named 'b'");
+        // A self-reference is just an unknown name: the field is installed only
+        // once its own expression has resolved, which is what keeps the
+        // dependency graph acyclic.
+        requireRejected({{"a", "a + 1"}}, 0, "no field or coordinate");
+        // ...and so is a forward reference to a later definition.
+        requireRejected({{"a", "b + 1"}, {"b", "density"}}, 0,
+            "no field or coordinate");
+        requireRejected({{"a", "density + z"}}, 0, "not an axis of a 2-D",
+            makeMetadata(2));
+        {
+            auto metadata = makeMetadata();
+            metadata.hasPhysicalGeometry = false;
+            requireRejected(
+                {{"a", "density*x"}}, 0, "physical coordinates", metadata);
+        }
+        {
+            auto metadata = makeMetadata();
+            metadata.fields[1].centering = Centering::Node;
+            requireRejected({{"a", "density + temperature"}}, 0,
+                "not centered like", metadata);
+        }
+        {
+            // One symbol past the input cap.
+            std::string expression = "density";
+            for (std::size_t index = 0; index <= amrvis::maximumDerivedFieldInputs;
+                ++index) {
+                expression += " + ${f" + std::to_string(index) + "}";
+            }
+            auto metadata = makeMetadata();
+            for (std::size_t index = 0; index <= amrvis::maximumDerivedFieldInputs;
+                ++index) {
+                metadata.fields.push_back(
+                    FieldMetadata{.name = "f" + std::to_string(index),
+                        .centering = Centering::Cell, .componentNames = {}});
+            }
+            requireRejected({{"a", expression}}, 0, "at most", metadata);
+        }
+
+        {
+            // Skip: a definition that does not resolve is left out, the ones
+            // around it are still installed, and the metadata stays usable.
+            // The ids of the installed ones therefore follow the definition
+            // order with the skipped ones removed.
+            auto metadata = makeMetadata();
+            auto installation = amrvis::installDerivedFields(metadata,
+                std::vector<DerivedFieldDefinition>{
+                    {"good", "density*2"},
+                    {"missing", "absent + 1"},
+                    {"alsogood", "good + temperature"},
+                    {"chained", "missing + 1"},
+                },
+                amrvis::DerivedFieldPolicy::Skip);
+            require(installation.programs.size() == 2,
+                "Skip installed the wrong number of definitions");
+            require(metadata.fields.size() == 5
+                    && metadata.fields[3].name == "good"
+                    && metadata.fields[4].name == "alsogood",
+                "Skip left the metadata in the wrong shape");
+            require(amrvis::validateMetadata(metadata).empty(),
+                "Skip left the metadata invalid");
+            require(installation.skipped.size() == 2,
+                "Skip did not report both unresolvable definitions");
+            require(installation.skipped[0].definitionIndex == 1
+                    && installation.skipped[0].name == "missing"
+                    && installation.skipped[0].reason.find("absent")
+                        != std::string::npos,
+                "the first skip does not name what was missing");
+            // A definition reading a skipped one is skipped in turn, for
+            // naming a field that is not there.
+            require(installation.skipped[1].definitionIndex == 3
+                    && installation.skipped[1].reason.find("'missing'")
+                        != std::string::npos,
+                "a definition reading a skipped one was not skipped too");
+            // The one that read an installed derived field resolved to its id,
+            // which is the id after the skip removed a slot.
+            require(installation.programs[1].inputs[0].field.value == 3,
+                "Skip left an installed definition pointing at the wrong id");
+        }
+
+        std::cout << "derived field tests passed\n";
+        return EXIT_SUCCESS;
+    } catch (const std::exception& error) {
+        std::cerr << "test_derived_field failed: " << error.what() << '\n';
+        return EXIT_FAILURE;
+    }
+}

--- a/tests/unit/test_slice_pipeline.cpp
+++ b/tests/unit/test_slice_pipeline.cpp
@@ -3,7 +3,8 @@
 // coveredCells (a request's data resolution along an axis), finestNativeOutputSize
 // (native render resolution), and slicePlaneAxes (the in-plane axis pair).
 // resolveRange/resolveDisplayRange/effectiveRangeMode already have coverage in
-// test_slice_range_resolver.cpp.
+// test_slice_range_resolver.cpp. resolveSpecField (what a carried field
+// selection means in the next frame's own field list) is here too.
 #include <amrexplorer/pipeline/SlicePipeline.hpp>
 
 #include <amrexplorer/core/Metadata.hpp>
@@ -12,6 +13,8 @@
 #include <array>
 #include <cstdlib>
 #include <iostream>
+#include <string>
+#include <vector>
 
 namespace {
 
@@ -225,6 +228,40 @@ int main()
         fine2d, huge, 2, {800, 600});
     require(largeViewport == (std::array<int, 2>{600, 600}),
         "remote viewport sizing did not retain bounded downsampling");
+
+    // --- resolveSpecField -------------------------------------------------
+    {
+        const auto listed = [](const std::vector<std::string>& names) {
+            amrvis::DatasetMetadata metadata;
+            metadata.dimension = 2;
+            for (const auto& name : names) {
+                metadata.fields.push_back(
+                    {name, amrvis::Centering::Cell, {}});
+            }
+            return metadata;
+        };
+        // The frame the selection was made on: "speed" is a derived field at
+        // id 4, after three stored fields and one earlier derived one.
+        const auto before = listed({"rho", "temp", "vel", "flux", "speed"});
+        require(amrvis::resolveSpecField(before, "speed", 4) == 4,
+            "a name present at its own index did not resolve to it");
+
+        // The next frame lacks "temp", so "flux" (which read it) was skipped
+        // and every id after it moved down two. The index alone lands on a
+        // different field; the name is what still means the same thing.
+        const auto after = listed({"rho", "vel", "speed"});
+        require(amrvis::resolveSpecField(after, "speed", 4) == 2,
+            "the name did not follow the field through a renumbering");
+        require(amrvis::resolveSpecField(after, "", 4) == 2,
+            "an index with no name is not clamped into range");
+        require(amrvis::resolveSpecField(after, "flux", 3) == 2,
+            "a name this frame does not have did not fall back to the index");
+        require(amrvis::resolveSpecField(after, "rho", 4) == 0,
+            "a name did not win over an out-of-range index");
+        // Nothing to select from at all.
+        require(amrvis::resolveSpecField(listed({}), "rho", 7) == 0,
+            "an empty field list did not resolve to zero");
+    }
 
     // --- slicePlaneAxes ---------------------------------------------------
     require(amrvis::slicePlaneAxes(2, 0) == (std::array<int, 2>{0, 1}),


### PR DESCRIPTION
A derived field is a real FieldId appended to the dataset's field list and materialised per block in PlotfileDataset, so the slice, line, page, volume and range paths all treat it like any other field with no change of their own.

Installed when the dataset is opened, not later: the field list is shared with the block reader and read by workers without a lock, so it has to be immutable for the session's life. Editing the definitions therefore means opening a new dataset.

A definition that does not resolve is left out and reported rather than failing the open (DerivedFieldPolicy::Skip): one written for another plotfile, or a sequence frame that happens to lack a field, must not make the dataset unopenable. Strict is for whoever is validating a list the user just typed.

A derived block covers the grid's valid box and reads each input through that input's own box, which is the valid box grown by the level's ghost width. The two disagree by the ghost width, and an expression over coordinates alone has no input to inherit a box from at all, so anything that assumed one layout broke as soon as the two were mixed.

Symbols resolve to a stored field, then an earlier derived field, then the x/y/z sample coordinates -- so a dataset with a field named x uses that field. Every field an expression reads must share one centering, which the derived field then takes.