### PR TITLE
edit derived fields from the Variable menu

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -67,7 +67,7 @@ the window, wired to it in one of two ways:
 | `FabNavigator` | standalone FAB / MultiFab navigation: the selector dock, drill-down and return, the async header reads | `test_fab_navigator` |
 | `RemoteSessionController` | the ssh-launched server session and its connection, the Open Remote dialog (`RemoteOpenDialog`), the remote browser (`RemoteFileDialog`), per-destination settings | `test_remote_session_controller`, `test_remote_open_dialog`, `test_remote_file_dialog` |
 | `RangeController` | the range mode / User min-max / Log widgets and the per-field range memory | `test_range_controller` |
-| `DerivedFieldController` | the window's derived-field definitions (deliberately not persisted), the Variable menu's Expression Editor and its dialog, and the expression-list JSON; validates a list before asking the host to reopen the dataset with it | `test_derived_field_controller`, the `--derived-field-*-smoke-test` harnesses |
+| `DerivedFieldController` | one window's view of `DerivedFieldStore` -- the derived-field definitions every window of the process shares, held for the session and never persisted -- plus the Variable menu's Expression Editor, its dialog and the expression-list JSON; checks a list for what is wrong whatever the data, then commits it to the store, from which every window reloads | `test_derived_field_controller`, the `--derived-field-*-smoke-test` harnesses |
 | `VolumeController` | the Volume Rendering window (an `IsoWidget` view with the rendered volume under its wireframe, and the opacity/quality controls), following the field, level, range and palette; render scheduling with drafts while the camera moves | `test_volume_controller` |
 
 Two rules keep the seams honest. A collaborator exposes only what has a

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -67,6 +67,7 @@ the window, wired to it in one of two ways:
 | `FabNavigator` | standalone FAB / MultiFab navigation: the selector dock, drill-down and return, the async header reads | `test_fab_navigator` |
 | `RemoteSessionController` | the ssh-launched server session and its connection, the Open Remote dialog (`RemoteOpenDialog`), the remote browser (`RemoteFileDialog`), per-destination settings | `test_remote_session_controller`, `test_remote_open_dialog`, `test_remote_file_dialog` |
 | `RangeController` | the range mode / User min-max / Log widgets and the per-field range memory | `test_range_controller` |
+| `DerivedFieldController` | the derived-field definitions, the Variable menu's Expression Editor and its dialog, the expression-list JSON, and the settings persistence; validates a list before asking the host to reopen the dataset with it | `test_derived_field_controller`, the `--derived-field-smoke-test` harness |
 | `VolumeController` | the Volume Rendering window (an `IsoWidget` view with the rendered volume under its wireframe, and the opacity/quality controls), following the field, level, range and palette; render scheduling with drafts while the camera moves | `test_volume_controller` |
 
 Two rules keep the seams honest. A collaborator exposes only what has a

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -67,7 +67,7 @@ the window, wired to it in one of two ways:
 | `FabNavigator` | standalone FAB / MultiFab navigation: the selector dock, drill-down and return, the async header reads | `test_fab_navigator` |
 | `RemoteSessionController` | the ssh-launched server session and its connection, the Open Remote dialog (`RemoteOpenDialog`), the remote browser (`RemoteFileDialog`), per-destination settings | `test_remote_session_controller`, `test_remote_open_dialog`, `test_remote_file_dialog` |
 | `RangeController` | the range mode / User min-max / Log widgets and the per-field range memory | `test_range_controller` |
-| `DerivedFieldController` | the derived-field definitions, the Variable menu's Expression Editor and its dialog, the expression-list JSON, and the settings persistence; validates a list before asking the host to reopen the dataset with it | `test_derived_field_controller`, the `--derived-field-smoke-test` harness |
+| `DerivedFieldController` | the window's derived-field definitions (deliberately not persisted), the Variable menu's Expression Editor and its dialog, and the expression-list JSON; validates a list before asking the host to reopen the dataset with it | `test_derived_field_controller`, the `--derived-field-*-smoke-test` harnesses |
 | `VolumeController` | the Volume Rendering window (an `IsoWidget` view with the rendered volume under its wireframe, and the opacity/quality controls), following the field, level, range and palette; render scheduling with drafts while the camera moves | `test_volume_controller` |
 
 Two rules keep the seams honest. A collaborator exposes only what has a

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -427,6 +427,59 @@ Useful shortcuts are:
 | Ctrl+1 through Ctrl+9 | Composite levels 0 through N |
 | Alt+0 through Alt+9 | Exact level N |
 
+## Derived fields
+
+**Variable > Expression Editor...** defines fields computed from the ones the
+plotfile stores. Give each a name and a single-line expression; **Apply**
+checks the whole list and, if it holds, reopens the dataset with the new
+fields, which then appear in the field selector and the **Variable** menu and
+behave like any other field -- slices, line plots, the volume view, the probe
+and export all work on them.
+
+Expressions use `+`, `-`, `*`, `/` and `**` (or the equivalent `pow(a,b)`),
+with `abs`, `sqrt`, `exp`, `log`, `exp10` and `log10`, and parentheses. For
+example:
+
+```text
+sqrt(x_velocity**2 + y_velocity**2)
+```
+
+A field whose name is not a plain identifier -- anything but letters, digits,
+`_` and `.` -- is written `${...}`, which takes the name exactly as given:
+
+```text
+sqrt(${x-momentum}**2 + ${y-momentum}**2) / density
+log10(${Y(H2)})
+```
+
+`x`, `y` and `z` are the sample's coordinates, so `sqrt(x**2 + y**2)` is a
+radius field. They are the dataset's own axis coordinates: on a spherical or
+cylindrical dataset they are (r, theta) or (r, z), not Cartesian. A dataset
+with a field actually named `x` uses that field instead. Coordinates are
+unavailable for standalone FABs and MultiFabs, which carry no physical
+geometry.
+
+An expression may also use the derived fields defined above it in the list, so
+a long formula can be built in steps. Each definition is checked against the
+dataset when you apply it, and an error names the definition and points into
+the expression.
+
+Other notes:
+
+- Derived fields have no stored minimum and maximum, so the **File** and
+  **Level** range modes are unavailable for them and the range starts on
+  **Visible**. **User** works as usual.
+- A result that is not a number -- `log` of a negative value, a division by
+  zero -- is treated as missing data, like any other non-finite sample.
+- The list is remembered between sessions and applies to whatever you open
+  next. A definition that a dataset cannot satisfy (a field it does not have)
+  is simply left out, and the status bar says which; the rest still apply.
+- **Import...** and **Export...** read and write the list as a JSON expression
+  list. An import replaces what the editor is showing; nothing reaches the
+  dataset until you select **Apply**.
+- Derived fields are computed where the data is read, so they are not
+  available for a dataset opened from a remote server.
+
 ## Ranges, logarithms, and palettes
 
 The **Range** control determines which values map to the ends of the color

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -432,9 +432,12 @@ Useful shortcuts are:
 **Variable > Expression Editor...** defines fields computed from the ones the
 plotfile stores. Give each a name and a single-line expression; **Apply**
 checks the whole list and, if it holds, reopens the dataset with the new
-fields, which then appear in the field selector and the **Variable** menu and
-behave like any other field -- slices, line plots, the volume view, the probe
-and export all work on them.
+fields, which then behave like any other field -- slices, line plots, the
+volume view, the probe and export all work on them.
+
+They appear in the field selector and the **Variable** menu below the fields
+the plotfile stores, separated from them by a line, and each shows its own
+expression as a tooltip.
 
 Expressions use `+`, `-`, `*`, `/` and `**` (or the equivalent `pow(a,b)`),
 with `abs`, `sqrt`, `exp`, `log`, `exp10` and `log10`, and parentheses. For
@@ -472,12 +475,18 @@ Other notes:
   **Visible**. **User** works as usual.
 - A result that is not a number -- `log` of a negative value, a division by
   zero -- is treated as missing data, like any other non-finite sample.
-- The list is remembered between sessions and applies to whatever you open
-  next. A definition that a dataset cannot satisfy (a field it does not have)
-  is simply left out, and the status bar says which; the rest still apply.
+- The list belongs to the window and to the dataset open in it: opening
+  another dataset, or a sequence, starts again with none. It is not saved
+  between sessions -- a definition is written against one plotfile's fields,
+  and kept around it would only reappear against unrelated data, where it can
+  do nothing but refuse the next thing you try to add.
+- Within a sequence the list stays put, so a definition follows the frames. One
+  a particular frame cannot satisfy is left out of that frame, and the status
+  bar says which; the rest still apply.
 - **Import...** and **Export...** read and write the list as a JSON expression
-  list. An import replaces what the editor is showing; nothing reaches the
-  dataset until you select **Apply**.
+  list, which is how a set of definitions is kept for another session. An
+  import replaces what the editor is showing; nothing reaches the dataset until
+  you select **Apply**.
 - Derived fields are computed where the data is read, so they are not
   available for a dataset opened from a remote server.
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -465,9 +465,11 @@ geometry.
 
 An expression may also use the derived fields defined above it in the list, so
 a long formula can be built in steps. Each definition is checked against the
-dataset when you apply it; the editor selects the definition that failed and
-says what is wrong with it, and nothing reaches the dataset until the whole
-list is accepted.
+expression when you apply it: the editor selects the definition that failed and
+says what is wrong with it. Only what is wrong whatever the data is refused --
+a missing or repeated name, an expression that does not parse. Reading a field
+this particular dataset happens not to have is not an error; that definition is
+simply greyed out here.
 
 Other notes:
 
@@ -476,14 +478,16 @@ Other notes:
   **Visible**. **User** works as usual.
 - A result that is not a number -- `log` of a negative value, a division by
   zero -- is treated as missing data, like any other non-finite sample.
-- The list belongs to the window and to the dataset open in it: opening
-  another dataset, or a sequence, starts again with none. It is not saved
-  between sessions -- a definition is written against one plotfile's fields,
-  and kept around it would only reappear against unrelated data, where it can
-  do nothing but refuse the next thing you try to add.
-- Within a sequence the list stays put, so a definition follows the frames. One
-  a particular frame cannot satisfy is left out of that frame, and the status
-  bar says which; the rest still apply.
+- The list is shared by every window of one running viewer: define a field in
+  one window and it is there in the others too. It is not saved between
+  sessions, so quitting forgets it and a viewer started afresh has none. A
+  viewer launched separately from the command line is its own program with its
+  own list.
+- A definition the data in front of you cannot provide -- it reads a field this
+  plotfile does not have, or this frame of a sequence does not -- is greyed out
+  in the field selector and the **Variable** menu, with the reason on its
+  tooltip. It is still yours, and still applies wherever it can: in another
+  window on other data, or on a frame that does carry the field.
 - **Import...** and **Export...** read and write the list as a JSON expression
   list, which is how a set of definitions is kept for another session. An
   import replaces what the editor is showing; nothing reaches the dataset until

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -430,7 +430,8 @@ Useful shortcuts are:
 ## Derived fields
 
 **Variable > Expression Editor...** defines fields computed from the ones the
-plotfile stores. Give each a name and a single-line expression; **Apply**
+plotfile stores. Give each a name and an expression, which may run over
+several lines if that reads better; **Apply**
 checks the whole list and, if it holds, reopens the dataset with the new
 fields, which then behave like any other field -- slices, line plots, the
 volume view, the probe and export all work on them.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -461,8 +461,9 @@ geometry.
 
 An expression may also use the derived fields defined above it in the list, so
 a long formula can be built in steps. Each definition is checked against the
-dataset when you apply it, and an error names the definition and points into
-the expression.
+dataset when you apply it; the editor selects the definition that failed and
+says what is wrong with it, and nothing reaches the dataset until the whole
+list is accepted.
 
 Other notes:
 

--- a/include/amrexplorer/core/DerivedField.hpp
+++ b/include/amrexplorer/core/DerivedField.hpp
@@ -141,6 +141,23 @@ inline constexpr std::size_t maximumDerivedFieldDepth = 16;
 // the metadata it passed in; under Skip the metadata is always left usable.
 // Either way the caller passes a copy, since a dataset's stored metadata is
 // shared.
+// A fault in a definition list that no dataset can make good: an expression
+// reading more fields than one evaluation may pin, or a dependency chain
+// deeper than evaluation may recurse. Both are properties of the list alone --
+// a symbol that names no earlier definition and no coordinate is a stored
+// field wherever the list is installed -- so an editor can refuse them once
+// instead of every dataset greying the same row and saying why.
+//
+// Nullopt when the list has no such fault. Names, duplicates and expressions
+// that do not parse are the caller's own to check first; this assumes the list
+// got that far.
+struct DerivedFieldListFault {
+    std::size_t definitionIndex = 0;
+    std::string message;
+};
+[[nodiscard]] std::optional<DerivedFieldListFault> validateDerivedFieldGraph(
+    std::span<const DerivedFieldDefinition> definitions);
+
 [[nodiscard]] DerivedFieldInstallation installDerivedFields(
     DatasetMetadata& metadata,
     std::span<const DerivedFieldDefinition> definitions,

--- a/include/amrexplorer/data/DatasetSession.hpp
+++ b/include/amrexplorer/data/DatasetSession.hpp
@@ -113,6 +113,16 @@ public:
     {
         return {};
     }
+    // The derived-field definitions this session was opened with, installed or
+    // not. A caller holding a newer list compares against this to find out
+    // whether the session on screen is the one that list describes; the field
+    // names cannot answer it, because an expression can change under a name
+    // that does not. Empty for a session that installs none.
+    [[nodiscard]] virtual std::vector<DerivedFieldDefinition>
+    derivedFieldDefinitions() const
+    {
+        return {};
+    }
 
     // Whether this session can present fields computed from expressions over
     // the stored ones (core/DerivedField.hpp). They are installed when the

--- a/include/amrexplorer/data/LocalDatasetSession.hpp
+++ b/include/amrexplorer/data/LocalDatasetSession.hpp
@@ -121,6 +121,8 @@ public:
     [[nodiscard]] std::size_t storedFieldCount() const noexcept override;
     [[nodiscard]] std::vector<DerivedFieldSkip> skippedDerivedFields()
         const override;
+    [[nodiscard]] std::vector<DerivedFieldDefinition> derivedFieldDefinitions()
+        const override;
 
     // The block pool alone. setCacheBudget deliberately moves both pools,
     // which is what a user setting one number wants -- but a server applying
@@ -148,6 +150,7 @@ private:
     std::vector<ParticleSpeciesMetadata> m_particleSpecies;
     std::size_t m_storedFieldCount = 0;
     std::vector<DerivedFieldSkip> m_skippedDerivedFields;
+    std::vector<DerivedFieldDefinition> m_derivedFieldDefinitions;
     mutable std::mutex m_mutex;
     std::shared_ptr<PlotfileDataset> m_dataset;
     // File-scope ranges for a standalone FAB, by field. These are scanned out

--- a/include/amrexplorer/expression/Expression.hpp
+++ b/include/amrexplorer/expression/Expression.hpp
@@ -8,8 +8,10 @@
 #include <string_view>
 #include <vector>
 
-// Single-line algebraic expressions over named symbols, compiled once into a
-// flat instruction list and evaluated by a small stack machine. The grammar:
+// Algebraic expressions over named symbols, compiled once into a flat
+// instruction list and evaluated by a small stack machine. Line breaks are
+// whitespace, so a long expression may be laid out over several lines. The
+// grammar:
 //
 //   expression      := additive
 //   additive        := multiplicative (("+" | "-") multiplicative)*

--- a/include/amrexplorer/io/PlotfileDataset.hpp
+++ b/include/amrexplorer/io/PlotfileDataset.hpp
@@ -79,6 +79,13 @@ public:
     // asked for it to say so.
     [[nodiscard]] const std::vector<DerivedFieldSkip>& skippedDerivedFields()
         const noexcept;
+    // The definitions this dataset was opened with, installed or not. What a
+    // caller holding a newer list compares against to find out whether this
+    // session is still the one that list describes -- which cannot be
+    // inferred from the field names, since an expression can change under a
+    // name that does not.
+    [[nodiscard]] const std::vector<DerivedFieldDefinition>&
+    derivedFieldDefinitions() const noexcept;
 
     // A block of any field the metadata lists. A derived field's block is
     // evaluated from its inputs' blocks (recursively, so one derived field may
@@ -102,6 +109,9 @@ private:
         std::vector<DerivedFieldProgram> programs;
         std::size_t storedCount = 0;
         std::vector<DerivedFieldSkip> skipped;
+        // As given, not as installed: a caller comparing against its own list
+        // is asking what this session was built from.
+        std::vector<DerivedFieldDefinition> definitions;
     };
     [[nodiscard]] static Fields installFields(
         const PlotfileMetadataResult& source,

--- a/src/core/DerivedField.cpp
+++ b/src/core/DerivedField.cpp
@@ -75,6 +75,60 @@ const std::string& DerivedFieldError::message() const noexcept
     return m_message;
 }
 
+std::optional<DerivedFieldListFault> validateDerivedFieldGraph(
+    std::span<const DerivedFieldDefinition> definitions)
+{
+    // Mirrors what installDerivedFields counts, without a dataset to resolve
+    // against: a symbol naming an earlier definition is a derived input, x/y/z
+    // is a coordinate, and anything else is a stored field -- which is what it
+    // will be in every dataset that can satisfy the list at all.
+    std::vector<std::size_t> depths;
+    depths.reserve(definitions.size());
+    for (std::size_t index = 0; index < definitions.size(); ++index) {
+        const auto& definition = definitions[index];
+        // Not default-constructible, and an expression that does not parse is
+        // the caller's to report, with the offset it carries.
+        std::optional<CompiledExpression> expression;
+        try {
+            expression = CompiledExpression::compile(definition.expression);
+        } catch (const ExpressionError&) {
+            return std::nullopt;
+        }
+        std::size_t fieldInputs = 0;
+        std::size_t depth = 1;
+        for (const auto& symbol : expression->symbols()) {
+            std::optional<std::size_t> earlier;
+            for (std::size_t before = 0; before < index; ++before) {
+                if (definitions[before].name == symbol) {
+                    earlier = before;
+                }
+            }
+            if (earlier) {
+                ++fieldInputs;
+                depth = std::max(depth, depths[*earlier] + 1);
+                continue;
+            }
+            if (coordinateAxis(symbol)) {
+                continue;
+            }
+            ++fieldInputs;
+        }
+        if (fieldInputs > maximumDerivedFieldInputs) {
+            return DerivedFieldListFault{index,
+                "an expression may read at most "
+                    + std::to_string(maximumDerivedFieldInputs) + " fields"};
+        }
+        if (depth > maximumDerivedFieldDepth) {
+            return DerivedFieldListFault{index,
+                "a derived field may not read a chain of more than "
+                    + std::to_string(maximumDerivedFieldDepth)
+                    + " derived fields"};
+        }
+        depths.push_back(depth);
+    }
+    return std::nullopt;
+}
+
 DerivedFieldInstallation installDerivedFields(DatasetMetadata& metadata,
     std::span<const DerivedFieldDefinition> definitions,
     DerivedFieldPolicy policy)

--- a/src/data/LocalDatasetSession.cpp
+++ b/src/data/LocalDatasetSession.cpp
@@ -109,6 +109,9 @@ LocalDatasetSession::LocalDatasetSession(
     , m_skippedDerivedFields(
           dataset ? dataset->skippedDerivedFields()
                   : std::vector<DerivedFieldSkip>{})
+    , m_derivedFieldDefinitions(
+          dataset ? dataset->derivedFieldDefinitions()
+                  : std::vector<DerivedFieldDefinition>{})
     , m_dataset(std::move(dataset))
 {
     if (!m_dataset) {
@@ -301,6 +304,12 @@ std::size_t LocalDatasetSession::storedFieldCount() const noexcept
 std::vector<DerivedFieldSkip> LocalDatasetSession::skippedDerivedFields() const
 {
     return m_skippedDerivedFields;
+}
+
+std::vector<DerivedFieldDefinition>
+LocalDatasetSession::derivedFieldDefinitions() const
+{
+    return m_derivedFieldDefinitions;
 }
 
 bool LocalDatasetSession::supportsVolumeRendering() const noexcept

--- a/src/expression/Expression.cpp
+++ b/src/expression/Expression.cpp
@@ -147,16 +147,13 @@ public:
 
     Token next()
     {
-        skipHorizontalWhitespace();
+        skipWhitespace();
         if (m_position == m_source.size()) {
             return {.kind = TokenKind::End, .offset = m_position};
         }
 
         const auto offset = m_position;
         const auto value = m_source[m_position];
-        if (value == '\n' || value == '\r') {
-            throw ExpressionError("newlines are not allowed", offset);
-        }
         if ((value >= '0' && value <= '9')
             || (value == '.' && m_position + 1 < m_source.size()
                 && m_source[m_position + 1] >= '0'
@@ -210,11 +207,16 @@ public:
     }
 
 private:
-    void skipHorizontalWhitespace()
+    // Line breaks are whitespace like any other: a long expression reads
+    // better broken across lines, and nothing in the grammar needs a line to
+    // mean anything. A break inside a ${...} name is still refused -- there it
+    // is a typo rather than a layout choice.
+    void skipWhitespace()
     {
         while (m_position < m_source.size()
-            && (m_source[m_position] == ' '
-                || m_source[m_position] == '\t')) {
+            && (m_source[m_position] == ' ' || m_source[m_position] == '\t'
+                || m_source[m_position] == '\n'
+                || m_source[m_position] == '\r')) {
             ++m_position;
         }
     }

--- a/src/io/plotfile/PlotfileDataset.cpp
+++ b/src/io/plotfile/PlotfileDataset.cpp
@@ -66,14 +66,15 @@ PlotfileDataset::Fields PlotfileDataset::installFields(
         throw std::invalid_argument("dataset metadata is unavailable");
     }
     if (definitions.empty()) {
-        return {source.metadata, {}, source.metadata->fields.size(), {}};
+        return {source.metadata, {}, source.metadata->fields.size(), {}, {}};
     }
     auto metadata = std::make_shared<DatasetMetadata>(*source.metadata);
     const auto storedCount = metadata->fields.size();
     auto installation = installDerivedFields(
         *metadata, definitions, DerivedFieldPolicy::Skip);
     return {std::move(metadata), std::move(installation.programs), storedCount,
-        std::move(installation.skipped)};
+        std::move(installation.skipped),
+        {definitions.begin(), definitions.end()}};
 }
 
 PlotfileDataset::PlotfileDataset(
@@ -124,6 +125,12 @@ bool PlotfileDataset::isDerivedField(FieldId field) const noexcept
 {
     return field.value >= m_fields.storedCount
         && static_cast<std::size_t>(field.value) < m_fields.metadata->fields.size();
+}
+
+const std::vector<DerivedFieldDefinition>&
+PlotfileDataset::derivedFieldDefinitions() const noexcept
+{
+    return m_fields.definitions;
 }
 
 std::size_t PlotfileDataset::storedFieldCount() const noexcept

--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -11,8 +11,12 @@ add_executable(amrexplorer_qt
     DatasetExtract.hpp
     DatasetWindow.cpp
     DatasetWindow.hpp
+    DerivedFieldController.cpp
+    DerivedFieldController.hpp
     DiagnosticsModel.cpp
     DiagnosticsModel.hpp
+    ExpressionEditorDialog.cpp
+    ExpressionEditorDialog.hpp
     FabNavigator.cpp
     FabNavigator.hpp
     FabSelectorDock.cpp
@@ -82,6 +86,7 @@ if(AMREXPLORER_BUILD_TESTS)
         MainWindowTestAccess.cpp
         SmokeHarness.cpp
         SmokeHarness.hpp
+        SmokeHarnessDerived.cpp
         SmokeHarnessFab.cpp
         SmokeHarnessInternal.hpp
         SmokeHarnessLifecycle.cpp

--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -13,6 +13,8 @@ add_executable(amrexplorer_qt
     DatasetWindow.hpp
     DerivedFieldController.cpp
     DerivedFieldController.hpp
+    DerivedFieldStore.cpp
+    DerivedFieldStore.hpp
     DiagnosticsModel.cpp
     DiagnosticsModel.hpp
     ExpressionEditorDialog.cpp

--- a/src/qt/DerivedFieldController.cpp
+++ b/src/qt/DerivedFieldController.cpp
@@ -182,8 +182,9 @@ void DerivedFieldController::showEditor(QWidget* parent)
             }
             // The committed list is what the editor should now be editing:
             // apply() may have trimmed names, and the draft must not drift
-            // from what the dataset was reopened with.
-            dialog->setDraft(m_definitions);
+            // from what the dataset was reopened with. On the row the user was
+            // editing, which is the one they are looking at.
+            dialog->setDraft(m_definitions, dialog->selectedIndex());
             emit statusMessage(
                 m_definitions.empty()
                     ? tr("Derived fields cleared.")
@@ -225,12 +226,9 @@ void DerivedFieldController::showEditor(QWidget* parent)
             if (!m_hooks.chooseFile) {
                 return;
             }
-            auto path = m_hooks.chooseFile(dialog, true);
+            const auto path = m_hooks.chooseFile(dialog, true);
             if (path.isEmpty()) {
                 return;
-            }
-            if (QFileInfo(path).suffix().isEmpty()) {
-                path += QStringLiteral(".json");
             }
             // The draft, which is what the user is looking at -- exporting
             // only what has been applied would silently drop their edits.

--- a/src/qt/DerivedFieldController.cpp
+++ b/src/qt/DerivedFieldController.cpp
@@ -12,6 +12,7 @@
 #include <QJsonObject>
 #include <QJsonParseError>
 #include <QJsonValue>
+#include <QPointer>
 #include <QSaveFile>
 #include <QWidget>
 
@@ -29,11 +30,19 @@ ExpressionListFile parseExpressionList(const QByteArray& json)
 {
     QJsonParseError parseError{};
     const auto document = QJsonDocument::fromJson(json, &parseError);
-    if (parseError.error != QJsonParseError::NoError || !document.isObject()) {
+    if (parseError.error != QJsonParseError::NoError) {
         return {{},
             DerivedFieldController::tr("not a valid expression-list JSON "
                                        "file: %1")
                 .arg(parseError.errorString())};
+    }
+    if (!document.isObject()) {
+        // Well-formed JSON that is not an object: errorString() would say "no
+        // error occurred", which is not a reason anyone can act on.
+        return {{},
+            DerivedFieldController::tr(
+                "not an expression list: the file's top level is not an "
+                "object")};
     }
     const auto root = document.object();
     const auto format = root.value(QStringLiteral("format"));
@@ -133,8 +142,12 @@ void DerivedFieldController::refreshAvailability()
 std::optional<DerivedFieldController::Refusal> DerivedFieldController::apply(
     std::vector<DerivedFieldDefinition> definitions)
 {
-    auto stored = m_hooks.storedMetadata ? m_hooks.storedMetadata()
-                                         : std::nullopt;
+    // The same question the action's enablement asks, not a weaker one: the
+    // editor is modeless, so the window can enter a state it is disabled for
+    // (a FAB drill-down) while it is still open in front of the user.
+    const auto usable = m_hooks.available && m_hooks.available();
+    auto stored = usable && m_hooks.storedMetadata ? m_hooks.storedMetadata()
+                                                   : std::nullopt;
     if (!stored) {
         return Refusal{tr("No dataset that can take derived fields is open."),
             std::nullopt};
@@ -150,6 +163,11 @@ std::optional<DerivedFieldController::Refusal> DerivedFieldController::apply(
             error.definitionIndex()};
     }
 
+    if (definitions == m_definitions) {
+        // Nothing to install: a reload here would re-read the plotfile and,
+        // for a sequence, close the Dataset and Line Plot windows.
+        return std::nullopt;
+    }
     m_definitions = std::move(definitions);
     if (m_hooks.reload) {
         m_hooks.reload();
@@ -159,10 +177,10 @@ std::optional<DerivedFieldController::Refusal> DerivedFieldController::apply(
 
 void DerivedFieldController::clear()
 {
-    if (m_definitions.empty()) {
-        return;
-    }
     m_definitions.clear();
+    // The editor's draft too, committed or not: definitions typed against the
+    // last dataset's fields and never applied would otherwise sit there
+    // refusing every Apply against the new one.
     if (m_dialog) {
         m_dialog->setDraft({});
     }
@@ -190,20 +208,23 @@ void DerivedFieldController::showEditor(QWidget* parent)
             // from what the dataset was reopened with. On the row the user was
             // editing, which is the one they are looking at.
             dialog->setDraft(m_definitions, dialog->selectedIndex());
-            emit statusMessage(
-                m_definitions.empty()
-                    ? tr("Derived fields cleared.")
-                    : tr("Applied %n derived field(s).", nullptr,
-                          static_cast<int>(m_definitions.size())),
-                4000);
+            // Not a status message: apply() has already started the reload,
+            // and showSlice clears the status bar when its slices land. The
+            // editor is in front of the user anyway, so it says so itself.
+            dialog->showApplied(m_definitions.size());
         });
     connect(dialog, &ExpressionEditorDialog::importRequested, dialog,
         [this, dialog] {
             if (!m_hooks.chooseFile) {
                 return;
             }
+            // chooseFile runs a nested event loop, which can deliver the
+            // deleteLater that closing this editor posts (refreshAvailability
+            // closes it when the dataset goes away). Nothing below may assume
+            // the dialog outlived the call.
+            const QPointer<ExpressionEditorDialog> alive(dialog);
             const auto path = m_hooks.chooseFile(dialog, false);
-            if (path.isEmpty()) {
+            if (path.isEmpty() || alive.isNull()) {
                 return;
             }
             QFile file(path);
@@ -231,8 +252,9 @@ void DerivedFieldController::showEditor(QWidget* parent)
             if (!m_hooks.chooseFile) {
                 return;
             }
+            const QPointer<ExpressionEditorDialog> alive(dialog);
             const auto path = m_hooks.chooseFile(dialog, true);
-            if (path.isEmpty()) {
+            if (path.isEmpty() || alive.isNull()) {
                 return;
             }
             // The draft, which is what the user is looking at -- exporting

--- a/src/qt/DerivedFieldController.cpp
+++ b/src/qt/DerivedFieldController.cpp
@@ -26,6 +26,25 @@ constexpr int kExpressionListVersion = 1;
 
 } // namespace
 
+QString escapedExpression(const std::string& expression)
+{
+    // One line: an expression may be laid out over several, and a tooltip
+    // showing the breaks would be as tall as the editor it was typed in.
+    // simplified() folds every run of whitespace into a single space. Escaped
+    // because it is the user's own bytes; richTooltip is what makes the
+    // escaping show through as the characters they stand for.
+    return QString::fromStdString(expression).simplified().toHtmlEscaped();
+}
+
+QString richTooltip(const QString& escaped)
+{
+    // Qt renders a tooltip as rich text only when it thinks it might be some:
+    // `&lt;` decides it, `&amp;` on its own does not, so escaped text is shown
+    // either as the user wrote it or with the escapes visible, depending on
+    // which characters they used. The wrapper settles it for every string.
+    return QStringLiteral("<qt>%1</qt>").arg(escaped);
+}
+
 ExpressionListFile parseExpressionList(const QByteArray& json)
 {
     QJsonParseError parseError{};
@@ -122,9 +141,13 @@ DerivedFieldController::DerivedFieldController(
 
 void DerivedFieldController::adoptStoreChange()
 {
-    // Nothing to replace in the window whose own Apply made the change: its
-    // draft is already exactly this list.
-    if (m_dialog && m_dialog->draft() != m_store.definitions()) {
+    if (m_dialog && m_dialog->draft() == m_store.definitions()) {
+        // Already editing exactly this list: nothing to replace, but it is now
+        // the committed one -- whether this window's own Apply made the change
+        // or a peer committed the same thing -- and saying otherwise leaves
+        // the editor reporting unapplied edits it does not have.
+        m_dialog->markDraftCommitted();
+    } else if (m_dialog) {
         if (m_dialog->hasUnappliedEdits()) {
             // Written here and not applied. One list is shared by every
             // window, so adopting would take an editor out from under the user
@@ -159,8 +182,11 @@ void DerivedFieldController::refreshAvailability()
     const auto usable = available();
     if (m_action) {
         m_action->setEnabled(usable);
+        // Never empty: the Variable menu shows tooltips (for the derived
+        // rows), and QAction falls back to its own text, so an empty one pops
+        // a tooltip repeating the entry's label.
         m_action->setToolTip(usable
-                ? QString()
+                ? tr("Define fields computed from the stored ones")
                 : tr("Derived fields need a local dataset."));
     }
     // The editor stays open when the dataset does not. It edits the session's
@@ -225,6 +251,16 @@ std::optional<DerivedFieldController::Refusal> DerivedFieldController::apply(
         } catch (const ExpressionError& error) {
             return Refusal{QString::fromUtf8(error.what()), index};
         }
+    }
+
+    // What is wrong with the list as a list, whatever the data: too many
+    // fields read at once, or a dependency chain deeper than evaluation may
+    // recurse. Left to installation these would be skipped per dataset, so
+    // every window would grey the same row and say why, over a fault no data
+    // could fix.
+    if (const auto fault = validateDerivedFieldGraph(definitions)) {
+        return Refusal{QString::fromStdString(fault->message),
+            fault->definitionIndex};
     }
 
     // set() is what reloads -- here and in every other window -- and does

--- a/src/qt/DerivedFieldController.cpp
+++ b/src/qt/DerivedFieldController.cpp
@@ -16,6 +16,7 @@
 #include <QSaveFile>
 #include <QWidget>
 
+#include <algorithm>
 #include <utility>
 
 namespace amrvis::qt {
@@ -101,10 +102,28 @@ QByteArray writeExpressionList(
     return QJsonDocument(root).toJson(QJsonDocument::Indented);
 }
 
-DerivedFieldController::DerivedFieldController(Hooks hooks, QObject* parent)
+DerivedFieldController::DerivedFieldController(
+    Hooks hooks, DerivedFieldStore& store, QObject* parent)
     : QObject(parent)
     , m_hooks(std::move(hooks))
+    , m_store(store)
 {
+    connect(&m_store, &DerivedFieldStore::changed, this,
+        [this] { adoptStoreChange(); });
+}
+
+void DerivedFieldController::adoptStoreChange()
+{
+    if (m_dialog) {
+        m_dialog->setDraft(m_store.definitions(), m_dialog->selectedIndex());
+    }
+    // Including the window whose Apply made the change: one path installs the
+    // list, whoever asked for it. A window that cannot take derived fields --
+    // a remote session, or a FAB -- has nothing to reload, and will not show
+    // them either way.
+    if (m_hooks.reload && m_hooks.available && m_hooks.available()) {
+        m_hooks.reload();
+    }
 }
 
 QAction* DerivedFieldController::createAction(QWidget* parent)
@@ -145,45 +164,47 @@ std::optional<DerivedFieldController::Refusal> DerivedFieldController::apply(
     // The same question the action's enablement asks, not a weaker one: the
     // editor is modeless, so the window can enter a state it is disabled for
     // (a FAB drill-down) while it is still open in front of the user.
-    const auto usable = m_hooks.available && m_hooks.available();
-    auto stored = usable && m_hooks.storedMetadata ? m_hooks.storedMetadata()
-                                                   : std::nullopt;
-    if (!stored) {
+    if (!m_hooks.available || !m_hooks.available()) {
         return Refusal{tr("No dataset that can take derived fields is open."),
             std::nullopt};
     }
-    try {
-        // Strict, on a copy: the user is being told whether what they typed
-        // works, so the first problem is the answer -- and the metadata this
-        // validates against is thrown away either way.
-        static_cast<void>(installDerivedFields(
-            *stored, definitions, DerivedFieldPolicy::Strict));
-    } catch (const DerivedFieldError& error) {
-        return Refusal{QString::fromUtf8(error.what()),
-            error.definitionIndex()};
+
+    // Checked without reference to any dataset: whether a definition applies
+    // *here* is decided when a dataset installs it, and shown by greying the
+    // field out. One list is shared by windows showing different data, so only
+    // what is wrong whatever the data is can be refused.
+    for (std::size_t index = 0; index < definitions.size(); ++index) {
+        const auto& definition = definitions[index];
+        if (definition.name.empty()) {
+            return Refusal{tr("A derived field needs a name."), index};
+        }
+        const auto upto =
+            definitions.begin() + static_cast<std::ptrdiff_t>(index);
+        if (std::find_if(definitions.begin(), upto,
+                [&definition](const DerivedFieldDefinition& earlier) {
+                    return earlier.name == definition.name;
+                })
+            != upto) {
+            return Refusal{
+                tr("Another derived field is already called \"%1\".")
+                    .arg(QString::fromStdString(definition.name)),
+                index};
+        }
+        if (definition.expression.empty()) {
+            return Refusal{tr("A derived field needs an expression."), index};
+        }
+        try {
+            static_cast<void>(
+                CompiledExpression::compile(definition.expression));
+        } catch (const ExpressionError& error) {
+            return Refusal{QString::fromUtf8(error.what()), index};
+        }
     }
 
-    if (definitions == m_definitions) {
-        // Nothing to install: a reload here would re-read the plotfile and,
-        // for a sequence, close the Dataset and Line Plot windows.
-        return std::nullopt;
-    }
-    m_definitions = std::move(definitions);
-    if (m_hooks.reload) {
-        m_hooks.reload();
-    }
+    // set() is what reloads -- here and in every other window -- and does
+    // nothing at all when the list has not moved.
+    m_store.set(std::move(definitions));
     return std::nullopt;
-}
-
-void DerivedFieldController::clear()
-{
-    m_definitions.clear();
-    // The editor's draft too, committed or not: definitions typed against the
-    // last dataset's fields and never applied would otherwise sit there
-    // refusing every Apply against the new one.
-    if (m_dialog) {
-        m_dialog->setDraft({});
-    }
 }
 
 void DerivedFieldController::showEditor(QWidget* parent)
@@ -193,7 +214,8 @@ void DerivedFieldController::showEditor(QWidget* parent)
         m_dialog->activateWindow();
         return;
     }
-    auto* dialog = new ExpressionEditorDialog(m_definitions, parent);
+    auto* dialog =
+        new ExpressionEditorDialog(m_store.definitions(), parent);
     dialog->setAttribute(Qt::WA_DeleteOnClose);
     connect(dialog, &ExpressionEditorDialog::applyRequested, dialog,
         [this, dialog] {
@@ -207,11 +229,11 @@ void DerivedFieldController::showEditor(QWidget* parent)
             // apply() may have trimmed names, and the draft must not drift
             // from what the dataset was reopened with. On the row the user was
             // editing, which is the one they are looking at.
-            dialog->setDraft(m_definitions, dialog->selectedIndex());
+            dialog->setDraft(m_store.definitions(), dialog->selectedIndex());
             // Not a status message: apply() has already started the reload,
             // and showSlice clears the status bar when its slices land. The
             // editor is in front of the user anyway, so it says so itself.
-            dialog->showApplied(m_definitions.size());
+            dialog->showApplied(m_store.definitions().size());
         });
     connect(dialog, &ExpressionEditorDialog::importRequested, dialog,
         [this, dialog] {
@@ -276,29 +298,5 @@ void DerivedFieldController::showEditor(QWidget* parent)
     m_dialog = dialog;
     dialog->show();
 }
-
-QString DerivedFieldController::skippedReport(
-    const std::vector<DerivedFieldSkip>& skipped) const
-{
-    if (skipped.empty()) {
-        return {};
-    }
-    QStringList names;
-    for (const auto& entry : skipped) {
-        names.append(entry.name.empty()
-                ? tr("(unnamed)")
-                : QString::fromStdString(entry.name));
-    }
-    // One reason in full, the first: with several skips they are usually the
-    // same missing field, and the status bar has room for one.
-    const auto reason = QString::fromStdString(skipped.front().reason);
-    return skipped.size() == 1
-        ? tr("Derived field \"%1\" is unavailable for this dataset: %2")
-              .arg(names.front(), reason)
-        : tr("%1 derived fields are unavailable for this dataset: %2 (%3)")
-              .arg(skipped.size())
-              .arg(names.join(QStringLiteral(", ")), reason);
-}
-
 
 } // namespace amrvis::qt

--- a/src/qt/DerivedFieldController.cpp
+++ b/src/qt/DerivedFieldController.cpp
@@ -6,7 +6,6 @@
 #include <QByteArray>
 #include <QDir>
 #include <QFile>
-#include <QFileInfo>
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
@@ -61,8 +60,17 @@ ExpressionListFile parseExpressionList(const QByteArray& json)
                 .arg(kExpressionListVersion)};
     }
 
-    std::vector<DerivedFieldDefinition> definitions;
     const auto array = entries.toArray();
+    // Refused before a row is built for any of it: the draft goes into a list
+    // widget an item at a time, so a file with a hundred thousand entries
+    // would freeze the window long before Apply could refuse its length.
+    if (static_cast<std::size_t>(array.size()) > maximumDerivedFieldCount) {
+        return {{},
+            DerivedFieldController::tr(
+                "an expression list may define at most %1 derived fields")
+                .arg(static_cast<qulonglong>(maximumDerivedFieldCount))};
+    }
+    std::vector<DerivedFieldDefinition> definitions;
     definitions.reserve(static_cast<std::size_t>(array.size()));
     for (const auto& value : array) {
         if (!value.isObject()) {
@@ -155,17 +163,12 @@ void DerivedFieldController::refreshAvailability()
                 ? QString()
                 : tr("Derived fields need a local dataset."));
     }
-    // An editor left open over a dataset that has gone (or a remote one that
-    // cannot take derived fields) would apply into nothing.
-    if (!usable && m_dialog) {
-        // Cleared here rather than left to the deleteLater that close()
-        // schedules: until that is delivered the pointer is still set, and a
-        // showEditor before then would raise the dying dialog instead of
-        // opening one.
-        auto* dialog = m_dialog.data();
-        m_dialog = nullptr;
-        dialog->close();
-    }
+    // The editor stays open when the dataset does not. It edits the session's
+    // list rather than the dataset's, and closing it would take with it a
+    // draft the user has typed or imported and not yet applied -- during an
+    // ordinary File > Open, which resets the dataset for the whole of the
+    // load. Apply refuses meanwhile, saying why, and starts working again by
+    // itself when a dataset it can install into arrives.
 }
 
 std::optional<DerivedFieldController::Refusal> DerivedFieldController::apply(
@@ -190,6 +193,7 @@ std::optional<DerivedFieldController::Refusal> DerivedFieldController::apply(
                                maximumDerivedFieldCount)),
             std::nullopt};
     }
+
 
     // Checked without reference to any dataset: whether a definition applies
     // *here* is decided when a dataset installs it, and shown by greying the

--- a/src/qt/DerivedFieldController.cpp
+++ b/src/qt/DerivedFieldController.cpp
@@ -114,14 +114,24 @@ DerivedFieldController::DerivedFieldController(
 
 void DerivedFieldController::adoptStoreChange()
 {
-    if (m_dialog) {
-        m_dialog->setDraft(m_store.definitions(), m_dialog->selectedIndex());
+    // Nothing to replace in the window whose own Apply made the change: its
+    // draft is already exactly this list.
+    if (m_dialog && m_dialog->draft() != m_store.definitions()) {
+        if (m_dialog->hasUnappliedEdits()) {
+            // Written here and not applied. One list is shared by every
+            // window, so adopting would take an editor out from under the user
+            // mid-sentence, with nothing said and nothing to undo it with.
+            m_dialog->showListChangedElsewhere();
+        } else {
+            m_dialog->setCommitted(
+                m_store.definitions(), m_dialog->selectedIndex());
+        }
     }
     // Including the window whose Apply made the change: one path installs the
     // list, whoever asked for it. A window that cannot take derived fields --
     // a remote session, or a FAB -- has nothing to reload, and will not show
     // them either way.
-    if (m_hooks.reload && m_hooks.available && m_hooks.available()) {
+    if (m_hooks.reload && available()) {
         m_hooks.reload();
     }
 }
@@ -138,16 +148,16 @@ QAction* DerivedFieldController::createAction(QWidget* parent)
 
 void DerivedFieldController::refreshAvailability()
 {
-    const auto available = m_hooks.available && m_hooks.available();
+    const auto usable = available();
     if (m_action) {
-        m_action->setEnabled(available);
-        m_action->setToolTip(available
+        m_action->setEnabled(usable);
+        m_action->setToolTip(usable
                 ? QString()
                 : tr("Derived fields need a local dataset."));
     }
     // An editor left open over a dataset that has gone (or a remote one that
     // cannot take derived fields) would apply into nothing.
-    if (!available && m_dialog) {
+    if (!usable && m_dialog) {
         // Cleared here rather than left to the deleteLater that close()
         // schedules: until that is delivered the pointer is still set, and a
         // showEditor before then would raise the dying dialog instead of
@@ -164,8 +174,20 @@ std::optional<DerivedFieldController::Refusal> DerivedFieldController::apply(
     // The same question the action's enablement asks, not a weaker one: the
     // editor is modeless, so the window can enter a state it is disabled for
     // (a FAB drill-down) while it is still open in front of the user.
-    if (!m_hooks.available || !m_hooks.available()) {
+    if (!available()) {
         return Refusal{tr("No dataset that can take derived fields is open."),
+            std::nullopt};
+    }
+
+    // Bounded here as well as at installation, because this is where an
+    // imported file's length is first seen: past the cap every dataset would
+    // install the first 256 and skip the rest, so each window would list
+    // thousands of definitions it has greyed out, and re-install the list
+    // frame by frame through a sequence.
+    if (definitions.size() > maximumDerivedFieldCount) {
+        return Refusal{tr("A list may define at most %1 derived fields.")
+                           .arg(static_cast<qulonglong>(
+                               maximumDerivedFieldCount)),
             std::nullopt};
     }
 
@@ -225,11 +247,13 @@ void DerivedFieldController::showEditor(QWidget* parent)
                     refusal->message, refusal->definitionIndex);
                 return;
             }
-            // The committed list is what the editor should now be editing:
-            // apply() may have trimmed names, and the draft must not drift
-            // from what the dataset was reopened with. On the row the user was
-            // editing, which is the one they are looking at.
-            dialog->setDraft(m_store.definitions(), dialog->selectedIndex());
+            // The draft is now the committed list, which is what later
+            // edits are measured against -- and what a change arriving from
+            // another window may replace without asking. Same content, so
+            // nothing on screen moves but the row the user was editing, which
+            // is kept.
+            dialog->setCommitted(
+                m_store.definitions(), dialog->selectedIndex());
             // Not a status message: apply() has already started the reload,
             // and showSlice clears the status bar when its slices land. The
             // editor is in front of the user anyway, so it says so itself.

--- a/src/qt/DerivedFieldController.cpp
+++ b/src/qt/DerivedFieldController.cpp
@@ -13,7 +13,6 @@
 #include <QJsonParseError>
 #include <QJsonValue>
 #include <QSaveFile>
-#include <QSettings>
 #include <QWidget>
 
 #include <utility>
@@ -23,11 +22,6 @@ namespace {
 
 constexpr auto kExpressionListFormat = "amrexplorer-expression-list";
 constexpr int kExpressionListVersion = 1;
-
-QString settingsKey()
-{
-    return QStringLiteral("derivedFields/list");
-}
 
 } // namespace
 
@@ -157,15 +151,21 @@ std::optional<DerivedFieldController::Refusal> DerivedFieldController::apply(
     }
 
     m_definitions = std::move(definitions);
-    if (m_hooks.settings) {
-        if (auto settings = m_hooks.settings()) {
-            save(*settings);
-        }
-    }
     if (m_hooks.reload) {
         m_hooks.reload();
     }
     return std::nullopt;
+}
+
+void DerivedFieldController::clear()
+{
+    if (m_definitions.empty()) {
+        return;
+    }
+    m_definitions.clear();
+    if (m_dialog) {
+        m_dialog->setDraft({});
+    }
 }
 
 void DerivedFieldController::showEditor(QWidget* parent)
@@ -278,27 +278,5 @@ QString DerivedFieldController::skippedReport(
               .arg(names.join(QStringLiteral(", ")), reason);
 }
 
-void DerivedFieldController::restore(const QSettings& settings)
-{
-    const auto stored = settings.value(settingsKey()).toString();
-    if (stored.isEmpty()) {
-        return;
-    }
-    auto parsed = parseExpressionList(stored.toUtf8());
-    if (!parsed.error.isEmpty()) {
-        return;
-    }
-    m_definitions = std::move(parsed.definitions);
-}
-
-void DerivedFieldController::save(QSettings& settings) const
-{
-    if (m_definitions.empty()) {
-        settings.remove(settingsKey());
-        return;
-    }
-    settings.setValue(settingsKey(),
-        QString::fromUtf8(writeExpressionList(m_definitions)));
-}
 
 } // namespace amrvis::qt

--- a/src/qt/DerivedFieldController.cpp
+++ b/src/qt/DerivedFieldController.cpp
@@ -1,0 +1,301 @@
+#include "DerivedFieldController.hpp"
+
+#include "ExpressionEditorDialog.hpp"
+
+#include <QAction>
+#include <QByteArray>
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonParseError>
+#include <QJsonValue>
+#include <QSaveFile>
+#include <QSettings>
+#include <QWidget>
+
+#include <utility>
+
+namespace amrvis::qt {
+namespace {
+
+constexpr auto kExpressionListFormat = "amrexplorer-expression-list";
+constexpr int kExpressionListVersion = 1;
+
+QString settingsKey()
+{
+    return QStringLiteral("derivedFields/list");
+}
+
+} // namespace
+
+ExpressionListFile parseExpressionList(const QByteArray& json)
+{
+    QJsonParseError parseError{};
+    const auto document = QJsonDocument::fromJson(json, &parseError);
+    if (parseError.error != QJsonParseError::NoError || !document.isObject()) {
+        return {{},
+            DerivedFieldController::tr("not a valid expression-list JSON "
+                                       "file: %1")
+                .arg(parseError.errorString())};
+    }
+    const auto root = document.object();
+    const auto format = root.value(QStringLiteral("format"));
+    const auto version = root.value(QStringLiteral("version"));
+    const auto entries = root.value(QStringLiteral("expressions"));
+    if (!format.isString()
+        || format.toString() != QLatin1String(kExpressionListFormat)
+        || !version.isDouble() || version.toInt() != kExpressionListVersion
+        || !entries.isArray()) {
+        return {{},
+            DerivedFieldController::tr(
+                "not a supported expression list (expected format \"%1\" "
+                "version %2)")
+                .arg(QLatin1String(kExpressionListFormat))
+                .arg(kExpressionListVersion)};
+    }
+
+    std::vector<DerivedFieldDefinition> definitions;
+    const auto array = entries.toArray();
+    definitions.reserve(static_cast<std::size_t>(array.size()));
+    for (const auto& value : array) {
+        if (!value.isObject()) {
+            return {{},
+                DerivedFieldController::tr(
+                    "every expression-list entry must be an object")};
+        }
+        const auto entry = value.toObject();
+        const auto name = entry.value(QStringLiteral("name"));
+        const auto expression = entry.value(QStringLiteral("expression"));
+        if (!name.isString() || !expression.isString()) {
+            return {{},
+                DerivedFieldController::tr(
+                    "every expression-list entry needs string \"name\" and "
+                    "\"expression\" values")};
+        }
+        definitions.push_back({name.toString().trimmed().toStdString(),
+            expression.toString().trimmed().toStdString()});
+    }
+    return {std::move(definitions), {}};
+}
+
+QByteArray writeExpressionList(
+    const std::vector<DerivedFieldDefinition>& definitions)
+{
+    QJsonArray entries;
+    for (const auto& definition : definitions) {
+        entries.append(QJsonObject{
+            {QStringLiteral("name"), QString::fromStdString(definition.name)},
+            {QStringLiteral("expression"),
+                QString::fromStdString(definition.expression)}});
+    }
+    const QJsonObject root{
+        {QStringLiteral("format"), QLatin1String(kExpressionListFormat)},
+        {QStringLiteral("version"), kExpressionListVersion},
+        {QStringLiteral("expressions"), entries}};
+    return QJsonDocument(root).toJson(QJsonDocument::Indented);
+}
+
+DerivedFieldController::DerivedFieldController(Hooks hooks, QObject* parent)
+    : QObject(parent)
+    , m_hooks(std::move(hooks))
+{
+}
+
+QAction* DerivedFieldController::createAction(QWidget* parent)
+{
+    m_action = new QAction(tr("&Expression Editor..."), parent);
+    m_action->setObjectName(QStringLiteral("expressionEditorAction"));
+    connect(m_action, &QAction::triggered, this,
+        [this, parent] { showEditor(parent); });
+    refreshAvailability();
+    return m_action;
+}
+
+void DerivedFieldController::refreshAvailability()
+{
+    const auto available = m_hooks.available && m_hooks.available();
+    if (m_action) {
+        m_action->setEnabled(available);
+        m_action->setToolTip(available
+                ? QString()
+                : tr("Derived fields need a local dataset."));
+    }
+    // An editor left open over a dataset that has gone (or a remote one that
+    // cannot take derived fields) would apply into nothing.
+    if (!available && m_dialog) {
+        m_dialog->close();
+    }
+}
+
+std::optional<DerivedFieldController::Refusal> DerivedFieldController::apply(
+    std::vector<DerivedFieldDefinition> definitions)
+{
+    auto stored = m_hooks.storedMetadata ? m_hooks.storedMetadata()
+                                         : std::nullopt;
+    if (!stored) {
+        return Refusal{tr("No dataset that can take derived fields is open."),
+            std::nullopt};
+    }
+    try {
+        // Strict, on a copy: the user is being told whether what they typed
+        // works, so the first problem is the answer -- and the metadata this
+        // validates against is thrown away either way.
+        static_cast<void>(installDerivedFields(
+            *stored, definitions, DerivedFieldPolicy::Strict));
+    } catch (const DerivedFieldError& error) {
+        return Refusal{QString::fromUtf8(error.what()),
+            error.definitionIndex()};
+    }
+
+    m_definitions = std::move(definitions);
+    if (m_hooks.settings) {
+        if (auto settings = m_hooks.settings()) {
+            save(*settings);
+        }
+    }
+    emit definitionsChanged();
+    if (m_hooks.reload) {
+        m_hooks.reload();
+    }
+    return std::nullopt;
+}
+
+void DerivedFieldController::showEditor(QWidget* parent)
+{
+    if (m_dialog) {
+        m_dialog->raise();
+        m_dialog->activateWindow();
+        return;
+    }
+    auto* dialog = new ExpressionEditorDialog(m_definitions, parent);
+    dialog->setAttribute(Qt::WA_DeleteOnClose);
+    connect(dialog, &ExpressionEditorDialog::applyRequested, dialog,
+        [this, dialog] {
+            const auto refusal = apply(dialog->draft());
+            if (refusal) {
+                dialog->showError(
+                    refusal->message, refusal->definitionIndex);
+                return;
+            }
+            // The committed list is what the editor should now be editing:
+            // apply() may have trimmed names, and the draft must not drift
+            // from what the dataset was reopened with.
+            dialog->setDraft(m_definitions);
+            emit statusMessage(
+                m_definitions.empty()
+                    ? tr("Derived fields cleared.")
+                    : tr("Applied %n derived field(s).", nullptr,
+                          static_cast<int>(m_definitions.size())),
+                4000);
+        });
+    connect(dialog, &ExpressionEditorDialog::importRequested, dialog,
+        [this, dialog] {
+            if (!m_hooks.chooseFile) {
+                return;
+            }
+            const auto path = m_hooks.chooseFile(dialog, false);
+            if (path.isEmpty()) {
+                return;
+            }
+            QFile file(path);
+            if (!file.open(QIODevice::ReadOnly)) {
+                dialog->showError(tr("Could not open %1: %2")
+                        .arg(QDir::toNativeSeparators(path),
+                            file.errorString()),
+                    std::nullopt);
+                return;
+            }
+            auto parsed = parseExpressionList(file.readAll());
+            if (!parsed.error.isEmpty()) {
+                dialog->showError(
+                    tr("%1: %2").arg(QDir::toNativeSeparators(path),
+                        parsed.error),
+                    std::nullopt);
+                return;
+            }
+            // Imported into the draft, not committed: nothing reaches the
+            // dataset until the user applies it.
+            dialog->setDraft(std::move(parsed.definitions));
+        });
+    connect(dialog, &ExpressionEditorDialog::exportRequested, dialog,
+        [this, dialog] {
+            if (!m_hooks.chooseFile) {
+                return;
+            }
+            auto path = m_hooks.chooseFile(dialog, true);
+            if (path.isEmpty()) {
+                return;
+            }
+            if (QFileInfo(path).suffix().isEmpty()) {
+                path += QStringLiteral(".json");
+            }
+            // The draft, which is what the user is looking at -- exporting
+            // only what has been applied would silently drop their edits.
+            QSaveFile file(path);
+            const auto json = writeExpressionList(dialog->draft());
+            if (!file.open(QIODevice::WriteOnly)
+                || file.write(json) != json.size() || !file.commit()) {
+                dialog->showError(tr("Could not write %1: %2")
+                        .arg(QDir::toNativeSeparators(path),
+                            file.errorString()),
+                    std::nullopt);
+                return;
+            }
+            emit statusMessage(tr("Exported derived fields to %1.")
+                    .arg(QDir::toNativeSeparators(path)),
+                4000);
+        });
+    m_dialog = dialog;
+    dialog->show();
+}
+
+QString DerivedFieldController::skippedReport(
+    const std::vector<DerivedFieldSkip>& skipped) const
+{
+    if (skipped.empty()) {
+        return {};
+    }
+    QStringList names;
+    for (const auto& entry : skipped) {
+        names.append(entry.name.empty()
+                ? tr("(unnamed)")
+                : QString::fromStdString(entry.name));
+    }
+    // One reason in full, the first: with several skips they are usually the
+    // same missing field, and the status bar has room for one.
+    const auto reason = QString::fromStdString(skipped.front().reason);
+    return skipped.size() == 1
+        ? tr("Derived field \"%1\" is unavailable for this dataset: %2")
+              .arg(names.front(), reason)
+        : tr("%1 derived fields are unavailable for this dataset: %2 (%3)")
+              .arg(skipped.size())
+              .arg(names.join(QStringLiteral(", ")), reason);
+}
+
+void DerivedFieldController::restore(const QSettings& settings)
+{
+    const auto stored = settings.value(settingsKey()).toString();
+    if (stored.isEmpty()) {
+        return;
+    }
+    auto parsed = parseExpressionList(stored.toUtf8());
+    if (!parsed.error.isEmpty()) {
+        return;
+    }
+    m_definitions = std::move(parsed.definitions);
+}
+
+void DerivedFieldController::save(QSettings& settings) const
+{
+    if (m_definitions.empty()) {
+        settings.remove(settingsKey());
+        return;
+    }
+    settings.setValue(settingsKey(),
+        QString::fromUtf8(writeExpressionList(m_definitions)));
+}
+
+} // namespace amrvis::qt

--- a/src/qt/DerivedFieldController.cpp
+++ b/src/qt/DerivedFieldController.cpp
@@ -126,7 +126,13 @@ void DerivedFieldController::refreshAvailability()
     // An editor left open over a dataset that has gone (or a remote one that
     // cannot take derived fields) would apply into nothing.
     if (!available && m_dialog) {
-        m_dialog->close();
+        // Cleared here rather than left to the deleteLater that close()
+        // schedules: until that is delivered the pointer is still set, and a
+        // showEditor before then would raise the dying dialog instead of
+        // opening one.
+        auto* dialog = m_dialog.data();
+        m_dialog = nullptr;
+        dialog->close();
     }
 }
 
@@ -156,7 +162,6 @@ std::optional<DerivedFieldController::Refusal> DerivedFieldController::apply(
             save(*settings);
         }
     }
-    emit definitionsChanged();
     if (m_hooks.reload) {
         m_hooks.reload();
     }

--- a/src/qt/DerivedFieldController.hpp
+++ b/src/qt/DerivedFieldController.hpp
@@ -10,13 +10,11 @@
 
 #include <cstddef>
 #include <functional>
-#include <memory>
 #include <optional>
 #include <vector>
 
 class QAction;
 class QByteArray;
-class QSettings;
 class QWidget;
 
 namespace amrvis::qt {
@@ -42,9 +40,15 @@ struct ExpressionListFile {
 [[nodiscard]] QByteArray writeExpressionList(
     const std::vector<DerivedFieldDefinition>& definitions);
 
-// The derived-field definitions the viewer carries: the committed list, the
-// Variable menu's Expression Editor action and its modeless dialog, the
-// import/export of an expression list, and the settings persistence.
+// The derived-field definitions this window carries: the committed list, the
+// Variable menu's Expression Editor action and its modeless dialog, and the
+// import/export of an expression list.
+//
+// The list lives as long as the window and is deliberately not persisted. A
+// definition is written against the fields of a particular dataset, so one
+// restored into a later session showed up against unrelated plotfiles, where
+// it could only be reported as unavailable. Export writes one to a file for
+// anyone who wants it back.
 //
 // The list is installed when a dataset is opened, so committing a change means
 // asking the host to reopen what is on screen with the new list (the `reload`
@@ -70,7 +74,6 @@ public:
         std::function<std::optional<DatasetMetadata>()> storedMetadata;
         // Reopen the open dataset with the committed definitions.
         std::function<void()> reload;
-        std::function<std::unique_ptr<QSettings>()> settings;
         // A path to import from (forSaving false) or export to (true); empty
         // cancels. The host runs the file dialog, as it does for palettes.
         std::function<QString(QWidget* parent, bool forSaving)> chooseFile;
@@ -103,6 +106,13 @@ public:
     [[nodiscard]] std::optional<Refusal> apply(
         std::vector<DerivedFieldDefinition> definitions);
 
+    // Forgets every definition. Called where a *different* dataset is opened,
+    // which is the point at which a list written against the last one stops
+    // meaning anything: the editor validates the whole list on Apply, so
+    // definitions naming fields the new dataset does not have would refuse
+    // every later edit until they were deleted by hand.
+    void clear();
+
     // Opens the editor (or raises it if it is already open) on the committed
     // list. Modeless: the reload an Apply triggers is an ordinary dataset load,
     // so there is nothing a nested event loop would have to be held back from.
@@ -114,13 +124,6 @@ public:
     // is silently missing from the field list otherwise.
     [[nodiscard]] QString skippedReport(
         const std::vector<DerivedFieldSkip>& skipped) const;
-
-    // "derivedFields/list": the committed list, in the same JSON as an
-    // exported file. restore() installs it without validating (there is no
-    // dataset open yet) and without reloading, so a host that has wired
-    // definitionsChanged is not made to reload nothing at startup.
-    void restore(const QSettings& settings);
-    void save(QSettings& settings) const;
 
 signals:
     void statusMessage(const QString& message, int timeoutMs);

--- a/src/qt/DerivedFieldController.hpp
+++ b/src/qt/DerivedFieldController.hpp
@@ -1,0 +1,138 @@
+#pragma once
+
+#include <amrexplorer/core/DerivedField.hpp>
+#include <amrexplorer/core/Metadata.hpp>
+
+#include <QObject>
+#include <QPointer>
+#include <QString>
+#include <QStringList>
+
+#include <cstddef>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <vector>
+
+class QAction;
+class QByteArray;
+class QSettings;
+class QWidget;
+
+namespace amrvis::qt {
+
+class ExpressionEditorDialog;
+
+// The `amrexplorer-expression-list` JSON the Expression Editor exports and
+// imports:
+// {"format": "amrexplorer-expression-list", "version": 1,
+//  "expressions": [{"name": ..., "expression": ...}, ...]}
+//
+// Both directions live here rather than in the dialog so the format is
+// testable without a widget, and because it is the same format the settings
+// store keeps the list in.
+struct ExpressionListFile {
+    std::vector<DerivedFieldDefinition> definitions;
+    // Empty when the parse succeeded. Nothing is returned in definitions
+    // otherwise: an expression list is imported whole or not at all.
+    QString error;
+};
+
+[[nodiscard]] ExpressionListFile parseExpressionList(const QByteArray& json);
+[[nodiscard]] QByteArray writeExpressionList(
+    const std::vector<DerivedFieldDefinition>& definitions);
+
+// The derived-field definitions the viewer carries: the committed list, the
+// Variable menu's Expression Editor action and its modeless dialog, the
+// import/export of an expression list, and the settings persistence.
+//
+// The list is installed when a dataset is opened, so committing a change means
+// asking the host to reopen what is on screen with the new list (the `reload`
+// hook, which the host answers the way it answers a sequence frame switch).
+// Validation happens here, before any of that: an editor's Apply is checked
+// strictly against the open dataset's stored fields so the user is told which
+// definition is wrong and why, while a dataset opening with the committed list
+// skips what it cannot resolve (DerivedFieldPolicy) rather than refusing to
+// open -- a list written for one plotfile must not make another unopenable.
+class DerivedFieldController final : public QObject {
+    Q_OBJECT
+
+public:
+    struct Hooks {
+        // Whether a dataset that can take derived fields is open. Asked on
+        // every dataset load, which is why it is not storedMetadata's
+        // has_value(): that copies a whole field and block list to answer a
+        // question about one pointer.
+        std::function<bool()> available;
+        // The fields a definition may read: the open dataset's metadata with
+        // the derived fields removed, or nullopt when none is open. Asked only
+        // when a list is validated.
+        std::function<std::optional<DatasetMetadata>()> storedMetadata;
+        // Reopen the open dataset with the committed definitions.
+        std::function<void()> reload;
+        std::function<std::unique_ptr<QSettings>()> settings;
+        // A path to import from (forSaving false) or export to (true); empty
+        // cancels. The host runs the file dialog, as it does for palettes.
+        std::function<QString(QWidget* parent, bool forSaving)> chooseFile;
+    };
+
+    explicit DerivedFieldController(Hooks hooks, QObject* parent = nullptr);
+
+    // The Variable menu's "Expression Editor..." action, enabled while the
+    // open dataset can take derived fields. Owned by `parent`.
+    QAction* createAction(QWidget* parent);
+    // Re-derives the action's enablement from the hooks; the host calls it
+    // when a dataset opens or closes.
+    void refreshAvailability();
+
+    [[nodiscard]] const std::vector<DerivedFieldDefinition>& definitions()
+        const noexcept
+    {
+        return m_definitions;
+    }
+
+    struct Refusal {
+        QString message;
+        // The definition the refusal belongs to, when it is about one.
+        std::optional<std::size_t> definitionIndex;
+    };
+
+    // Validates the list against the open dataset and, if every definition
+    // resolves, commits it, persists it and asks the host to reload. Returns
+    // the refusal otherwise, having changed nothing.
+    [[nodiscard]] std::optional<Refusal> apply(
+        std::vector<DerivedFieldDefinition> definitions);
+
+    // Opens the editor (or raises it if it is already open) on the committed
+    // list. Modeless: the reload an Apply triggers is an ordinary dataset load,
+    // so there is nothing a nested event loop would have to be held back from.
+    void showEditor(QWidget* parent);
+
+    // The definitions the last dataset load could not install, as a single
+    // line for the status bar, or empty when there were none. The host calls
+    // it once a load has settled -- a definition written for another plotfile
+    // is silently missing from the field list otherwise.
+    [[nodiscard]] QString skippedReport(
+        const std::vector<DerivedFieldSkip>& skipped) const;
+
+    // "derivedFields/list": the committed list, in the same JSON as an
+    // exported file. restore() installs it without validating (there is no
+    // dataset open yet) and without reloading, so a host that has wired
+    // definitionsChanged is not made to reload nothing at startup.
+    void restore(const QSettings& settings);
+    void save(QSettings& settings) const;
+
+signals:
+    void statusMessage(const QString& message, int timeoutMs);
+    // The committed list changed. The host reloads through the hook rather
+    // than off this signal; this is for anything else that shows the list.
+    void definitionsChanged();
+
+private:
+    Hooks m_hooks;
+    std::vector<DerivedFieldDefinition> m_definitions;
+    QPointer<QAction> m_action;
+    QPointer<ExpressionEditorDialog> m_dialog;
+};
+
+} // namespace amrvis::qt

--- a/src/qt/DerivedFieldController.hpp
+++ b/src/qt/DerivedFieldController.hpp
@@ -3,7 +3,6 @@
 #include "DerivedFieldStore.hpp"
 
 #include <amrexplorer/core/DerivedField.hpp>
-#include <amrexplorer/core/Metadata.hpp>
 
 #include <QObject>
 #include <QPointer>
@@ -11,6 +10,7 @@
 #include <QStringList>
 
 #include <cstddef>
+#include <cstdint>
 #include <functional>
 #include <optional>
 #include <vector>
@@ -45,34 +45,29 @@ struct ExpressionListFile {
 // Variable menu's Expression Editor action and its modeless dialog, and the
 // import/export of an expression list.
 //
-// The list lives as long as the window and is deliberately not persisted. A
-// definition is written against the fields of a particular dataset, so one
-// restored into a later session showed up against unrelated plotfiles, where
-// it could only be reported as unavailable. Export writes one to a file for
-// anyone who wants it back.
+// The list lives in the session's DerivedFieldStore, shared by every window,
+// and is deliberately not persisted: a definition is written against the
+// fields of a particular dataset, so one restored into a later session showed
+// up against unrelated plotfiles it could only be unavailable for. Export
+// writes one to a file for anyone who wants it back.
 //
 // The list is installed when a dataset is opened, so committing a change means
 // asking the host to reopen what is on screen with the new list (the `reload`
 // hook, which the host answers the way it answers a sequence frame switch).
-// Validation happens here, before any of that: an editor's Apply is checked
-// strictly against the open dataset's stored fields so the user is told which
-// definition is wrong and why, while a dataset opening with the committed list
+// Validation happens here, before any of that, and only of what is wrong
+// whatever the data (see apply): a dataset opening with the committed list
 // skips what it cannot resolve (DerivedFieldPolicy) rather than refusing to
-// open -- a list written for one plotfile must not make another unopenable.
+// open -- a list written for one plotfile must not make another unopenable --
+// and the window shows what was skipped greyed out.
 class DerivedFieldController final : public QObject {
     Q_OBJECT
 
 public:
     struct Hooks {
         // Whether a dataset that can take derived fields is open. Asked on
-        // every dataset load, which is why it is not storedMetadata's
-        // has_value(): that copies a whole field and block list to answer a
-        // question about one pointer.
+        // every dataset load, so it answers from one pointer rather than by
+        // copying anything.
         std::function<bool()> available;
-        // The fields a definition may read: the open dataset's metadata with
-        // the derived fields removed, or nullopt when none is open. Asked only
-        // when a list is validated.
-        std::function<std::optional<DatasetMetadata>()> storedMetadata;
         // Reopen the open dataset with the committed definitions.
         std::function<void()> reload;
         // A path to import from (forSaving false) or export to (true); empty
@@ -92,6 +87,20 @@ public:
     // Re-derives the action's enablement from the hooks; the host calls it
     // when a dataset opens or closes.
     void refreshAvailability();
+
+    // Whether a dataset that can take derived fields is open, and how many
+    // times the shared list has changed. The host asks both when one of its
+    // own loads lands: it counts as unavailable for the whole of an open, so
+    // a change committed meanwhile reached every other window but not the
+    // session it was opening (see DerivedFieldStore::revision).
+    [[nodiscard]] bool available() const
+    {
+        return m_hooks.available && m_hooks.available();
+    }
+    [[nodiscard]] std::uint64_t storeRevision() const noexcept
+    {
+        return m_store.revision();
+    }
 
     [[nodiscard]] const std::vector<DerivedFieldDefinition>& definitions()
         const noexcept

--- a/src/qt/DerivedFieldController.hpp
+++ b/src/qt/DerivedFieldController.hpp
@@ -124,9 +124,6 @@ public:
 
 signals:
     void statusMessage(const QString& message, int timeoutMs);
-    // The committed list changed. The host reloads through the hook rather
-    // than off this signal; this is for anything else that shows the list.
-    void definitionsChanged();
 
 private:
     Hooks m_hooks;

--- a/src/qt/DerivedFieldController.hpp
+++ b/src/qt/DerivedFieldController.hpp
@@ -7,7 +7,6 @@
 #include <QObject>
 #include <QPointer>
 #include <QString>
-#include <QStringList>
 
 #include <cstddef>
 #include <cstdint>

--- a/src/qt/DerivedFieldController.hpp
+++ b/src/qt/DerivedFieldController.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "DerivedFieldStore.hpp"
+
 #include <amrexplorer/core/DerivedField.hpp>
 #include <amrexplorer/core/Metadata.hpp>
 
@@ -78,7 +80,11 @@ public:
         std::function<QString(QWidget* parent, bool forSaving)> chooseFile;
     };
 
-    explicit DerivedFieldController(Hooks hooks, QObject* parent = nullptr);
+    // `store` outlives the controller: the session's own, or a test's. Every
+    // window's controller shares one, which is how a definition written in one
+    // window reaches the others.
+    DerivedFieldController(
+        Hooks hooks, DerivedFieldStore& store, QObject* parent = nullptr);
 
     // The Variable menu's "Expression Editor..." action, enabled while the
     // open dataset can take derived fields. Owned by `parent`.
@@ -90,7 +96,7 @@ public:
     [[nodiscard]] const std::vector<DerivedFieldDefinition>& definitions()
         const noexcept
     {
-        return m_definitions;
+        return m_store.definitions();
     }
 
     struct Refusal {
@@ -99,38 +105,35 @@ public:
         std::optional<std::size_t> definitionIndex;
     };
 
-    // Validates the list against the open dataset and, if every definition
-    // resolves, commits it and asks the host to reload. Returns the refusal
-    // otherwise, having changed nothing; a list equal to the committed one is
-    // accepted and reloads nothing.
+    // Checks the list and, if it holds, commits it to the store -- from which
+    // this window and every other one takes it. Returns the refusal otherwise,
+    // having changed nothing; a list equal to the committed one changes and
+    // reloads nothing.
+    //
+    // Only what is wrong whatever the data is refused: a name that is empty or
+    // used twice, and an expression that does not parse. Whether a *particular*
+    // dataset can provide the fields a definition reads is not this list's
+    // business -- one list is shared by windows showing different data, so a
+    // definition simply does not apply in some of them, and is shown greyed
+    // out there rather than refused everywhere.
     [[nodiscard]] std::optional<Refusal> apply(
         std::vector<DerivedFieldDefinition> definitions);
-
-    // Forgets every definition. Called where a *different* dataset is opened,
-    // which is the point at which a list written against the last one stops
-    // meaning anything: the editor validates the whole list on Apply, so
-    // definitions naming fields the new dataset does not have would refuse
-    // every later edit until they were deleted by hand.
-    void clear();
 
     // Opens the editor (or raises it if it is already open) on the committed
     // list. Modeless: the reload an Apply triggers is an ordinary dataset load,
     // so there is nothing a nested event loop would have to be held back from.
     void showEditor(QWidget* parent);
 
-    // The definitions the last dataset load could not install, as a single
-    // line for the status bar, or empty when there were none. The host calls
-    // it once a load has settled -- a definition written for another plotfile
-    // is silently missing from the field list otherwise.
-    [[nodiscard]] QString skippedReport(
-        const std::vector<DerivedFieldSkip>& skipped) const;
-
 signals:
     void statusMessage(const QString& message, int timeoutMs);
 
 private:
+    // Re-reads the store: refreshes an open editor, and asks the host to
+    // reload so the change reaches this window's field list too.
+    void adoptStoreChange();
+
     Hooks m_hooks;
-    std::vector<DerivedFieldDefinition> m_definitions;
+    DerivedFieldStore& m_store;
     QPointer<QAction> m_action;
     QPointer<ExpressionEditorDialog> m_dialog;
 };

--- a/src/qt/DerivedFieldController.hpp
+++ b/src/qt/DerivedFieldController.hpp
@@ -9,7 +9,7 @@
 #include <QString>
 
 #include <cstddef>
-#include <cstdint>
+#include <string>
 #include <functional>
 #include <optional>
 #include <vector>
@@ -35,6 +35,13 @@ struct ExpressionListFile {
     // otherwise: an expression list is imported whole or not at all.
     QString error;
 };
+
+// An expression as a tooltip: one line whatever its layout, and escaped.
+[[nodiscard]] QString escapedExpression(const std::string& expression);
+// Escaped text as a tooltip Qt is certain to render as rich text. Without the
+// wrapper, an expression holding `<` decides it and one holding only `&` does
+// not, so the escapes show up as themselves.
+[[nodiscard]] QString richTooltip(const QString& escaped);
 
 [[nodiscard]] ExpressionListFile parseExpressionList(const QByteArray& json);
 [[nodiscard]] QByteArray writeExpressionList(
@@ -87,18 +94,13 @@ public:
     // when a dataset opens or closes.
     void refreshAvailability();
 
-    // Whether a dataset that can take derived fields is open, and how many
-    // times the shared list has changed. The host asks both when one of its
-    // own loads lands: it counts as unavailable for the whole of an open, so
-    // a change committed meanwhile reached every other window but not the
-    // session it was opening (see DerivedFieldStore::revision).
+    // Whether a dataset that can take derived fields is open. The host asks
+    // it when one of its own loads lands: a window counts as unavailable for
+    // the whole of an open, so a list committed meanwhile reached every other
+    // window but not the session it was opening.
     [[nodiscard]] bool available() const
     {
         return m_hooks.available && m_hooks.available();
-    }
-    [[nodiscard]] std::uint64_t storeRevision() const noexcept
-    {
-        return m_store.revision();
     }
 
     [[nodiscard]] const std::vector<DerivedFieldDefinition>& definitions()

--- a/src/qt/DerivedFieldController.hpp
+++ b/src/qt/DerivedFieldController.hpp
@@ -27,8 +27,7 @@ class ExpressionEditorDialog;
 //  "expressions": [{"name": ..., "expression": ...}, ...]}
 //
 // Both directions live here rather than in the dialog so the format is
-// testable without a widget, and because it is the same format the settings
-// store keeps the list in.
+// testable without a widget.
 struct ExpressionListFile {
     std::vector<DerivedFieldDefinition> definitions;
     // Empty when the parse succeeded. Nothing is returned in definitions
@@ -101,8 +100,9 @@ public:
     };
 
     // Validates the list against the open dataset and, if every definition
-    // resolves, commits it, persists it and asks the host to reload. Returns
-    // the refusal otherwise, having changed nothing.
+    // resolves, commits it and asks the host to reload. Returns the refusal
+    // otherwise, having changed nothing; a list equal to the committed one is
+    // accepted and reloads nothing.
     [[nodiscard]] std::optional<Refusal> apply(
         std::vector<DerivedFieldDefinition> definitions);
 

--- a/src/qt/DerivedFieldStore.cpp
+++ b/src/qt/DerivedFieldStore.cpp
@@ -26,7 +26,6 @@ void DerivedFieldStore::set(std::vector<DerivedFieldDefinition> definitions)
         return;
     }
     m_definitions = std::move(definitions);
-    ++m_revision;
     emit changed();
 }
 

--- a/src/qt/DerivedFieldStore.cpp
+++ b/src/qt/DerivedFieldStore.cpp
@@ -24,6 +24,7 @@ void DerivedFieldStore::set(std::vector<DerivedFieldDefinition> definitions)
         return;
     }
     m_definitions = std::move(definitions);
+    ++m_revision;
     emit changed();
 }
 

--- a/src/qt/DerivedFieldStore.cpp
+++ b/src/qt/DerivedFieldStore.cpp
@@ -13,9 +13,11 @@ DerivedFieldStore& DerivedFieldStore::session()
 {
     // Function-local, so it exists from first use and outlives every window
     // that reaches for it. No parent: it belongs to the process, not to a
-    // widget tree that comes and goes.
-    static DerivedFieldStore store;
-    return store;
+    // widget tree that comes and goes. Never destroyed, deliberately: a
+    // QObject with static storage duration is torn down after QApplication
+    // has gone, which is the ordering Qt asks callers to stay out of.
+    static auto* const store = new DerivedFieldStore;
+    return *store;
 }
 
 void DerivedFieldStore::set(std::vector<DerivedFieldDefinition> definitions)

--- a/src/qt/DerivedFieldStore.cpp
+++ b/src/qt/DerivedFieldStore.cpp
@@ -1,0 +1,30 @@
+#include "DerivedFieldStore.hpp"
+
+#include <utility>
+
+namespace amrvis::qt {
+
+DerivedFieldStore::DerivedFieldStore(QObject* parent)
+    : QObject(parent)
+{
+}
+
+DerivedFieldStore& DerivedFieldStore::session()
+{
+    // Function-local, so it exists from first use and outlives every window
+    // that reaches for it. No parent: it belongs to the process, not to a
+    // widget tree that comes and goes.
+    static DerivedFieldStore store;
+    return store;
+}
+
+void DerivedFieldStore::set(std::vector<DerivedFieldDefinition> definitions)
+{
+    if (definitions == m_definitions) {
+        return;
+    }
+    m_definitions = std::move(definitions);
+    emit changed();
+}
+
+} // namespace amrvis::qt

--- a/src/qt/DerivedFieldStore.hpp
+++ b/src/qt/DerivedFieldStore.hpp
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <amrexplorer/core/DerivedField.hpp>
+
+#include <QObject>
+
+#include <vector>
+
+namespace amrvis::qt {
+
+// The derived-field definitions, shared by every window of one running
+// viewer. Deliberately process-wide and deliberately not persisted:
+//
+//  - a definition written in one window belongs in the others, which is what
+//    "the expression list" means to someone with two windows open on the same
+//    kind of data;
+//  - a viewer started separately from the command line gets its own, because
+//    it is its own process -- the isolation comes free with the scope;
+//  - nothing survives the session, so a list written for one plotfile cannot
+//    come back weeks later against unrelated data.
+//
+// Held by reference rather than reached through a global, so a test can give
+// its controllers a store of their own -- and can give two controllers the
+// same one to check that they see each other's edits.
+class DerivedFieldStore final : public QObject {
+    Q_OBJECT
+
+public:
+    explicit DerivedFieldStore(QObject* parent = nullptr);
+
+    // The store every window of this process shares.
+    [[nodiscard]] static DerivedFieldStore& session();
+
+    [[nodiscard]] const std::vector<DerivedFieldDefinition>& definitions()
+        const noexcept
+    {
+        return m_definitions;
+    }
+
+    // Replaces the list and tells everyone. A list equal to the current one
+    // changes nothing and emits nothing, so a window re-applying what is
+    // already installed does not make every other window reload.
+    void set(std::vector<DerivedFieldDefinition> definitions);
+
+signals:
+    // The list changed. Every window re-reads it: the one that made the change
+    // and the ones that did not.
+    void changed();
+
+private:
+    std::vector<DerivedFieldDefinition> m_definitions;
+};
+
+} // namespace amrvis::qt

--- a/src/qt/DerivedFieldStore.hpp
+++ b/src/qt/DerivedFieldStore.hpp
@@ -4,7 +4,6 @@
 
 #include <QObject>
 
-#include <cstdint>
 #include <vector>
 
 namespace amrvis::qt {
@@ -43,17 +42,6 @@ public:
     // already installed does not make every other window reload.
     void set(std::vector<DerivedFieldDefinition> definitions);
 
-    // How many times the list has actually changed. A window is not told to
-    // reload while it has no dataset -- which is the whole of an open, not
-    // just its start -- so a load launched before a change lands after it,
-    // holding a session built from the older list. Capturing this when the
-    // load is launched and reading it again when the load lands is how that
-    // window notices.
-    [[nodiscard]] std::uint64_t revision() const noexcept
-    {
-        return m_revision;
-    }
-
 signals:
     // The list changed. Every window re-reads it: the one that made the change
     // and the ones that did not.
@@ -61,7 +49,6 @@ signals:
 
 private:
     std::vector<DerivedFieldDefinition> m_definitions;
-    std::uint64_t m_revision = 0;
 };
 
 } // namespace amrvis::qt

--- a/src/qt/DerivedFieldStore.hpp
+++ b/src/qt/DerivedFieldStore.hpp
@@ -4,6 +4,7 @@
 
 #include <QObject>
 
+#include <cstdint>
 #include <vector>
 
 namespace amrvis::qt {
@@ -42,6 +43,17 @@ public:
     // already installed does not make every other window reload.
     void set(std::vector<DerivedFieldDefinition> definitions);
 
+    // How many times the list has actually changed. A window is not told to
+    // reload while it has no dataset -- which is the whole of an open, not
+    // just its start -- so a load launched before a change lands after it,
+    // holding a session built from the older list. Capturing this when the
+    // load is launched and reading it again when the load lands is how that
+    // window notices.
+    [[nodiscard]] std::uint64_t revision() const noexcept
+    {
+        return m_revision;
+    }
+
 signals:
     // The list changed. Every window re-reads it: the one that made the change
     // and the ones that did not.
@@ -49,6 +61,7 @@ signals:
 
 private:
     std::vector<DerivedFieldDefinition> m_definitions;
+    std::uint64_t m_revision = 0;
 };
 
 } // namespace amrvis::qt

--- a/src/qt/ExpressionEditorDialog.cpp
+++ b/src/qt/ExpressionEditorDialog.cpp
@@ -1,0 +1,243 @@
+#include "ExpressionEditorDialog.hpp"
+
+#include <QDialogButtonBox>
+#include <QFormLayout>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QLineEdit>
+#include <QListWidget>
+#include <QPlainTextEdit>
+#include <QPushButton>
+#include <QSignalBlocker>
+#include <QVBoxLayout>
+
+#include <algorithm>
+#include <utility>
+
+namespace amrvis::qt {
+namespace {
+
+QString displayName(const DerivedFieldDefinition& definition)
+{
+    return definition.name.empty()
+        ? ExpressionEditorDialog::tr("(unnamed)")
+        : QString::fromStdString(definition.name);
+}
+
+} // namespace
+
+ExpressionEditorDialog::ExpressionEditorDialog(
+    std::vector<DerivedFieldDefinition> definitions, QWidget* parent)
+    : QDialog(parent)
+    , m_draft(std::move(definitions))
+{
+    setObjectName(QStringLiteral("expressionEditor"));
+    setWindowTitle(tr("Expression Editor"));
+
+    m_list = new QListWidget(this);
+    m_list->setObjectName(QStringLiteral("expressionList"));
+    m_list->setSelectionMode(QAbstractItemView::SingleSelection);
+    m_list->setMinimumWidth(180);
+
+    auto* add = new QPushButton(tr("&New"), this);
+    add->setObjectName(QStringLiteral("newExpressionButton"));
+    m_remove = new QPushButton(tr("&Delete"), this);
+    m_remove->setObjectName(QStringLiteral("deleteExpressionButton"));
+    auto* importButton = new QPushButton(tr("&Import..."), this);
+    importButton->setObjectName(QStringLiteral("importExpressionsButton"));
+    auto* exportButton = new QPushButton(tr("E&xport..."), this);
+    exportButton->setObjectName(QStringLiteral("exportExpressionsButton"));
+
+    m_name = new QLineEdit(this);
+    m_name->setObjectName(QStringLiteral("expressionName"));
+    m_name->setPlaceholderText(tr("e.g. speed"));
+    m_expression = new QPlainTextEdit(this);
+    m_expression->setObjectName(QStringLiteral("expressionSource"));
+    m_expression->setPlaceholderText(
+        tr("e.g. sqrt(x_velocity**2 + y_velocity**2)"));
+    m_expression->setTabChangesFocus(true);
+    m_expression->setMinimumWidth(360);
+    m_expression->setMaximumHeight(110);
+
+    auto* help = new QLabel(
+        tr("Algebra over the dataset's fields with + - * / and ** (or "
+           "pow(a,b)), and abs, sqrt, exp, log, exp10, log10. Write a name "
+           "that is not a plain identifier as ${name}. x, y and z are the "
+           "sample coordinates. An expression may also use the fields defined "
+           "above it in the list."),
+        this);
+    help->setObjectName(QStringLiteral("expressionHelp"));
+    help->setWordWrap(true);
+
+    m_error = new QLabel(this);
+    m_error->setObjectName(QStringLiteral("expressionError"));
+    m_error->setWordWrap(true);
+    m_error->setVisible(false);
+    // As SetContoursDialog styles its own warning.
+    m_error->setStyleSheet(QStringLiteral("QLabel { color: red; }"));
+
+    auto* buttons = new QDialogButtonBox(this);
+    m_apply = buttons->addButton(QDialogButtonBox::Apply);
+    m_apply->setObjectName(QStringLiteral("applyExpressionsButton"));
+    auto* close = buttons->addButton(QDialogButtonBox::Close);
+    close->setObjectName(QStringLiteral("closeExpressionsButton"));
+
+    auto* sidebarButtons = new QHBoxLayout;
+    sidebarButtons->addWidget(add);
+    sidebarButtons->addWidget(m_remove);
+    auto* fileButtons = new QHBoxLayout;
+    fileButtons->addWidget(importButton);
+    fileButtons->addWidget(exportButton);
+    auto* sidebar = new QVBoxLayout;
+    sidebar->addWidget(new QLabel(tr("Derived fields"), this));
+    sidebar->addWidget(m_list, 1);
+    sidebar->addLayout(sidebarButtons);
+    sidebar->addLayout(fileButtons);
+
+    auto* form = new QFormLayout;
+    form->addRow(tr("&Name:"), m_name);
+    form->addRow(tr("&Expression:"), m_expression);
+    auto* editor = new QVBoxLayout;
+    editor->addLayout(form);
+    editor->addWidget(help);
+    editor->addWidget(m_error);
+    editor->addStretch(1);
+
+    auto* columns = new QHBoxLayout;
+    columns->addLayout(sidebar);
+    columns->addLayout(editor, 1);
+    auto* root = new QVBoxLayout(this);
+    root->addLayout(columns, 1);
+    root->addWidget(buttons);
+
+    connect(m_list, &QListWidget::currentRowChanged, this, [this] {
+        clearError();
+        showSelected();
+    });
+    connect(add, &QPushButton::clicked, this, [this] { addDefinition(); });
+    connect(
+        m_remove, &QPushButton::clicked, this, [this] { removeSelected(); });
+    connect(importButton, &QPushButton::clicked, this,
+        [this] { emit importRequested(); });
+    connect(exportButton, &QPushButton::clicked, this,
+        [this] { emit exportRequested(); });
+    connect(m_name, &QLineEdit::textChanged, this, [this](const QString& text) {
+        const auto index = selectedIndex();
+        if (m_loading || !index) {
+            return;
+        }
+        m_draft[*index].name = text.trimmed().toStdString();
+        m_list->item(static_cast<int>(*index))
+            ->setText(displayName(m_draft[*index]));
+    });
+    connect(m_expression, &QPlainTextEdit::textChanged, this, [this] {
+        const auto index = selectedIndex();
+        if (m_loading || !index) {
+            return;
+        }
+        m_draft[*index].expression =
+            m_expression->toPlainText().trimmed().toStdString();
+    });
+    connect(m_apply, &QPushButton::clicked, this, [this] {
+        clearError();
+        emit applyRequested();
+    });
+    connect(close, &QPushButton::clicked, this, &QDialog::reject);
+
+    rebuildList(m_draft.empty() ? std::nullopt : std::optional<std::size_t>{0});
+    resize(720, 420);
+}
+
+void ExpressionEditorDialog::setDraft(
+    std::vector<DerivedFieldDefinition> definitions,
+    std::optional<std::size_t> select)
+{
+    m_draft = std::move(definitions);
+    clearError();
+    rebuildList(select);
+}
+
+void ExpressionEditorDialog::showError(
+    const QString& message, std::optional<std::size_t> definitionIndex)
+{
+    if (definitionIndex && *definitionIndex < m_draft.size()) {
+        m_list->setCurrentRow(static_cast<int>(*definitionIndex));
+    }
+    m_error->setText(message);
+    m_error->setVisible(true);
+}
+
+void ExpressionEditorDialog::clearError()
+{
+    m_error->clear();
+    m_error->setVisible(false);
+}
+
+void ExpressionEditorDialog::rebuildList(std::optional<std::size_t> select)
+{
+    {
+        const QSignalBlocker blocker(m_list);
+        m_list->clear();
+        for (const auto& definition : m_draft) {
+            m_list->addItem(displayName(definition));
+        }
+    }
+    const auto row = select && *select < m_draft.size()
+        ? static_cast<int>(*select)
+        : (m_draft.empty() ? -1 : 0);
+    // Unblocked, so the row change loads the selection through the same path
+    // every other selection change takes.
+    m_list->setCurrentRow(row);
+    if (row < 0) {
+        showSelected();
+    }
+}
+
+void ExpressionEditorDialog::showSelected()
+{
+    const auto index = selectedIndex();
+    m_loading = true;
+    if (index) {
+        m_name->setText(QString::fromStdString(m_draft[*index].name));
+        m_expression->setPlainText(
+            QString::fromStdString(m_draft[*index].expression));
+    } else {
+        m_name->clear();
+        m_expression->clear();
+    }
+    m_loading = false;
+    m_name->setEnabled(index.has_value());
+    m_expression->setEnabled(index.has_value());
+    m_remove->setEnabled(index.has_value());
+}
+
+void ExpressionEditorDialog::addDefinition()
+{
+    clearError();
+    m_draft.push_back({});
+    rebuildList(m_draft.size() - 1);
+    m_name->setFocus();
+}
+
+void ExpressionEditorDialog::removeSelected()
+{
+    const auto index = selectedIndex();
+    if (!index) {
+        return;
+    }
+    clearError();
+    m_draft.erase(m_draft.begin() + static_cast<std::ptrdiff_t>(*index));
+    rebuildList(*index == 0 ? std::optional<std::size_t>{0}
+                            : std::optional<std::size_t>{*index - 1});
+}
+
+std::optional<std::size_t> ExpressionEditorDialog::selectedIndex() const
+{
+    const auto row = m_list->currentRow();
+    if (row < 0 || static_cast<std::size_t>(row) >= m_draft.size()) {
+        return std::nullopt;
+    }
+    return static_cast<std::size_t>(row);
+}
+
+} // namespace amrvis::qt

--- a/src/qt/ExpressionEditorDialog.cpp
+++ b/src/qt/ExpressionEditorDialog.cpp
@@ -180,6 +180,11 @@ void ExpressionEditorDialog::setCommitted(
 {
     setDraft(std::move(definitions), select);
     m_committed = m_draft;
+    // The draft and the shared list agree again, which is the only thing that
+    // ends the conflict the notice is about -- whether that came of adopting
+    // the change or of committing over it.
+    m_notice->clear();
+    m_notice->setVisible(false);
 }
 
 void ExpressionEditorDialog::showError(
@@ -206,7 +211,6 @@ void ExpressionEditorDialog::showApplied(std::size_t count)
 
 void ExpressionEditorDialog::showListChangedElsewhere()
 {
-    clearError();
     m_notice->setText(
         tr("The derived fields were changed in another window. The edits here "
            "are unapplied and have been kept; Apply replaces the shared list "
@@ -216,12 +220,15 @@ void ExpressionEditorDialog::showListChangedElsewhere()
 
 void ExpressionEditorDialog::clearError()
 {
+    // Not the notice: a peer's commit is a standing conflict, not a message
+    // about the last thing done here. Selecting another row, adding a
+    // definition or pressing Apply all come through here, and any of them
+    // taking the warning away would leave a draft that still overwrites the
+    // shared list with nothing on screen saying so. setCommitted ends it.
     m_error->clear();
     m_error->setVisible(false);
     m_applied->clear();
     m_applied->setVisible(false);
-    m_notice->clear();
-    m_notice->setVisible(false);
 }
 
 void ExpressionEditorDialog::rebuildList(std::optional<std::size_t> select)

--- a/src/qt/ExpressionEditorDialog.cpp
+++ b/src/qt/ExpressionEditorDialog.cpp
@@ -94,9 +94,6 @@ ExpressionEditorDialog::ExpressionEditorDialog(
     auto* buttons = new QDialogButtonBox(this);
     m_apply = buttons->addButton(QDialogButtonBox::Apply);
     m_apply->setObjectName(QStringLiteral("applyExpressionsButton"));
-    // Left to the button box, whose rejected() this dialog already receives
-    // as its parent: wiring clicked() as well would run reject() twice and
-    // emit finished() twice for one close.
     auto* close = buttons->addButton(QDialogButtonBox::Close);
     close->setObjectName(QStringLiteral("closeExpressionsButton"));
 
@@ -162,6 +159,10 @@ ExpressionEditorDialog::ExpressionEditorDialog(
         clearError();
         emit applyRequested();
     });
+    // Explicitly: a QDialogButtonBox parented to a dialog does *not* have its
+    // rejected() wired to that dialog's reject() -- probed, not assumed --
+    // so without this the Close button does nothing at all.
+    connect(buttons, &QDialogButtonBox::rejected, this, &QDialog::reject);
 
     rebuildList(m_draft.empty() ? std::nullopt : std::optional<std::size_t>{0});
     resize(720, 420);
@@ -174,6 +175,13 @@ void ExpressionEditorDialog::setDraft(
     m_draft = std::move(definitions);
     clearError();
     rebuildList(select);
+}
+
+void ExpressionEditorDialog::markDraftCommitted()
+{
+    m_committed = m_draft;
+    m_notice->clear();
+    m_notice->setVisible(false);
 }
 
 void ExpressionEditorDialog::setCommitted(

--- a/src/qt/ExpressionEditorDialog.cpp
+++ b/src/qt/ExpressionEditorDialog.cpp
@@ -94,6 +94,9 @@ ExpressionEditorDialog::ExpressionEditorDialog(
     auto* buttons = new QDialogButtonBox(this);
     m_apply = buttons->addButton(QDialogButtonBox::Apply);
     m_apply->setObjectName(QStringLiteral("applyExpressionsButton"));
+    // Left to the button box, whose rejected() this dialog already receives
+    // as its parent: wiring clicked() as well would run reject() twice and
+    // emit finished() twice for one close.
     auto* close = buttons->addButton(QDialogButtonBox::Close);
     close->setObjectName(QStringLiteral("closeExpressionsButton"));
 
@@ -159,7 +162,6 @@ ExpressionEditorDialog::ExpressionEditorDialog(
         clearError();
         emit applyRequested();
     });
-    connect(close, &QPushButton::clicked, this, &QDialog::reject);
 
     rebuildList(m_draft.empty() ? std::nullopt : std::optional<std::size_t>{0});
     resize(720, 420);

--- a/src/qt/ExpressionEditorDialog.cpp
+++ b/src/qt/ExpressionEditorDialog.cpp
@@ -76,6 +76,11 @@ ExpressionEditorDialog::ExpressionEditorDialog(
     // As SetContoursDialog styles its own warning.
     m_error->setStyleSheet(QStringLiteral("QLabel { color: red; }"));
 
+    m_applied = new QLabel(this);
+    m_applied->setObjectName(QStringLiteral("expressionApplied"));
+    m_applied->setWordWrap(true);
+    m_applied->setVisible(false);
+
     auto* buttons = new QDialogButtonBox(this);
     m_apply = buttons->addButton(QDialogButtonBox::Apply);
     m_apply->setObjectName(QStringLiteral("applyExpressionsButton"));
@@ -101,6 +106,7 @@ ExpressionEditorDialog::ExpressionEditorDialog(
     editor->addLayout(form);
     editor->addWidget(help);
     editor->addWidget(m_error);
+    editor->addWidget(m_applied);
     editor->addStretch(1);
 
     auto* columns = new QHBoxLayout;
@@ -160,6 +166,8 @@ void ExpressionEditorDialog::setDraft(
 void ExpressionEditorDialog::showError(
     const QString& message, std::optional<std::size_t> definitionIndex)
 {
+    m_applied->clear();
+    m_applied->setVisible(false);
     if (definitionIndex && *definitionIndex < m_draft.size()) {
         m_list->setCurrentRow(static_cast<int>(*definitionIndex));
     }
@@ -167,10 +175,22 @@ void ExpressionEditorDialog::showError(
     m_error->setVisible(true);
 }
 
+void ExpressionEditorDialog::showApplied(std::size_t count)
+{
+    clearError();
+    m_applied->setText(count == 0
+            ? tr("Applied: no derived fields.")
+            : tr("Applied %n derived field(s).", nullptr,
+                  static_cast<int>(count)));
+    m_applied->setVisible(true);
+}
+
 void ExpressionEditorDialog::clearError()
 {
     m_error->clear();
     m_error->setVisible(false);
+    m_applied->clear();
+    m_applied->setVisible(false);
 }
 
 void ExpressionEditorDialog::rebuildList(std::optional<std::size_t> select)

--- a/src/qt/ExpressionEditorDialog.cpp
+++ b/src/qt/ExpressionEditorDialog.cpp
@@ -30,6 +30,7 @@ ExpressionEditorDialog::ExpressionEditorDialog(
     std::vector<DerivedFieldDefinition> definitions, QWidget* parent)
     : QDialog(parent)
     , m_draft(std::move(definitions))
+    , m_committed(m_draft)
 {
     setObjectName(QStringLiteral("expressionEditor"));
     setWindowTitle(tr("Expression Editor"));
@@ -73,6 +74,10 @@ ExpressionEditorDialog::ExpressionEditorDialog(
     m_error->setObjectName(QStringLiteral("expressionError"));
     m_error->setWordWrap(true);
     m_error->setVisible(false);
+    // The message quotes what the user typed, and a QLabel left on AutoText
+    // renders anything Qt takes for markup: an expression holding `<` would be
+    // shown with a piece missing.
+    m_error->setTextFormat(Qt::PlainText);
     // As SetContoursDialog styles its own warning.
     m_error->setStyleSheet(QStringLiteral("QLabel { color: red; }"));
 
@@ -80,6 +85,11 @@ ExpressionEditorDialog::ExpressionEditorDialog(
     m_applied->setObjectName(QStringLiteral("expressionApplied"));
     m_applied->setWordWrap(true);
     m_applied->setVisible(false);
+
+    m_notice = new QLabel(this);
+    m_notice->setObjectName(QStringLiteral("expressionNotice"));
+    m_notice->setWordWrap(true);
+    m_notice->setVisible(false);
 
     auto* buttons = new QDialogButtonBox(this);
     m_apply = buttons->addButton(QDialogButtonBox::Apply);
@@ -107,6 +117,7 @@ ExpressionEditorDialog::ExpressionEditorDialog(
     editor->addWidget(help);
     editor->addWidget(m_error);
     editor->addWidget(m_applied);
+    editor->addWidget(m_notice);
     editor->addStretch(1);
 
     auto* columns = new QHBoxLayout;
@@ -163,6 +174,14 @@ void ExpressionEditorDialog::setDraft(
     rebuildList(select);
 }
 
+void ExpressionEditorDialog::setCommitted(
+    std::vector<DerivedFieldDefinition> definitions,
+    std::optional<std::size_t> select)
+{
+    setDraft(std::move(definitions), select);
+    m_committed = m_draft;
+}
+
 void ExpressionEditorDialog::showError(
     const QString& message, std::optional<std::size_t> definitionIndex)
 {
@@ -185,12 +204,24 @@ void ExpressionEditorDialog::showApplied(std::size_t count)
     m_applied->setVisible(true);
 }
 
+void ExpressionEditorDialog::showListChangedElsewhere()
+{
+    clearError();
+    m_notice->setText(
+        tr("The derived fields were changed in another window. The edits here "
+           "are unapplied and have been kept; Apply replaces the shared list "
+           "with them."));
+    m_notice->setVisible(true);
+}
+
 void ExpressionEditorDialog::clearError()
 {
     m_error->clear();
     m_error->setVisible(false);
     m_applied->clear();
     m_applied->setVisible(false);
+    m_notice->clear();
+    m_notice->setVisible(false);
 }
 
 void ExpressionEditorDialog::rebuildList(std::optional<std::size_t> select)

--- a/src/qt/ExpressionEditorDialog.hpp
+++ b/src/qt/ExpressionEditorDialog.hpp
@@ -50,6 +50,9 @@ public:
     // window.
     void setCommitted(std::vector<DerivedFieldDefinition> definitions,
         std::optional<std::size_t> select = std::nullopt);
+    // Takes the draft as committed without touching the widgets, for a draft
+    // that already equals the list someone else committed.
+    void markDraftCommitted();
     // Whether the draft has moved since it was last committed. One list is
     // shared by every window, so a commit made elsewhere asks this before
     // replacing what is on screen here.

--- a/src/qt/ExpressionEditorDialog.hpp
+++ b/src/qt/ExpressionEditorDialog.hpp
@@ -49,7 +49,6 @@ public:
     // the definition it belongs to so the user is looking at what failed.
     void showError(
         const QString& message, std::optional<std::size_t> definitionIndex);
-    void clearError();
     // The row being edited, so a host that replaces the draft with an
     // equivalent list can leave the user where they were.
     [[nodiscard]] std::optional<std::size_t> selectedIndex() const;
@@ -62,6 +61,7 @@ signals:
     void exportRequested();
 
 private:
+    void clearError();
     void rebuildList(std::optional<std::size_t> select);
     void showSelected();
     void addDefinition();

--- a/src/qt/ExpressionEditorDialog.hpp
+++ b/src/qt/ExpressionEditorDialog.hpp
@@ -50,6 +50,9 @@ public:
     void showError(
         const QString& message, std::optional<std::size_t> definitionIndex);
     void clearError();
+    // The row being edited, so a host that replaces the draft with an
+    // equivalent list can leave the user where they were.
+    [[nodiscard]] std::optional<std::size_t> selectedIndex() const;
 
 signals:
     // The draft is offered for validation; the host accepts it (setDraft, and
@@ -63,7 +66,6 @@ private:
     void showSelected();
     void addDefinition();
     void removeSelected();
-    [[nodiscard]] std::optional<std::size_t> selectedIndex() const;
 
     std::vector<DerivedFieldDefinition> m_draft;
     QListWidget* m_list = nullptr;

--- a/src/qt/ExpressionEditorDialog.hpp
+++ b/src/qt/ExpressionEditorDialog.hpp
@@ -1,0 +1,80 @@
+#pragma once
+
+#include <amrexplorer/core/DerivedField.hpp>
+
+#include <QDialog>
+#include <QString>
+
+#include <cstddef>
+#include <optional>
+#include <vector>
+
+class QLabel;
+class QLineEdit;
+class QListWidget;
+class QPlainTextEdit;
+class QPushButton;
+
+namespace amrvis::qt {
+
+// The Expression Editor: the list of derived-field definitions, the selected
+// one's name and expression, and the New / Delete / Import / Export / Apply
+// buttons. Pure presentation -- it validates nothing and knows nothing about
+// the open dataset. It edits a *draft* of the list and asks the host to accept
+// it (applyRequested), which either replaces the draft with what was accepted
+// or shows a reason in place (showError); Import and Export are the host's too,
+// since only it can run a file dialog and parse the format.
+//
+// Names are kept as typed. An empty one is shown as "(unnamed)" in the list
+// and refused by the host, which is where every rule about a definition lives.
+class ExpressionEditorDialog final : public QDialog {
+    Q_OBJECT
+
+public:
+    ExpressionEditorDialog(
+        std::vector<DerivedFieldDefinition> definitions, QWidget* parent);
+
+    // The draft as it stands, which is what applyRequested refers to.
+    [[nodiscard]] const std::vector<DerivedFieldDefinition>& draft()
+        const noexcept
+    {
+        return m_draft;
+    }
+    // Replaces the draft: an accepted apply, or an import. Selects the row
+    // named by `select` when it is still in range, otherwise the first.
+    void setDraft(std::vector<DerivedFieldDefinition> definitions,
+        std::optional<std::size_t> select = std::nullopt);
+
+    // Reports a refusal in place rather than over a second dialog, and selects
+    // the definition it belongs to so the user is looking at what failed.
+    void showError(
+        const QString& message, std::optional<std::size_t> definitionIndex);
+    void clearError();
+
+signals:
+    // The draft is offered for validation; the host accepts it (setDraft, and
+    // usually accept()) or refuses it (showError).
+    void applyRequested();
+    void importRequested();
+    void exportRequested();
+
+private:
+    void rebuildList(std::optional<std::size_t> select);
+    void showSelected();
+    void addDefinition();
+    void removeSelected();
+    [[nodiscard]] std::optional<std::size_t> selectedIndex() const;
+
+    std::vector<DerivedFieldDefinition> m_draft;
+    QListWidget* m_list = nullptr;
+    QLineEdit* m_name = nullptr;
+    QPlainTextEdit* m_expression = nullptr;
+    QLabel* m_error = nullptr;
+    QPushButton* m_remove = nullptr;
+    QPushButton* m_apply = nullptr;
+    // Set while the widgets are being written from the draft, so the edit
+    // signals do not write straight back into it.
+    bool m_loading = false;
+};
+
+} // namespace amrvis::qt

--- a/src/qt/ExpressionEditorDialog.hpp
+++ b/src/qt/ExpressionEditorDialog.hpp
@@ -49,6 +49,10 @@ public:
     // the definition it belongs to so the user is looking at what failed.
     void showError(
         const QString& message, std::optional<std::size_t> definitionIndex);
+    // Confirms an accepted Apply in the same place a refusal appears. Said
+    // here rather than in the status bar, which the reload this announces
+    // clears as soon as its slices arrive.
+    void showApplied(std::size_t count);
     // The row being edited, so a host that replaces the draft with an
     // equivalent list can leave the user where they were.
     [[nodiscard]] std::optional<std::size_t> selectedIndex() const;
@@ -72,6 +76,9 @@ private:
     QLineEdit* m_name = nullptr;
     QPlainTextEdit* m_expression = nullptr;
     QLabel* m_error = nullptr;
+    // Kept apart from m_error so "is something wrong?" stays a question the
+    // dialog -- and a test -- can answer by looking at one widget.
+    QLabel* m_applied = nullptr;
     QPushButton* m_remove = nullptr;
     QPushButton* m_apply = nullptr;
     // Set while the widgets are being written from the draft, so the edit

--- a/src/qt/ExpressionEditorDialog.hpp
+++ b/src/qt/ExpressionEditorDialog.hpp
@@ -40,10 +40,23 @@ public:
     {
         return m_draft;
     }
-    // Replaces the draft: an accepted apply, or an import. Selects the row
-    // named by `select` when it is still in range, otherwise the first.
+    // Replaces the draft with content the user has not committed -- an
+    // import. Selects the row named by `select` when it is still in range,
+    // otherwise the first.
     void setDraft(std::vector<DerivedFieldDefinition> definitions,
         std::optional<std::size_t> select = std::nullopt);
+    // Replaces the draft with the committed list, which later edits are then
+    // measured against: an accepted apply, or a list committed in another
+    // window.
+    void setCommitted(std::vector<DerivedFieldDefinition> definitions,
+        std::optional<std::size_t> select = std::nullopt);
+    // Whether the draft has moved since it was last committed. One list is
+    // shared by every window, so a commit made elsewhere asks this before
+    // replacing what is on screen here.
+    [[nodiscard]] bool hasUnappliedEdits() const noexcept
+    {
+        return m_draft != m_committed;
+    }
 
     // Reports a refusal in place rather than over a second dialog, and selects
     // the definition it belongs to so the user is looking at what failed.
@@ -53,6 +66,9 @@ public:
     // here rather than in the status bar, which the reload this announces
     // clears as soon as its slices arrive.
     void showApplied(std::size_t count);
+    // Says that the shared list was committed in another window and that this
+    // editor's own edits were kept rather than replaced by it.
+    void showListChangedElsewhere();
     // The row being edited, so a host that replaces the draft with an
     // equivalent list can leave the user where they were.
     [[nodiscard]] std::optional<std::size_t> selectedIndex() const;
@@ -72,6 +88,10 @@ private:
     void removeSelected();
 
     std::vector<DerivedFieldDefinition> m_draft;
+    // The draft as it was last committed, which is the whole of what makes an
+    // edit unapplied: compared rather than flagged, so typing something and
+    // taking it back leaves nothing to protect.
+    std::vector<DerivedFieldDefinition> m_committed;
     QListWidget* m_list = nullptr;
     QLineEdit* m_name = nullptr;
     QPlainTextEdit* m_expression = nullptr;
@@ -79,6 +99,10 @@ private:
     // Kept apart from m_error so "is something wrong?" stays a question the
     // dialog -- and a test -- can answer by looking at one widget.
     QLabel* m_applied = nullptr;
+    // Neither a refusal nor a confirmation of this window's own work: a shared
+    // list that moved elsewhere. Its own widget for the same reason m_applied
+    // is one.
+    QLabel* m_notice = nullptr;
     QPushButton* m_remove = nullptr;
     QPushButton* m_apply = nullptr;
     // Set while the widgets are being written from the draft, so the edit

--- a/src/qt/FabNavigator.cpp
+++ b/src/qt/FabNavigator.cpp
@@ -177,6 +177,13 @@ std::optional<FrameSliceSpec> FabNavigator::selectedEntrySpec() const
         spec->levelSelection = -1;
         spec->rangeMode = RangeMode::File;
         spec->userRange.reset();
+        // Not the derived fields: this spec is built before the drill-down
+        // sets fabMode, so the host still believes they can travel. A FAB
+        // session is what the Expression Editor is disabled over, so carrying
+        // them here installs fields the user cannot then edit or remove --
+        // and the next drill-down, made with fabMode already set, drops them
+        // again for no reason it could explain.
+        spec->derivedFields.clear();
     }
     return spec;
 }

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -33,14 +33,17 @@ MainWindow::MainWindow(QWidget* parent)
     m_derivedFields = new DerivedFieldController(
         DerivedFieldController::Hooks{
             .available = [this] {
-                // Not for a standalone FAB, drilled out of a MultiFab or
-                // opened straight from a file: applying reopens m_datasetPath,
-                // and what that entry describes -- a synthesised metadata, or
-                // one record of a multi-record file -- is not what re-reading
-                // the path produces.
+                // Two questions, and both have to hold: whether the open
+                // session can take derived fields, and whether a load built
+                // now would carry them (derivedFieldsReachNextLoad). Not for a
+                // standalone FAB, drilled out of a MultiFab or opened straight
+                // from a file: applying reopens m_datasetPath, and what that
+                // entry describes -- a synthesised metadata, or one record of
+                // a multi-record file -- is not what re-reading the path
+                // produces.
                 return m_dataset && m_dataset->supportsDerivedFields()
                     && !m_dataset->metadata().isFab
-                    && !m_fabNavigator->fabMode();
+                    && derivedFieldsReachNextLoad();
             },
             .reload = [this] { reloadCurrentDataset(); },
             .chooseFile =
@@ -289,6 +292,7 @@ MainWindow::MainWindow(QWidget* parent)
 
     m_metadataDock = new QDockWidget(tr("Dataset Metadata"), this);
     m_metadataTree = new QTreeWidget(m_metadataDock);
+    m_metadataTree->setObjectName(QStringLiteral("metadataTree"));
     m_metadataTree->setColumnCount(2);
     m_metadataTree->setHeaderLabels({tr("Property"), tr("Value")});
     m_metadataTree->header()->setSectionResizeMode(0, QHeaderView::ResizeToContents);
@@ -1395,6 +1399,9 @@ void MainWindow::rebuildVariableMenu()
     const auto addField = [this, currentField](
                               const QString& name, std::size_t field) {
         auto* action = m_variableMenu->addAction(name);
+        // Returned rather than looked up again: QMenu::actions() copies the
+        // whole list, and "the one just added is last" stops being true the
+        // moment addField grows a separator or a submenu.
         action->setCheckable(true);
         action->setActionGroup(m_variableGroup);
         action->setChecked(static_cast<std::uint32_t>(field) == currentField);
@@ -1406,46 +1413,24 @@ void MainWindow::rebuildVariableMenu()
                 m_fieldSelector->setCurrentIndex(index);
             }
         });
+        return action;
     };
     for (std::size_t field = 0; field < stored; ++field) {
         addField(QString::fromStdString(metadata.fields[field].name), field);
     }
 
-    // The same list as the field selector, dimmed the same way: see
-    // populateFieldSelector.
-    const auto& definitions = m_derivedFields->definitions();
-    if (!definitions.empty()) {
+    // The same rows as the field selector, from the same place, dimmed the
+    // same way (derivedFieldRows).
+    const auto rows = derivedFieldRows();
+    if (!rows.empty()) {
         m_variableMenu->addSeparator();
     }
-    const auto skipped = m_dataset->skippedDerivedFields();
-    for (const auto& definition : definitions) {
-        const auto name = QString::fromStdString(definition.name);
-        const auto installed = std::find_if(
-            metadata.fields.begin() + static_cast<std::ptrdiff_t>(stored),
-            metadata.fields.end(),
-            [&definition](const FieldMetadata& field) {
-                return field.name == definition.name;
-            });
-        if (installed != metadata.fields.end()) {
-            addField(name, static_cast<std::size_t>(
-                std::distance(metadata.fields.begin(), installed)));
-            m_variableMenu->actions().back()->setToolTip(
-                expressionTooltip(definition.expression));
-            continue;
-        }
-        auto* action = m_variableMenu->addAction(name);
-        action->setEnabled(false);
-        const auto reason = std::find_if(skipped.begin(), skipped.end(),
-            [&definition](const DerivedFieldSkip& entry) {
-                return entry.name == definition.name;
-            });
-        action->setToolTip(reason != skipped.end()
-                ? tr("%1 -- unavailable here: %2")
-                      .arg(expressionTooltip(definition.expression),
-                          QString::fromStdString(reason->reason)
-                              .toHtmlEscaped())
-                : tr("%1 -- unavailable for this dataset")
-                      .arg(expressionTooltip(definition.expression)));
+    for (const auto& row : rows) {
+        auto* action = row.field
+            ? addField(row.name, static_cast<std::size_t>(*row.field))
+            : m_variableMenu->addAction(row.name);
+        action->setEnabled(row.field.has_value());
+        action->setToolTip(row.tooltip);
     }
 
     // Re-added after every rebuild: clear() above only *removes* it, because
@@ -1464,10 +1449,11 @@ void MainWindow::syncVariableMenu()
         ? m_fieldSelector->currentData().toUInt() : 0;
     // Only the field entries, which are the ones in the group: the separator
     // and the Expression Editor action follow them.
-    const auto actions = m_variableGroup->actions();
-    for (int i = 0; i < actions.size(); ++i) {
-        actions[i]->setChecked(
-            static_cast<std::uint32_t>(i) == currentField);
+    // By the id each action carries, not by its position: the two agree only
+    // while every field in the list is in the group, and a definition the
+    // open session could not install is listed without being one of them.
+    for (auto* action : m_variableGroup->actions()) {
+        action->setChecked(action->data().toUInt() == currentField);
     }
 }
 
@@ -1538,11 +1524,16 @@ void MainWindow::reloadCurrentDataset()
     if (m_playbackMode == PlaybackMode::Sequence) {
         // Mid-playback: reloading here would restart the frame under the user,
         // and every frame load reads the list for itself (buildFrameSpec), so
-        // the next frame picks the change up on its own. A plane sweep is not
-        // that -- it moves the slice position on the session already open and
-        // never reopens it -- so skipping the reload there would leave the
+        // the next frame picks the change up on its own -- but only if it is
+        // actually loaded. The frame after this one may already be prefetched,
+        // rendered against the list as it was, and goToFrame publishes such a
+        // frame instead of loading it; dropping it is what makes "the next
+        // frame reads the list" true. A plane sweep is not this case at all --
+        // it moves the slice position on the session already open and never
+        // reopens it -- so skipping the reload there would leave the
         // definition uninstalled for good, with the editor reporting that it
         // had been applied.
+        m_sequenceController->invalidatePrefetch();
         return;
     }
     if (m_sequenceController->hasSequence()) {
@@ -1555,9 +1546,10 @@ void MainWindow::reloadCurrentDataset()
     // Not openDataset: that ends the sequence, drops the zoom and closes the
     // line-plot, dataset and volume windows. This is the same reload a
     // sequence frame switch performs, on the frame already shown.
+    // No m_initialStopSource reset here: requestInitialSlice stops and
+    // replaces it on the way in, and the token the worker is given comes from
+    // that one.
     const auto generation = ++m_generation;
-    m_initialStopSource.request_stop();
-    m_initialStopSource = StopSource{};
     for (auto* state : allViewStates()) {
         state->stopSource.request_stop();
         ++state->sliceGeneration;

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -1420,8 +1420,7 @@ void MainWindow::rebuildVariableMenu()
                     return candidate.name == metadata.fields[field].name;
                 });
             if (definition != definitions.end()) {
-                action->setToolTip(
-                    QString::fromStdString(definition->expression));
+                action->setToolTip(expressionTooltip(definition->expression));
             }
         }
         action->setCheckable(true);

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -33,7 +33,11 @@ MainWindow::MainWindow(QWidget* parent)
     m_derivedFields = new DerivedFieldController(
         DerivedFieldController::Hooks{
             .available = [this] {
-                return m_dataset && m_dataset->supportsDerivedFields();
+                // Not while a FAB drilled out of a MultiFab is displayed:
+                // applying reopens m_datasetPath, and that entry's metadata
+                // exists only as something the navigator synthesised.
+                return m_dataset && m_dataset->supportsDerivedFields()
+                    && !m_fabNavigator->fabMode();
             },
             .storedMetadata = [this]() -> std::optional<DatasetMetadata> {
                 if (!m_dataset || !m_dataset->supportsDerivedFields()) {
@@ -1377,8 +1381,10 @@ void MainWindow::rebuildVariableMenu()
 {
     m_variableMenu->clear();
     // The menu stays enabled with nothing open: it then holds the Expression
-    // Editor entry alone, disabled with a reason, which is more discoverable
-    // than a menu that cannot be opened at all.
+    // Editor entry alone, greyed out, which is more discoverable than a menu
+    // that cannot be opened at all. (The action carries its reason as a
+    // tooltip, which a QMenu shows only with setToolTipsVisible; nothing here
+    // sets it, so treat the reason as documentation rather than as UI.)
     m_variableMenu->setEnabled(true);
     if (!m_dataset) {
         m_variableMenu->addAction(m_expressionEditorAction);
@@ -1457,14 +1463,27 @@ QString MainWindow::chooseExpressionListPath(QWidget* parent, bool forSaving)
             == QLatin1String("offscreen")
         ? QFileDialog::Options{QFileDialog::DontUseNativeDialog}
         : QFileDialog::Options{};
-    const auto path = forSaving
-        ? QFileDialog::getSaveFileName(parent, tr("Export Derived Fields"),
-              directory.isEmpty()
-                  ? QStringLiteral("expressions.json")
-                  : directory + QStringLiteral("/expressions.json"),
-              filter, nullptr, options)
-        : QFileDialog::getOpenFileName(parent, tr("Import Derived Fields"),
-              directory, filter, nullptr, options);
+    QString path;
+    if (forSaving) {
+        // Built rather than taken from getSaveFileName so the default suffix
+        // is applied *before* the overwrite confirmation: appending ".json"
+        // afterwards means the dialog asks about "fields" while the write
+        // lands on an existing "fields.json" it never mentioned.
+        QFileDialog dialog(parent, tr("Export Derived Fields"),
+            directory.isEmpty() ? QStringLiteral("expressions.json")
+                                : directory + QStringLiteral("/expressions.json"),
+            filter);
+        dialog.setOptions(options);
+        dialog.setAcceptMode(QFileDialog::AcceptSave);
+        dialog.setDefaultSuffix(QStringLiteral("json"));
+        if (dialog.exec() == QDialog::Accepted
+            && !dialog.selectedFiles().isEmpty()) {
+            path = dialog.selectedFiles().front();
+        }
+    } else {
+        path = QFileDialog::getOpenFileName(parent,
+            tr("Import Derived Fields"), directory, filter, nullptr, options);
+    }
     if (!path.isEmpty()) {
         settings.setValue(QStringLiteral("lastOpenDirectory"),
             QFileInfo(path).absolutePath());
@@ -1495,10 +1514,19 @@ void MainWindow::reloadCurrentDataset()
         ++state->sliceGeneration;
     }
     m_sliceDebounce->stop();
-    requestInitialSlice(m_datasetPath, generation, std::nullopt,
-        m_dataset->metadata().isFab ? std::filesystem::path{}
-                                    : std::filesystem::path{},
-        buildFrameSpec());
+    // As openDatasetImpl and the frame-switch handler do: stopping the timer
+    // cancels the flush but leaves what it had coalesced, and that would be
+    // replayed against the new session by the next unrelated request.
+    m_pendingAllViews = false;
+    m_pendingViews.clear();
+    // No prepared metadata and no data root: with none, the session derives
+    // both from the path, which is what re-reading a plotfile means. A FAB
+    // drilled out of a MultiFab cannot be reopened this way -- its metadata is
+    // synthesised by the navigator, not read from the path -- which is why the
+    // editor is unavailable while one is on screen (see the controller's
+    // availability hook).
+    requestInitialSlice(
+        m_datasetPath, generation, std::nullopt, {}, buildFrameSpec());
 }
 
 void MainWindow::refreshMetadataDisplay()

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -42,19 +42,6 @@ MainWindow::MainWindow(QWidget* parent)
                     && !m_dataset->metadata().isFab
                     && !m_fabNavigator->fabMode();
             },
-            .storedMetadata = [this]() -> std::optional<DatasetMetadata> {
-                if (!m_dataset || !m_dataset->supportsDerivedFields()) {
-                    return std::nullopt;
-                }
-                auto metadata = m_dataset->metadata();
-                // The stored fields alone: a definition is validated against
-                // what the plotfile holds, not against the derived fields the
-                // open session already installed (which the list replaces).
-                const auto stored = std::min(
-                    m_dataset->storedFieldCount(), metadata.fields.size());
-                metadata.fields.resize(stored);
-                return metadata;
-            },
             .reload = [this] { reloadCurrentDataset(); },
             .chooseFile =
                 [this](QWidget*, bool forSaving) {
@@ -1455,7 +1442,8 @@ void MainWindow::rebuildVariableMenu()
         action->setToolTip(reason != skipped.end()
                 ? tr("%1 -- unavailable here: %2")
                       .arg(expressionTooltip(definition.expression),
-                          QString::fromStdString(reason->reason))
+                          QString::fromStdString(reason->reason)
+                              .toHtmlEscaped())
                 : tr("%1 -- unavailable for this dataset")
                       .arg(expressionTooltip(definition.expression)));
     }
@@ -1547,10 +1535,14 @@ void MainWindow::reloadCurrentDataset()
     if (!m_dataset || m_datasetPath.empty()) {
         return;
     }
-    if (m_playbackMode != PlaybackMode::None) {
-        // Mid-playback: reloading here would restart the frame under the user.
-        // Every frame load reads the list for itself (buildFrameSpec), so the
-        // next one picks the change up on its own.
+    if (m_playbackMode == PlaybackMode::Sequence) {
+        // Mid-playback: reloading here would restart the frame under the user,
+        // and every frame load reads the list for itself (buildFrameSpec), so
+        // the next frame picks the change up on its own. A plane sweep is not
+        // that -- it moves the slice position on the session already open and
+        // never reopens it -- so skipping the reload there would leave the
+        // definition uninstalled for good, with the editor reporting that it
+        // had been applied.
         return;
     }
     if (m_sequenceController->hasSequence()) {

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -33,10 +33,13 @@ MainWindow::MainWindow(QWidget* parent)
     m_derivedFields = new DerivedFieldController(
         DerivedFieldController::Hooks{
             .available = [this] {
-                // Not while a FAB drilled out of a MultiFab is displayed:
-                // applying reopens m_datasetPath, and that entry's metadata
-                // exists only as something the navigator synthesised.
+                // Not for a standalone FAB, drilled out of a MultiFab or
+                // opened straight from a file: applying reopens m_datasetPath,
+                // and what that entry describes -- a synthesised metadata, or
+                // one record of a multi-record file -- is not what re-reading
+                // the path produces.
                 return m_dataset && m_dataset->supportsDerivedFields()
+                    && !m_dataset->metadata().isFab
                     && !m_fabNavigator->fabMode();
             },
             .storedMetadata = [this]() -> std::optional<DatasetMetadata> {
@@ -55,8 +58,13 @@ MainWindow::MainWindow(QWidget* parent)
             .reload = [this] { reloadCurrentDataset(); },
             .settings = [] { return makeSettingsPtr(); },
             .chooseFile =
-                [this](QWidget* dialog, bool forSaving) {
-                    return chooseExpressionListPath(dialog, forSaving);
+                [this](QWidget*, bool forSaving) {
+                    // Parented to the window, not to the editor that asked:
+                    // the editor is WA_DeleteOnClose, and a dataset load
+                    // settling inside the file dialog's nested loop can close
+                    // it -- destroying the file dialog with it. loadPaletteFile
+                    // parents to the window for the same reason.
+                    return chooseExpressionListPath(this, forSaving);
                 },
         },
         this);
@@ -250,7 +258,7 @@ MainWindow::MainWindow(QWidget* parent)
             // animation blocks signals and preserves the index, so the range
             // stays constant across frames.
             if (m_controlsReady && index >= 0) {
-                m_range->switchField(m_fieldSelector->itemData(index).toUInt());
+                m_range->switchField(m_fieldSelector->itemText(index));
             }
             // A deferred full-domain range store (m_pendingRangeStore) is keyed
             // to the field/level/mode in effect when it was queued. Changing any

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -25,11 +25,11 @@ MainWindow::MainWindow(QWidget* parent)
     connect(m_paletteController, &PaletteController::loadFileRequested, this,
         [this] { loadPaletteFile(); });
 
-    // Derived fields: the controller owns the definition list, its editor and
-    // its persistence. It asks the window for the fields a definition may read
-    // (the open dataset's stored ones) and for the reload that installs a
-    // committed list, since only the window knows whether a sequence is
-    // running. buildFrameSpec is where the list reaches a dataset.
+    // Derived fields: the controller owns this window's definition list and
+    // its editor. It asks the window for the fields a definition may read (the
+    // open dataset's stored ones) and for the reload that installs a committed
+    // list, since only the window knows whether a sequence is running.
+    // buildFrameSpec is where the list reaches a dataset.
     m_derivedFields = new DerivedFieldController(
         DerivedFieldController::Hooks{
             .available = [this] {
@@ -56,7 +56,6 @@ MainWindow::MainWindow(QWidget* parent)
                 return metadata;
             },
             .reload = [this] { reloadCurrentDataset(); },
-            .settings = [] { return makeSettingsPtr(); },
             .chooseFile =
                 [this](QWidget*, bool forSaving) {
                     // Parented to the window, not to the editor that asked:
@@ -1281,6 +1280,10 @@ void MainWindow::createMenus()
 
     // Variable menu: lists all fields with a bullet on the active one.
     m_variableMenu = menuBar()->addMenu(tr("&Variable"));
+    // Menus hide action tooltips unless asked: the derived fields carry their
+    // expressions there, and the Expression Editor entry carries the reason it
+    // is unavailable, neither of which reaches anyone otherwise.
+    m_variableMenu->setToolTipsVisible(true);
     m_variableGroup = new QActionGroup(this);
     // Owned by the window, not the menu, so rebuildVariableMenu's clear()
     // leaves it alive to be re-added. The menu itself stays enabled with no
@@ -1389,10 +1392,8 @@ void MainWindow::rebuildVariableMenu()
 {
     m_variableMenu->clear();
     // The menu stays enabled with nothing open: it then holds the Expression
-    // Editor entry alone, greyed out, which is more discoverable than a menu
-    // that cannot be opened at all. (The action carries its reason as a
-    // tooltip, which a QMenu shows only with setToolTipsVisible; nothing here
-    // sets it, so treat the reason as documentation rather than as UI.)
+    // Editor entry alone, greyed out with the reason on its tooltip, which is
+    // more discoverable than a menu that cannot be opened at all.
     m_variableMenu->setEnabled(true);
     if (!m_dataset) {
         m_variableMenu->addAction(m_expressionEditorAction);
@@ -1402,9 +1403,27 @@ void MainWindow::rebuildVariableMenu()
     const auto& metadata = m_dataset->metadata();
     const auto currentField = m_fieldSelector->currentIndex() >= 0
         ? m_fieldSelector->currentData().toUInt() : 0;
+    const auto stored =
+        std::min(m_dataset->storedFieldCount(), metadata.fields.size());
+    const auto& definitions = m_derivedFields->definitions();
     for (std::size_t field = 0; field < metadata.fields.size(); ++field) {
+        if (field == stored) {
+            m_variableMenu->addSeparator();
+        }
         const auto name = QString::fromStdString(metadata.fields[field].name);
         auto* action = m_variableMenu->addAction(name);
+        if (field >= stored) {
+            // Matched by name: a definition this dataset could not resolve is
+            // not in the field list, so the two are not index-for-index.
+            const auto definition = std::find_if(definitions.begin(),
+                definitions.end(), [&metadata, field](const auto& candidate) {
+                    return candidate.name == metadata.fields[field].name;
+                });
+            if (definition != definitions.end()) {
+                action->setToolTip(
+                    QString::fromStdString(definition->expression));
+            }
+        }
         action->setCheckable(true);
         action->setActionGroup(m_variableGroup);
         action->setChecked(static_cast<std::uint32_t>(field) == currentField);

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -25,6 +25,42 @@ MainWindow::MainWindow(QWidget* parent)
     connect(m_paletteController, &PaletteController::loadFileRequested, this,
         [this] { loadPaletteFile(); });
 
+    // Derived fields: the controller owns the definition list, its editor and
+    // its persistence. It asks the window for the fields a definition may read
+    // (the open dataset's stored ones) and for the reload that installs a
+    // committed list, since only the window knows whether a sequence is
+    // running. buildFrameSpec is where the list reaches a dataset.
+    m_derivedFields = new DerivedFieldController(
+        DerivedFieldController::Hooks{
+            .available = [this] {
+                return m_dataset && m_dataset->supportsDerivedFields();
+            },
+            .storedMetadata = [this]() -> std::optional<DatasetMetadata> {
+                if (!m_dataset || !m_dataset->supportsDerivedFields()) {
+                    return std::nullopt;
+                }
+                auto metadata = m_dataset->metadata();
+                // The stored fields alone: a definition is validated against
+                // what the plotfile holds, not against the derived fields the
+                // open session already installed (which the list replaces).
+                const auto stored = std::min(
+                    m_dataset->storedFieldCount(), metadata.fields.size());
+                metadata.fields.resize(stored);
+                return metadata;
+            },
+            .reload = [this] { reloadCurrentDataset(); },
+            .settings = [] { return makeSettingsPtr(); },
+            .chooseFile =
+                [this](QWidget* dialog, bool forSaving) {
+                    return chooseExpressionListPath(dialog, forSaving);
+                },
+        },
+        this);
+    connect(m_derivedFields, &DerivedFieldController::statusMessage, this,
+        [this](const QString& message, int timeoutMs) {
+            statusBar()->showMessage(message, timeoutMs);
+        });
+
     // The plot area is a stacked widget: page 0 holds the single 2-D view,
     // page 1 the 3-D grid (XY top-left, XZ top-right, YZ bottom-left, iso
     // wireframe bottom-right).
@@ -1234,6 +1270,12 @@ void MainWindow::createMenus()
     // Variable menu: lists all fields with a bullet on the active one.
     m_variableMenu = menuBar()->addMenu(tr("&Variable"));
     m_variableGroup = new QActionGroup(this);
+    // Owned by the window, not the menu, so rebuildVariableMenu's clear()
+    // leaves it alive to be re-added. The menu itself stays enabled with no
+    // dataset open so the editor's own (disabled) entry is discoverable.
+    m_expressionEditorAction = m_derivedFields->createAction(this);
+    m_variableMenu->addAction(m_expressionEditorAction);
+    m_variableMenu->setEnabled(true);
 
     auto* helpMenu = menuBar()->addMenu(tr("&Help"));
     auto* guideAction = new QAction(tr("&User Guide..."), this);
@@ -1334,11 +1376,15 @@ void MainWindow::syncMenuChecks()
 void MainWindow::rebuildVariableMenu()
 {
     m_variableMenu->clear();
+    // The menu stays enabled with nothing open: it then holds the Expression
+    // Editor entry alone, disabled with a reason, which is more discoverable
+    // than a menu that cannot be opened at all.
+    m_variableMenu->setEnabled(true);
     if (!m_dataset) {
-        m_variableMenu->setEnabled(false);
+        m_variableMenu->addAction(m_expressionEditorAction);
+        m_derivedFields->refreshAvailability();
         return;
     }
-    m_variableMenu->setEnabled(true);
     const auto& metadata = m_dataset->metadata();
     const auto currentField = m_fieldSelector->currentIndex() >= 0
         ? m_fieldSelector->currentData().toUInt() : 0;
@@ -1357,6 +1403,11 @@ void MainWindow::rebuildVariableMenu()
             }
         });
     }
+    // Re-added after every rebuild: clear() above only *removes* it, because
+    // the action belongs to the window rather than to the menu.
+    m_variableMenu->addSeparator();
+    m_variableMenu->addAction(m_expressionEditorAction);
+    m_derivedFields->refreshAvailability();
 }
 
 void MainWindow::syncVariableMenu()
@@ -1366,7 +1417,9 @@ void MainWindow::syncVariableMenu()
     }
     const auto currentField = m_fieldSelector->currentIndex() >= 0
         ? m_fieldSelector->currentData().toUInt() : 0;
-    const auto actions = m_variableMenu->actions();
+    // Only the field entries, which are the ones in the group: the separator
+    // and the Expression Editor action follow them.
+    const auto actions = m_variableGroup->actions();
     for (int i = 0; i < actions.size(); ++i) {
         actions[i]->setChecked(
             static_cast<std::uint32_t>(i) == currentField);
@@ -1390,6 +1443,75 @@ void MainWindow::loadPaletteFile()
     auto writableSettings = makeSettings();
     writableSettings.setValue(QStringLiteral("lastOpenDirectory"),
         QFileInfo(filename).absolutePath());
+}
+
+QString MainWindow::chooseExpressionListPath(QWidget* parent, bool forSaving)
+{
+    auto settings = makeSettings();
+    const auto directory =
+        settings.value(QStringLiteral("lastOpenDirectory")).toString();
+    const auto filter = tr("Expression lists (*.json);;All files (*)");
+    // The offscreen platform the smoke tests run on has no native dialog to
+    // drive, and a native one would not be scriptable there either.
+    const auto options = QApplication::platformName()
+            == QLatin1String("offscreen")
+        ? QFileDialog::Options{QFileDialog::DontUseNativeDialog}
+        : QFileDialog::Options{};
+    const auto path = forSaving
+        ? QFileDialog::getSaveFileName(parent, tr("Export Derived Fields"),
+              directory.isEmpty()
+                  ? QStringLiteral("expressions.json")
+                  : directory + QStringLiteral("/expressions.json"),
+              filter, nullptr, options)
+        : QFileDialog::getOpenFileName(parent, tr("Import Derived Fields"),
+              directory, filter, nullptr, options);
+    if (!path.isEmpty()) {
+        settings.setValue(QStringLiteral("lastOpenDirectory"),
+            QFileInfo(path).absolutePath());
+    }
+    return path;
+}
+
+void MainWindow::reloadCurrentDataset()
+{
+    if (!m_dataset || m_datasetPath.empty()) {
+        return;
+    }
+    if (m_sequenceController->hasSequence()) {
+        // A prefetched frame was rendered against the previous field list.
+        m_sequenceController->invalidatePrefetch();
+        m_sequenceController->goToFrame(
+            m_sequenceController->currentIndex(), true);
+        return;
+    }
+    // Not openDataset: that ends the sequence, drops the zoom and closes the
+    // line-plot, dataset and volume windows. This is the same reload a
+    // sequence frame switch performs, on the frame already shown.
+    const auto generation = ++m_generation;
+    m_initialStopSource.request_stop();
+    m_initialStopSource = StopSource{};
+    for (auto* state : allViewStates()) {
+        state->stopSource.request_stop();
+        ++state->sliceGeneration;
+    }
+    m_sliceDebounce->stop();
+    requestInitialSlice(m_datasetPath, generation, std::nullopt,
+        m_dataset->metadata().isFab ? std::filesystem::path{}
+                                    : std::filesystem::path{},
+        buildFrameSpec());
+}
+
+void MainWindow::refreshMetadataDisplay()
+{
+    if (!m_dataset) {
+        return;
+    }
+    PlotfileMetadataResult displayed;
+    displayed.metadata =
+        std::make_shared<const DatasetMetadata>(m_dataset->metadata());
+    displayed.metrics = m_dataset->metadataReadMetrics();
+    displayed.fileVersion = m_dataset->fileVersion();
+    showMetadata(displayed, m_datasetPath);
 }
 
 void MainWindow::refreshPaletteDisplay()

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -410,7 +410,15 @@ MainWindow::MainWindow(QWidget* parent)
     // shutdown flag) and reacts to its signals below.
     m_sequenceController = new SequenceController(
         SequenceController::Hooks{
-            [this] { return buildFrameSpec(); },
+            [this] {
+                // The list this frame is being loaded with. A window has no
+                // dataset while it opens a sequence, so a change committed
+                // meanwhile is not reported to it (available()), and during
+                // playback the reload stands aside; both are noticed by
+                // comparing this against the store afterwards.
+                m_frameSpecRevision = m_derivedFields->storeRevision();
+                return buildFrameSpec();
+            },
             [this](InitialSliceResult& result, bool defaultPositions) {
                 displayFrameResult(result, defaultPositions);
             },
@@ -1379,7 +1387,7 @@ void MainWindow::syncMenuChecks()
     }
 }
 
-void MainWindow::rebuildVariableMenu()
+void MainWindow::rebuildVariableMenu(const std::vector<DerivedFieldRow>& rows)
 {
     m_variableMenu->clear();
     // The menu stays enabled with nothing open: it then holds the Expression
@@ -1416,12 +1424,14 @@ void MainWindow::rebuildVariableMenu()
         return action;
     };
     for (std::size_t field = 0; field < stored; ++field) {
-        addField(QString::fromStdString(metadata.fields[field].name), field);
+        // A tooltip of its own, because the menu shows them for the derived
+        // rows and QAction falls back to the action's own text: without this
+        // every plotfile field pops a tooltip repeating its name.
+        addField(QString::fromStdString(metadata.fields[field].name), field)
+            ->setToolTip(tr("Stored in the plotfile"));
     }
 
-    // The same rows as the field selector, from the same place, dimmed the
-    // same way (derivedFieldRows).
-    const auto rows = derivedFieldRows();
+    // The same rows the field selector was given, dimmed the same way.
     if (!rows.empty()) {
         m_variableMenu->addSeparator();
     }
@@ -1546,6 +1556,17 @@ void MainWindow::reloadCurrentDataset()
     // Not openDataset: that ends the sequence, drops the zoom and closes the
     // line-plot, dataset and volume windows. This is the same reload a
     // sequence frame switch performs, on the frame already shown.
+    // The Dataset window and the line plot are snapshots of the session this
+    // is about to replace: the frame switch closes them for that reason
+    // (frameSwitchStarted) and a reload is the same replacement. Left open
+    // they would show the old field list with no sign of being stale, and
+    // pin the outgoing session and its block cache besides.
+    closeDatasetWindow();
+    auto* linePlotWindow = m_linePlotWindow;
+    m_linePlotWindow = nullptr;
+    if (linePlotWindow != nullptr) {
+        linePlotWindow->close();
+    }
     // No m_initialStopSource reset here: requestInitialSlice stops and
     // replaces it on the way in, and the token the worker is given comes from
     // that one.

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -10,6 +10,18 @@
 #include <QStyle>
 
 namespace amrvis::qt {
+namespace {
+
+// The offscreen platform the smoke tests run on has no native dialog to drive,
+// and a native one would not be scriptable there either.
+[[nodiscard]] QFileDialog::Options fileDialogOptions()
+{
+    return QApplication::platformName() == QLatin1String("offscreen")
+        ? QFileDialog::Options{QFileDialog::DontUseNativeDialog}
+        : QFileDialog::Options{};
+}
+
+} // namespace
 
 MainWindow::MainWindow(QWidget* parent)
     : QMainWindow(parent)
@@ -410,15 +422,7 @@ MainWindow::MainWindow(QWidget* parent)
     // shutdown flag) and reacts to its signals below.
     m_sequenceController = new SequenceController(
         SequenceController::Hooks{
-            [this] {
-                // The list this frame is being loaded with. A window has no
-                // dataset while it opens a sequence, so a change committed
-                // meanwhile is not reported to it (available()), and during
-                // playback the reload stands aside; both are noticed by
-                // comparing this against the store afterwards.
-                m_frameSpecRevision = m_derivedFields->storeRevision();
-                return buildFrameSpec();
-            },
+            [this] { return buildFrameSpec(); },
             [this](InitialSliceResult& result, bool defaultPositions) {
                 displayFrameResult(result, defaultPositions);
             },
@@ -1467,13 +1471,29 @@ void MainWindow::syncVariableMenu()
     }
 }
 
+QString MainWindow::rememberedDialogDirectory() const
+{
+    return makeSettings()
+        .value(QStringLiteral("lastOpenDirectory"))
+        .toString();
+}
+
+void MainWindow::rememberDialogDirectory(const QString& path)
+{
+    if (path.isEmpty()) {
+        return;
+    }
+    auto settings = makeSettings();
+    settings.setValue(QStringLiteral("lastOpenDirectory"),
+        QFileInfo(path).absolutePath());
+}
+
 void MainWindow::loadPaletteFile()
 {
-    const auto settings = makeSettings();
     const auto filename = QFileDialog::getOpenFileName(this,
-        tr("Load Palette File"),
-        settings.value(QStringLiteral("lastOpenDirectory")).toString(),
-        tr("Legacy palette files (*.pal);;All files (*)"));
+        tr("Load Palette File"), rememberedDialogDirectory(),
+        tr("Legacy palette files (*.pal);;All files (*)"), nullptr,
+        fileDialogOptions());
     if (filename.isEmpty()) {
         return;
     }
@@ -1481,23 +1501,14 @@ void MainWindow::loadPaletteFile()
         QMessageBox::critical(this, tr("Cannot load palette"), *error);
         return;
     }
-    auto writableSettings = makeSettings();
-    writableSettings.setValue(QStringLiteral("lastOpenDirectory"),
-        QFileInfo(filename).absolutePath());
+    rememberDialogDirectory(filename);
 }
 
 QString MainWindow::chooseExpressionListPath(QWidget* parent, bool forSaving)
 {
-    auto settings = makeSettings();
-    const auto directory =
-        settings.value(QStringLiteral("lastOpenDirectory")).toString();
+    const auto directory = rememberedDialogDirectory();
     const auto filter = tr("Expression lists (*.json);;All files (*)");
-    // The offscreen platform the smoke tests run on has no native dialog to
-    // drive, and a native one would not be scriptable there either.
-    const auto options = QApplication::platformName()
-            == QLatin1String("offscreen")
-        ? QFileDialog::Options{QFileDialog::DontUseNativeDialog}
-        : QFileDialog::Options{};
+    const auto options = fileDialogOptions();
     QString path;
     if (forSaving) {
         // Built rather than taken from getSaveFileName so the default suffix
@@ -1519,16 +1530,16 @@ QString MainWindow::chooseExpressionListPath(QWidget* parent, bool forSaving)
         path = QFileDialog::getOpenFileName(parent,
             tr("Import Derived Fields"), directory, filter, nullptr, options);
     }
-    if (!path.isEmpty()) {
-        settings.setValue(QStringLiteral("lastOpenDirectory"),
-            QFileInfo(path).absolutePath());
-    }
+    rememberDialogDirectory(path);
     return path;
 }
 
 void MainWindow::reloadCurrentDataset()
 {
-    if (!m_dataset || m_datasetPath.empty()) {
+    // Not while closing: another window's Apply reaches every window, and a
+    // worker started here would hold the I/O mutex against the quit. The
+    // completion handler checks m_closing, but the read still runs.
+    if (m_closing || !m_dataset || m_datasetPath.empty()) {
         return;
     }
     if (m_playbackMode == PlaybackMode::Sequence) {

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -66,7 +66,7 @@ MainWindow::MainWindow(QWidget* parent)
                     return chooseExpressionListPath(this, forSaving);
                 },
         },
-        this);
+        DerivedFieldStore::session(), this);
     connect(m_derivedFields, &DerivedFieldController::statusMessage, this,
         [this](const QString& message, int timeoutMs) {
             statusBar()->showMessage(message, timeoutMs);
@@ -1405,24 +1405,9 @@ void MainWindow::rebuildVariableMenu()
         ? m_fieldSelector->currentData().toUInt() : 0;
     const auto stored =
         std::min(m_dataset->storedFieldCount(), metadata.fields.size());
-    const auto& definitions = m_derivedFields->definitions();
-    for (std::size_t field = 0; field < metadata.fields.size(); ++field) {
-        if (field == stored) {
-            m_variableMenu->addSeparator();
-        }
-        const auto name = QString::fromStdString(metadata.fields[field].name);
+    const auto addField = [this, currentField](
+                              const QString& name, std::size_t field) {
         auto* action = m_variableMenu->addAction(name);
-        if (field >= stored) {
-            // Matched by name: a definition this dataset could not resolve is
-            // not in the field list, so the two are not index-for-index.
-            const auto definition = std::find_if(definitions.begin(),
-                definitions.end(), [&metadata, field](const auto& candidate) {
-                    return candidate.name == metadata.fields[field].name;
-                });
-            if (definition != definitions.end()) {
-                action->setToolTip(expressionTooltip(definition->expression));
-            }
-        }
         action->setCheckable(true);
         action->setActionGroup(m_variableGroup);
         action->setChecked(static_cast<std::uint32_t>(field) == currentField);
@@ -1434,7 +1419,47 @@ void MainWindow::rebuildVariableMenu()
                 m_fieldSelector->setCurrentIndex(index);
             }
         });
+    };
+    for (std::size_t field = 0; field < stored; ++field) {
+        addField(QString::fromStdString(metadata.fields[field].name), field);
     }
+
+    // The same list as the field selector, dimmed the same way: see
+    // populateFieldSelector.
+    const auto& definitions = m_derivedFields->definitions();
+    if (!definitions.empty()) {
+        m_variableMenu->addSeparator();
+    }
+    const auto skipped = m_dataset->skippedDerivedFields();
+    for (const auto& definition : definitions) {
+        const auto name = QString::fromStdString(definition.name);
+        const auto installed = std::find_if(
+            metadata.fields.begin() + static_cast<std::ptrdiff_t>(stored),
+            metadata.fields.end(),
+            [&definition](const FieldMetadata& field) {
+                return field.name == definition.name;
+            });
+        if (installed != metadata.fields.end()) {
+            addField(name, static_cast<std::size_t>(
+                std::distance(metadata.fields.begin(), installed)));
+            m_variableMenu->actions().back()->setToolTip(
+                expressionTooltip(definition.expression));
+            continue;
+        }
+        auto* action = m_variableMenu->addAction(name);
+        action->setEnabled(false);
+        const auto reason = std::find_if(skipped.begin(), skipped.end(),
+            [&definition](const DerivedFieldSkip& entry) {
+                return entry.name == definition.name;
+            });
+        action->setToolTip(reason != skipped.end()
+                ? tr("%1 -- unavailable here: %2")
+                      .arg(expressionTooltip(definition.expression),
+                          QString::fromStdString(reason->reason))
+                : tr("%1 -- unavailable for this dataset")
+                      .arg(expressionTooltip(definition.expression)));
+    }
+
     // Re-added after every rebuild: clear() above only *removes* it, because
     // the action belongs to the window rather than to the menu.
     m_variableMenu->addSeparator();
@@ -1520,6 +1545,12 @@ QString MainWindow::chooseExpressionListPath(QWidget* parent, bool forSaving)
 void MainWindow::reloadCurrentDataset()
 {
     if (!m_dataset || m_datasetPath.empty()) {
+        return;
+    }
+    if (m_playbackMode != PlaybackMode::None) {
+        // Mid-playback: reloading here would restart the frame under the user.
+        // Every frame load reads the list for itself (buildFrameSpec), so the
+        // next one picks the change up on its own.
         return;
     }
     if (m_sequenceController->hasSequence()) {

--- a/src/qt/MainWindow.hpp
+++ b/src/qt/MainWindow.hpp
@@ -552,6 +552,12 @@ private:
     // stay findData-based and the separator (which carries none) cannot be
     // mistaken for a field.
     void populateFieldSelector();
+    // Selects a field entry, stepping past the separator if `index` lands on
+    // it and falling back to the first entry when it is out of range.
+    void selectFieldItem(int index);
+    // An expression as a tooltip: one line, whatever its layout.
+    [[nodiscard]] static QString expressionTooltip(
+        const std::string& expression);
     [[nodiscard]] std::array<std::string, 3> vectorFieldNames() const;
     void restoreVectorFields(const std::array<std::string, 3>& names);
     void syncMenuChecks();

--- a/src/qt/MainWindow.hpp
+++ b/src/qt/MainWindow.hpp
@@ -144,11 +144,13 @@ public:
     }
     // Runs on the GUI thread just after an initial-slice load is launched --
     // the only point at which a test can change something while one is in
-    // flight, since the completion arrives as a queued signal.
-    void setInitialSliceLaunchedHookForTest(std::function<void()> hook)
-    {
-        m_initialSliceLaunchedForTest = std::move(hook);
-    }
+    // flight, since the completion arrives as a queued signal. Defined in
+    // MainWindowTestAccess.cpp, as every accessor that touches a member the
+    // release build does not have is: the body cannot be inline here, where
+    // AMREXPLORER_QT_TEST_ACCESS is not necessarily on.
+    void setInitialSliceLaunchedHookForTest(std::function<void()> hook);
+    // The sequence frame waiting in the prefetch slot, if any.
+    [[nodiscard]] std::optional<int> prefetchedSequenceFrameForTest() const;
     // The slot an idle frame-slider press-and-release lands in, which must not
     // restart a frame that is already on screen.
     void requestSequenceFrameForTest(int index) { goToSequenceFrame(index); }
@@ -570,25 +572,55 @@ private:
     // which a reload can change (a derived field appears or leaves) without
     // going through the open path that first filled it.
     void refreshMetadataDisplay();
+    // Fills the field selector from the open dataset: the stored fields, then
+    // a separator, then the derived ones (see derivedFieldRows). Shared by the
+    // two configure paths, which populated it identically. Only the field rows
+    // carry a field id as item data, so lookups stay findData-based and
+    // nothing that reads item data can take the separator -- or a definition
+    // this dataset could not install -- for a field.
+    void populateFieldSelector();
+    // Selects a field entry: `index` is where to start looking, and the
+    // selection comes to rest on the nearest row that is actually a field.
+    void selectFieldItem(int index);
+    // One row of the derived part of a field list.
+    struct DerivedFieldRow {
+        QString name;
+        // The id this dataset installed the definition under; nullopt when it
+        // could not, which is what the row being shown greyed out means.
+        std::optional<std::uint32_t> field;
+        // Rich text, so the expression survives whatever the user wrote:
+        // Qt reads a tooltip as markup as soon as it might be one, and only
+        // some of the escapes it needs make it decide that.
+        QString tooltip;
+    };
+    // The session's definitions as rows to list, in the order they were
+    // written. The field selector and the Variable menu are the same list
+    // shown twice, and the comment saying so kept them in step by hand.
+    [[nodiscard]] std::vector<DerivedFieldRow> derivedFieldRows() const;
+    // Adds a listed-but-unchoosable row to the field selector. False when the
+    // combo's model is not one whose item flags can be set, in which case no
+    // row is added at all: a row that looks selectable but carries no field id
+    // is read as field 0 by everything downstream.
+    [[nodiscard]] bool addUnavailableFieldItem(
+        const QString& name, const QString& tooltip);
+    // An expression for a tooltip: one line whatever its layout, and escaped.
+    [[nodiscard]] static QString escapedExpression(
+        const std::string& expression);
+    // Escaped text as a tooltip Qt is certain to render as rich text. Without
+    // the wrapper, an expression holding `<` decides it and one holding only
+    // `&` does not, so the escapes show up as themselves.
+    [[nodiscard]] static QString richTooltip(const QString& escaped);
     // The vector-glyph selections travel by name for the same reason the
     // scalar one does: an id means something only in the field list it came
     // from. Captured before a load swaps the dataset, resolved again after.
-    // Fills the field selector from the open dataset: the stored fields, then
-    // a separator, then the derived ones, each carrying its expression as a
-    // tooltip. Shared by the two configure paths, which populated it
-    // identically. Every item carries its field id as item data, so lookups
-    // stay findData-based and the separator (which carries none) cannot be
-    // mistaken for a field.
-    void populateFieldSelector();
-    // Selects a field entry, stepping past the separator if `index` lands on
-    // it and falling back to the first entry when it is out of range.
-    void selectFieldItem(int index);
-    // Greys a field-selector row, for a definition this dataset cannot
-    // provide: shown, but not something to choose.
-    void setFieldItemEnabled(int index, bool enabled);
-    // An expression as a tooltip: one line, whatever its layout.
-    [[nodiscard]] static QString expressionTooltip(
-        const std::string& expression);
+    // Whether a load built from the window's state as it stands can install
+    // derived fields. Deliberately not asked of m_dataset: a sequence builds
+    // its first spec while the *outgoing* dataset is still installed (see
+    // prepareSequence), so frame 0 would load without the definitions and
+    // frame 1 would make them appear. A prepared session cannot take them
+    // either, but that is a property of the load, not of the window, so
+    // requestInitialSlice asks it there.
+    [[nodiscard]] bool derivedFieldsReachNextLoad() const;
     [[nodiscard]] std::array<std::string, 3> vectorFieldNames() const;
     void restoreVectorFields(const std::array<std::string, 3>& names);
     void syncMenuChecks();

--- a/src/qt/MainWindow.hpp
+++ b/src/qt/MainWindow.hpp
@@ -135,9 +135,40 @@ public:
     }
     void setAnimationDockVisibleForTest(bool visible);
     void toggleSequencePlaybackForTest() { toggleSequencePlayback(); }
+    // The plane sweep, which unlike sequence playback never reopens the
+    // dataset: a change that needs a reload has to be given one outright.
+    void toggleSweepPlaybackForTest() { toggleSweepPlayback(); }
+    [[nodiscard]] bool sweepPlayingForTest() const noexcept
+    {
+        return m_playbackMode == PlaybackMode::Sweep;
+    }
+    // Runs on the GUI thread just after an initial-slice load is launched --
+    // the only point at which a test can change something while one is in
+    // flight, since the completion arrives as a queued signal.
+    void setInitialSliceLaunchedHookForTest(std::function<void()> hook)
+    {
+        m_initialSliceLaunchedForTest = std::move(hook);
+    }
     // The slot an idle frame-slider press-and-release lands in, which must not
     // restart a frame that is already on screen.
     void requestSequenceFrameForTest(int index) { goToSequenceFrame(index); }
+    // The step every field selection goes through, so a test can ask for a row
+    // that is not a field -- the separator, or a definition this dataset
+    // cannot provide -- and see where the selection actually lands.
+    void selectFieldItemForTest(int index) { selectFieldItem(index); }
+    // The vector-glyph selections, as ids into the open field list. A reload
+    // carries them by name (restoreVectorFields), so a test needs to set them
+    // over one dataset and read them back over the next.
+    [[nodiscard]] std::array<int, 3> vectorFieldsForTest() const
+    {
+        return {m_vectorUField, m_vectorVField, m_vectorWField};
+    }
+    void setVectorFieldsForTest(int u, int v, int w)
+    {
+        m_vectorUField = u;
+        m_vectorVField = v;
+        m_vectorWField = w;
+    }
 
     // Test-only: move each 3-D plane to slicePositions (per axis, so the three
     // panels sample different data with different local ranges), switch to
@@ -884,6 +915,9 @@ private:
     bool m_visibleSyncRerun = false;
     std::optional<amrvis::DisplayCoordinator::RangeKey> m_pendingRangeStore;
 #ifdef AMREXPLORER_QT_TEST_ACCESS
+    // Test-only: run just after an initial-slice load is launched; see
+    // setInitialSliceLaunchedHookForTest.
+    std::function<void()> m_initialSliceLaunchedForTest;
     // Test-only: superseded visible-range sync outcomes dropped by the
     // rerun guard. Sole writer is that drop, so the overlapping-sync test can
     // assert an exact count. The DiagnosticsModel's stale count carries the

--- a/src/qt/MainWindow.hpp
+++ b/src/qt/MainWindow.hpp
@@ -539,9 +539,6 @@ private:
     // which a reload can change (a derived field appears or leaves) without
     // going through the open path that first filled it.
     void refreshMetadataDisplay();
-    // Says which committed definitions the session that has just been
-    // installed could not provide, once per change in that answer.
-    void reportSkippedDerivedFields();
     // The vector-glyph selections travel by name for the same reason the
     // scalar one does: an id means something only in the field list it came
     // from. Captured before a load swaps the dataset, resolved again after.
@@ -555,6 +552,9 @@ private:
     // Selects a field entry, stepping past the separator if `index` lands on
     // it and falling back to the first entry when it is out of range.
     void selectFieldItem(int index);
+    // Greys a field-selector row, for a definition this dataset cannot
+    // provide: shown, but not something to choose.
+    void setFieldItemEnabled(int index, bool enabled);
     // An expression as a tooltip: one line, whatever its layout.
     [[nodiscard]] static QString expressionTooltip(
         const std::string& expression);
@@ -928,9 +928,6 @@ private:
     QActionGroup* m_variableGroup = nullptr;
     // Window-owned so rebuildVariableMenu's clear() does not delete it.
     QAction* m_expressionEditorAction = nullptr;
-    // The last skipped-definition report shown, so a sequence playback does
-    // not repeat it frame after frame.
-    QString m_lastSkippedDerivedReport;
     QAction* m_boxesAction = nullptr;
     QAction* m_slicePlanesAction = nullptr;
     QAction* m_resetZoomAction = nullptr;

--- a/src/qt/MainWindow.hpp
+++ b/src/qt/MainWindow.hpp
@@ -556,7 +556,18 @@ private:
         bool includeColorBar, qreal scaleFactor) const;
     void createMenus();
     void rebuildLevelMenu();
-    void rebuildVariableMenu();
+    // One row of the derived part of a field list.
+    struct DerivedFieldRow {
+        QString name;
+        // The id this dataset installed the definition under; nullopt when it
+        // could not, which is what the row being shown greyed out means.
+        std::optional<std::uint32_t> field;
+        // Rich text, so the expression survives whatever the user wrote:
+        // Qt reads a tooltip as markup as soon as it might be one, and only
+        // some of the escapes it needs make it decide that.
+        QString tooltip;
+    };
+    void rebuildVariableMenu(const std::vector<DerivedFieldRow>& rows);
     // Reopens what is on screen with the current frame spec -- the derived
     // field list included -- without the teardown a fresh open performs: the
     // sequence, the zoom and the open windows all stay. A sequence goes
@@ -578,21 +589,13 @@ private:
     // carry a field id as item data, so lookups stay findData-based and
     // nothing that reads item data can take the separator -- or a definition
     // this dataset could not install -- for a field.
-    void populateFieldSelector();
+    // `rows` is derivedFieldRows(), which the caller shares with
+    // rebuildVariableMenu: the two views are the same list, and building it
+    // twice per load means twice the work per sequence frame.
+    void populateFieldSelector(const std::vector<DerivedFieldRow>& rows);
     // Selects a field entry: `index` is where to start looking, and the
     // selection comes to rest on the nearest row that is actually a field.
     void selectFieldItem(int index);
-    // One row of the derived part of a field list.
-    struct DerivedFieldRow {
-        QString name;
-        // The id this dataset installed the definition under; nullopt when it
-        // could not, which is what the row being shown greyed out means.
-        std::optional<std::uint32_t> field;
-        // Rich text, so the expression survives whatever the user wrote:
-        // Qt reads a tooltip as markup as soon as it might be one, and only
-        // some of the escapes it needs make it decide that.
-        QString tooltip;
-    };
     // The session's definitions as rows to list, in the order they were
     // written. The field selector and the Variable menu are the same list
     // shown twice, and the comment saying so kept them in step by hand.
@@ -610,9 +613,6 @@ private:
     // the wrapper, an expression holding `<` decides it and one holding only
     // `&` does not, so the escapes show up as themselves.
     [[nodiscard]] static QString richTooltip(const QString& escaped);
-    // The vector-glyph selections travel by name for the same reason the
-    // scalar one does: an id means something only in the field list it came
-    // from. Captured before a load swaps the dataset, resolved again after.
     // Whether a load built from the window's state as it stands can install
     // derived fields. Deliberately not asked of m_dataset: a sequence builds
     // its first spec while the *outgoing* dataset is still installed (see
@@ -621,6 +621,9 @@ private:
     // either, but that is a property of the load, not of the window, so
     // requestInitialSlice asks it there.
     [[nodiscard]] bool derivedFieldsReachNextLoad() const;
+    // The vector-glyph selections travel by name for the same reason the
+    // scalar one does: an id means something only in the field list it came
+    // from. Captured before a load swaps the dataset, resolved again after.
     [[nodiscard]] std::array<std::string, 3> vectorFieldNames() const;
     void restoreVectorFields(const std::array<std::string, 3>& names);
     void syncMenuChecks();
@@ -946,6 +949,9 @@ private:
     bool m_visibleSyncInFlight = false;
     bool m_visibleSyncRerun = false;
     std::optional<amrvis::DisplayCoordinator::RangeKey> m_pendingRangeStore;
+    // The store revision the last sequence frame spec was built with, so a
+    // frame that loaded with an older list can be told from one that did not.
+    std::uint64_t m_frameSpecRevision = 0;
 #ifdef AMREXPLORER_QT_TEST_ACCESS
     // Test-only: run just after an initial-slice load is launched; see
     // setInitialSliceLaunchedHookForTest.

--- a/src/qt/MainWindow.hpp
+++ b/src/qt/MainWindow.hpp
@@ -808,7 +808,11 @@ private:
     // Sequence frame switching lives in the SequenceController; this window
     // supplies the GUI-coupled pieces below as its hooks.
     void displayFrameResult(InitialSliceResult& result, bool defaultPositions);
-    void configureSequenceControls(bool defaultPositions);
+    // `displayedField` is the field the frame was actually rendered with,
+    // which the pipeline resolves by name (resolveSpecField) and so need not
+    // be the id -- or the combo position -- the previous frame used.
+    void configureSequenceControls(
+        bool defaultPositions, std::optional<std::uint32_t> displayedField);
     [[nodiscard]] FrameSliceSpec buildFrameSpec();
     // Stop timers and request stop on every async task this window can launch,
     // so an in-flight read that holds the global I/O mutex bails promptly and

--- a/src/qt/MainWindow.hpp
+++ b/src/qt/MainWindow.hpp
@@ -29,6 +29,7 @@
 #include <cstdint>
 #include <exception>
 #include <filesystem>
+#include <functional>
 #include <memory>
 #include <optional>
 #include <string>
@@ -576,6 +577,13 @@ private:
     // new generation both invalidates the in-flight work and gives the
     // replacement session a dataset id of its own.
     void reloadCurrentDataset();
+    // The directory the last file dialog ended in, remembered across all of
+    // them. The dialogs themselves stay separate -- one picks several
+    // directories, one saves with a default suffix -- but this was copied into
+    // each of them, as was the offscreen option (fileDialogOptions, in
+    // MainWindow.cpp, where both its callers are).
+    [[nodiscard]] QString rememberedDialogDirectory() const;
+    void rememberDialogDirectory(const QString& path);
     // The Import/Export file dialog the derived-field controller asks for.
     [[nodiscard]] QString chooseExpressionListPath(
         QWidget* parent, bool forSaving);
@@ -606,13 +614,6 @@ private:
     // is read as field 0 by everything downstream.
     [[nodiscard]] bool addUnavailableFieldItem(
         const QString& name, const QString& tooltip);
-    // An expression for a tooltip: one line whatever its layout, and escaped.
-    [[nodiscard]] static QString escapedExpression(
-        const std::string& expression);
-    // Escaped text as a tooltip Qt is certain to render as rich text. Without
-    // the wrapper, an expression holding `<` decides it and one holding only
-    // `&` does not, so the escapes show up as themselves.
-    [[nodiscard]] static QString richTooltip(const QString& escaped);
     // Whether a load built from the window's state as it stands can install
     // derived fields. Deliberately not asked of m_dataset: a sequence builds
     // its first spec while the *outgoing* dataset is still installed (see
@@ -621,6 +622,17 @@ private:
     // either, but that is a property of the load, not of the window, so
     // requestInitialSlice asks it there.
     [[nodiscard]] bool derivedFieldsReachNextLoad() const;
+    // Whether the session on screen was opened with the list the editor now
+    // holds. Asked of the session itself rather than inferred from when
+    // things happened: a window is not told to reload while it has no dataset
+    // (the whole of an open), a reload stands aside during playback, and a FAB
+    // return reopens from a spec captured before any of it.
+    [[nodiscard]] bool openSessionHasCurrentDefinitions() const;
+    // Reloads the open dataset if it does not, once the caller's own work is
+    // off the stack. Deferred because the frame path reaches this from inside
+    // SequenceController::finishLoad, which goes on to touch its own state
+    // after the display call returns.
+    void reloadIfDefinitionsMoved();
     // The vector-glyph selections travel by name for the same reason the
     // scalar one does: an id means something only in the field list it came
     // from. Captured before a load swaps the dataset, resolved again after.
@@ -949,9 +961,6 @@ private:
     bool m_visibleSyncInFlight = false;
     bool m_visibleSyncRerun = false;
     std::optional<amrvis::DisplayCoordinator::RangeKey> m_pendingRangeStore;
-    // The store revision the last sequence frame spec was built with, so a
-    // frame that loaded with an older list can be told from one that did not.
-    std::uint64_t m_frameSpecRevision = 0;
 #ifdef AMREXPLORER_QT_TEST_ACCESS
     // Test-only: run just after an initial-slice load is launched; see
     // setInitialSliceLaunchedHookForTest.

--- a/src/qt/MainWindow.hpp
+++ b/src/qt/MainWindow.hpp
@@ -542,6 +542,11 @@ private:
     // Says which committed definitions the session that has just been
     // installed could not provide, once per change in that answer.
     void reportSkippedDerivedFields();
+    // The vector-glyph selections travel by name for the same reason the
+    // scalar one does: an id means something only in the field list it came
+    // from. Captured before a load swaps the dataset, resolved again after.
+    [[nodiscard]] std::array<std::string, 3> vectorFieldNames() const;
+    void restoreVectorFields(const std::array<std::string, 3>& names);
     void syncMenuChecks();
     void syncVariableMenu();
     // Runs the palette-file dialog for the controller's Load Palette File...

--- a/src/qt/MainWindow.hpp
+++ b/src/qt/MainWindow.hpp
@@ -76,6 +76,7 @@ class LinePlotWindow;
 class ScientificDoubleSpinBox;
 class DiagnosticsModel;
 class FabNavigator;
+class DerivedFieldController;
 class PaletteController;
 class ParticleController;
 class RangeController;
@@ -523,6 +524,24 @@ private:
     void createMenus();
     void rebuildLevelMenu();
     void rebuildVariableMenu();
+    // Reopens what is on screen with the current frame spec -- the derived
+    // field list included -- without the teardown a fresh open performs: the
+    // sequence, the zoom and the open windows all stay. A sequence goes
+    // through its controller so its frame bookkeeping stays consistent; a
+    // single dataset is reloaded straight through requestInitialSlice, whose
+    // new generation both invalidates the in-flight work and gives the
+    // replacement session a dataset id of its own.
+    void reloadCurrentDataset();
+    // The Import/Export file dialog the derived-field controller asks for.
+    [[nodiscard]] QString chooseExpressionListPath(
+        QWidget* parent, bool forSaving);
+    // Rebuilds the Dataset Metadata dock from the open session's metadata,
+    // which a reload can change (a derived field appears or leaves) without
+    // going through the open path that first filled it.
+    void refreshMetadataDisplay();
+    // Says which committed definitions the session that has just been
+    // installed could not provide, once per change in that answer.
+    void reportSkippedDerivedFields();
     void syncMenuChecks();
     void syncVariableMenu();
     // Runs the palette-file dialog for the controller's Load Palette File...
@@ -885,6 +904,11 @@ private:
     QActionGroup* m_scaleGroup = nullptr;
     QActionGroup* m_levelGroup = nullptr;
     QActionGroup* m_variableGroup = nullptr;
+    // Window-owned so rebuildVariableMenu's clear() does not delete it.
+    QAction* m_expressionEditorAction = nullptr;
+    // The last skipped-definition report shown, so a sequence playback does
+    // not repeat it frame after frame.
+    QString m_lastSkippedDerivedReport;
     QAction* m_boxesAction = nullptr;
     QAction* m_slicePlanesAction = nullptr;
     QAction* m_resetZoomAction = nullptr;
@@ -937,6 +961,7 @@ private:
     // Owns the palette selection, its widgets and persistence; palette() is
     // what the renderer, color bar and overlays use.
     PaletteController* m_paletteController = nullptr;
+    DerivedFieldController* m_derivedFields = nullptr;
     QString m_numberFormat = defaultNumberFormat();
     bool m_controlsReady = false;
     std::uint64_t m_generation = 0;

--- a/src/qt/MainWindow.hpp
+++ b/src/qt/MainWindow.hpp
@@ -545,6 +545,13 @@ private:
     // The vector-glyph selections travel by name for the same reason the
     // scalar one does: an id means something only in the field list it came
     // from. Captured before a load swaps the dataset, resolved again after.
+    // Fills the field selector from the open dataset: the stored fields, then
+    // a separator, then the derived ones, each carrying its expression as a
+    // tooltip. Shared by the two configure paths, which populated it
+    // identically. Every item carries its field id as item data, so lookups
+    // stay findData-based and the separator (which carries none) cannot be
+    // mistaken for a field.
+    void populateFieldSelector();
     [[nodiscard]] std::array<std::string, 3> vectorFieldNames() const;
     void restoreVectorFields(const std::array<std::string, 3>& names);
     void syncMenuChecks();

--- a/src/qt/MainWindowDataset.cpp
+++ b/src/qt/MainWindowDataset.cpp
@@ -833,11 +833,9 @@ void MainWindow::openDatasetImpl(const std::filesystem::path& path,
     m_levelMenu->setEnabled(false);
     m_contoursAction->setEnabled(false);
     m_particleController->suspendAction();
-    // The dataset is gone as of the reset above: the editor must not stay open
-    // over nothing, and the next dataset's skip report must be said even if it
-    // reads exactly like this one's.
+    // The dataset is gone as of the reset above: the editor must not stay
+    // open over nothing.
     m_derivedFields->refreshAvailability();
-    m_lastSkippedDerivedReport.clear();
     m_datasetAction->setEnabled(false);
     m_exportAnimationAction->setEnabled(false);
     m_openMetadata.reset();
@@ -1203,9 +1201,6 @@ void MainWindow::requestInitialSlice(
                     }
                     const auto cache = m_dataset->cacheMetrics();
                     m_diagnosticsModel->setCacheMetrics(cache);
-                    // Before the cache-fallback notice below, for the same
-                    // reason the sequence path reports it in that order.
-                    reportSkippedDerivedFields();
                     if (result.cacheFallbackToLevel >= 0) {
                         // Non-modal: an informational cache-fallback notice must
                         // not pop a modal dialog that would block the quit path.

--- a/src/qt/MainWindowDataset.cpp
+++ b/src/qt/MainWindowDataset.cpp
@@ -1019,10 +1019,10 @@ void MainWindow::requestInitialSlice(
     // file range (falling back to Visible when metadata statistics are
     // unavailable), linear scale, whole domain, midpoint positions.
     FrameSliceSpec spec = initialSpec.value_or(FrameSliceSpec{});
-    // Only where there is no spec to have decided already: a fresh open has
-    // none, so a list restored from settings would otherwise never be
-    // installed. A spec built by buildFrameSpec has its own rule and must not
-    // be second-guessed here -- two rules for one field is how they drift.
+    // Only where there is no spec to have decided already: an open with no
+    // spec has nothing else to carry the list. A spec built by buildFrameSpec
+    // has its own rule and must not be second-guessed here -- two rules for
+    // one field is how they drift.
     if (!initialSpec) {
         spec.derivedFields = preparedSession
             ? std::vector<DerivedFieldDefinition>{}

--- a/src/qt/MainWindowDataset.cpp
+++ b/src/qt/MainWindowDataset.cpp
@@ -1066,10 +1066,17 @@ void MainWindow::requestInitialSlice(
     statusBar()->showMessage(tr("Loading initial slice..."));
     updateDiagnostics();
 
+    // The list this load is being launched with. A window counts as unable to
+    // take derived fields for the whole of an open -- m_dataset is null from
+    // openDatasetImpl until the load below lands -- so a definition committed
+    // in another window meanwhile reloads every window but this one, and this
+    // session would keep the older list.
+    const auto derivedRevision = m_derivedFields->storeRevision();
+
     auto* watcher = new QFutureWatcher<InitialSliceResult>(this);
     connect(watcher, &QFutureWatcher<InitialSliceResult>::finished, this,
         [this, watcher, generation, cancellation, views, viewGenerations,
-            restoredSpec, isRemote] {
+            restoredSpec, isRemote, derivedRevision] {
             m_diagnosticsModel->adjustActivity(-1);
             if (m_closing) {
                 watcher->deleteLater();
@@ -1093,12 +1100,17 @@ void MainWindow::requestInitialSlice(
                     m_particleController->configureForDataset(
                         restoredSpec.has_value());
                     m_volumeController->configureForDataset();
-                    configureSliceControls();
-                    // The dock was filled from the file's own metadata before
-                    // this session existed, so it lists neither the derived
-                    // fields the session installed nor, after a reload, the
-                    // ones that have gone.
+                    // Before configureSliceControls, which reads the open
+                    // metadata this replaces: ensureVectorFieldDefaults checks
+                    // the just-restored vector fields against it, and against
+                    // the outgoing list an index that has gone out of range
+                    // still looks valid. The sequence path shows the metadata
+                    // first for the same reason. The dock was filled from the
+                    // file's own metadata before this session existed, so it
+                    // lists neither the derived fields the session installed
+                    // nor, after a reload, the ones that have gone.
                     refreshMetadataDisplay();
+                    configureSliceControls();
                     if (restoredSpec) {
                         const QSignalBlocker fieldBlocker(m_fieldSelector);
                         const QSignalBlocker levelBlocker(m_levelSelector);
@@ -1209,6 +1221,16 @@ void MainWindow::requestInitialSlice(
                             result.cacheFallbackToLevel));
                     }
                     emit initialSliceFinished(true);
+                    // Emitted first: this load did finish, and what follows
+                    // is a fresh one. The list moved while it was on a worker,
+                    // so the session on screen was built from the older one --
+                    // its derived fields would otherwise sit greyed out here
+                    // while every other window had them, or, on a name written
+                    // twice, show one expression and compute another.
+                    if (derivedRevision != m_derivedFields->storeRevision()
+                        && m_derivedFields->available()) {
+                        reloadCurrentDataset();
+                    }
                 } else {
                     m_diagnosticsModel->noteStaleResult();
                 }
@@ -1244,6 +1266,15 @@ void MainWindow::requestInitialSlice(
             initialCacheBudget(), cancellation,
             std::move(preparedMetadata), std::move(dataRoot));
     }));
+#ifdef AMREXPLORER_QT_TEST_ACCESS
+    // The one moment a test can act *during* a load: the spec above is built
+    // and the work is running, while the completion is a queued signal that
+    // cannot be delivered until this returns. Changing the derived-field list
+    // here is what another window's Apply does to a window that is opening.
+    if (m_initialSliceLaunchedForTest) {
+        m_initialSliceLaunchedForTest();
+    }
+#endif
 }
 
 } // namespace amrvis::qt

--- a/src/qt/MainWindowDataset.cpp
+++ b/src/qt/MainWindowDataset.cpp
@@ -833,8 +833,11 @@ void MainWindow::openDatasetImpl(const std::filesystem::path& path,
     m_levelMenu->setEnabled(false);
     m_contoursAction->setEnabled(false);
     m_particleController->suspendAction();
-    // The dataset is gone as of the reset above: the editor must not stay
-    // open over nothing.
+    // The dataset is gone as of the reset above, so the Variable menu's field
+    // entries name a session that no longer exists: triggering one would drive
+    // a combo that is merely disabled, not emptied. This is the caller the
+    // menu's no-dataset branch was written for.
+    rebuildVariableMenu({});
     m_derivedFields->refreshAvailability();
     m_datasetAction->setEnabled(false);
     m_exportAnimationAction->setEnabled(false);
@@ -1067,17 +1070,10 @@ void MainWindow::requestInitialSlice(
     statusBar()->showMessage(tr("Loading initial slice..."));
     updateDiagnostics();
 
-    // The list this load is being launched with. A window counts as unable to
-    // take derived fields for the whole of an open -- m_dataset is null from
-    // openDatasetImpl until the load below lands -- so a definition committed
-    // in another window meanwhile reloads every window but this one, and this
-    // session would keep the older list.
-    const auto derivedRevision = m_derivedFields->storeRevision();
-
     auto* watcher = new QFutureWatcher<InitialSliceResult>(this);
     connect(watcher, &QFutureWatcher<InitialSliceResult>::finished, this,
         [this, watcher, generation, cancellation, views, viewGenerations,
-            restoredSpec, isRemote, derivedRevision] {
+            restoredSpec, isRemote] {
             m_diagnosticsModel->adjustActivity(-1);
             if (m_closing) {
                 watcher->deleteLater();
@@ -1238,15 +1234,12 @@ void MainWindow::requestInitialSlice(
                     }
                     emit initialSliceFinished(true);
                     // Emitted first: this load did finish, and what follows
-                    // is a fresh one. The list moved while it was on a worker,
-                    // so the session on screen was built from the older one --
-                    // its derived fields would otherwise sit greyed out here
-                    // while every other window had them, or, on a name written
-                    // twice, show one expression and compute another.
-                    if (derivedRevision != m_derivedFields->storeRevision()
-                        && m_derivedFields->available()) {
-                        reloadCurrentDataset();
-                    }
+                    // is a fresh one. A window counts as unable to take
+                    // derived fields for the whole of an open, so a list
+                    // committed meanwhile reached every window but this one,
+                    // and a FAB return reopens from a spec captured before any
+                    // of it. Either way the session says so itself.
+                    reloadIfDefinitionsMoved();
                 } else {
                     m_diagnosticsModel->noteStaleResult();
                 }

--- a/src/qt/MainWindowDataset.cpp
+++ b/src/qt/MainWindowDataset.cpp
@@ -1024,15 +1024,15 @@ void MainWindow::requestInitialSlice(
     // file range (falling back to Visible when metadata statistics are
     // unavailable), linear scale, whole domain, midpoint positions.
     FrameSliceSpec spec = initialSpec.value_or(FrameSliceSpec{});
-    // Set whatever the spec came from: the derived-field list is a viewer-wide
-    // setting rather than per-frame state, and the specs that reach here
-    // without it are the ones that matter most -- a fresh open (which has no
-    // spec at all, so a list restored from settings would never be installed)
-    // and a FAB round-trip's default. A remote session is already open and
-    // installs none (see FrameSliceSpec::derivedFields).
-    spec.derivedFields = preparedSession
-        ? std::vector<DerivedFieldDefinition>{}
-        : m_derivedFields->definitions();
+    // Only where there is no spec to have decided already: a fresh open has
+    // none, so a list restored from settings would otherwise never be
+    // installed. A spec built by buildFrameSpec has its own rule and must not
+    // be second-guessed here -- two rules for one field is how they drift.
+    if (!initialSpec) {
+        spec.derivedFields = preparedSession
+            ? std::vector<DerivedFieldDefinition>{}
+            : m_derivedFields->definitions();
+    }
     if (!initialSpec) {
         spec.palette = m_paletteController->palette();
         spec.displayMode = m_displayMode;
@@ -1130,7 +1130,7 @@ void MainWindow::requestInitialSlice(
                         m_range->setSelection({restoredSpec->rangeMode,
                             restoredSpec->userRange, restoredSpec->logarithmic});
                         m_range->setTrackedField(
-                            m_fieldSelector->currentData().toUInt());
+                            m_fieldSelector->currentText());
                         m_range->commitFieldRange(m_range->trackedField());
                         // The menu was rebuilt by configureSliceControls
                         // above, while the combo still sat on field 0; it is

--- a/src/qt/MainWindowDataset.cpp
+++ b/src/qt/MainWindowDataset.cpp
@@ -115,6 +115,10 @@ void MainWindow::restoreSettings()
     }
     m_colorBar->setPalette(&m_paletteController->palette());
 
+    // Installed without validating: no dataset is open yet, and the next one
+    // to open takes what of the list it can resolve.
+    m_derivedFields->restore(settings);
+
     m_range->showLogarithmic(
         settings.value(QStringLiteral("range/logarithmic"), false).toBool());
     {
@@ -180,6 +184,7 @@ void MainWindow::saveSettings()
     // session would produce unexpected color bars.
     settings.setValue(QStringLiteral("range/logarithmic"), m_range->logarithmic());
     m_paletteController->save(settings);
+    m_derivedFields->save(settings);
     settings.setValue(QStringLiteral("numberFormat"), m_numberFormat);
     settings.setValue(QStringLiteral("animation/speed"),
         m_animationPanel->speedValue());
@@ -1014,6 +1019,15 @@ void MainWindow::requestInitialSlice(
     // file range (falling back to Visible when metadata statistics are
     // unavailable), linear scale, whole domain, midpoint positions.
     FrameSliceSpec spec = initialSpec.value_or(FrameSliceSpec{});
+    // Set whatever the spec came from: the derived-field list is a viewer-wide
+    // setting rather than per-frame state, and the specs that reach here
+    // without it are the ones that matter most -- a fresh open (which has no
+    // spec at all, so a list restored from settings would never be installed)
+    // and a FAB round-trip's default. A remote session is already open and
+    // installs none (see FrameSliceSpec::derivedFields).
+    spec.derivedFields = preparedSession
+        ? std::vector<DerivedFieldDefinition>{}
+        : m_derivedFields->definitions();
     if (!initialSpec) {
         spec.palette = m_paletteController->palette();
         spec.displayMode = m_displayMode;
@@ -1080,6 +1094,11 @@ void MainWindow::requestInitialSlice(
                         restoredSpec.has_value());
                     m_volumeController->configureForDataset();
                     configureSliceControls();
+                    // The dock was filled from the file's own metadata before
+                    // this session existed, so it lists neither the derived
+                    // fields the session installed nor, after a reload, the
+                    // ones that have gone.
+                    refreshMetadataDisplay();
                     if (restoredSpec) {
                         const QSignalBlocker fieldBlocker(m_fieldSelector);
                         const QSignalBlocker levelBlocker(m_levelSelector);
@@ -1168,6 +1187,9 @@ void MainWindow::requestInitialSlice(
                     }
                     const auto cache = m_dataset->cacheMetrics();
                     m_diagnosticsModel->setCacheMetrics(cache);
+                    // Before the cache-fallback notice below, for the same
+                    // reason the sequence path reports it in that order.
+                    reportSkippedDerivedFields();
                     if (result.cacheFallbackToLevel >= 0) {
                         // Non-modal: an informational cache-fallback notice must
                         // not pop a modal dialog that would block the quit path.

--- a/src/qt/MainWindowDataset.cpp
+++ b/src/qt/MainWindowDataset.cpp
@@ -115,10 +115,6 @@ void MainWindow::restoreSettings()
     }
     m_colorBar->setPalette(&m_paletteController->palette());
 
-    // Installed without validating: no dataset is open yet, and the next one
-    // to open takes what of the list it can resolve.
-    m_derivedFields->restore(settings);
-
     m_range->showLogarithmic(
         settings.value(QStringLiteral("range/logarithmic"), false).toBool());
     {
@@ -184,7 +180,6 @@ void MainWindow::saveSettings()
     // session would produce unexpected color bars.
     settings.setValue(QStringLiteral("range/logarithmic"), m_range->logarithmic());
     m_paletteController->save(settings);
-    m_derivedFields->save(settings);
     settings.setValue(QStringLiteral("numberFormat"), m_numberFormat);
     settings.setValue(QStringLiteral("animation/speed"),
         m_animationPanel->speedValue());

--- a/src/qt/MainWindowDataset.cpp
+++ b/src/qt/MainWindowDataset.cpp
@@ -838,6 +838,11 @@ void MainWindow::openDatasetImpl(const std::filesystem::path& path,
     m_levelMenu->setEnabled(false);
     m_contoursAction->setEnabled(false);
     m_particleController->suspendAction();
+    // The dataset is gone as of the reset above: the editor must not stay open
+    // over nothing, and the next dataset's skip report must be said even if it
+    // reads exactly like this one's.
+    m_derivedFields->refreshAvailability();
+    m_lastSkippedDerivedReport.clear();
     m_datasetAction->setEnabled(false);
     m_exportAnimationAction->setEnabled(false);
     m_openMetadata.reset();
@@ -1080,7 +1085,9 @@ void MainWindow::requestInitialSlice(
             try {
                 auto result = watcher->future().takeResult();
                 if (generation == m_generation) {
+                    const auto previousVectorFields = vectorFieldNames();
                     m_dataset = result.dataset;
+                    restoreVectorFields(previousVectorFields);
                     m_particleController->setSamples(
                         std::move(result.particles));
                     if (restoredSpec) {
@@ -1125,6 +1132,12 @@ void MainWindow::requestInitialSlice(
                         m_range->setTrackedField(
                             m_fieldSelector->currentData().toUInt());
                         m_range->commitFieldRange(m_range->trackedField());
+                        // The menu was rebuilt by configureSliceControls
+                        // above, while the combo still sat on field 0; it is
+                        // the same selection shown twice, so it has to follow
+                        // the combo here. (The sequence path rebuilds its menu
+                        // after selecting, so it needs none of this.)
+                        syncVariableMenu();
                         // Before the extraction the User bounds were written
                         // unblocked here, which scheduled a (redundant)
                         // re-slice; kept so this path renders as it did.

--- a/src/qt/MainWindowDataset.cpp
+++ b/src/qt/MainWindowDataset.cpp
@@ -1102,8 +1102,16 @@ void MainWindow::requestInitialSlice(
                     if (restoredSpec) {
                         const QSignalBlocker fieldBlocker(m_fieldSelector);
                         const QSignalBlocker levelBlocker(m_levelSelector);
-                        const auto fieldIndex = m_fieldSelector->findData(
-                            restoredSpec->field);
+                        // The field the load was actually rendered with,
+                        // which the pipeline resolves by name and so need not
+                        // be the id the spec carried (resolveSpecField).
+                        // Selecting the spec's id would name one field in the
+                        // combo while the view showed another.
+                        const auto rendered = result.displays.empty()
+                            ? restoredSpec->field
+                            : result.displays.front().request.field.value;
+                        const auto fieldIndex =
+                            m_fieldSelector->findData(rendered);
                         if (fieldIndex >= 0) {
                             m_fieldSelector->setCurrentIndex(fieldIndex);
                         }

--- a/src/qt/MainWindowDataset.cpp
+++ b/src/qt/MainWindowDataset.cpp
@@ -1017,16 +1017,17 @@ void MainWindow::requestInitialSlice(
     // file range (falling back to Visible when metadata statistics are
     // unavailable), linear scale, whole domain, midpoint positions.
     FrameSliceSpec spec = initialSpec.value_or(FrameSliceSpec{});
-    // Only where there is no spec to have decided already: an open with no
-    // spec has nothing else to carry the list. A spec built by buildFrameSpec
-    // has its own rule and must not be second-guessed here -- two rules for
-    // one field is how they drift.
     if (!initialSpec) {
-        spec.derivedFields = preparedSession
+        // An open with no spec has nothing else to carry the list; one built
+        // by buildFrameSpec has decided already and must not be
+        // second-guessed here, since two rules for one field is how they
+        // drift. A prepared session's field list is fixed before this window
+        // sees it, which is a property of the load rather than of the window,
+        // so it is asked here and the rest through the shared predicate.
+        spec.derivedFields
+            = preparedSession || !derivedFieldsReachNextLoad()
             ? std::vector<DerivedFieldDefinition>{}
             : m_derivedFields->definitions();
-    }
-    if (!initialSpec) {
         spec.palette = m_paletteController->palette();
         spec.displayMode = m_displayMode;
         spec.includeGridBoxes = m_boxesAction->isChecked();
@@ -1105,11 +1106,26 @@ void MainWindow::requestInitialSlice(
                     // the just-restored vector fields against it, and against
                     // the outgoing list an index that has gone out of range
                     // still looks valid. The sequence path shows the metadata
-                    // first for the same reason. The dock was filled from the
-                    // file's own metadata before this session existed, so it
-                    // lists neither the derived fields the session installed
-                    // nor, after a reload, the ones that have gone.
-                    refreshMetadataDisplay();
+                    // first for the same reason.
+                    //
+                    // Only when the session's fields are not the ones already
+                    // listed: the open path filled the dock from the file's
+                    // own metadata a moment ago, and rebuilding it costs a
+                    // copy of every level's box list and a tree item per box.
+                    // What it can miss is the derived fields the session
+                    // installed, and, after a reload, the ones that have gone.
+                    const auto& sessionFields = m_dataset->metadata().fields;
+                    const auto listed = m_openMetadata
+                        && std::equal(m_openMetadata->fields.begin(),
+                            m_openMetadata->fields.end(),
+                            sessionFields.begin(), sessionFields.end(),
+                            [](const FieldMetadata& shown,
+                                const FieldMetadata& session) {
+                                return shown.name == session.name;
+                            });
+                    if (!listed) {
+                        refreshMetadataDisplay();
+                    }
                     configureSliceControls();
                     if (restoredSpec) {
                         const QSignalBlocker fieldBlocker(m_fieldSelector);

--- a/src/qt/MainWindowInternal.hpp
+++ b/src/qt/MainWindowInternal.hpp
@@ -9,6 +9,7 @@
 #include "QtErrorText.hpp"
 #include "AnimationExporter.hpp"
 #include "AppSettings.hpp"
+#include "DerivedFieldController.hpp"
 #include "DiagnosticsModel.hpp"
 #include "FabNavigator.hpp"
 #include "PaletteController.hpp"

--- a/src/qt/MainWindowInternal.hpp
+++ b/src/qt/MainWindowInternal.hpp
@@ -10,6 +10,7 @@
 #include "AnimationExporter.hpp"
 #include "AppSettings.hpp"
 #include "DerivedFieldController.hpp"
+#include "DerivedFieldStore.hpp"
 #include "DiagnosticsModel.hpp"
 #include "FabNavigator.hpp"
 #include "PaletteController.hpp"

--- a/src/qt/MainWindowSlice.cpp
+++ b/src/qt/MainWindowSlice.cpp
@@ -1570,7 +1570,11 @@ void MainWindow::displayFrameResult(InitialSliceResult& result,
         ? result.fileVersion : m_fileVersion;
     showMetadata(frameMetadata, m_datasetPath);
 
-    configureSequenceControls(defaultPositions);
+    configureSequenceControls(defaultPositions,
+        result.displays.empty()
+            ? std::nullopt
+            : std::optional<std::uint32_t>{
+                  result.displays.front().request.field.value});
     if (selectCacheFallbackLevel(m_levelSelector, result.cacheFallbackToLevel)) {
         configureSlicePositionControls();
         updateRangeModeAvailability();
@@ -1600,7 +1604,8 @@ void MainWindow::displayFrameResult(InitialSliceResult& result,
     }
 }
 
-void MainWindow::configureSequenceControls(bool defaultPositions)
+void MainWindow::configureSequenceControls(
+    bool defaultPositions, std::optional<std::uint32_t> displayedField)
 {
     if (!m_dataset) {
         return;
@@ -1623,8 +1628,18 @@ void MainWindow::configureSequenceControls(bool defaultPositions)
                 QString::fromStdString(metadata.fields[field].name),
                 static_cast<unsigned int>(field));
         }
-        m_fieldSelector->setCurrentIndex(
-            std::clamp(previousField, 0, m_fieldSelector->count() - 1));
+        // The field this frame was rendered with, not the position the last
+        // frame's combo happened to be at: the two agree only while every
+        // frame lists the same fields in the same order, and a definition one
+        // frame cannot resolve compacts the ids after it. Selecting by
+        // position there would label the plot with a different field's name
+        // and point the colour range at it.
+        const auto displayedIndex = displayedField
+            ? m_fieldSelector->findData(*displayedField)
+            : -1;
+        m_fieldSelector->setCurrentIndex(displayedIndex >= 0
+                ? displayedIndex
+                : std::clamp(previousField, 0, m_fieldSelector->count() - 1));
         m_levelSelector->clear();
         populateLevelCombo(m_levelSelector, metadata.finestLevel);
         const auto levelIndex = m_levelSelector->findData(previousLevel);
@@ -1720,6 +1735,24 @@ FrameSliceSpec MainWindow::buildFrameSpec()
     }
     spec.field = m_controlsReady && m_fieldSelector->currentIndex() >= 0
         ? m_fieldSelector->currentData().toUInt() : 0U;
+    // The names alongside the indices: an index means something only in the
+    // field list it came from, and the next frame's list can differ -- by its
+    // stored fields, or by a derived definition that frame could not resolve
+    // and left out, which compacts every id after it. Without a name the
+    // reload lands on whatever now occupies that slot (resolveSpecField).
+    const auto nameOf = [this](int field) {
+        if (!m_dataset) {
+            return std::string{};
+        }
+        const auto& fields = m_dataset->metadata().fields;
+        return field >= 0 && static_cast<std::size_t>(field) < fields.size()
+            ? fields[static_cast<std::size_t>(field)].name
+            : std::string{};
+    };
+    spec.fieldName = nameOf(static_cast<int>(spec.field));
+    spec.vectorUFieldName = nameOf(m_vectorUField);
+    spec.vectorVFieldName = nameOf(m_vectorVField);
+    spec.vectorWFieldName = nameOf(m_vectorWField);
     spec.levelSelection = m_controlsReady && m_levelSelector->currentIndex() >= 0
         ? m_levelSelector->currentData().toInt() : -1;
     spec.vectorUField = static_cast<std::uint32_t>(std::max(m_vectorUField, 0));

--- a/src/qt/MainWindowSlice.cpp
+++ b/src/qt/MainWindowSlice.cpp
@@ -88,7 +88,11 @@ QString MainWindow::expressionTooltip(const std::string& expression)
     // One line: an expression may be laid out over several, and a tooltip
     // showing the breaks would be as tall as the editor it was typed in.
     // simplified() folds every run of whitespace into a single space.
-    return QString::fromStdString(expression).simplified();
+    //
+    // Escaped, because the expression is the user's own bytes and Qt reads a
+    // tooltip as rich text as soon as it might be one: ${a<b} would otherwise
+    // be taken for markup and shown with a piece missing.
+    return QString::fromStdString(expression).simplified().toHtmlEscaped();
 }
 
 void MainWindow::setFieldItemEnabled(int index, bool enabled)
@@ -110,18 +114,34 @@ void MainWindow::setFieldItemEnabled(int index, bool enabled)
 
 void MainWindow::selectFieldItem(int index)
 {
-    // The separator between the stored and the derived fields is an item, and
-    // setCurrentIndex does not skip one: landing there shows a blank row whose
-    // currentData() is invalid, which every reader of it then takes for field
-    // 0 while the range memory files itself under an empty name.
-    if (index >= 0 && index < m_fieldSelector->count()
-        && !m_fieldSelector->itemData(index).isValid()) {
-        ++index;
+    // Not every row is a field: the separator between the stored and the
+    // derived ones carries no item data, and neither does a definition this
+    // dataset cannot provide. setCurrentIndex skips none of them, and landing
+    // on one shows a row whose currentData() is invalid, which every reader of
+    // it then takes for field 0 while the range memory files itself under that
+    // row's name. So the caller's index is where to start looking rather than
+    // what to select: the selection goes to the first field at or after it,
+    // and failing that to the nearest one before it.
+    const auto count = m_fieldSelector->count();
+    const auto isField = [this](int row) {
+        return m_fieldSelector->itemData(row).isValid();
+    };
+    auto selected = -1;
+    for (auto row = std::max(index, 0); row < count; ++row) {
+        if (isField(row)) {
+            selected = row;
+            break;
+        }
     }
-    if (index < 0 || index >= m_fieldSelector->count()) {
-        index = 0;
+    for (auto row = std::min(index, count) - 1; selected < 0 && row >= 0;
+        --row) {
+        if (isField(row)) {
+            selected = row;
+        }
     }
-    m_fieldSelector->setCurrentIndex(index);
+    // -1 when the list holds no field at all, which leaves nothing selected
+    // rather than naming a row that is not one.
+    m_fieldSelector->setCurrentIndex(selected);
 }
 
 void MainWindow::populateFieldSelector()
@@ -177,7 +197,8 @@ void MainWindow::populateFieldSelector()
             reason != skipped.end()
                 ? tr("%1 -- unavailable here: %2")
                       .arg(expressionTooltip(definition.expression),
-                          QString::fromStdString(reason->reason))
+                          QString::fromStdString(reason->reason)
+                              .toHtmlEscaped())
                 : tr("%1 -- unavailable for this dataset")
                       .arg(expressionTooltip(definition.expression)),
             Qt::ToolTipRole);
@@ -216,16 +237,20 @@ void MainWindow::restoreVectorFields(const std::array<std::string, 3>& names)
         if (*field < 0 || names[axis].empty()) {
             continue;
         }
-        // Only where the name is actually here. Clamping an unresolved one
-        // into range instead would put all three on the same field *and* look
-        // valid to ensureVectorFieldDefaults, which then skips the re-detection
-        // that an out-of-range id is precisely the signal for.
-        for (std::size_t candidate = 0; candidate < fields.size(); ++candidate) {
-            if (fields[candidate].name == names[axis]) {
-                *field = static_cast<int>(candidate);
-                break;
-            }
-        }
+        // By name, and out of range when the name is not here. Leaving the
+        // old id would re-point the component at whatever field now holds it:
+        // the derived fields are part of this list, so an id outlives the
+        // definition it named and means a different one afterwards. Clamping
+        // would be worse still -- all three on one field, and looking valid to
+        // ensureVectorFieldDefaults, which then skips the re-detection that an
+        // out-of-range id is precisely the signal for.
+        const auto found = std::find_if(fields.begin(), fields.end(),
+            [&names, axis](const FieldMetadata& candidate) {
+                return candidate.name == names[axis];
+            });
+        *field = found != fields.end()
+            ? static_cast<int>(std::distance(fields.begin(), found))
+            : -1;
     }
 }
 

--- a/src/qt/MainWindowSlice.cpp
+++ b/src/qt/MainWindowSlice.cpp
@@ -51,7 +51,12 @@ void MainWindow::configureSliceControls()
     const auto& metadata = m_dataset->metadata();
 
     populateFieldSelector();
-    m_fieldSelector->setCurrentIndex(0);
+    selectFieldItem(0);
+    // The range memory is filed under the field's name, so the widgets have to
+    // be told which field they represent here too -- the restored-spec and
+    // sequence paths are not the only ones that select a field, and without
+    // this the first field's range is committed under an empty name and lost.
+    m_range->setTrackedField(m_fieldSelector->currentText());
 
     populateLevelCombo(m_levelSelector, metadata.finestLevel);
     m_levelSelector->setCurrentIndex(0);
@@ -74,6 +79,30 @@ void MainWindow::configureSliceControls()
         publishSlicePositions();
     }
     ensureVectorFieldDefaults();
+}
+
+QString MainWindow::expressionTooltip(const std::string& expression)
+{
+    // One line: an expression may be laid out over several, and a tooltip
+    // showing the breaks would be as tall as the editor it was typed in.
+    // simplified() folds every run of whitespace into a single space.
+    return QString::fromStdString(expression).simplified();
+}
+
+void MainWindow::selectFieldItem(int index)
+{
+    // The separator between the stored and the derived fields is an item, and
+    // setCurrentIndex does not skip one: landing there shows a blank row whose
+    // currentData() is invalid, which every reader of it then takes for field
+    // 0 while the range memory files itself under an empty name.
+    if (index >= 0 && index < m_fieldSelector->count()
+        && !m_fieldSelector->itemData(index).isValid()) {
+        ++index;
+    }
+    if (index < 0 || index >= m_fieldSelector->count()) {
+        index = 0;
+    }
+    m_fieldSelector->setCurrentIndex(index);
 }
 
 void MainWindow::populateFieldSelector()
@@ -106,8 +135,7 @@ void MainWindow::populateFieldSelector()
             });
         if (definition != definitions.end()) {
             m_fieldSelector->setItemData(m_fieldSelector->count() - 1,
-                QString::fromStdString(definition->expression),
-                Qt::ToolTipRole);
+                expressionTooltip(definition->expression), Qt::ToolTipRole);
         }
     }
 }
@@ -1705,7 +1733,7 @@ void MainWindow::configureSequenceControls(
         const auto displayedIndex = displayedField
             ? m_fieldSelector->findData(*displayedField)
             : -1;
-        m_fieldSelector->setCurrentIndex(displayedIndex >= 0
+        selectFieldItem(displayedIndex >= 0
                 ? displayedIndex
                 : std::clamp(previousField, 0, m_fieldSelector->count() - 1));
         // The range memory is keyed by field id, and the ids moved with the
@@ -1764,6 +1792,7 @@ void MainWindow::resetRangeState()
     // memory is, and is forgotten at the same two points: a different dataset,
     // or a sequence, is being opened.
     m_derivedFields->clear();
+    m_lastSkippedDerivedReport.clear();
     m_range->reset();
     m_displayCoordinator.invalidateRangeCache();
     m_pendingRangeStore.reset();

--- a/src/qt/MainWindowSlice.cpp
+++ b/src/qt/MainWindowSlice.cpp
@@ -83,33 +83,95 @@ void MainWindow::configureSliceControls()
     ensureVectorFieldDefaults();
 }
 
-QString MainWindow::expressionTooltip(const std::string& expression)
+QString MainWindow::escapedExpression(const std::string& expression)
 {
     // One line: an expression may be laid out over several, and a tooltip
     // showing the breaks would be as tall as the editor it was typed in.
-    // simplified() folds every run of whitespace into a single space.
-    //
-    // Escaped, because the expression is the user's own bytes and Qt reads a
-    // tooltip as rich text as soon as it might be one: ${a<b} would otherwise
-    // be taken for markup and shown with a piece missing.
+    // simplified() folds every run of whitespace into a single space. Escaped
+    // because it is the user's own bytes; richTooltip is what makes the
+    // escaping show through as the characters they stand for.
     return QString::fromStdString(expression).simplified().toHtmlEscaped();
 }
 
-void MainWindow::setFieldItemEnabled(int index, bool enabled)
+QString MainWindow::richTooltip(const QString& escaped)
+{
+    // Qt renders a tooltip as rich text only when it thinks it might be some:
+    // `&lt;` decides it, `&amp;` on its own does not, so escaped text is shown
+    // either as the user wrote it or with the escapes visible, depending on
+    // which characters they used. The wrapper settles it for every string.
+    return QStringLiteral("<qt>%1</qt>").arg(escaped);
+}
+
+bool MainWindow::addUnavailableFieldItem(
+    const QString& name, const QString& tooltip)
 {
     // Through the model, because a combo box has no per-item enable of its
     // own: an item that is not selectable is skipped by the keyboard and drawn
-    // greyed by the style.
+    // greyed by the style. Without one there is no way to add this row safely,
+    // so it is not added -- leaving a definition off a list says less than
+    // showing it greyed out, but far less than offering a broken selection.
     auto* model = qobject_cast<QStandardItemModel*>(m_fieldSelector->model());
     if (model == nullptr) {
-        return;
+        return false;
     }
-    if (auto* item = model->item(index); item != nullptr) {
-        item->setFlags(enabled
-                ? item->flags() | Qt::ItemIsSelectable | Qt::ItemIsEnabled
-                : item->flags()
-                    & ~(Qt::ItemIsSelectable | Qt::ItemIsEnabled));
+    const auto row = m_fieldSelector->count();
+    // No field id: nothing that reads item data can mistake it for one.
+    m_fieldSelector->addItem(name);
+    m_fieldSelector->setItemData(row, tooltip, Qt::ToolTipRole);
+    auto* item = model->item(row);
+    if (item == nullptr) {
+        m_fieldSelector->removeItem(row);
+        return false;
     }
+    item->setFlags(
+        item->flags() & ~(Qt::ItemIsSelectable | Qt::ItemIsEnabled));
+    return true;
+}
+
+std::vector<MainWindow::DerivedFieldRow> MainWindow::derivedFieldRows() const
+{
+    std::vector<DerivedFieldRow> rows;
+    if (!m_dataset) {
+        return rows;
+    }
+    const auto& fields = m_dataset->metadata().fields;
+    const auto stored = std::min(m_dataset->storedFieldCount(), fields.size());
+    const auto& definitions = m_derivedFields->definitions();
+    const auto skipped = m_dataset->skippedDerivedFields();
+    rows.reserve(definitions.size());
+    for (const auto& definition : definitions) {
+        DerivedFieldRow row;
+        row.name = QString::fromStdString(definition.name);
+        const auto expression = escapedExpression(definition.expression);
+        const auto installed = std::find_if(
+            fields.begin() + static_cast<std::ptrdiff_t>(stored), fields.end(),
+            [&definition](const FieldMetadata& field) {
+                return field.name == definition.name;
+            });
+        if (installed != fields.end()) {
+            row.field = static_cast<std::uint32_t>(
+                std::distance(fields.begin(), installed));
+            row.tooltip = richTooltip(expression);
+            rows.push_back(std::move(row));
+            continue;
+        }
+        // Not installed here, and saying why. The list is shared by every
+        // window, so a definition that means nothing here means something
+        // next door, and showing it as unavailable says so better than its
+        // absence does.
+        const auto reason = std::find_if(skipped.begin(), skipped.end(),
+            [&definition](const DerivedFieldSkip& entry) {
+                return entry.name == definition.name;
+            });
+        row.tooltip = richTooltip(reason != skipped.end()
+                ? tr("%1 -- unavailable here: %2")
+                      .arg(expression,
+                          QString::fromStdString(reason->reason)
+                              .toHtmlEscaped())
+                : tr("%1 -- unavailable for this dataset").arg(expression));
+        rows.push_back(std::move(row));
+    }
+    return rows;
 }
 
 void MainWindow::selectFieldItem(int index)
@@ -157,53 +219,32 @@ void MainWindow::populateFieldSelector()
             static_cast<unsigned int>(field));
     }
 
-    // Every definition the session carries, in the order it was written --
-    // including the ones this dataset cannot provide, which are listed greyed
-    // out rather than left out. The list is shared by every window, so a
-    // definition that means nothing here means something next door, and
-    // showing it as unavailable says so better than its absence does.
-    const auto& definitions = m_derivedFields->definitions();
-    if (definitions.empty()) {
+    const auto rows = derivedFieldRows();
+    if (rows.empty()) {
         return;
     }
     // The computed fields are a different kind of thing from the ones the
     // plotfile holds; the rule is worth showing rather than leaving to be
     // inferred from the order.
     m_fieldSelector->insertSeparator(m_fieldSelector->count());
-    const auto skipped = m_dataset->skippedDerivedFields();
-    for (const auto& definition : definitions) {
-        const auto name = QString::fromStdString(definition.name);
-        const auto installed = std::find_if(fields.begin() + static_cast<std::ptrdiff_t>(stored),
-            fields.end(), [&definition](const FieldMetadata& field) {
-                return field.name == definition.name;
-            });
-        const auto row = m_fieldSelector->count();
-        if (installed != fields.end()) {
-            m_fieldSelector->addItem(name,
-                static_cast<unsigned int>(
-                    std::distance(fields.begin(), installed)));
-            m_fieldSelector->setItemData(row,
-                expressionTooltip(definition.expression), Qt::ToolTipRole);
+    for (const auto& row : rows) {
+        if (!row.field) {
+            static_cast<void>(addUnavailableFieldItem(row.name, row.tooltip));
             continue;
         }
-        // Not installed here: shown, not selectable, and saying why. No field
-        // id either, so nothing that reads item data can mistake it for one.
-        m_fieldSelector->addItem(name);
-        const auto reason = std::find_if(skipped.begin(), skipped.end(),
-            [&definition](const DerivedFieldSkip& entry) {
-                return entry.name == definition.name;
-            });
-        m_fieldSelector->setItemData(row,
-            reason != skipped.end()
-                ? tr("%1 -- unavailable here: %2")
-                      .arg(expressionTooltip(definition.expression),
-                          QString::fromStdString(reason->reason)
-                              .toHtmlEscaped())
-                : tr("%1 -- unavailable for this dataset")
-                      .arg(expressionTooltip(definition.expression)),
-            Qt::ToolTipRole);
-        setFieldItemEnabled(row, false);
+        const auto index = m_fieldSelector->count();
+        m_fieldSelector->addItem(
+            row.name, static_cast<unsigned int>(*row.field));
+        m_fieldSelector->setItemData(index, row.tooltip, Qt::ToolTipRole);
     }
+}
+
+bool MainWindow::derivedFieldsReachNextLoad() const
+{
+    // A remote sequence fixes its field lists on the server, and a FAB
+    // drilled out of a MultiFab is what the editor is unavailable over -- for
+    // the same reason the reload cannot rebuild one.
+    return !m_remoteSequence && !m_fabNavigator->fabMode();
 }
 
 std::array<std::string, 3> MainWindow::vectorFieldNames() const
@@ -1864,16 +1905,10 @@ FrameSliceSpec MainWindow::buildFrameSpec()
 {
     FrameSliceSpec spec;
     // A viewer-wide setting, so it travels with every spec except where the
-    // load it is built for cannot install it: a remote sequence, whose
-    // sessions fix their field lists on the server, and a FAB drilled out of a
-    // MultiFab, where the editor is unavailable for the same reason the reload
-    // cannot rebuild one. Deliberately not asked of m_dataset: a sequence
-    // builds its first spec while the *outgoing* dataset is still installed
-    // (see prepareSequence), so frame 0 would load without the definitions and
-    // frame 1 would make them appear.
-    spec.derivedFields = m_remoteSequence || m_fabNavigator->fabMode()
-        ? std::vector<DerivedFieldDefinition>{}
-        : m_derivedFields->definitions();
+    // load it is built for cannot install it (derivedFieldsReachNextLoad).
+    spec.derivedFields = derivedFieldsReachNextLoad()
+        ? m_derivedFields->definitions()
+        : std::vector<DerivedFieldDefinition>{};
     spec.displayMode = m_displayMode;
     spec.palette = m_paletteController->palette();
     spec.contourCount = m_contourCount;

--- a/src/qt/MainWindowSlice.cpp
+++ b/src/qt/MainWindowSlice.cpp
@@ -1,5 +1,7 @@
 #include "MainWindowInternal.hpp"
 
+#include <QStandardItemModel>
+
 namespace amrvis::qt {
 
 namespace {
@@ -89,6 +91,23 @@ QString MainWindow::expressionTooltip(const std::string& expression)
     return QString::fromStdString(expression).simplified();
 }
 
+void MainWindow::setFieldItemEnabled(int index, bool enabled)
+{
+    // Through the model, because a combo box has no per-item enable of its
+    // own: an item that is not selectable is skipped by the keyboard and drawn
+    // greyed by the style.
+    auto* model = qobject_cast<QStandardItemModel*>(m_fieldSelector->model());
+    if (model == nullptr) {
+        return;
+    }
+    if (auto* item = model->item(index); item != nullptr) {
+        item->setFlags(enabled
+                ? item->flags() | Qt::ItemIsSelectable | Qt::ItemIsEnabled
+                : item->flags()
+                    & ~(Qt::ItemIsSelectable | Qt::ItemIsEnabled));
+    }
+}
+
 void MainWindow::selectFieldItem(int index)
 {
     // The separator between the stored and the derived fields is an item, and
@@ -113,30 +132,56 @@ void MainWindow::populateFieldSelector()
     }
     const auto& fields = m_dataset->metadata().fields;
     const auto stored = std::min(m_dataset->storedFieldCount(), fields.size());
+    for (std::size_t field = 0; field < stored; ++field) {
+        m_fieldSelector->addItem(QString::fromStdString(fields[field].name),
+            static_cast<unsigned int>(field));
+    }
+
+    // Every definition the session carries, in the order it was written --
+    // including the ones this dataset cannot provide, which are listed greyed
+    // out rather than left out. The list is shared by every window, so a
+    // definition that means nothing here means something next door, and
+    // showing it as unavailable says so better than its absence does.
     const auto& definitions = m_derivedFields->definitions();
-    for (std::size_t field = 0; field < fields.size(); ++field) {
-        if (field == stored) {
-            // The computed fields are a different kind of thing from the ones
-            // the plotfile holds; the rule is worth showing rather than
-            // leaving to be inferred from the order.
-            m_fieldSelector->insertSeparator(m_fieldSelector->count());
-        }
-        const auto name = QString::fromStdString(fields[field].name);
-        m_fieldSelector->addItem(name, static_cast<unsigned int>(field));
-        if (field < stored) {
+    if (definitions.empty()) {
+        return;
+    }
+    // The computed fields are a different kind of thing from the ones the
+    // plotfile holds; the rule is worth showing rather than leaving to be
+    // inferred from the order.
+    m_fieldSelector->insertSeparator(m_fieldSelector->count());
+    const auto skipped = m_dataset->skippedDerivedFields();
+    for (const auto& definition : definitions) {
+        const auto name = QString::fromStdString(definition.name);
+        const auto installed = std::find_if(fields.begin() + static_cast<std::ptrdiff_t>(stored),
+            fields.end(), [&definition](const FieldMetadata& field) {
+                return field.name == definition.name;
+            });
+        const auto row = m_fieldSelector->count();
+        if (installed != fields.end()) {
+            m_fieldSelector->addItem(name,
+                static_cast<unsigned int>(
+                    std::distance(fields.begin(), installed)));
+            m_fieldSelector->setItemData(row,
+                expressionTooltip(definition.expression), Qt::ToolTipRole);
             continue;
         }
-        // What the field is, on the field itself. Matched by name rather than
-        // by position: a definition the dataset could not resolve is left out
-        // of the field list, so the two are not index-for-index.
-        const auto definition = std::find_if(definitions.begin(),
-            definitions.end(), [&fields, field](const auto& candidate) {
-                return candidate.name == fields[field].name;
+        // Not installed here: shown, not selectable, and saying why. No field
+        // id either, so nothing that reads item data can mistake it for one.
+        m_fieldSelector->addItem(name);
+        const auto reason = std::find_if(skipped.begin(), skipped.end(),
+            [&definition](const DerivedFieldSkip& entry) {
+                return entry.name == definition.name;
             });
-        if (definition != definitions.end()) {
-            m_fieldSelector->setItemData(m_fieldSelector->count() - 1,
-                expressionTooltip(definition->expression), Qt::ToolTipRole);
-        }
+        m_fieldSelector->setItemData(row,
+            reason != skipped.end()
+                ? tr("%1 -- unavailable here: %2")
+                      .arg(expressionTooltip(definition.expression),
+                          QString::fromStdString(reason->reason))
+                : tr("%1 -- unavailable for this dataset")
+                      .arg(expressionTooltip(definition.expression)),
+            Qt::ToolTipRole);
+        setFieldItemEnabled(row, false);
     }
 }
 
@@ -181,26 +226,6 @@ void MainWindow::restoreVectorFields(const std::array<std::string, 3>& names)
                 break;
             }
         }
-    }
-}
-
-void MainWindow::reportSkippedDerivedFields()
-{
-    if (!m_dataset) {
-        return;
-    }
-    // Called from where a load's own notices are shown (after the slices, past
-    // showSlice's clearMessage), so this is a status message that stays up.
-    const auto report =
-        m_derivedFields->skippedReport(m_dataset->skippedDerivedFields());
-    // Only on a change: a sequence whose frames all lack the same field would
-    // otherwise repeat the message on every frame of a playback.
-    if (report == m_lastSkippedDerivedReport) {
-        return;
-    }
-    m_lastSkippedDerivedReport = report;
-    if (!report.isEmpty()) {
-        statusBar()->showMessage(report, 8000);
     }
 }
 
@@ -1695,9 +1720,6 @@ void MainWindow::displayFrameResult(InitialSliceResult& result,
     // from one. A scale picked on an earlier frame otherwise kept that frame's
     // number.
     refreshScaleReport();
-    // Before the cache-fallback notice, which is about the render the user is
-    // looking at and so takes the status bar if both happened.
-    reportSkippedDerivedFields();
     if (result.cacheFallbackToLevel >= 0) {
         statusBar()->showMessage(cacheFallbackMessage(
             *result.dataset, result.cacheFallbackFromLevel,
@@ -1788,11 +1810,6 @@ void MainWindow::configureSequenceControls(
 
 void MainWindow::resetRangeState()
 {
-    // The derived-field list is dataset-scoped for the same reason the range
-    // memory is, and is forgotten at the same two points: a different dataset,
-    // or a sequence, is being opened.
-    m_derivedFields->clear();
-    m_lastSkippedDerivedReport.clear();
     m_range->reset();
     m_displayCoordinator.invalidateRangeCache();
     m_pendingRangeStore.reset();

--- a/src/qt/MainWindowSlice.cpp
+++ b/src/qt/MainWindowSlice.cpp
@@ -30,6 +30,11 @@ void populateLevelCombo(QComboBox* combo, int finestLevel)
 void MainWindow::enableDatasetControls(const DatasetMetadata& metadata)
 {
     m_controlsReady = true;
+    // Both configure paths (a single dataset and a sequence frame) come
+    // through here, so this is where the editor's availability is re-derived
+    // for the newly installed session. What that session could *not* install
+    // is reported once its slices are on screen -- showSlice clears the status
+    // bar, so a message from here would not survive the load that follows it.
     m_fieldSelector->setEnabled(true);
     m_levelSelector->setEnabled(true);
     m_range->setControlsReady(true);
@@ -78,6 +83,26 @@ void MainWindow::configureSliceControls()
         publishSlicePositions();
     }
     ensureVectorFieldDefaults();
+}
+
+void MainWindow::reportSkippedDerivedFields()
+{
+    if (!m_dataset) {
+        return;
+    }
+    // Called from where a load's own notices are shown (after the slices, past
+    // showSlice's clearMessage), so this is a status message that stays up.
+    const auto report =
+        m_derivedFields->skippedReport(m_dataset->skippedDerivedFields());
+    // Only on a change: a sequence whose frames all lack the same field would
+    // otherwise repeat the message on every frame of a playback.
+    if (report == m_lastSkippedDerivedReport) {
+        return;
+    }
+    m_lastSkippedDerivedReport = report;
+    if (!report.isEmpty()) {
+        statusBar()->showMessage(report, 8000);
+    }
 }
 
 void MainWindow::publishSlicePositions()
@@ -1565,6 +1590,9 @@ void MainWindow::displayFrameResult(InitialSliceResult& result,
     // from one. A scale picked on an earlier frame otherwise kept that frame's
     // number.
     refreshScaleReport();
+    // Before the cache-fallback notice, which is about the render the user is
+    // looking at and so takes the status bar if both happened.
+    reportSkippedDerivedFields();
     if (result.cacheFallbackToLevel >= 0) {
         statusBar()->showMessage(cacheFallbackMessage(
             *result.dataset, result.cacheFallbackFromLevel,
@@ -1672,6 +1700,13 @@ void MainWindow::updateRangeModeAvailability()
 FrameSliceSpec MainWindow::buildFrameSpec()
 {
     FrameSliceSpec spec;
+    // The session a frame load opens installs these. A remote session cannot,
+    // and the list can be non-empty over one (restored from settings, or
+    // applied to a local dataset before connecting), so the spec carries them
+    // only where they can be honoured -- see FrameSliceSpec::derivedFields.
+    spec.derivedFields = m_dataset && m_dataset->supportsDerivedFields()
+        ? m_derivedFields->definitions()
+        : std::vector<DerivedFieldDefinition>{};
     spec.displayMode = m_displayMode;
     spec.palette = m_paletteController->palette();
     spec.contourCount = m_contourCount;

--- a/src/qt/MainWindowSlice.cpp
+++ b/src/qt/MainWindowSlice.cpp
@@ -52,7 +52,10 @@ void MainWindow::configureSliceControls()
     const QSignalBlocker levelBlocker(m_levelSelector);
     const auto& metadata = m_dataset->metadata();
 
-    populateFieldSelector();
+    // Built once and shared: the field selector and the Variable menu list
+    // the same definitions.
+    const auto derivedRows = derivedFieldRows();
+    populateFieldSelector(derivedRows);
     selectFieldItem(0);
     // The range memory is filed under the field's name, so the widgets have to
     // be told which field they represent here too -- the restored-spec and
@@ -65,7 +68,7 @@ void MainWindow::configureSliceControls()
 
     enableDatasetControls(metadata);
 
-    rebuildVariableMenu();
+    rebuildVariableMenu(derivedRows);
     updateRangeModeAvailability();
 
     // Switch the stacked page to match the dataset dimension and, for 3-D,
@@ -131,7 +134,13 @@ bool MainWindow::addUnavailableFieldItem(
 std::vector<MainWindow::DerivedFieldRow> MainWindow::derivedFieldRows() const
 {
     std::vector<DerivedFieldRow> rows;
-    if (!m_dataset) {
+    // Nothing at all where no definition could ever apply: a remote session
+    // reports every field as stored, so each one would list as "unavailable
+    // for this dataset" beside an editor saying derived fields need a local
+    // one -- two explanations of the same fact, and clutter that cannot
+    // become usable while this session is open.
+    if (!m_dataset || !m_dataset->supportsDerivedFields()
+        || m_dataset->metadata().isFab) {
         return rows;
     }
     const auto& fields = m_dataset->metadata().fields;
@@ -206,7 +215,7 @@ void MainWindow::selectFieldItem(int index)
     m_fieldSelector->setCurrentIndex(selected);
 }
 
-void MainWindow::populateFieldSelector()
+void MainWindow::populateFieldSelector(const std::vector<DerivedFieldRow>& rows)
 {
     m_fieldSelector->clear();
     if (!m_dataset) {
@@ -219,7 +228,6 @@ void MainWindow::populateFieldSelector()
             static_cast<unsigned int>(field));
     }
 
-    const auto rows = derivedFieldRows();
     if (rows.empty()) {
         return;
     }
@@ -1781,6 +1789,14 @@ void MainWindow::displayFrameResult(InitialSliceResult& result,
     }
     const auto cache = m_dataset->cacheMetrics();
     m_diagnosticsModel->setCacheMetrics(cache);
+    // As the open path does: this window has no dataset while it opens a
+    // sequence, so a definition committed in another window meanwhile reached
+    // every window but this one, and this frame carries the older list.
+    // Mid-playback the reload stands aside and setPlaybackMode picks it up.
+    if (m_frameSpecRevision != m_derivedFields->storeRevision()
+        && m_derivedFields->available()) {
+        reloadCurrentDataset();
+    }
     validateVectorMode();
     // Frames need not share a domain, and the clamped scale report is computed
     // from one. A scale picked on an earlier frame otherwise kept that frame's
@@ -1808,10 +1824,11 @@ void MainWindow::configureSequenceControls(
     const auto previousLevel = m_controlsReady
         && m_levelSelector->currentIndex() >= 0
             ? m_levelSelector->currentData().toInt() : -1;
+    const auto derivedRows = derivedFieldRows();
     {
         const QSignalBlocker fieldBlocker(m_fieldSelector);
         const QSignalBlocker levelBlocker(m_levelSelector);
-        populateFieldSelector();
+        populateFieldSelector(derivedRows);
         // The field this frame was rendered with, not the position the last
         // frame's combo happened to be at: the two agree only while every
         // frame lists the same fields in the same order, and a definition one
@@ -1869,7 +1886,7 @@ void MainWindow::configureSequenceControls(
 
     enableDatasetControls(metadata);
     m_exportAnimationAction->setEnabled(true);
-    rebuildVariableMenu();
+    rebuildVariableMenu(derivedRows);
     ensureVectorFieldDefaults();
     updateRangeModeAvailability();
 }
@@ -2024,6 +2041,14 @@ void MainWindow::setPlaybackMode(PlaybackMode mode)
         m_playbackTimer->stop();
     } else {
         m_playbackTimer->start(m_animationPanel->frameDelayMs());
+    }
+    // Playback is why the reload stood aside: the next frame reads the list
+    // for itself, and stopping means there is no next frame. What is on
+    // screen was rendered against the list as it was, so it is reloaded here
+    // rather than left computing an expression the editor has replaced.
+    if (wasSequence && mode != PlaybackMode::Sequence
+        && m_frameSpecRevision != m_derivedFields->storeRevision()) {
+        reloadCurrentDataset();
     }
     // Every frame of a sequence renders the volume as a draft, so what is
     // standing in the window when playback stops is a half-size one. Ask for

--- a/src/qt/MainWindowSlice.cpp
+++ b/src/qt/MainWindowSlice.cpp
@@ -85,6 +85,42 @@ void MainWindow::configureSliceControls()
     ensureVectorFieldDefaults();
 }
 
+std::array<std::string, 3> MainWindow::vectorFieldNames() const
+{
+    std::array<std::string, 3> names;
+    if (!m_dataset) {
+        return names;
+    }
+    const auto& fields = m_dataset->metadata().fields;
+    const std::array<int, 3> selected{
+        m_vectorUField, m_vectorVField, m_vectorWField};
+    for (std::size_t axis = 0; axis < names.size(); ++axis) {
+        const auto field = selected[axis];
+        if (field >= 0 && static_cast<std::size_t>(field) < fields.size()) {
+            names[axis] = fields[static_cast<std::size_t>(field)].name;
+        }
+    }
+    return names;
+}
+
+void MainWindow::restoreVectorFields(const std::array<std::string, 3>& names)
+{
+    if (!m_dataset) {
+        return;
+    }
+    const auto& metadata = m_dataset->metadata();
+    std::array<int*, 3> selected{
+        &m_vectorUField, &m_vectorVField, &m_vectorWField};
+    for (std::size_t axis = 0; axis < names.size(); ++axis) {
+        auto* field = selected[axis];
+        if (*field < 0) {
+            continue;
+        }
+        *field = static_cast<int>(resolveSpecField(metadata, names[axis],
+            static_cast<std::uint32_t>(*field)));
+    }
+}
+
 void MainWindow::reportSkippedDerivedFields()
 {
     if (!m_dataset) {
@@ -1555,7 +1591,9 @@ void MainWindow::displayFrameResult(InitialSliceResult& result,
         m_pendingRangeStore.reset();
         m_remoteSequenceConnectionGeneration = result.connectionGeneration;
     }
+    const auto previousVectorFields = vectorFieldNames();
     m_dataset = result.dataset;
+    restoreVectorFields(previousVectorFields);
     m_particleController->setSamples(std::move(result.particles));
     m_particleController->configureForDataset(true);
     m_volumeController->configureForDataset();
@@ -1640,6 +1678,11 @@ void MainWindow::configureSequenceControls(
         m_fieldSelector->setCurrentIndex(displayedIndex >= 0
                 ? displayedIndex
                 : std::clamp(previousField, 0, m_fieldSelector->count() - 1));
+        // The range memory is keyed by field id, and the ids moved with the
+        // field list, so the widgets have to be told which field they now
+        // represent or the next switch commits this frame's range onto
+        // whatever field used to hold that id.
+        m_range->setTrackedField(m_fieldSelector->currentData().toUInt());
         m_levelSelector->clear();
         populateLevelCombo(m_levelSelector, metadata.finestLevel);
         const auto levelIndex = m_levelSelector->findData(previousLevel);

--- a/src/qt/MainWindowSlice.cpp
+++ b/src/qt/MainWindowSlice.cpp
@@ -30,11 +30,6 @@ void populateLevelCombo(QComboBox* combo, int finestLevel)
 void MainWindow::enableDatasetControls(const DatasetMetadata& metadata)
 {
     m_controlsReady = true;
-    // Both configure paths (a single dataset and a sequence frame) come
-    // through here, so this is where the editor's availability is re-derived
-    // for the newly installed session. What that session could *not* install
-    // is reported once its slices are on screen -- showSlice clears the status
-    // bar, so a message from here would not survive the load that follows it.
     m_fieldSelector->setEnabled(true);
     m_levelSelector->setEnabled(true);
     m_range->setControlsReady(true);
@@ -108,16 +103,24 @@ void MainWindow::restoreVectorFields(const std::array<std::string, 3>& names)
     if (!m_dataset) {
         return;
     }
-    const auto& metadata = m_dataset->metadata();
+    const auto& fields = m_dataset->metadata().fields;
     std::array<int*, 3> selected{
         &m_vectorUField, &m_vectorVField, &m_vectorWField};
     for (std::size_t axis = 0; axis < names.size(); ++axis) {
         auto* field = selected[axis];
-        if (*field < 0) {
+        if (*field < 0 || names[axis].empty()) {
             continue;
         }
-        *field = static_cast<int>(resolveSpecField(metadata, names[axis],
-            static_cast<std::uint32_t>(*field)));
+        // Only where the name is actually here. Clamping an unresolved one
+        // into range instead would put all three on the same field *and* look
+        // valid to ensureVectorFieldDefaults, which then skips the re-detection
+        // that an out-of-range id is precisely the signal for.
+        for (std::size_t candidate = 0; candidate < fields.size(); ++candidate) {
+            if (fields[candidate].name == names[axis]) {
+                *field = static_cast<int>(candidate);
+                break;
+            }
+        }
     }
 }
 
@@ -1682,7 +1685,7 @@ void MainWindow::configureSequenceControls(
         // field list, so the widgets have to be told which field they now
         // represent or the next switch commits this frame's range onto
         // whatever field used to hold that id.
-        m_range->setTrackedField(m_fieldSelector->currentData().toUInt());
+        m_range->setTrackedField(m_fieldSelector->currentText());
         m_levelSelector->clear();
         populateLevelCombo(m_levelSelector, metadata.finestLevel);
         const auto levelIndex = m_levelSelector->findData(previousLevel);
@@ -1752,19 +1755,23 @@ void MainWindow::updateRangeModeAvailability()
             .level = m_dataset->rangeAvailable(RangeRequest{
                 field, maximumLevel, composition, RangeScope::Level}),
         },
-        field.value);
+        m_fieldSelector->currentText());
 }
 
 FrameSliceSpec MainWindow::buildFrameSpec()
 {
     FrameSliceSpec spec;
-    // The session a frame load opens installs these. A remote session cannot,
-    // and the list can be non-empty over one (restored from settings, or
-    // applied to a local dataset before connecting), so the spec carries them
-    // only where they can be honoured -- see FrameSliceSpec::derivedFields.
-    spec.derivedFields = m_dataset && m_dataset->supportsDerivedFields()
-        ? m_derivedFields->definitions()
-        : std::vector<DerivedFieldDefinition>{};
+    // A viewer-wide setting, so it travels with every spec except where the
+    // load it is built for cannot install it: a remote sequence, whose
+    // sessions fix their field lists on the server, and a FAB drilled out of a
+    // MultiFab, where the editor is unavailable for the same reason the reload
+    // cannot rebuild one. Deliberately not asked of m_dataset: a sequence
+    // builds its first spec while the *outgoing* dataset is still installed
+    // (see prepareSequence), so frame 0 would load without the definitions and
+    // frame 1 would make them appear.
+    spec.derivedFields = m_remoteSequence || m_fabNavigator->fabMode()
+        ? std::vector<DerivedFieldDefinition>{}
+        : m_derivedFields->definitions();
     spec.displayMode = m_displayMode;
     spec.palette = m_paletteController->palette();
     spec.contourCount = m_contourCount;

--- a/src/qt/MainWindowSlice.cpp
+++ b/src/qt/MainWindowSlice.cpp
@@ -50,11 +50,7 @@ void MainWindow::configureSliceControls()
     const QSignalBlocker levelBlocker(m_levelSelector);
     const auto& metadata = m_dataset->metadata();
 
-    m_fieldSelector->clear();
-    for (std::size_t field = 0; field < metadata.fields.size(); ++field) {
-        m_fieldSelector->addItem(QString::fromStdString(metadata.fields[field].name),
-            static_cast<unsigned int>(field));
-    }
+    populateFieldSelector();
     m_fieldSelector->setCurrentIndex(0);
 
     populateLevelCombo(m_levelSelector, metadata.finestLevel);
@@ -78,6 +74,42 @@ void MainWindow::configureSliceControls()
         publishSlicePositions();
     }
     ensureVectorFieldDefaults();
+}
+
+void MainWindow::populateFieldSelector()
+{
+    m_fieldSelector->clear();
+    if (!m_dataset) {
+        return;
+    }
+    const auto& fields = m_dataset->metadata().fields;
+    const auto stored = std::min(m_dataset->storedFieldCount(), fields.size());
+    const auto& definitions = m_derivedFields->definitions();
+    for (std::size_t field = 0; field < fields.size(); ++field) {
+        if (field == stored) {
+            // The computed fields are a different kind of thing from the ones
+            // the plotfile holds; the rule is worth showing rather than
+            // leaving to be inferred from the order.
+            m_fieldSelector->insertSeparator(m_fieldSelector->count());
+        }
+        const auto name = QString::fromStdString(fields[field].name);
+        m_fieldSelector->addItem(name, static_cast<unsigned int>(field));
+        if (field < stored) {
+            continue;
+        }
+        // What the field is, on the field itself. Matched by name rather than
+        // by position: a definition the dataset could not resolve is left out
+        // of the field list, so the two are not index-for-index.
+        const auto definition = std::find_if(definitions.begin(),
+            definitions.end(), [&fields, field](const auto& candidate) {
+                return candidate.name == fields[field].name;
+            });
+        if (definition != definitions.end()) {
+            m_fieldSelector->setItemData(m_fieldSelector->count() - 1,
+                QString::fromStdString(definition->expression),
+                Qt::ToolTipRole);
+        }
+    }
 }
 
 std::array<std::string, 3> MainWindow::vectorFieldNames() const
@@ -1663,12 +1695,7 @@ void MainWindow::configureSequenceControls(
     {
         const QSignalBlocker fieldBlocker(m_fieldSelector);
         const QSignalBlocker levelBlocker(m_levelSelector);
-        m_fieldSelector->clear();
-        for (std::size_t field = 0; field < metadata.fields.size(); ++field) {
-            m_fieldSelector->addItem(
-                QString::fromStdString(metadata.fields[field].name),
-                static_cast<unsigned int>(field));
-        }
+        populateFieldSelector();
         // The field this frame was rendered with, not the position the last
         // frame's combo happened to be at: the two agree only while every
         // frame lists the same fields in the same order, and a definition one
@@ -1733,6 +1760,10 @@ void MainWindow::configureSequenceControls(
 
 void MainWindow::resetRangeState()
 {
+    // The derived-field list is dataset-scoped for the same reason the range
+    // memory is, and is forgotten at the same two points: a different dataset,
+    // or a sequence, is being opened.
+    m_derivedFields->clear();
     m_range->reset();
     m_displayCoordinator.invalidateRangeCache();
     m_pendingRangeStore.reset();

--- a/src/qt/MainWindowSlice.cpp
+++ b/src/qt/MainWindowSlice.cpp
@@ -86,25 +86,6 @@ void MainWindow::configureSliceControls()
     ensureVectorFieldDefaults();
 }
 
-QString MainWindow::escapedExpression(const std::string& expression)
-{
-    // One line: an expression may be laid out over several, and a tooltip
-    // showing the breaks would be as tall as the editor it was typed in.
-    // simplified() folds every run of whitespace into a single space. Escaped
-    // because it is the user's own bytes; richTooltip is what makes the
-    // escaping show through as the characters they stand for.
-    return QString::fromStdString(expression).simplified().toHtmlEscaped();
-}
-
-QString MainWindow::richTooltip(const QString& escaped)
-{
-    // Qt renders a tooltip as rich text only when it thinks it might be some:
-    // `&lt;` decides it, `&amp;` on its own does not, so escaped text is shown
-    // either as the user wrote it or with the escapes visible, depending on
-    // which characters they used. The wrapper settles it for every string.
-    return QStringLiteral("<qt>%1</qt>").arg(escaped);
-}
-
 bool MainWindow::addUnavailableFieldItem(
     const QString& name, const QString& tooltip)
 {
@@ -245,6 +226,32 @@ void MainWindow::populateFieldSelector(const std::vector<DerivedFieldRow>& rows)
             row.name, static_cast<unsigned int>(*row.field));
         m_fieldSelector->setItemData(index, row.tooltip, Qt::ToolTipRole);
     }
+}
+
+bool MainWindow::openSessionHasCurrentDefinitions() const
+{
+    return m_dataset
+        && m_dataset->derivedFieldDefinitions()
+            == m_derivedFields->definitions();
+}
+
+void MainWindow::reloadIfDefinitionsMoved()
+{
+    if (m_closing || !m_derivedFields->available()
+        || openSessionHasCurrentDefinitions()) {
+        return;
+    }
+    // Not now: the frame path is called from inside the sequence controller's
+    // own load completion, which sets m_inFlight and emits frameDisplayed
+    // after this returns -- starting a load from here would have it clobber
+    // the load this reload starts.
+    QTimer::singleShot(0, this, [this] {
+        if (m_closing || !m_derivedFields->available()
+            || openSessionHasCurrentDefinitions()) {
+            return;
+        }
+        reloadCurrentDataset();
+    });
 }
 
 bool MainWindow::derivedFieldsReachNextLoad() const
@@ -1519,7 +1526,6 @@ void MainWindow::reportVisibleSyncFailure(const std::exception& error)
 
 void MainWindow::choosePlotfileSequence()
 {
-    const auto settings = makeSettings();
     // Select the plotfile directories directly with click / Ctrl-click /
     // Shift-click. QFileDialog::Directory only permits selecting more than one
     // directory on the non-native dialog, so disable the native one and force
@@ -1528,7 +1534,7 @@ void MainWindow::choosePlotfileSequence()
     // plotfiles (Header + Level_N) by openSequence.
     QFileDialog dialog(this,
         tr("Open Plotfile Sequence — select two or more plotfile directories"),
-        settings.value(QStringLiteral("lastOpenDirectory")).toString());
+        rememberedDialogDirectory());
     dialog.setFileMode(QFileDialog::Directory);
     dialog.setOption(QFileDialog::DontUseNativeDialog, true);
     for (auto* view : dialog.findChildren<QListView*>()) {
@@ -1789,14 +1795,11 @@ void MainWindow::displayFrameResult(InitialSliceResult& result,
     }
     const auto cache = m_dataset->cacheMetrics();
     m_diagnosticsModel->setCacheMetrics(cache);
-    // As the open path does: this window has no dataset while it opens a
-    // sequence, so a definition committed in another window meanwhile reached
-    // every window but this one, and this frame carries the older list.
-    // Mid-playback the reload stands aside and setPlaybackMode picks it up.
-    if (m_frameSpecRevision != m_derivedFields->storeRevision()
-        && m_derivedFields->available()) {
-        reloadCurrentDataset();
-    }
+    // This window has no dataset while it opens a sequence, so a definition
+    // committed in another window meanwhile reached every window but this one,
+    // and this frame carries the older list. Mid-playback the reload stands
+    // aside and setPlaybackMode picks it up.
+    reloadIfDefinitionsMoved();
     validateVectorMode();
     // Frames need not share a domain, and the clamped scale report is computed
     // from one. A scale picked on an earlier frame otherwise kept that frame's
@@ -1838,9 +1841,11 @@ void MainWindow::configureSequenceControls(
         const auto displayedIndex = displayedField
             ? m_fieldSelector->findData(*displayedField)
             : -1;
-        selectFieldItem(displayedIndex >= 0
-                ? displayedIndex
-                : std::clamp(previousField, 0, m_fieldSelector->count() - 1));
+        // Not clamped: std::clamp is undefined when the list is empty
+        // (count() - 1 < 0), and selectFieldItem takes any index and comes to
+        // rest on a field or on nothing.
+        selectFieldItem(
+            displayedIndex >= 0 ? displayedIndex : previousField);
         // The range memory is keyed by field id, and the ids moved with the
         // field list, so the widgets have to be told which field they now
         // represent or the next switch commits this frame's range onto
@@ -2043,12 +2048,12 @@ void MainWindow::setPlaybackMode(PlaybackMode mode)
         m_playbackTimer->start(m_animationPanel->frameDelayMs());
     }
     // Playback is why the reload stood aside: the next frame reads the list
-    // for itself, and stopping means there is no next frame. What is on
-    // screen was rendered against the list as it was, so it is reloaded here
-    // rather than left computing an expression the editor has replaced.
-    if (wasSequence && mode != PlaybackMode::Sequence
-        && m_frameSpecRevision != m_derivedFields->storeRevision()) {
-        reloadCurrentDataset();
+    // for itself, and stopping means there is no next frame. What is on screen
+    // may then have been rendered against an older list, and only the session
+    // itself can say -- a prefetch of the next frame is built from the current
+    // one, so "when was a spec last built" answers a different question.
+    if (wasSequence && mode != PlaybackMode::Sequence) {
+        reloadIfDefinitionsMoved();
     }
     // Every frame of a sequence renders the volume as a draft, so what is
     // standing in the window when playback stops is a half-size one. Ask for

--- a/src/qt/MainWindowTestAccess.cpp
+++ b/src/qt/MainWindowTestAccess.cpp
@@ -2,6 +2,16 @@
 
 namespace amrvis::qt {
 
+void MainWindow::setInitialSliceLaunchedHookForTest(std::function<void()> hook)
+{
+    m_initialSliceLaunchedForTest = std::move(hook);
+}
+
+std::optional<int> MainWindow::prefetchedSequenceFrameForTest() const
+{
+    return m_sequenceController->prefetchedFrameForTest();
+}
+
 void MainWindow::requestVisibleSyncForTest()
 {
     syncVisibleRanges();

--- a/src/qt/RangeController.cpp
+++ b/src/qt/RangeController.cpp
@@ -151,7 +151,13 @@ void RangeController::switchField(const QString& field)
     if (field == m_trackedField) {
         return;
     }
-    commitFieldRange(m_trackedField);
+    // Nothing tracked yet -- before the first setTrackedField, or where a
+    // selection could not come to rest on a field -- so there is no field
+    // whose range this is. Committing would file the widgets' current state
+    // under the empty name and hand it back to whatever asked for it next.
+    if (!m_trackedField.isEmpty()) {
+        commitFieldRange(m_trackedField);
+    }
     m_trackedField = field;
     applyFieldRange(field);
 }

--- a/src/qt/RangeController.cpp
+++ b/src/qt/RangeController.cpp
@@ -146,7 +146,7 @@ void RangeController::setNumberFormat(const QString& format)
     m_maximum->setNumberFormat(format);
 }
 
-void RangeController::switchField(std::uint32_t field)
+void RangeController::switchField(const QString& field)
 {
     if (field == m_trackedField) {
         return;
@@ -156,7 +156,7 @@ void RangeController::switchField(std::uint32_t field)
     applyFieldRange(field);
 }
 
-void RangeController::commitFieldRange(std::uint32_t field)
+void RangeController::commitFieldRange(const QString& field)
 {
     FieldRange range;
     range.mode = mode();
@@ -166,10 +166,10 @@ void RangeController::commitFieldRange(std::uint32_t field)
     m_fieldRanges[field] = std::move(range);
 }
 
-void RangeController::applyFieldRange(std::uint32_t field)
+void RangeController::applyFieldRange(const QString& field)
 {
-    const auto it = m_fieldRanges.find(field);
-    const auto range = it != m_fieldRanges.end() ? it->second : FieldRange{};
+    const auto it = m_fieldRanges.constFind(field);
+    const auto range = it != m_fieldRanges.constEnd() ? it.value() : FieldRange{};
     {
         const QSignalBlocker minBlocker(m_minimum);
         const QSignalBlocker maxBlocker(m_maximum);
@@ -185,7 +185,7 @@ void RangeController::applyFieldRange(std::uint32_t field)
 void RangeController::reset()
 {
     m_fieldRanges.clear();
-    m_trackedField = 0;
+    m_trackedField.clear();
     const QSignalBlocker minBlocker(m_minimum);
     const QSignalBlocker maxBlocker(m_maximum);
     setMode(RangeMode::File);
@@ -196,7 +196,7 @@ void RangeController::reset()
 }
 
 void RangeController::updateAvailability(
-    const Availability& availability, std::uint32_t field)
+    const Availability& availability, const QString& field)
 {
     auto* model = qobject_cast<QStandardItemModel*>(m_mode->model());
     if (model == nullptr) {

--- a/src/qt/RangeController.cpp
+++ b/src/qt/RangeController.cpp
@@ -164,6 +164,13 @@ void RangeController::switchField(const QString& field)
 
 void RangeController::commitFieldRange(const QString& field)
 {
+    // The empty name is not a field. Its callers can reach here with nothing
+    // tracked -- a restored spec commits whatever trackedField() says, and
+    // that is empty until a field is selected -- and a snapshot filed under
+    // it is handed back to the next switch as if it belonged to something.
+    if (field.isEmpty()) {
+        return;
+    }
     FieldRange range;
     range.mode = mode();
     if (range.mode == RangeMode::User) {
@@ -232,7 +239,11 @@ void RangeController::updateAvailability(
     setMode(RangeMode::Visible);
     m_minimum->setEnabled(false);
     m_maximum->setEnabled(false);
-    m_fieldRanges[field].mode = RangeMode::Visible;
+    if (!field.isEmpty()) {
+        // As commitFieldRange: nothing is remembered for a name that is not
+        // a field's, or the next switch to one inherits it.
+        m_fieldRanges[field].mode = RangeMode::Visible;
+    }
     emit statusMessage(
         tr("Metadata range unavailable; using the visible-data range."), 0);
 }

--- a/src/qt/RangeController.hpp
+++ b/src/qt/RangeController.hpp
@@ -2,12 +2,11 @@
 
 #include <amrexplorer/pipeline/SlicePipeline.hpp>
 
+#include <QHash>
 #include <QObject>
 #include <QString>
 
-#include <cstdint>
 #include <optional>
-#include <unordered_map>
 #include <utility>
 
 class QCheckBox;
@@ -68,28 +67,32 @@ public:
     void setControlsReady(bool ready);
     void setNumberFormat(const QString& format);
 
-    // Per-field memory. The widgets represent trackedField(); switchField
-    // snapshots them for that field and loads the new field's snapshot (or
-    // the default: File, no range) -- a no-op for the same field. commit
-    // snapshots the widgets for a field outright (a restore, after
-    // setSelection). reset forgets every field for a fresh dataset and puts
-    // the widgets back to File, 0..1, min/max disabled.
-    void switchField(std::uint32_t field);
-    void commitFieldRange(std::uint32_t field);
+    // Per-field memory, keyed by the field's *name*. The widgets represent
+    // trackedField(); switchField snapshots them for that field and loads the
+    // new field's snapshot (or the default: File, no range) -- a no-op for the
+    // same field. commit snapshots the widgets for a field outright (a
+    // restore, after setSelection). reset forgets every field for a fresh
+    // dataset and puts the widgets back to File, 0..1, min/max disabled.
+    //
+    // By name and not by field id: an id means something only in the field
+    // list it came from, and that list moves -- a sequence frame need not
+    // agree with the last one, and a derived definition that one frame cannot
+    // resolve compacts every id after it. Keyed by id, selecting a field then
+    // restored whichever field used to hold that number.
+    void switchField(const QString& field);
+    void commitFieldRange(const QString& field);
     void reset();
-    [[nodiscard]] std::uint32_t trackedField() const noexcept
+    [[nodiscard]] const QString& trackedField() const noexcept
     {
         return m_trackedField;
     }
-    void setTrackedField(std::uint32_t field) noexcept
-    {
-        m_trackedField = field;
-    }
+    void setTrackedField(const QString& field) { m_trackedField = field; }
     // Enables or disables the File and Level entries for what `field` at the
     // current level can offer. A selected mode that became unavailable falls
     // back to Visible (recorded in the field's snapshot) with a status
     // message; that fallback is silent otherwise -- no modeChanged.
-    void updateAvailability(const Availability& availability, std::uint32_t field);
+    void updateAvailability(
+        const Availability& availability, const QString& field);
 
 signals:
     // A user's edit of the mode, of a User bound, or of Log. Blocked writes
@@ -106,7 +109,7 @@ private:
     };
 
     void setMode(RangeMode mode);
-    void applyFieldRange(std::uint32_t field);
+    void applyFieldRange(const QString& field);
     void updateUserRangeEnabled();
 
     QComboBox* m_mode = nullptr;
@@ -114,8 +117,8 @@ private:
     ScientificDoubleSpinBox* m_maximum = nullptr;
     QCheckBox* m_logarithmic = nullptr;
     bool m_controlsReady = false;
-    std::unordered_map<std::uint32_t, FieldRange> m_fieldRanges;
-    std::uint32_t m_trackedField = 0;
+    QHash<QString, FieldRange> m_fieldRanges;
+    QString m_trackedField;
 };
 
 } // namespace amrvis::qt

--- a/src/qt/SequenceController.hpp
+++ b/src/qt/SequenceController.hpp
@@ -107,6 +107,17 @@ signals:
     // dropped; the host counts these in its diagnostics.
     void staleResultDropped();
 
+public:
+    // The frame sitting in the prefetch slot, if any. A frame prefetched
+    // before the derived-field list changed was rendered against the list as
+    // it was, so a change has to have dropped it (invalidatePrefetch).
+    [[nodiscard]] std::optional<int> prefetchedFrameForTest() const
+    {
+        return m_prefetched
+            ? std::optional<int>{m_prefetched->frameIndex}
+            : std::nullopt;
+    }
+
 private:
     // One prefetched sequence frame: the dataset plus its rendered slice(s),
     // consumable only while the slice spec that produced it is unchanged.

--- a/src/qt/SmokeHarness.cpp
+++ b/src/qt/SmokeHarness.cpp
@@ -4,7 +4,6 @@
 
 #include <QString>
 
-
 #include <amrexplorer/remote/Connection.hpp>
 #include <amrexplorer/remote/Server.hpp>
 

--- a/src/qt/SmokeHarness.cpp
+++ b/src/qt/SmokeHarness.cpp
@@ -2,11 +2,8 @@
 
 #include "MainWindow.hpp"
 
-#include <QSettings>
 #include <QString>
 
-#include <cstdlib>
-#include <string_view>
 
 #include <amrexplorer/remote/Connection.hpp>
 #include <amrexplorer/remote/Server.hpp>
@@ -34,38 +31,6 @@ void attachSmokeServer(amrvis::qt::MainWindow& window,
                 .clientName = "AMReXplorer Qt smoke",
                 .sessionToken = server->token()}),
         QStringLiteral("127.0.0.1:%1").arg(server->port()));
-}
-
-void isolateSettings(int argc, char** argv)
-{
-    if (argc < 2) {
-        return;
-    }
-    const std::string_view option(argv[1]);
-    if (option.find("-smoke-test") == std::string_view::npos
-        && option.find("-repro") == std::string_view::npos) {
-        return;
-    }
-#if defined(_MSC_VER)
-    char* configured = nullptr;
-    std::size_t configuredSize = 0;
-    if (::_dupenv_s(&configured, &configuredSize, "XDG_CONFIG_HOME") != 0) {
-        return;
-    }
-    const auto directory = configured == nullptr
-        ? QString() : QString::fromLocal8Bit(configured);
-    std::free(configured);
-#else
-    const auto* configured = std::getenv("XDG_CONFIG_HOME");
-    const auto directory = configured == nullptr
-        ? QString() : QString::fromLocal8Bit(configured);
-#endif
-    if (directory.isEmpty()) {
-        return;
-    }
-    QSettings::setDefaultFormat(QSettings::IniFormat);
-    QSettings::setPath(
-        QSettings::IniFormat, QSettings::UserScope, directory);
 }
 
 Outcome dispatch(Context& context)

--- a/src/qt/SmokeHarness.cpp
+++ b/src/qt/SmokeHarness.cpp
@@ -44,7 +44,8 @@ Outcome dispatch(Context& context)
              &dispatchZoom,
              &dispatchFab,
              &dispatchSequence,
-             &dispatchVolume
+             &dispatchVolume,
+             &dispatchDerived
          }) {
         if (auto outcome = themed(context); outcome.handled) {
             return outcome;

--- a/src/qt/SmokeHarness.cpp
+++ b/src/qt/SmokeHarness.cpp
@@ -2,7 +2,11 @@
 
 #include "MainWindow.hpp"
 
+#include <QSettings>
 #include <QString>
+
+#include <cstdlib>
+#include <string_view>
 
 #include <amrexplorer/remote/Connection.hpp>
 #include <amrexplorer/remote/Server.hpp>
@@ -30,6 +34,38 @@ void attachSmokeServer(amrvis::qt::MainWindow& window,
                 .clientName = "AMReXplorer Qt smoke",
                 .sessionToken = server->token()}),
         QStringLiteral("127.0.0.1:%1").arg(server->port()));
+}
+
+void isolateSettings(int argc, char** argv)
+{
+    if (argc < 2) {
+        return;
+    }
+    const std::string_view option(argv[1]);
+    if (option.find("-smoke-test") == std::string_view::npos
+        && option.find("-repro") == std::string_view::npos) {
+        return;
+    }
+#if defined(_MSC_VER)
+    char* configured = nullptr;
+    std::size_t configuredSize = 0;
+    if (::_dupenv_s(&configured, &configuredSize, "XDG_CONFIG_HOME") != 0) {
+        return;
+    }
+    const auto directory = configured == nullptr
+        ? QString() : QString::fromLocal8Bit(configured);
+    std::free(configured);
+#else
+    const auto* configured = std::getenv("XDG_CONFIG_HOME");
+    const auto directory = configured == nullptr
+        ? QString() : QString::fromLocal8Bit(configured);
+#endif
+    if (directory.isEmpty()) {
+        return;
+    }
+    QSettings::setDefaultFormat(QSettings::IniFormat);
+    QSettings::setPath(
+        QSettings::IniFormat, QSettings::UserScope, directory);
 }
 
 Outcome dispatch(Context& context)

--- a/src/qt/SmokeHarness.hpp
+++ b/src/qt/SmokeHarness.hpp
@@ -42,16 +42,6 @@ struct Outcome {
     std::optional<int> exitCode;
 };
 
-// Points QSettings at a store of this run's own, before anything reads one.
-// A scenario persists settings deliberately -- the derived-field ones apply a
-// definition in one run and expect it back in the next -- so each test needs
-// its own store, which the driver arranges through XDG_CONFIG_HOME. QSettings
-// honours that on Unix only: on Windows it is registry-backed, where every
-// test of a run shares one key and they overwrite each other's state. Pinning
-// the format and the path makes the driver's isolation hold everywhere. A
-// no-op unless argv names a smoke scenario.
-void isolateSettings(int argc, char** argv);
-
 // Arms the scenario argv names, exactly as the inline branches in main() did:
 // connections and single-shot timers on the window and the application.
 // {false, nullopt} for a non-smoke option.

--- a/src/qt/SmokeHarness.hpp
+++ b/src/qt/SmokeHarness.hpp
@@ -42,6 +42,16 @@ struct Outcome {
     std::optional<int> exitCode;
 };
 
+// Points QSettings at a store of this run's own, before anything reads one.
+// A scenario persists settings deliberately -- the derived-field ones apply a
+// definition in one run and expect it back in the next -- so each test needs
+// its own store, which the driver arranges through XDG_CONFIG_HOME. QSettings
+// honours that on Unix only: on Windows it is registry-backed, where every
+// test of a run shares one key and they overwrite each other's state. Pinning
+// the format and the path makes the driver's isolation hold everywhere. A
+// no-op unless argv names a smoke scenario.
+void isolateSettings(int argc, char** argv);
+
 // Arms the scenario argv names, exactly as the inline branches in main() did:
 // connections and single-shot timers on the window and the application.
 // {false, nullopt} for a non-smoke option.

--- a/src/qt/SmokeHarnessDerived.cpp
+++ b/src/qt/SmokeHarnessDerived.cpp
@@ -11,7 +11,6 @@
 #include <QMenuBar>
 #include <QPlainTextEdit>
 #include <QPushButton>
-#include <QStatusBar>
 #include <QStringList>
 #include <QTimer>
 
@@ -42,6 +41,11 @@ QStringList fieldNames(const amrvis::qt::MainWindow& window)
         return names;
     }
     for (int index = 0; index < selector->count(); ++index) {
+        // Fields carry their id as item data; the separator between the stored
+        // and the derived ones carries none.
+        if (!selector->itemData(index).isValid()) {
+            continue;
+        }
         names.append(selector->itemText(index));
     }
     return names;
@@ -87,52 +91,6 @@ bool errorShown(const amrvis::qt::ExpressionEditorDialog& dialog)
     const auto* error =
         dialog.findChild<QLabel*>(QStringLiteral("expressionError"));
     return error != nullptr && error->isVisible() && !error->text().isEmpty();
-}
-
-// Arms the follow-on scenarios, which run in the same isolated settings store
-// the accept scenario above wrote to: the committed list comes back on the next
-// launch, and a dataset that cannot satisfy it still opens without the
-// definition and without an error. `expected` is the field list the selector
-// must show once the dataset is up.
-void armRestoreChecks(amrvis::qt::MainWindow& window, QApplication& application,
-    QStringList expected, bool expectSkipReport)
-{
-    QObject::connect(&window, &amrvis::qt::MainWindow::initialSliceFinished,
-        &application,
-        [&window, &application, expected = std::move(expected),
-            expectSkipReport](bool success) {
-            if (!success) {
-                qCritical("the dataset did not open with a restored list");
-                application.exit(2);
-                return;
-            }
-            const auto names = fieldNames(window);
-            if (names != expected) {
-                qCritical("the restored list produced the wrong fields: %s",
-                    qPrintable(names.join(QStringLiteral(", "))));
-                application.exit(3);
-                return;
-            }
-            // A definition this dataset cannot satisfy is left out, not
-            // reported as a failure: the open is a success either way.
-            if (window.backgroundErrorCountForTest() != 0) {
-                qCritical("a skipped definition was reported as an error");
-                application.exit(4);
-                return;
-            }
-            // It has to be *said*, though: a definition silently missing from
-            // the field list is the failure mode this reports against.
-            const auto message = window.statusBar()->currentMessage();
-            const auto reported = message.contains(QStringLiteral("product"))
-                && message.contains(QStringLiteral("unavailable"));
-            if (reported != expectSkipReport) {
-                qCritical("the status bar said \"%s\"", qPrintable(message));
-                application.exit(5);
-                return;
-            }
-            application.exit(0);
-        });
-    QTimer::singleShot(30000, &application, [&application] { application.exit(13); });
 }
 
 // Arms the scenario on `window`: exit 0 once a derived field has been
@@ -284,7 +242,25 @@ void armDerivedChecks(amrvis::qt::MainWindow& window, QApplication& application)
                 }
                 auto* selector = window.findChild<QComboBox*>(
                     QStringLiteral("fieldSelector"));
-                selector->setCurrentIndex(2);
+                // The derived field is set apart from the stored ones, and
+                // says what it is: the separator sits directly before it, and
+                // the entry carries its expression as a tooltip.
+                const auto product = selector->findData(2U);
+                if (product < 1 || selector->itemData(product - 1).isValid()) {
+                    qCritical("no separator precedes the derived field");
+                    finish(14);
+                    return;
+                }
+                if (selector->itemData(product, Qt::ToolTipRole).toString()
+                    != QStringLiteral("density * temperature")) {
+                    qCritical("the derived field carries no expression: %s",
+                        qPrintable(selector
+                                ->itemData(product, Qt::ToolTipRole)
+                                .toString()));
+                    finish(15);
+                    return;
+                }
+                selector->setCurrentIndex(product);
                 *phase = 4;
                 return;
             }
@@ -426,21 +402,10 @@ Outcome dispatchDerived(Context& context)
     }
     const std::string_view option(context.argv[1]);
     const std::filesystem::path path(context.argv[2]);
-    if (option == "--derived-field-smoke-test") {
-        armDerivedChecks(window, application);
-    } else if (option == "--derived-field-restore-smoke-test") {
-        // The definition the accept scenario applied, persisted by it.
-        armRestoreChecks(window, application,
-            QStringList{QStringLiteral("density"),
-                QStringLiteral("temperature"), QStringLiteral("product")},
-            false);
-    } else if (option == "--derived-field-skip-smoke-test") {
-        // A dataset with neither field the persisted definition reads.
-        armRestoreChecks(
-            window, application, QStringList{QStringLiteral("q")}, true);
-    } else {
+    if (option != "--derived-field-smoke-test") {
         return {false, std::nullopt};
     }
+    armDerivedChecks(window, application);
     QTimer::singleShot(
         0, &window, [&window, path] { window.openDataset(path); });
     return {true, std::nullopt};

--- a/src/qt/SmokeHarnessDerived.cpp
+++ b/src/qt/SmokeHarnessDerived.cpp
@@ -254,17 +254,27 @@ void armDerivedChecks(amrvis::qt::MainWindow& window, QApplication& application)
                     return;
                 }
                 // And the Variable menu, which is the same selection shown
-                // twice and has its own rebuild.
-                const auto actions = window.menuBar()->actions();
+                // twice and has its own rebuild. That menu alone: scanning
+                // every menu would pass on the name turning up anywhere at
+                // all, which is not what the failure below claims.
+                const QMenu* variableMenu = nullptr;
+                for (const auto* menuAction : window.menuBar()->actions()) {
+                    auto* menu = menuAction->menu();
+                    if (menu != nullptr
+                        && menuAction->text().remove(QLatin1Char('&'))
+                            == QStringLiteral("Variable")) {
+                        variableMenu = menu;
+                    }
+                }
+                if (variableMenu == nullptr) {
+                    qCritical("there is no Variable menu to look in");
+                    finish(10);
+                    return;
+                }
                 bool inVariableMenu = false;
-                for (const auto* menuAction : actions) {
-                    if (menuAction->menu() == nullptr) {
-                        continue;
-                    }
-                    for (const auto* entry : menuAction->menu()->actions()) {
-                        inVariableMenu = inVariableMenu
-                            || entry->text() == QStringLiteral("product");
-                    }
+                for (const auto* entry : variableMenu->actions()) {
+                    inVariableMenu = inVariableMenu
+                        || entry->text() == QStringLiteral("product");
                 }
                 if (!inVariableMenu) {
                     qCritical("the derived field did not reach the Variable "

--- a/src/qt/SmokeHarnessDerived.cpp
+++ b/src/qt/SmokeHarnessDerived.cpp
@@ -1,0 +1,439 @@
+#include "SmokeHarnessInternal.hpp"
+
+#include "ExpressionEditorDialog.hpp"
+#include "MainWindow.hpp"
+
+#include <QAction>
+#include <QComboBox>
+#include <QLabel>
+#include <QLineEdit>
+#include <QMenu>
+#include <QMenuBar>
+#include <QPlainTextEdit>
+#include <QPushButton>
+#include <QStatusBar>
+#include <QStringList>
+#include <QTimer>
+
+#include <filesystem>
+#include <memory>
+#include <string_view>
+#include <vector>
+
+// Derived fields: the Variable menu's Expression Editor over a local
+// plotfile, driven through the real action, the real dialog widgets and the
+// real Apply, which reopens the dataset with the definition installed. What
+// this covers and the data-layer tests cannot: that the action is reachable
+// and enabled, that a refused definition is reported in the dialog and
+// changes nothing, and that an accepted one reaches the field selector and
+// the Variable menu and renders when selected. The values themselves are
+// test_derived_field_query's business.
+
+namespace amrvis::qt::smoke {
+
+namespace {
+
+QStringList fieldNames(const amrvis::qt::MainWindow& window)
+{
+    QStringList names;
+    const auto* selector =
+        window.findChild<QComboBox*>(QStringLiteral("fieldSelector"));
+    if (selector == nullptr) {
+        return names;
+    }
+    for (int index = 0; index < selector->count(); ++index) {
+        names.append(selector->itemText(index));
+    }
+    return names;
+}
+
+// Fills the dialog's editor with one definition, replacing whatever is there:
+// New, then the name and expression through the same widgets a user types in.
+bool writeDefinition(amrvis::qt::ExpressionEditorDialog& dialog,
+    const QString& name, const QString& expression)
+{
+    auto* add =
+        dialog.findChild<QPushButton*>(QStringLiteral("newExpressionButton"));
+    auto* nameEdit =
+        dialog.findChild<QLineEdit*>(QStringLiteral("expressionName"));
+    auto* source =
+        dialog.findChild<QPlainTextEdit*>(QStringLiteral("expressionSource"));
+    if (add == nullptr || nameEdit == nullptr || source == nullptr) {
+        return false;
+    }
+    if (dialog.draft().empty()) {
+        add->click();
+    }
+    nameEdit->setText(name);
+    source->setPlainText(expression);
+    return dialog.draft().size() == 1
+        && dialog.draft().front().name == name.toStdString()
+        && dialog.draft().front().expression == expression.toStdString();
+}
+
+bool clickApply(amrvis::qt::ExpressionEditorDialog& dialog)
+{
+    auto* apply = dialog.findChild<QPushButton*>(
+        QStringLiteral("applyExpressionsButton"));
+    if (apply == nullptr) {
+        return false;
+    }
+    apply->click();
+    return true;
+}
+
+bool errorShown(const amrvis::qt::ExpressionEditorDialog& dialog)
+{
+    const auto* error =
+        dialog.findChild<QLabel*>(QStringLiteral("expressionError"));
+    return error != nullptr && error->isVisible() && !error->text().isEmpty();
+}
+
+// Arms the follow-on scenarios, which run in the same isolated settings store
+// the accept scenario above wrote to: the committed list comes back on the next
+// launch, and a dataset that cannot satisfy it still opens without the
+// definition and without an error. `expected` is the field list the selector
+// must show once the dataset is up.
+void armRestoreChecks(amrvis::qt::MainWindow& window, QApplication& application,
+    QStringList expected, bool expectSkipReport)
+{
+    QObject::connect(&window, &amrvis::qt::MainWindow::initialSliceFinished,
+        &application,
+        [&window, &application, expected = std::move(expected),
+            expectSkipReport](bool success) {
+            if (!success) {
+                qCritical("the dataset did not open with a restored list");
+                application.exit(2);
+                return;
+            }
+            const auto names = fieldNames(window);
+            if (names != expected) {
+                qCritical("the restored list produced the wrong fields: %s",
+                    qPrintable(names.join(QStringLiteral(", "))));
+                application.exit(3);
+                return;
+            }
+            // A definition this dataset cannot satisfy is left out, not
+            // reported as a failure: the open is a success either way.
+            if (window.backgroundErrorCountForTest() != 0) {
+                qCritical("a skipped definition was reported as an error");
+                application.exit(4);
+                return;
+            }
+            // It has to be *said*, though: a definition silently missing from
+            // the field list is the failure mode this reports against.
+            const auto message = window.statusBar()->currentMessage();
+            const auto reported = message.contains(QStringLiteral("product"))
+                && message.contains(QStringLiteral("unavailable"));
+            if (reported != expectSkipReport) {
+                qCritical("the status bar said \"%s\"", qPrintable(message));
+                application.exit(5);
+                return;
+            }
+            application.exit(0);
+        });
+    QTimer::singleShot(30000, &application, [&application] { application.exit(13); });
+}
+
+// Arms the scenario on `window`: exit 0 once a derived field has been
+// refused, accepted, and rendered; a nonzero code names the step that failed.
+void armDerivedChecks(amrvis::qt::MainWindow& window, QApplication& application)
+{
+    auto phase = std::make_shared<int>(0);
+    auto loads = std::make_shared<int>(0);
+    QObject::connect(&window, &amrvis::qt::MainWindow::initialSliceFinished,
+        &application, [&application, loads](bool success) {
+            if (!success) {
+                application.exit(2);
+                return;
+            }
+            ++*loads;
+        });
+
+    auto* timer = new QTimer(&window);
+    timer->setInterval(25);
+    QObject::connect(timer, &QTimer::timeout, &application,
+        [&window, &application, phase, loads, timer] {
+            const auto finish = [&application, timer](int code) {
+                timer->stop();
+                application.exit(code);
+            };
+            if (*loads == 0) {
+                return;  // the dataset is still opening
+            }
+            auto* dialog =
+                window.findChild<amrvis::qt::ExpressionEditorDialog*>();
+
+            if (*phase == 0) {
+                if (fieldNames(window)
+                    != QStringList{QStringLiteral("density"),
+                        QStringLiteral("temperature")}) {
+                    qCritical("the fixture's own fields are not listed");
+                    finish(3);
+                    return;
+                }
+                auto* action = window.findChild<QAction*>(
+                    QStringLiteral("expressionEditorAction"));
+                if (action == nullptr || !action->isEnabled()) {
+                    qCritical("the Expression Editor action is not available "
+                              "over a local plotfile");
+                    finish(4);
+                    return;
+                }
+                action->trigger();
+                *phase = 1;
+                return;
+            }
+            if (*phase == 1) {
+                if (dialog == nullptr) {
+                    qCritical("the Expression Editor did not open");
+                    finish(5);
+                    return;
+                }
+                // A refusal must be reported in place and change nothing: not
+                // the field list, and not the dataset (no reload).
+                if (!writeDefinition(*dialog, QStringLiteral("product"),
+                        QStringLiteral("density * nonesuch"))) {
+                    qCritical("the editor did not take the definition");
+                    finish(6);
+                    return;
+                }
+                if (!clickApply(*dialog)) {
+                    qCritical("the editor has no Apply button");
+                    finish(6);
+                    return;
+                }
+                if (!errorShown(*dialog)) {
+                    qCritical("an unresolvable definition was not refused");
+                    finish(7);
+                    return;
+                }
+                if (*loads != 1 || fieldNames(window).size() != 2) {
+                    qCritical("a refused definition still changed the fields");
+                    finish(7);
+                    return;
+                }
+                *phase = 2;
+                return;
+            }
+            if (*phase == 2) {
+                if (dialog == nullptr) {
+                    qCritical("the editor closed on a refusal");
+                    finish(5);
+                    return;
+                }
+                if (!writeDefinition(*dialog, QStringLiteral("product"),
+                        QStringLiteral("density * temperature"))
+                    || !clickApply(*dialog)) {
+                    qCritical("the editor did not take the corrected "
+                              "definition");
+                    finish(6);
+                    return;
+                }
+                if (errorShown(*dialog)) {
+                    qCritical("a resolvable definition was refused");
+                    finish(8);
+                    return;
+                }
+                *phase = 3;
+                return;
+            }
+            if (*phase == 3) {
+                // Apply reopens the dataset: wait for that load to land.
+                if (*loads < 2) {
+                    return;
+                }
+                const auto names = fieldNames(window);
+                if (names
+                    != QStringList{QStringLiteral("density"),
+                        QStringLiteral("temperature"),
+                        QStringLiteral("product")}) {
+                    qCritical("the derived field did not reach the field "
+                              "selector");
+                    finish(9);
+                    return;
+                }
+                // And the Variable menu, which is the same selection shown
+                // twice and has its own rebuild.
+                const auto actions = window.menuBar()->actions();
+                bool inVariableMenu = false;
+                for (const auto* menuAction : actions) {
+                    if (menuAction->menu() == nullptr) {
+                        continue;
+                    }
+                    for (const auto* entry : menuAction->menu()->actions()) {
+                        inVariableMenu = inVariableMenu
+                            || entry->text() == QStringLiteral("product");
+                    }
+                }
+                if (!inVariableMenu) {
+                    qCritical("the derived field did not reach the Variable "
+                              "menu");
+                    finish(10);
+                    return;
+                }
+                auto* selector = window.findChild<QComboBox*>(
+                    QStringLiteral("fieldSelector"));
+                selector->setCurrentIndex(2);
+                *phase = 4;
+                return;
+            }
+            if (*phase == 4) {
+                if (window.sliceRequestPendingForTest()
+                    || window.slicesInFlightForTest() != 0) {
+                    return;  // the debounced re-slice is still coming
+                }
+                const auto size = window.activeViewImageSizeForTest();
+                if (size[0] <= 0 || size[1] <= 0) {
+                    qCritical("selecting the derived field rendered nothing");
+                    finish(11);
+                    return;
+                }
+                if (window.backgroundErrorCountForTest() != 0) {
+                    qCritical("the derived field's slice reported an error");
+                    finish(12);
+                    return;
+                }
+                finish(0);
+            }
+        });
+    timer->start();
+    QTimer::singleShot(30000, &application, [&application] { application.exit(13); });
+}
+
+// Arms the sequence scenario: applying a definition while a plotfile sequence
+// is open must reload the frame on screen *and* leave the sequence navigable,
+// with the definition surviving the next frame switch. A reload that went
+// through the ordinary open path would end the sequence instead.
+void armSequenceChecks(amrvis::qt::MainWindow& window, QApplication& application)
+{
+    auto phase = std::make_shared<int>(0);
+    auto frames = std::make_shared<int>(0);
+    const QStringList expected{QStringLiteral("density"),
+        QStringLiteral("temperature"), QStringLiteral("product")};
+    QObject::connect(&window, &amrvis::qt::MainWindow::sequenceFrameDisplayed,
+        &application, [frames](int) { ++*frames; });
+
+    auto* timer = new QTimer(&window);
+    timer->setInterval(25);
+    QObject::connect(timer, &QTimer::timeout, &application,
+        [&window, &application, phase, frames, timer, expected] {
+            const auto finish = [&application, timer](int code) {
+                timer->stop();
+                application.exit(code);
+            };
+            if (*frames == 0) {
+                return;  // frame 0 is still loading
+            }
+            auto* dialog =
+                window.findChild<amrvis::qt::ExpressionEditorDialog*>();
+            if (*phase == 0) {
+                window
+                    .findChild<QAction*>(
+                        QStringLiteral("expressionEditorAction"))
+                    ->trigger();
+                *phase = 1;
+                return;
+            }
+            if (*phase == 1) {
+                if (dialog == nullptr
+                    || !writeDefinition(*dialog, QStringLiteral("product"),
+                        QStringLiteral("density * temperature"))
+                    || !clickApply(*dialog) || errorShown(*dialog)) {
+                    qCritical("the editor refused the definition over a "
+                              "sequence");
+                    finish(6);
+                    return;
+                }
+                *phase = 2;
+                return;
+            }
+            if (*phase == 2) {
+                // The reload displays a frame of its own.
+                if (*frames < 2) {
+                    return;
+                }
+                if (fieldNames(window) != expected) {
+                    qCritical("the reload did not install the definition");
+                    finish(9);
+                    return;
+                }
+                // And the sequence is still a sequence: stepping to the other
+                // frame must work and keep the derived field.
+                window.requestSequenceFrameForTest(1);
+                *phase = 3;
+                return;
+            }
+            if (*phase == 3) {
+                if (*frames < 3) {
+                    return;
+                }
+                if (fieldNames(window) != expected) {
+                    qCritical("the derived field did not survive a frame "
+                              "switch");
+                    finish(10);
+                    return;
+                }
+                if (window.backgroundErrorCountForTest() != 0) {
+                    qCritical("the sequence reported an error");
+                    finish(12);
+                    return;
+                }
+                finish(0);
+            }
+        });
+    timer->start();
+    QTimer::singleShot(30000, &application, [&application] { application.exit(13); });
+}
+
+Outcome dispatchDerivedSequence(Context& context)
+{
+    if (context.argc != 4
+        || std::string_view(context.argv[1])
+            != "--derived-field-sequence-smoke-test") {
+        return {false, std::nullopt};
+    }
+    const std::vector<std::filesystem::path> frames{
+        std::filesystem::path(context.argv[2]),
+        std::filesystem::path(context.argv[3])};
+    armSequenceChecks(context.window, context.application);
+    QTimer::singleShot(0, &context.window,
+        [&window = context.window, frames] { window.openSequence(frames); });
+    return {true, std::nullopt};
+}
+
+} // namespace
+
+Outcome dispatchDerived(Context& context)
+{
+    if (auto outcome = dispatchDerivedSequence(context); outcome.handled) {
+        return outcome;
+    }
+    auto& application = context.application;
+    auto& window = context.window;
+    if (context.argc != 3) {
+        return {false, std::nullopt};
+    }
+    const std::string_view option(context.argv[1]);
+    const std::filesystem::path path(context.argv[2]);
+    if (option == "--derived-field-smoke-test") {
+        armDerivedChecks(window, application);
+    } else if (option == "--derived-field-restore-smoke-test") {
+        // The definition the accept scenario applied, persisted by it.
+        armRestoreChecks(window, application,
+            QStringList{QStringLiteral("density"),
+                QStringLiteral("temperature"), QStringLiteral("product")},
+            false);
+    } else if (option == "--derived-field-skip-smoke-test") {
+        // A dataset with neither field the persisted definition reads.
+        armRestoreChecks(
+            window, application, QStringList{QStringLiteral("q")}, true);
+    } else {
+        return {false, std::nullopt};
+    }
+    QTimer::singleShot(
+        0, &window, [&window, path] { window.openDataset(path); });
+    return {true, std::nullopt};
+}
+
+} // namespace amrvis::qt::smoke

--- a/src/qt/SmokeHarnessDerived.cpp
+++ b/src/qt/SmokeHarnessDerived.cpp
@@ -13,6 +13,7 @@
 #include <QMenuBar>
 #include <QPlainTextEdit>
 #include <QPushButton>
+#include <QStandardItemModel>
 #include <QStringList>
 #include <QTimer>
 
@@ -75,6 +76,27 @@ bool writeDefinition(amrvis::qt::ExpressionEditorDialog& dialog,
     return dialog.draft().size() == 1
         && dialog.draft().front().name == name.toStdString()
         && dialog.draft().front().expression == expression.toStdString();
+}
+
+// Adds a further definition rather than replacing the first.
+bool appendDefinition(amrvis::qt::ExpressionEditorDialog& dialog,
+    const QString& name, const QString& expression)
+{
+    auto* add =
+        dialog.findChild<QPushButton*>(QStringLiteral("newExpressionButton"));
+    auto* nameEdit =
+        dialog.findChild<QLineEdit*>(QStringLiteral("expressionName"));
+    auto* source =
+        dialog.findChild<QPlainTextEdit*>(QStringLiteral("expressionSource"));
+    if (add == nullptr || nameEdit == nullptr || source == nullptr) {
+        return false;
+    }
+    const auto before = dialog.draft().size();
+    add->click();
+    nameEdit->setText(name);
+    source->setPlainText(expression);
+    return dialog.draft().size() == before + 1
+        && dialog.draft().back().name == name.toStdString();
 }
 
 bool clickApply(amrvis::qt::ExpressionEditorDialog& dialog)
@@ -242,9 +264,13 @@ void armDerivedChecks(amrvis::qt::MainWindow& window, QApplication& application)
                     return;
                 }
                 // A refusal must be reported in place and change nothing: not
-                // the field list, and not the dataset (no reload).
+                // the field list, and not the dataset (no reload). What is
+                // refused is what is wrong whatever the data -- here, an
+                // expression that does not parse. A name this dataset happens
+                // not to have is *not* refused; it is dimmed, which phase 4
+                // checks.
                 if (!writeDefinition(*dialog, QStringLiteral("product"),
-                        QStringLiteral("density * nonesuch"))) {
+                        QStringLiteral("density *"))) {
                     qCritical("the editor did not take the definition");
                     finish(6);
                     return;
@@ -255,7 +281,7 @@ void armDerivedChecks(amrvis::qt::MainWindow& window, QApplication& application)
                     return;
                 }
                 if (!errorShown(*dialog)) {
-                    qCritical("an unresolvable definition was not refused");
+                    qCritical("an unparsable expression was not refused");
                     finish(7);
                     return;
                 }
@@ -334,8 +360,49 @@ void armDerivedChecks(amrvis::qt::MainWindow& window, QApplication& application)
                     finish(10);
                     return;
                 }
+                // A definition this dataset cannot satisfy is accepted and
+                // shown greyed out rather than refused: the list is shared
+                // with windows that may well be able to satisfy it.
+                if (!appendDefinition(*dialog, QStringLiteral("elsewhere"),
+                        QStringLiteral("nonesuch * 2"))
+                    || !clickApply(*dialog) || errorShown(*dialog)) {
+                    qCritical("a definition for another dataset was refused");
+                    finish(14);
+                    return;
+                }
+                *phase = 4;
+                return;
+            }
+            if (*phase == 4) {
+                if (*loads < 3) {
+                    return;
+                }
                 auto* selector = window.findChild<QComboBox*>(
                     QStringLiteral("fieldSelector"));
+                const auto unavailable =
+                    selector->findText(QStringLiteral("elsewhere"));
+                if (unavailable < 0
+                    || selector->itemData(unavailable).isValid()) {
+                    qCritical("the unavailable definition is not listed, or "
+                              "is listed as a field");
+                    finish(15);
+                    return;
+                }
+                const auto* model = qobject_cast<const QStandardItemModel*>(
+                    selector->model());
+                if (model == nullptr
+                    || model->item(unavailable)->isEnabled()) {
+                    qCritical("the unavailable definition is not dimmed");
+                    finish(16);
+                    return;
+                }
+                if (!selector->itemData(unavailable, Qt::ToolTipRole)
+                        .toString()
+                        .contains(QStringLiteral("unavailable"))) {
+                    qCritical("the dimmed entry does not say why");
+                    finish(17);
+                    return;
+                }
                 // The derived field is set apart from the stored ones, and
                 // says what it is: the separator sits directly before it, and
                 // the entry carries its expression as a tooltip.
@@ -356,10 +423,10 @@ void armDerivedChecks(amrvis::qt::MainWindow& window, QApplication& application)
                     return;
                 }
                 selector->setCurrentIndex(product);
-                *phase = 4;
+                *phase = 5;
                 return;
             }
-            if (*phase == 4) {
+            if (*phase == 5) {
                 if (window.sliceRequestPendingForTest()
                     || window.slicesInFlightForTest() != 0) {
                     return;  // the debounced re-slice is still coming

--- a/src/qt/SmokeHarnessDerived.cpp
+++ b/src/qt/SmokeHarnessDerived.cpp
@@ -566,6 +566,9 @@ void armSequenceChecks(
     auto frames = std::make_shared<int>(0);
     // Bounds the wait for a prefetch in phase 4.
     auto ticks = std::make_shared<int>(0);
+    // The frame count when playback was stopped, so the reload that follows
+    // can be told from the frames playback itself displayed.
+    auto framesAtStop = std::make_shared<int>(0);
     // Both frames list the same fields, so the frame stepped to lists what
     // this one does; frames that disagree are armFrameIdentityChecks.
     const QStringList expected{QStringLiteral("density"),
@@ -576,7 +579,8 @@ void armSequenceChecks(
     auto* timer = new QTimer(&window);
     timer->setInterval(25);
     QObject::connect(timer, &QTimer::timeout, &application,
-        [&window, &application, phase, frames, ticks, timer, expected] {
+        [&window, &application, phase, frames, ticks, framesAtStop, timer,
+            expected] {
             ++*ticks;
             const auto finish = [&application, timer](int code) {
                 timer->stop();
@@ -700,7 +704,40 @@ void armSequenceChecks(
                     finish(17);
                     return;
                 }
+                // Stopping now is the case the prefetch drop cannot cover:
+                // there is no next frame to read the list, so the frame on
+                // screen would go on computing the old expression.
+                *framesAtStop = *frames;
+                *ticks = 0;
                 window.toggleSequencePlaybackForTest();
+                *phase = 5;
+                return;
+            }
+            if (*phase == 5) {
+                if (*frames == *framesAtStop
+                    || window.sliceRequestPendingForTest()
+                    || window.slicesInFlightForTest() != 0) {
+                    if (*ticks > 200) {
+                        qCritical("stopping playback after an Apply never "
+                                  "reloaded the frame on screen");
+                        finish(18);
+                        return;
+                    }
+                    return;
+                }
+                if (!fieldNames(window).contains(QStringLiteral("late"))) {
+                    qCritical("the frame on screen lists %s, without the "
+                              "definition applied during playback",
+                        qPrintable(fieldNames(window).join(
+                            QStringLiteral(", "))));
+                    finish(19);
+                    return;
+                }
+                if (window.backgroundErrorCountForTest() != 0) {
+                    qCritical("the reload after playback reported an error");
+                    finish(12);
+                    return;
+                }
                 finish(0);
             }
         });

--- a/src/qt/SmokeHarnessDerived.cpp
+++ b/src/qt/SmokeHarnessDerived.cpp
@@ -19,6 +19,7 @@
 #include <QStandardItemModel>
 #include <QStringList>
 #include <QTimer>
+#include <QTreeWidget>
 
 #include <filesystem>
 #include <memory>
@@ -363,6 +364,22 @@ void armDerivedChecks(amrvis::qt::MainWindow& window, QApplication& application)
                     finish(10);
                     return;
                 }
+                // And the Dataset Metadata dock, which the open path filled
+                // from the file's own metadata before this session installed
+                // anything -- so it is refreshed exactly when the session's
+                // fields are not the ones already listed.
+                auto* metadataTree = window.findChild<QTreeWidget*>(
+                    QStringLiteral("metadataTree"));
+                if (metadataTree == nullptr
+                    || metadataTree
+                           ->findItems(QStringLiteral("product"),
+                               Qt::MatchExactly | Qt::MatchRecursive)
+                           .isEmpty()) {
+                    qCritical("the derived field did not reach the metadata "
+                              "dock");
+                    finish(18);
+                    return;
+                }
                 // A definition this dataset cannot satisfy is accepted and
                 // shown greyed out rather than refused: the list is shared
                 // with windows that may well be able to satisfy it.
@@ -415,9 +432,11 @@ void armDerivedChecks(amrvis::qt::MainWindow& window, QApplication& application)
                     finish(14);
                     return;
                 }
-                // The tooltip folds the layout back onto one line.
+                // The tooltip folds the layout back onto one line, and is
+                // rich text so that whatever the user wrote survives the
+                // escaping Qt would otherwise show as itself.
                 if (selector->itemData(product, Qt::ToolTipRole).toString()
-                    != QStringLiteral("density * temperature")) {
+                    != QStringLiteral("<qt>density * temperature</qt>")) {
                     qCritical("the derived field carries no expression: %s",
                         qPrintable(selector
                                 ->itemData(product, Qt::ToolTipRole)
@@ -540,25 +559,25 @@ void armDerivedChecks(amrvis::qt::MainWindow& window, QApplication& application)
 // is open must reload the frame on screen *and* leave the sequence navigable,
 // with the definition surviving the next frame switch. A reload that went
 // through the ordinary open path would end the sequence instead.
-void armSequenceChecks(amrvis::qt::MainWindow& window,
-    QApplication& application, QStringList afterStep)
+void armSequenceChecks(
+    amrvis::qt::MainWindow& window, QApplication& application)
 {
     auto phase = std::make_shared<int>(0);
     auto frames = std::make_shared<int>(0);
+    // Bounds the wait for a prefetch in phase 4.
+    auto ticks = std::make_shared<int>(0);
+    // Both frames list the same fields, so the frame stepped to lists what
+    // this one does; frames that disagree are armFrameIdentityChecks.
     const QStringList expected{QStringLiteral("density"),
         QStringLiteral("temperature"), QStringLiteral("product")};
-    // What the frame stepped to should list: the same again when the frames
-    // match, and only its own fields when it cannot satisfy the definition.
-    if (afterStep.isEmpty()) {
-        afterStep = expected;
-    }
     QObject::connect(&window, &amrvis::qt::MainWindow::sequenceFrameDisplayed,
         &application, [frames](int) { ++*frames; });
 
     auto* timer = new QTimer(&window);
     timer->setInterval(25);
     QObject::connect(timer, &QTimer::timeout, &application,
-        [&window, &application, phase, frames, timer, expected, afterStep] {
+        [&window, &application, phase, frames, ticks, timer, expected] {
+            ++*ticks;
             const auto finish = [&application, timer](int code) {
                 timer->stop();
                 application.exit(code);
@@ -616,7 +635,7 @@ void armSequenceChecks(amrvis::qt::MainWindow& window,
                     return;
                 }
                 const auto names = fieldNames(window);
-                if (names != afterStep) {
+                if (names != expected) {
                     qCritical("the stepped-to frame lists: %s",
                         qPrintable(names.join(QStringLiteral(", "))));
                     finish(10);
@@ -637,6 +656,51 @@ void armSequenceChecks(amrvis::qt::MainWindow& window,
                     finish(12);
                     return;
                 }
+                *ticks = 0;
+                *phase = 4;
+                return;
+            }
+            if (*phase == 4) {
+                // Playback is the case where the reload stands aside and lets
+                // the next frame read the list for itself -- which is only
+                // true of a frame that is actually loaded. The one already in
+                // the prefetch slot was rendered against the list as it was.
+                if (!window.sequencePlayingForTest()) {
+                    window.toggleSequencePlaybackForTest();
+                    if (!window.sequencePlayingForTest()) {
+                        qCritical("sequence playback did not start");
+                        finish(14);
+                        return;
+                    }
+                    return;
+                }
+                if (!window.prefetchedSequenceFrameForTest()) {
+                    if (*ticks > 200) {
+                        qCritical("no frame was ever prefetched");
+                        finish(15);
+                        return;
+                    }
+                    return;
+                }
+                auto* editor =
+                    window.findChild<amrvis::qt::ExpressionEditorDialog*>();
+                if (editor == nullptr
+                    || !appendDefinition(*editor, QStringLiteral("late"),
+                        QStringLiteral("temperature + 1"))
+                    || !clickApply(*editor) || errorShown(*editor)) {
+                    qCritical("the editor refused the definition mid-playback");
+                    finish(16);
+                    return;
+                }
+                // Synchronously: apply commits, the store tells this window,
+                // and the reload it asks for is what drops the prefetch.
+                if (window.prefetchedSequenceFrameForTest()) {
+                    qCritical("the frame prefetched before the change "
+                              "survived it");
+                    finish(17);
+                    return;
+                }
+                window.toggleSequencePlaybackForTest();
                 finish(0);
             }
         });
@@ -950,7 +1014,7 @@ Outcome dispatchDerivedSequence(Context& context)
     if (option == "--derived-field-frames-smoke-test") {
         armFrameIdentityChecks(context.window, context.application);
     } else {
-        armSequenceChecks(context.window, context.application, {});
+        armSequenceChecks(context.window, context.application);
     }
     QTimer::singleShot(0, &context.window,
         [&window = context.window, frames] { window.openSequence(frames); });

--- a/src/qt/SmokeHarnessDerived.cpp
+++ b/src/qt/SmokeHarnessDerived.cpp
@@ -2,9 +2,11 @@
 
 #include "ExpressionEditorDialog.hpp"
 #include "MainWindow.hpp"
+#include "RangeController.hpp"
 
 #include <QAction>
 #include <QComboBox>
+#include <QDoubleSpinBox>
 #include <QLabel>
 #include <QLineEdit>
 #include <QMenu>
@@ -91,6 +93,97 @@ bool errorShown(const amrvis::qt::ExpressionEditorDialog& dialog)
     const auto* error =
         dialog.findChild<QLabel*>(QStringLiteral("expressionError"));
     return error != nullptr && error->isVisible() && !error->text().isEmpty();
+}
+
+// Arms the range-memory scenario: a User range set on one field must still be
+// there when the user comes back to it. The memory is keyed by field name, and
+// the name it is filed under comes from the host -- so the host has to tell the
+// controller which field the widgets represent on *every* path that selects
+// one, the plain open included.
+void armRangeMemoryChecks(
+    amrvis::qt::MainWindow& window, QApplication& application)
+{
+    auto phase = std::make_shared<int>(0);
+    auto loaded = std::make_shared<bool>(false);
+    QObject::connect(&window, &amrvis::qt::MainWindow::initialSliceFinished,
+        &application, [&application, loaded](bool success) {
+            if (!success) {
+                application.exit(2);
+                return;
+            }
+            *loaded = true;
+        });
+
+    auto* timer = new QTimer(&window);
+    timer->setInterval(25);
+    QObject::connect(timer, &QTimer::timeout, &application,
+        [&window, &application, phase, loaded, timer] {
+            const auto finish = [&application, timer](int code) {
+                timer->stop();
+                application.exit(code);
+            };
+            if (!*loaded || window.sliceRequestPendingForTest()
+                || window.slicesInFlightForTest() != 0) {
+                return;
+            }
+            auto* selector = window.findChild<QComboBox*>(
+                QStringLiteral("fieldSelector"));
+            auto* mode = window.findChild<QComboBox*>(
+                QStringLiteral("rangeModeSelector"));
+            // The two range bounds, found through the toolbar that holds the
+            // mode selector: ScientificDoubleSpinBox has no Q_OBJECT of its
+            // own, and other spin boxes live elsewhere in the window.
+            const auto bounds = mode == nullptr
+                ? QList<QDoubleSpinBox*>{}
+                : mode->parentWidget()->findChildren<QDoubleSpinBox*>();
+            if (selector == nullptr || mode == nullptr || bounds.size() < 2
+                || selector->count() < 2) {
+                qCritical("the range widgets or a second field are missing");
+                finish(3);
+                return;
+            }
+            if (*phase == 0) {
+                const auto user = mode->findData(
+                    static_cast<int>(amrvis::qt::RangeMode::User));
+                if (user < 0) {
+                    qCritical("the range mode selector has no User entry");
+                    finish(4);
+                    return;
+                }
+                mode->setCurrentIndex(user);
+                bounds[0]->setValue(10.0);
+                bounds[1]->setValue(20.0);
+                *phase = 1;
+                return;
+            }
+            if (*phase == 1) {
+                selector->setCurrentIndex(1);  // another field
+                *phase = 2;
+                return;
+            }
+            if (*phase == 2) {
+                selector->setCurrentIndex(0);  // and back to the first
+                *phase = 3;
+                return;
+            }
+            if (*phase == 3) {
+                const auto restored = mode->currentData().toInt()
+                    == static_cast<int>(amrvis::qt::RangeMode::User)
+                    && bounds[0]->value() == 10.0
+                    && bounds[1]->value() == 20.0;
+                if (!restored) {
+                    qCritical("the first field's User range did not come back "
+                              "(mode %d, %g..%g)",
+                        mode->currentData().toInt(), bounds[0]->value(),
+                        bounds[1]->value());
+                    finish(5);
+                    return;
+                }
+                finish(0);
+            }
+        });
+    timer->start();
+    QTimer::singleShot(30000, &application, [&application] { application.exit(13); });
 }
 
 // Arms the scenario on `window`: exit 0 once a derived field has been
@@ -180,8 +273,9 @@ void armDerivedChecks(amrvis::qt::MainWindow& window, QApplication& application)
                     finish(5);
                     return;
                 }
+                // Written over two lines, as a long expression would be.
                 if (!writeDefinition(*dialog, QStringLiteral("product"),
-                        QStringLiteral("density * temperature"))
+                        QStringLiteral("density *\n    temperature"))
                     || !clickApply(*dialog)) {
                     qCritical("the editor did not take the corrected "
                               "definition");
@@ -251,6 +345,7 @@ void armDerivedChecks(amrvis::qt::MainWindow& window, QApplication& application)
                     finish(14);
                     return;
                 }
+                // The tooltip folds the layout back onto one line.
                 if (selector->itemData(product, Qt::ToolTipRole).toString()
                     != QStringLiteral("density * temperature")) {
                     qCritical("the derived field carries no expression: %s",
@@ -291,19 +386,25 @@ void armDerivedChecks(amrvis::qt::MainWindow& window, QApplication& application)
 // is open must reload the frame on screen *and* leave the sequence navigable,
 // with the definition surviving the next frame switch. A reload that went
 // through the ordinary open path would end the sequence instead.
-void armSequenceChecks(amrvis::qt::MainWindow& window, QApplication& application)
+void armSequenceChecks(amrvis::qt::MainWindow& window,
+    QApplication& application, QStringList afterStep)
 {
     auto phase = std::make_shared<int>(0);
     auto frames = std::make_shared<int>(0);
     const QStringList expected{QStringLiteral("density"),
         QStringLiteral("temperature"), QStringLiteral("product")};
+    // What the frame stepped to should list: the same again when the frames
+    // match, and only its own fields when it cannot satisfy the definition.
+    if (afterStep.isEmpty()) {
+        afterStep = expected;
+    }
     QObject::connect(&window, &amrvis::qt::MainWindow::sequenceFrameDisplayed,
         &application, [frames](int) { ++*frames; });
 
     auto* timer = new QTimer(&window);
     timer->setInterval(25);
     QObject::connect(timer, &QTimer::timeout, &application,
-        [&window, &application, phase, frames, timer, expected] {
+        [&window, &application, phase, frames, timer, expected, afterStep] {
             const auto finish = [&application, timer](int code) {
                 timer->stop();
                 application.exit(code);
@@ -314,10 +415,15 @@ void armSequenceChecks(amrvis::qt::MainWindow& window, QApplication& application
             auto* dialog =
                 window.findChild<amrvis::qt::ExpressionEditorDialog*>();
             if (*phase == 0) {
-                window
-                    .findChild<QAction*>(
-                        QStringLiteral("expressionEditorAction"))
-                    ->trigger();
+                auto* action = window.findChild<QAction*>(
+                    QStringLiteral("expressionEditorAction"));
+                if (action == nullptr || !action->isEnabled()) {
+                    qCritical("the Expression Editor action is not available "
+                              "over a sequence");
+                    finish(4);
+                    return;
+                }
+                action->trigger();
                 *phase = 1;
                 return;
             }
@@ -351,13 +457,25 @@ void armSequenceChecks(amrvis::qt::MainWindow& window, QApplication& application
                 return;
             }
             if (*phase == 3) {
-                if (*frames < 3) {
+                if (*frames < 3 || window.sliceRequestPendingForTest()
+                    || window.slicesInFlightForTest() != 0) {
                     return;
                 }
-                if (fieldNames(window) != expected) {
-                    qCritical("the derived field did not survive a frame "
-                              "switch");
+                const auto names = fieldNames(window);
+                if (names != afterStep) {
+                    qCritical("the stepped-to frame lists: %s",
+                        qPrintable(names.join(QStringLiteral(", "))));
                     finish(10);
+                    return;
+                }
+                // Whatever it lists, the combo must name the field the frame
+                // was actually rendered with.
+                auto* selector = window.findChild<QComboBox*>(
+                    QStringLiteral("fieldSelector"));
+                if (selector == nullptr
+                    || !selector->currentData().isValid()) {
+                    qCritical("the field selector is on no field at all");
+                    finish(11);
                     return;
                 }
                 if (window.backgroundErrorCountForTest() != 0) {
@@ -372,17 +490,137 @@ void armSequenceChecks(amrvis::qt::MainWindow& window, QApplication& application
     QTimer::singleShot(30000, &application, [&application] { application.exit(13); });
 }
 
+// Arms the frame-identity scenario. Two frames that list different fields, and
+// a selection whose *id* means a different field on the second: frame 0 is
+// [density, temperature, double], the user is on `temperature` (id 1), and
+// frame 1 has no `density`, so it lists [temperature, double] and id 1 is
+// `double`. Carrying the selection as an index lands on `double` while the
+// combo and the range still say `temperature`; carrying the name does not.
+void armFrameIdentityChecks(
+    amrvis::qt::MainWindow& window, QApplication& application)
+{
+    auto phase = std::make_shared<int>(0);
+    auto frames = std::make_shared<int>(0);
+    QObject::connect(&window, &amrvis::qt::MainWindow::sequenceFrameDisplayed,
+        &application, [frames](int) { ++*frames; });
+
+    auto* timer = new QTimer(&window);
+    timer->setInterval(25);
+    QObject::connect(timer, &QTimer::timeout, &application,
+        [&window, &application, phase, frames, timer] {
+            const auto finish = [&application, timer](int code) {
+                timer->stop();
+                application.exit(code);
+            };
+            if (*frames == 0 || window.sliceRequestPendingForTest()
+                || window.slicesInFlightForTest() != 0) {
+                return;
+            }
+            auto* dialog =
+                window.findChild<amrvis::qt::ExpressionEditorDialog*>();
+            auto* selector = window.findChild<QComboBox*>(
+                QStringLiteral("fieldSelector"));
+            if (selector == nullptr) {
+                qCritical("there is no field selector");
+                finish(3);
+                return;
+            }
+            if (*phase == 0) {
+                auto* action = window.findChild<QAction*>(
+                    QStringLiteral("expressionEditorAction"));
+                if (action == nullptr || !action->isEnabled()) {
+                    qCritical("the Expression Editor is unavailable");
+                    finish(4);
+                    return;
+                }
+                action->trigger();
+                *phase = 1;
+                return;
+            }
+            if (*phase == 1) {
+                // Reads only `temperature`, so the frame that drops `density`
+                // still has it -- at a different id.
+                if (dialog == nullptr
+                    || !writeDefinition(*dialog, QStringLiteral("double"),
+                        QStringLiteral("temperature * 2"))
+                    || !clickApply(*dialog) || errorShown(*dialog)) {
+                    qCritical("the editor refused the definition");
+                    finish(6);
+                    return;
+                }
+                *phase = 2;
+                return;
+            }
+            if (*phase == 2) {
+                if (*frames < 2) {
+                    return;
+                }
+                const auto temperature = selector->findText(
+                    QStringLiteral("temperature"));
+                if (temperature < 0 || selector->count() < 4) {
+                    qCritical("frame 0 does not list what it should");
+                    finish(9);
+                    return;
+                }
+                selector->setCurrentIndex(temperature);
+                *phase = 3;
+                return;
+            }
+            if (*phase == 3) {
+                window.requestSequenceFrameForTest(1);
+                *phase = 4;
+                return;
+            }
+            if (*phase == 4) {
+                if (*frames < 3) {
+                    return;
+                }
+                if (fieldNames(window)
+                    != QStringList{QStringLiteral("temperature"),
+                        QStringLiteral("double")}) {
+                    qCritical("the stepped-to frame lists: %s",
+                        qPrintable(fieldNames(window).join(
+                            QStringLiteral(", "))));
+                    finish(10);
+                    return;
+                }
+                if (selector->currentText() != QStringLiteral("temperature")) {
+                    qCritical("the selection became \"%s\" across the frame "
+                              "switch",
+                        qPrintable(selector->currentText()));
+                    finish(11);
+                    return;
+                }
+                if (window.backgroundErrorCountForTest() != 0) {
+                    qCritical("the frame switch reported an error");
+                    finish(12);
+                    return;
+                }
+                finish(0);
+            }
+        });
+    timer->start();
+    QTimer::singleShot(30000, &application, [&application] { application.exit(13); });
+}
+
 Outcome dispatchDerivedSequence(Context& context)
 {
-    if (context.argc != 4
-        || std::string_view(context.argv[1])
-            != "--derived-field-sequence-smoke-test") {
+    if (context.argc != 4) {
+        return {false, std::nullopt};
+    }
+    const std::string_view option(context.argv[1]);
+    if (option != "--derived-field-sequence-smoke-test"
+        && option != "--derived-field-frames-smoke-test") {
         return {false, std::nullopt};
     }
     const std::vector<std::filesystem::path> frames{
         std::filesystem::path(context.argv[2]),
         std::filesystem::path(context.argv[3])};
-    armSequenceChecks(context.window, context.application);
+    if (option == "--derived-field-frames-smoke-test") {
+        armFrameIdentityChecks(context.window, context.application);
+    } else {
+        armSequenceChecks(context.window, context.application, {});
+    }
     QTimer::singleShot(0, &context.window,
         [&window = context.window, frames] { window.openSequence(frames); });
     return {true, std::nullopt};
@@ -402,10 +640,13 @@ Outcome dispatchDerived(Context& context)
     }
     const std::string_view option(context.argv[1]);
     const std::filesystem::path path(context.argv[2]);
-    if (option != "--derived-field-smoke-test") {
+    if (option == "--field-range-memory-smoke-test") {
+        armRangeMemoryChecks(window, application);
+    } else if (option == "--derived-field-smoke-test") {
+        armDerivedChecks(window, application);
+    } else {
         return {false, std::nullopt};
     }
-    armDerivedChecks(window, application);
     QTimer::singleShot(
         0, &window, [&window, path] { window.openDataset(path); });
     return {true, std::nullopt};

--- a/src/qt/SmokeHarnessDerived.cpp
+++ b/src/qt/SmokeHarnessDerived.cpp
@@ -1,5 +1,6 @@
 #include "SmokeHarnessInternal.hpp"
 
+#include "DerivedFieldStore.hpp"
 #include "ExpressionEditorDialog.hpp"
 #include "MainWindow.hpp"
 #include "RangeController.hpp"
@@ -12,7 +13,9 @@
 #include <QMenu>
 #include <QMenuBar>
 #include <QPlainTextEdit>
+#include <QListWidget>
 #include <QPushButton>
+#include <QSignalBlocker>
 #include <QStandardItemModel>
 #include <QStringList>
 #include <QTimer>
@@ -442,6 +445,90 @@ void armDerivedChecks(amrvis::qt::MainWindow& window, QApplication& application)
                     finish(12);
                     return;
                 }
+                // A vector component pointed at the derived field, which is
+                // then renamed out from under it. The ids do not move, so a
+                // component that carried its old id over would now be reading
+                // a field the user never chose -- silently, since the id is
+                // still in range.
+                window.setVectorFieldsForTest(2, 1, 1);
+                if (dialog == nullptr) {
+                    qCritical("the editor closed before the rename");
+                    finish(18);
+                    return;
+                }
+                {
+                    auto* list = dialog->findChild<QListWidget*>(
+                        QStringLiteral("expressionList"));
+                    auto* nameEdit = dialog->findChild<QLineEdit*>(
+                        QStringLiteral("expressionName"));
+                    if (list == nullptr || nameEdit == nullptr) {
+                        qCritical("the editor has no list to rename in");
+                        finish(18);
+                        return;
+                    }
+                    list->setCurrentRow(0);
+                    nameEdit->setText(QStringLiteral("speed"));
+                    if (!clickApply(*dialog) || errorShown(*dialog)) {
+                        qCritical("the rename was refused");
+                        finish(18);
+                        return;
+                    }
+                }
+                *phase = 6;
+                return;
+            }
+            if (*phase == 6) {
+                if (*loads < 4 || window.sliceRequestPendingForTest()
+                    || window.slicesInFlightForTest() != 0) {
+                    return;
+                }
+                auto* selector = window.findChild<QComboBox*>(
+                    QStringLiteral("fieldSelector"));
+                if (selector == nullptr) {
+                    qCritical("there is no field selector");
+                    finish(19);
+                    return;
+                }
+                if (fieldNames(window)
+                    != QStringList{QStringLiteral("density"),
+                        QStringLiteral("temperature"),
+                        QStringLiteral("speed")}) {
+                    qCritical("the rename did not reach the field list: %s",
+                        qPrintable(fieldNames(window).join(
+                            QStringLiteral(", "))));
+                    finish(19);
+                    return;
+                }
+                // Read back through the selector, which is the same mapping
+                // from field id to name the glyphs are drawn through.
+                const auto vectors = window.vectorFieldsForTest();
+                for (const auto field : vectors) {
+                    if (field < 0
+                        || selector->findData(
+                               static_cast<unsigned int>(field))
+                            < 0) {
+                        qCritical("a vector component names no field: %d",
+                            field);
+                        finish(20);
+                        return;
+                    }
+                }
+                // `product` is gone, so the component set to it has to have
+                // been re-detected rather than left on the id, which now
+                // belongs to `speed`.
+                if (selector->itemText(selector->findData(
+                        static_cast<unsigned int>(vectors[0])))
+                    == QStringLiteral("speed")) {
+                    qCritical("the vector component followed its id onto "
+                              "\"speed\", which was never chosen");
+                    finish(21);
+                    return;
+                }
+                if (window.backgroundErrorCountForTest() != 0) {
+                    qCritical("the rename reported an error");
+                    finish(12);
+                    return;
+                }
                 finish(0);
             }
         });
@@ -605,13 +692,20 @@ void armFrameIdentityChecks(
                 return;
             }
             if (*phase == 1) {
-                // Reads only `temperature`, so the frame that drops `density`
-                // still has it -- at a different id.
+                // Two, in this order on purpose. The first reads `density`,
+                // which the stepped-to frame does not have, so there it is
+                // listed greyed out -- immediately after the separator, which
+                // puts two rows that are not fields next to each other. The
+                // second reads only `temperature`, so it survives the step at
+                // a different id.
                 if (dialog == nullptr
-                    || !writeDefinition(*dialog, QStringLiteral("double"),
+                    || !writeDefinition(*dialog,
+                        QStringLiteral("fromDensity"),
+                        QStringLiteral("density * 2"))
+                    || !appendDefinition(*dialog, QStringLiteral("double"),
                         QStringLiteral("temperature * 2"))
                     || !clickApply(*dialog) || errorShown(*dialog)) {
-                    qCritical("the editor refused the definition");
+                    qCritical("the editor refused the definitions");
                     finish(6);
                     return;
                 }
@@ -624,8 +718,11 @@ void armFrameIdentityChecks(
                 }
                 const auto temperature = selector->findText(
                     QStringLiteral("temperature"));
-                if (temperature < 0 || selector->count() < 4) {
-                    qCritical("frame 0 does not list what it should");
+                // density, temperature, the separator, and both definitions,
+                // which this frame can resolve.
+                if (temperature < 0 || selector->count() != 5) {
+                    qCritical("frame 0 lists %d row(s), not the 5 expected",
+                        selector->count());
                     finish(9);
                     return;
                 }
@@ -661,6 +758,173 @@ void armFrameIdentityChecks(
                 if (window.backgroundErrorCountForTest() != 0) {
                     qCritical("the frame switch reported an error");
                     finish(12);
+                    return;
+                }
+                // temperature, the separator, the greyed-out `fromDensity`
+                // and `double`: the two adjacent rows that are not fields are
+                // what the sweep below needs to be about anything.
+                if (selector->count() != 4) {
+                    qCritical("the stepped-to frame lists %d row(s), not the "
+                              "4 expected",
+                        selector->count());
+                    finish(14);
+                    return;
+                }
+                {
+                    // Wherever a selection is aimed -- a restored index, a
+                    // clamped one -- it has to come to rest on a field. A row
+                    // with no item data is read as field 0 by everything
+                    // downstream while the combo names something else.
+                    const QSignalBlocker blocker(selector);
+                    const auto restore = selector->currentIndex();
+                    for (int index = 0; index < selector->count(); ++index) {
+                        window.selectFieldItemForTest(index);
+                        if (!selector->currentData().isValid()) {
+                            qCritical("selecting row %d came to rest on row "
+                                      "%d, which is not a field",
+                                index, selector->currentIndex());
+                            finish(15);
+                            return;
+                        }
+                    }
+                    selector->setCurrentIndex(restore);
+                }
+                finish(0);
+            }
+        });
+    timer->start();
+    QTimer::singleShot(30000, &application, [&application] { application.exit(13); });
+}
+
+// Arms the playback/late-change scenario. Two ways a committed definition can
+// fail to reach the session on screen, neither of which the other scenarios
+// pass through: a plane sweep, which moves the slice position on the session
+// already open and never reopens it, so the reload an Apply asks for is the
+// only thing that can install the definition; and a list that changes while
+// this window is opening a dataset, when the window counts as unable to take
+// derived fields and so is not told to reload at all.
+void armPlaybackChecks(amrvis::qt::MainWindow& window,
+    QApplication& application, const std::filesystem::path& path)
+{
+    auto phase = std::make_shared<int>(0);
+    auto loads = std::make_shared<int>(0);
+    // Bounds the waits below, so a change that never arrives fails saying so
+    // rather than running into the watchdog.
+    auto ticks = std::make_shared<int>(0);
+    QObject::connect(&window, &amrvis::qt::MainWindow::initialSliceFinished,
+        &application, [&application, loads](bool success) {
+            if (!success) {
+                application.exit(2);
+                return;
+            }
+            ++*loads;
+        });
+
+    auto* timer = new QTimer(&window);
+    timer->setInterval(25);
+    QObject::connect(timer, &QTimer::timeout, &application,
+        [&window, &application, phase, loads, ticks, timer, path] {
+            const auto finish = [&application, timer](int code) {
+                timer->stop();
+                application.exit(code);
+            };
+            ++*ticks;
+            if (*loads == 0) {
+                return;  // the dataset is still opening
+            }
+            auto* selector = window.findChild<QComboBox*>(
+                QStringLiteral("fieldSelector"));
+            if (selector == nullptr) {
+                qCritical("there is no field selector");
+                finish(3);
+                return;
+            }
+            if (*phase == 0) {
+                window.toggleSweepPlaybackForTest();
+                if (!window.sweepPlayingForTest()) {
+                    qCritical("the plane sweep did not start");
+                    finish(4);
+                    return;
+                }
+                auto* action = window.findChild<QAction*>(
+                    QStringLiteral("expressionEditorAction"));
+                if (action == nullptr || !action->isEnabled()) {
+                    qCritical("the Expression Editor is unavailable");
+                    finish(5);
+                    return;
+                }
+                action->trigger();
+                *phase = 1;
+                return;
+            }
+            auto* dialog =
+                window.findChild<amrvis::qt::ExpressionEditorDialog*>();
+            if (*phase == 1) {
+                if (dialog == nullptr
+                    || !writeDefinition(*dialog, QStringLiteral("swept"),
+                        QStringLiteral("q * 2"))
+                    || !clickApply(*dialog) || errorShown(*dialog)) {
+                    qCritical("the editor refused the definition");
+                    finish(6);
+                    return;
+                }
+                *ticks = 0;
+                *phase = 2;
+                return;
+            }
+            if (*phase == 2) {
+                if (!fieldNames(window).contains(QStringLiteral("swept"))) {
+                    if (*ticks > 200) {
+                        qCritical("applying during a plane sweep never "
+                                  "reached the field list");
+                        finish(7);
+                        return;
+                    }
+                    return;
+                }
+                if (!window.sweepPlayingForTest()) {
+                    qCritical("the reload stopped the plane sweep");
+                    finish(8);
+                    return;
+                }
+                window.toggleSweepPlaybackForTest();
+                // What another window's Apply looks like from here: the list
+                // moves while this window has no dataset, which is the whole
+                // of an open rather than just its start.
+                *ticks = 0;
+                // Committed while the load is on a worker, which is the only
+                // time it can be missed: the spec that load carries was built
+                // a moment earlier, and this window is not told to reload
+                // because it has no dataset until the load lands. Left armed
+                // for the reload that follows, where it re-commits the same
+                // list and so changes nothing.
+                window.setInitialSliceLaunchedHookForTest([] {
+                    amrvis::qt::DerivedFieldStore::session().set(
+                        {{"swept", "q * 2"}, {"raced", "q + 1"}});
+                });
+                window.openDataset(path);
+                *phase = 3;
+                return;
+            }
+            if (*phase == 3) {
+                const auto raced = selector->findText(QStringLiteral("raced"));
+                // Listed *and* a field: a definition reaches the selector
+                // either way, greyed out when the open session could not
+                // install it.
+                if (raced < 0 || !selector->itemData(raced).isValid()) {
+                    if (*ticks > 200) {
+                        qCritical("a definition committed while the dataset "
+                                  "was opening never reached the session: %s",
+                            qPrintable(fieldNames(window).join(
+                                QStringLiteral(", "))));
+                        finish(9);
+                        return;
+                    }
+                    return;
+                }
+                if (window.backgroundErrorCountForTest() != 0) {
+                    qCritical("the late change reported an error");
+                    finish(10);
                     return;
                 }
                 finish(0);
@@ -711,6 +975,8 @@ Outcome dispatchDerived(Context& context)
         armRangeMemoryChecks(window, application);
     } else if (option == "--derived-field-smoke-test") {
         armDerivedChecks(window, application);
+    } else if (option == "--derived-field-playback-smoke-test") {
+        armPlaybackChecks(window, application, path);
     } else {
         return {false, std::nullopt};
     }

--- a/src/qt/SmokeHarnessInternal.hpp
+++ b/src/qt/SmokeHarnessInternal.hpp
@@ -43,5 +43,7 @@ Outcome dispatchFab(Context& context);
 Outcome dispatchSequence(Context& context);
 // SmokeHarnessVolume.cpp
 Outcome dispatchVolume(Context& context);
+// SmokeHarnessDerived.cpp
+Outcome dispatchDerived(Context& context);
 
 } // namespace amrvis::qt::smoke

--- a/src/qt/main.cpp
+++ b/src/qt/main.cpp
@@ -418,10 +418,6 @@ int main(int argc, char* argv[])
     icon.addFile(QStringLiteral(":/amrexplorer-256.png"));
     application.setWindowIcon(icon);
     ensureDesktopEntry();
-#ifdef AMREXPLORER_QT_TEST_ACCESS
-    // Before the window, whose constructor restores settings.
-    amrvis::qt::smoke::isolateSettings(argc, argv);
-#endif
     amrvis::qt::MainWindow window;
     window.show();
     // The smoke-test harnesses (SmokeHarness*.cpp) claim their options first;

--- a/src/qt/main.cpp
+++ b/src/qt/main.cpp
@@ -418,6 +418,10 @@ int main(int argc, char* argv[])
     icon.addFile(QStringLiteral(":/amrexplorer-256.png"));
     application.setWindowIcon(icon);
     ensureDesktopEntry();
+#ifdef AMREXPLORER_QT_TEST_ACCESS
+    // Before the window, whose constructor restores settings.
+    amrvis::qt::smoke::isolateSettings(argc, argv);
+#endif
     amrvis::qt::MainWindow window;
     window.show();
     // The smoke-test harnesses (SmokeHarness*.cpp) claim their options first;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1324,6 +1324,23 @@ if(TARGET amrexplorer_qt)
     )
     set_tests_properties(qt_derived_field_smoke PROPERTIES TIMEOUT 60)
 
+    # The two ways a committed definition can miss the session on screen: an
+    # Apply during a plane sweep, which never reopens the dataset of its own
+    # accord, and a list changed while this window is opening one, when it
+    # counts as unable to take derived fields and is told nothing. The 3-D
+    # fixture is what a plane sweep needs.
+    add_test(
+        NAME qt_derived_field_playback_smoke
+        COMMAND "${CMAKE_COMMAND}"
+            "-DMATERIALIZER=$<TARGET_FILE:fixture_materializer>"
+            "-DAMREXPLORER_QT=$<TARGET_FILE:amrexplorer_qt>"
+            "-DSOURCE=${CMAKE_CURRENT_SOURCE_DIR}/data/plotfile_3d"
+            "-DWORK=${CMAKE_CURRENT_BINARY_DIR}/fixtures_derived_field_playback"
+            -DMODE=derived-field-playback
+            -P "${CMAKE_CURRENT_SOURCE_DIR}/qt_smoke_driver.cmake"
+    )
+    set_tests_properties(qt_derived_field_playback_smoke PROPERTIES TIMEOUT 60)
+
     # Applying a definition while a plotfile sequence is open: the frame on
     # screen reloads with it and the sequence is still navigable afterwards,
     # which is what separates the reload from an ordinary dataset open.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -599,6 +599,30 @@ if(TARGET amrexplorer_qt)
     )
     add_test(NAME sequence_controller COMMAND test_sequence_controller)
 
+    add_executable(test_derived_field_controller
+        unit/test_derived_field_controller.cpp
+        "${PROJECT_SOURCE_DIR}/src/qt/DerivedFieldController.cpp"
+        "${PROJECT_SOURCE_DIR}/src/qt/DerivedFieldController.hpp"
+        "${PROJECT_SOURCE_DIR}/src/qt/ExpressionEditorDialog.cpp"
+        "${PROJECT_SOURCE_DIR}/src/qt/ExpressionEditorDialog.hpp"
+    )
+    set_target_properties(test_derived_field_controller
+        PROPERTIES AUTOMOC ON)
+    target_include_directories(test_derived_field_controller
+        PRIVATE "${PROJECT_SOURCE_DIR}/src/qt")
+    target_link_libraries(test_derived_field_controller
+        PRIVATE
+            amrexplorer::core
+            amrexplorer::warnings
+            Qt6::Core
+            Qt6::Gui
+            Qt6::Widgets
+    )
+    # Builds the real editor widgets, so it needs a QPA platform.
+    add_test(NAME derived_field_controller
+        COMMAND "${CMAKE_COMMAND}" -E env QT_QPA_PLATFORM=offscreen
+            "$<TARGET_FILE:test_derived_field_controller>")
+
     add_executable(test_palette_controller
         unit/test_palette_controller.cpp
         "${PROJECT_SOURCE_DIR}/src/qt/PaletteController.cpp"
@@ -1280,6 +1304,39 @@ if(TARGET amrexplorer_qt)
             -P "${CMAKE_CURRENT_SOURCE_DIR}/qt_smoke_driver.cmake"
     )
     set_tests_properties(qt_volume_smoke_3d PROPERTIES TIMEOUT 60)
+
+    # Derived fields through the GUI: the Variable menu's Expression Editor
+    # refuses a definition the dataset cannot satisfy and reports it in place,
+    # then an accepted one reaches the field selector and the Variable menu and
+    # renders when selected. The 2-D fixture has the two fields the expression
+    # multiplies.
+    add_test(
+        NAME qt_derived_field_smoke
+        COMMAND "${CMAKE_COMMAND}"
+            "-DMATERIALIZER=$<TARGET_FILE:fixture_materializer>"
+            "-DAMREXPLORER_QT=$<TARGET_FILE:amrexplorer_qt>"
+            "-DSOURCE=${CMAKE_CURRENT_SOURCE_DIR}/data/plotfile_2d"
+            "-DSECOND_SOURCE=${CMAKE_CURRENT_SOURCE_DIR}/data/plotfile_3d"
+            "-DWORK=${CMAKE_CURRENT_BINARY_DIR}/fixtures_derived_field"
+            -DMODE=derived-field
+            -P "${CMAKE_CURRENT_SOURCE_DIR}/qt_smoke_driver.cmake"
+    )
+    set_tests_properties(qt_derived_field_smoke PROPERTIES TIMEOUT 60)
+
+    # Applying a definition while a plotfile sequence is open: the frame on
+    # screen reloads with it and the sequence is still navigable afterwards,
+    # which is what separates the reload from an ordinary dataset open.
+    add_test(
+        NAME qt_derived_field_sequence_smoke
+        COMMAND "${CMAKE_COMMAND}"
+            "-DMATERIALIZER=$<TARGET_FILE:fixture_materializer>"
+            "-DAMREXPLORER_QT=$<TARGET_FILE:amrexplorer_qt>"
+            "-DSOURCE=${CMAKE_CURRENT_SOURCE_DIR}/data/plotfile_2d"
+            "-DWORK=${CMAKE_CURRENT_BINARY_DIR}/fixtures_derived_field_sequence"
+            -DMODE=derived-field-sequence
+            -P "${CMAKE_CURRENT_SOURCE_DIR}/qt_smoke_driver.cmake"
+    )
+    set_tests_properties(qt_derived_field_sequence_smoke PROPERTIES TIMEOUT 60)
     add_test(
         NAME qt_particle_visible_range_smoke_3d
         COMMAND "${CMAKE_COMMAND}"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -603,6 +603,8 @@ if(TARGET amrexplorer_qt)
         unit/test_derived_field_controller.cpp
         "${PROJECT_SOURCE_DIR}/src/qt/DerivedFieldController.cpp"
         "${PROJECT_SOURCE_DIR}/src/qt/DerivedFieldController.hpp"
+        "${PROJECT_SOURCE_DIR}/src/qt/DerivedFieldStore.cpp"
+        "${PROJECT_SOURCE_DIR}/src/qt/DerivedFieldStore.hpp"
         "${PROJECT_SOURCE_DIR}/src/qt/ExpressionEditorDialog.cpp"
         "${PROJECT_SOURCE_DIR}/src/qt/ExpressionEditorDialog.hpp"
     )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1321,7 +1321,9 @@ if(TARGET amrexplorer_qt)
             -DMODE=derived-field
             -P "${CMAKE_CURRENT_SOURCE_DIR}/qt_smoke_driver.cmake"
     )
-    set_tests_properties(qt_derived_field_smoke PROPERTIES TIMEOUT 60)
+    # Three application launches plus two fixture copies, each launch with a
+    # 30 s watchdog of its own: 60 s cannot tell a hang from a slow machine.
+    set_tests_properties(qt_derived_field_smoke PROPERTIES TIMEOUT 150)
 
     # Applying a definition while a plotfile sequence is open: the frame on
     # screen reloads with it and the sequence is still navigable afterwards,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1336,6 +1336,20 @@ if(TARGET amrexplorer_qt)
             -P "${CMAKE_CURRENT_SOURCE_DIR}/qt_smoke_driver.cmake"
     )
     set_tests_properties(qt_derived_field_sequence_smoke PROPERTIES TIMEOUT 60)
+
+    # The same, over frames that list different fields: the definition is left
+    # out of the frame that cannot satisfy it, which moves every id after it.
+    add_test(
+        NAME qt_derived_field_frames_smoke
+        COMMAND "${CMAKE_COMMAND}"
+            "-DMATERIALIZER=$<TARGET_FILE:fixture_materializer>"
+            "-DAMREXPLORER_QT=$<TARGET_FILE:amrexplorer_qt>"
+            "-DSOURCE=${CMAKE_CURRENT_SOURCE_DIR}/data/plotfile_2d"
+            "-DWORK=${CMAKE_CURRENT_BINARY_DIR}/fixtures_derived_field_frames"
+            -DMODE=derived-field-frames
+            -P "${CMAKE_CURRENT_SOURCE_DIR}/qt_smoke_driver.cmake"
+    )
+    set_tests_properties(qt_derived_field_frames_smoke PROPERTIES TIMEOUT 60)
     add_test(
         NAME qt_particle_visible_range_smoke_3d
         COMMAND "${CMAKE_COMMAND}"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1316,14 +1316,11 @@ if(TARGET amrexplorer_qt)
             "-DMATERIALIZER=$<TARGET_FILE:fixture_materializer>"
             "-DAMREXPLORER_QT=$<TARGET_FILE:amrexplorer_qt>"
             "-DSOURCE=${CMAKE_CURRENT_SOURCE_DIR}/data/plotfile_2d"
-            "-DSECOND_SOURCE=${CMAKE_CURRENT_SOURCE_DIR}/data/plotfile_3d"
             "-DWORK=${CMAKE_CURRENT_BINARY_DIR}/fixtures_derived_field"
             -DMODE=derived-field
             -P "${CMAKE_CURRENT_SOURCE_DIR}/qt_smoke_driver.cmake"
     )
-    # Three application launches plus two fixture copies, each launch with a
-    # 30 s watchdog of its own: 60 s cannot tell a hang from a slow machine.
-    set_tests_properties(qt_derived_field_smoke PROPERTIES TIMEOUT 150)
+    set_tests_properties(qt_derived_field_smoke PROPERTIES TIMEOUT 60)
 
     # Applying a definition while a plotfile sequence is open: the frame on
     # screen reloads with it and the sequence is still navigable afterwards,

--- a/tests/fixture_materializer/main.cpp
+++ b/tests/fixture_materializer/main.cpp
@@ -6,7 +6,7 @@
 //
 // Usage:
 //   fixture_materializer <sourceFixtureDir> <destDir>
-//       [newTime] [--no-statistics] [--non-finite]
+//       [newTime] [--no-statistics] [--non-finite] [--drop-field <name>]
 //
 // Copies the fixture into destDir and writes each level's Cell_D_* payloads
 // at the FabOnDisk offsets its Cell_H records. An optional time value replaces
@@ -21,6 +21,7 @@
 #include <iomanip>
 #include <iostream>
 #include <limits>
+#include <algorithm>
 #include <optional>
 #include <sstream>
 #include <string>
@@ -283,7 +284,7 @@ int main(int argc, char* argv[])
     require(argc >= 3 && argc <= 10,
         "usage: fixture_materializer <sourceFixtureDir> <destDir> "
         "[newTime] [--no-statistics] [--non-finite] [--scale <factor>] "
-        "[--domain-upper-x <value>]");
+        "[--domain-upper-x <value>] [--drop-field <name>]");
     const std::filesystem::path source(argv[1]);
     const std::filesystem::path destination(argv[2]);
     std::optional<std::string> newTime;
@@ -293,6 +294,11 @@ int main(int argc, char* argv[])
     // sequence can carry different ranges (used by the range-cache test).
     double scale = 1.0;
     std::optional<double> domainUpperX;
+    // Takes a field out of the Header's list, leaving the stored components
+    // alone: what a frame that simply does not carry that field looks like.
+    // A sequence of two such copies is the one shape that makes a field id
+    // mean different things from one frame to the next.
+    std::optional<std::string> droppedField;
     for (int argument = 3; argument < argc; ++argument) {
         const std::string value(argv[argument]);
         if (value == "--no-statistics") {
@@ -311,6 +317,11 @@ int main(int argc, char* argv[])
             } catch (const std::exception&) {
                 require(false, "--scale factor is not a number");
             }
+        } else if (value == "--drop-field") {
+            require(argument + 1 < argc, "--drop-field requires a name");
+            require(!droppedField.has_value(),
+                "--drop-field was specified more than once");
+            droppedField = argv[++argument];
         } else if (value == "--domain-upper-x") {
             require(argument + 1 < argc,
                 "--domain-upper-x requires a value");
@@ -326,7 +337,7 @@ int main(int argc, char* argv[])
     }
     require(std::filesystem::is_directory(source),
         "the source fixture directory is missing");
-    const auto header = readHeader(source / "Header");
+    auto header = readHeader(source / "Header");
 
     std::error_code error;
     std::filesystem::remove_all(destination, error);
@@ -339,7 +350,8 @@ int main(int argc, char* argv[])
         source, destination, std::filesystem::copy_options::recursive, error);
     require(!error, "could not copy the fixture");
 
-    if (newTime.has_value() || domainUpperX.has_value()) {
+    if (newTime.has_value() || domainUpperX.has_value()
+        || droppedField.has_value()) {
         auto lines = header.lines;
         if (newTime.has_value()) {
             lines[header.timeLine] = *newTime;
@@ -363,6 +375,19 @@ int main(int argc, char* argv[])
                 output << upper[axis];
             }
             lines[header.physicalUpperLine] = output.str();
+        }
+        if (droppedField) {
+            const auto first = lines.begin() + 2;
+            const auto last = first + header.fieldCount;
+            const auto found = std::find(first, last, *droppedField);
+            require(found != last, "the fixture has no such field to drop");
+            lines.erase(found);
+            --header.fieldCount;
+            lines[1] = std::to_string(header.fieldCount);
+            // The VisMF header carries the component count too, and the two
+            // are cross-checked when the plotfile is read, so its statistics
+            // (one column per component) go with the dropped field.
+            omitStatistics = true;
         }
         std::ofstream output(destination / "Header", std::ios::trunc);
         require(static_cast<bool>(output), "could not rewrite the Header");

--- a/tests/fixture_materializer/main.cpp
+++ b/tests/fixture_materializer/main.cpp
@@ -281,7 +281,7 @@ void writeHeaderWithoutStatistics(const std::filesystem::path& path,
 
 int main(int argc, char* argv[])
 {
-    require(argc >= 3 && argc <= 10,
+    require(argc >= 3 && argc <= 12,
         "usage: fixture_materializer <sourceFixtureDir> <destDir> "
         "[newTime] [--no-statistics] [--non-finite] [--scale <factor>] "
         "[--domain-upper-x <value>] [--drop-field <name>]");

--- a/tests/qt_smoke_driver.cmake
+++ b/tests/qt_smoke_driver.cmake
@@ -23,6 +23,7 @@
 #                 sequence-equal-size-transform-preserve |
 #                 sequence-geometry-refit | sequence-noop | sequence-failure |
 #                 remote-canvas-wheel | remote-cell-aspect | volume |
+#                 derived-field | derived-field-sequence |
 #                 scale-state | effective-scale |
 #                 arrow-key-routing | animation-dock-role | open-failure |
 #                 idle-ui-state | sequence-scale-report |
@@ -61,6 +62,26 @@ if(MODE STREQUAL "slice")
 elseif(MODE STREQUAL "volume")
     run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt")
     run_or_die("${AMREXPLORER_QT}" --volume-smoke-test "${WORK}/plt")
+elseif(MODE STREQUAL "derived-field")
+    if(NOT DEFINED SECOND_SOURCE)
+        message(FATAL_ERROR "derived-field requires -DSECOND_SOURCE=...")
+    endif()
+    run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt")
+    run_or_die("${MATERIALIZER}" "${SECOND_SOURCE}" "${WORK}/other")
+    # Three runs in one settings store (the driver isolates it per test, and
+    # does not clear it between runs): the first applies a definition, which
+    # persists it; the second must find it on the next launch; the third opens
+    # a dataset that cannot satisfy it, which must still open without it.
+    run_or_die("${AMREXPLORER_QT}" --derived-field-smoke-test "${WORK}/plt")
+    run_or_die("${AMREXPLORER_QT}" --derived-field-restore-smoke-test
+        "${WORK}/plt")
+    run_or_die("${AMREXPLORER_QT}" --derived-field-skip-smoke-test
+        "${WORK}/other")
+elseif(MODE STREQUAL "derived-field-sequence")
+    run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt00000")
+    run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt00010" "2.5")
+    run_or_die("${AMREXPLORER_QT}" --derived-field-sequence-smoke-test
+        "${WORK}/plt00000" "${WORK}/plt00010")
 elseif(MODE STREQUAL "sequence")
     run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt00000")
     run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt00010" "2.5")

--- a/tests/qt_smoke_driver.cmake
+++ b/tests/qt_smoke_driver.cmake
@@ -63,20 +63,8 @@ elseif(MODE STREQUAL "volume")
     run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt")
     run_or_die("${AMREXPLORER_QT}" --volume-smoke-test "${WORK}/plt")
 elseif(MODE STREQUAL "derived-field")
-    if(NOT DEFINED SECOND_SOURCE)
-        message(FATAL_ERROR "derived-field requires -DSECOND_SOURCE=...")
-    endif()
     run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt")
-    run_or_die("${MATERIALIZER}" "${SECOND_SOURCE}" "${WORK}/other")
-    # Three runs in one settings store (the driver isolates it per test, and
-    # does not clear it between runs): the first applies a definition, which
-    # persists it; the second must find it on the next launch; the third opens
-    # a dataset that cannot satisfy it, which must still open without it.
     run_or_die("${AMREXPLORER_QT}" --derived-field-smoke-test "${WORK}/plt")
-    run_or_die("${AMREXPLORER_QT}" --derived-field-restore-smoke-test
-        "${WORK}/plt")
-    run_or_die("${AMREXPLORER_QT}" --derived-field-skip-smoke-test
-        "${WORK}/other")
 elseif(MODE STREQUAL "derived-field-sequence")
     run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt00000")
     run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt00010" "2.5")

--- a/tests/qt_smoke_driver.cmake
+++ b/tests/qt_smoke_driver.cmake
@@ -24,6 +24,7 @@
 #                 sequence-geometry-refit | sequence-noop | sequence-failure |
 #                 remote-canvas-wheel | remote-cell-aspect | volume |
 #                 derived-field | derived-field-sequence |
+#                 derived-field-frames | derived-field-playback |
 #                 scale-state | effective-scale |
 #                 arrow-key-routing | animation-dock-role | open-failure |
 #                 idle-ui-state | sequence-scale-report |
@@ -77,6 +78,13 @@ elseif(MODE STREQUAL "derived-field-frames")
         --drop-field density)
     run_or_die("${AMREXPLORER_QT}" --derived-field-frames-smoke-test
         "${WORK}/plt00000" "${WORK}/plt00010")
+elseif(MODE STREQUAL "derived-field-playback")
+    # A plane sweep never reopens the dataset, and a window counts as unable to
+    # take derived fields for the whole of an open: two ways a committed
+    # definition can fail to reach the session on screen.
+    run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt")
+    run_or_die("${AMREXPLORER_QT}" --derived-field-playback-smoke-test
+        "${WORK}/plt")
 elseif(MODE STREQUAL "derived-field-sequence")
     run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt00000")
     run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt00010" "2.5")

--- a/tests/qt_smoke_driver.cmake
+++ b/tests/qt_smoke_driver.cmake
@@ -65,6 +65,18 @@ elseif(MODE STREQUAL "volume")
 elseif(MODE STREQUAL "derived-field")
     run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt")
     run_or_die("${AMREXPLORER_QT}" --derived-field-smoke-test "${WORK}/plt")
+    run_or_die("${AMREXPLORER_QT}" --field-range-memory-smoke-test
+        "${WORK}/plt")
+elseif(MODE STREQUAL "derived-field-frames")
+    # Two frames that do not list the same fields: the second drops the one a
+    # definition reads, so that definition is left out of it and every id after
+    # it moves. The one shape in which a carried field *index* means a
+    # different field from one frame to the next.
+    run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt00000")
+    run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt00010" "2.5"
+        --drop-field density)
+    run_or_die("${AMREXPLORER_QT}" --derived-field-frames-smoke-test
+        "${WORK}/plt00000" "${WORK}/plt00010")
 elseif(MODE STREQUAL "derived-field-sequence")
     run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt00000")
     run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt00010" "2.5")

--- a/tests/unit/test_derived_field.cpp
+++ b/tests/unit/test_derived_field.cpp
@@ -364,7 +364,42 @@ int main()
                 "Skip left an installed definition pointing at the wrong id");
         }
 
-        std::cout << "derived field tests passed\n";
+        // Faults in the list as a list, which no dataset can make good and which
+    // an editor therefore refuses once rather than every dataset greying the
+    // same row: a chain deeper than evaluation recurses, and an expression
+    // reading more fields than one evaluation may pin.
+    {
+        std::vector<amrvis::DerivedFieldDefinition> chain{
+            {"d0", "density"}};
+        for (std::size_t link = 1;
+            link <= amrvis::maximumDerivedFieldDepth; ++link) {
+            chain.push_back({"d" + std::to_string(link),
+                "d" + std::to_string(link - 1) + " * 2"});
+        }
+        const auto fault = amrvis::validateDerivedFieldGraph(chain);
+        require(fault.has_value()
+                && fault->definitionIndex == amrvis::maximumDerivedFieldDepth,
+            "a chain past the depth limit was accepted");
+        chain.pop_back();
+        require(!amrvis::validateDerivedFieldGraph(chain).has_value(),
+            "a chain at the depth limit was refused");
+
+        std::string wide = "a0";
+        for (std::size_t input = 1;
+            input <= amrvis::maximumDerivedFieldInputs; ++input) {
+            wide += " + a" + std::to_string(input);
+        }
+        const std::vector<amrvis::DerivedFieldDefinition> many{{"wide", wide}};
+        require(amrvis::validateDerivedFieldGraph(many).has_value(),
+            "an expression reading more fields than the cap was accepted");
+        // x, y and z are computed rather than read, so they do not count.
+        const std::vector<amrvis::DerivedFieldDefinition> coordinates{
+            {"place", "x + y + z + density"}};
+        require(!amrvis::validateDerivedFieldGraph(coordinates).has_value(),
+            "coordinates were counted as fields read");
+    }
+
+    std::cout << "derived field tests passed\n";
         return EXIT_SUCCESS;
     } catch (const std::exception& error) {
         std::cerr << "test_derived_field failed: " << error.what() << '\n';

--- a/tests/unit/test_derived_field_controller.cpp
+++ b/tests/unit/test_derived_field_controller.cpp
@@ -8,7 +8,6 @@
 #include <QListWidget>
 #include <QPlainTextEdit>
 #include <QPushButton>
-#include <QSettings>
 #include <QTemporaryDir>
 
 #include <cstdlib>
@@ -61,7 +60,6 @@ struct Fixture {
     // remote one) or for no dataset at all.
     bool datasetOpen = true;
     int reloads = 0;
-    QString settingsPath;
     // What the next chooseFile answers, and what it was asked for.
     QString chosenPath;
     std::optional<bool> lastChooseForSaving;
@@ -78,11 +76,6 @@ struct Fixture {
                 return storedMetadata();
             },
             .reload = [this] { ++reloads; },
-            .settings =
-                [this] {
-                    return std::make_unique<QSettings>(
-                        settingsPath, QSettings::IniFormat);
-                },
             .chooseFile =
                 [this](QWidget*, bool forSaving) {
                     lastChooseForSaving = forSaving;
@@ -104,7 +97,6 @@ int main(int argc, char** argv)
     // what committing a list does.
     {
         Fixture fixture;
-        fixture.settingsPath = dir.filePath(QStringLiteral("apply.ini"));
         DerivedFieldController controller(fixture.hooks());
 
         // A refusal changes nothing: not the committed list, not the settings,
@@ -119,8 +111,6 @@ int main(int argc, char** argv)
         require(controller.definitions().empty()
                 && fixture.reloads == 0,
             "a refused apply still changed the committed list");
-        require(!QFile::exists(fixture.settingsPath),
-            "a refused apply wrote settings");
 
         // The second definition is what makes this more than a single-entry
         // check: it reads the first, which only resolves because the list is
@@ -142,34 +132,12 @@ int main(int argc, char** argv)
         require(controller.definitions() == good,
             "a refused apply replaced the committed list");
 
-        // Persisted, and restored into a fresh controller as the same list.
-        {
-            Fixture other;
-            other.settingsPath = fixture.settingsPath;
-            DerivedFieldController restored(other.hooks());
-            const QSettings settings(
-                fixture.settingsPath, QSettings::IniFormat);
-            restored.restore(settings);
-            require(restored.definitions() == good,
-                "the committed list did not survive a restore");
-            require(other.reloads == 0,
-                "restoring reloaded, which would reload nothing at startup");
-        }
-
         // An empty list is a legitimate commit -- it clears the derived fields
         // -- and takes the stored key with it.
         require(!controller.apply({}).has_value(),
             "clearing the list was refused");
         require(controller.definitions().empty() && fixture.reloads == 2,
             "clearing the list did not commit and reload");
-        {
-            const QSettings settings(
-                fixture.settingsPath, QSettings::IniFormat);
-            DerivedFieldController restored(fixture.hooks());
-            restored.restore(settings);
-            require(restored.definitions().empty(),
-                "a cleared list came back from the settings");
-        }
     }
 
     // With no dataset that can take derived fields, the action is disabled and
@@ -177,7 +145,6 @@ int main(int argc, char** argv)
     {
         Fixture fixture;
         fixture.datasetOpen = false;
-        fixture.settingsPath = dir.filePath(QStringLiteral("closed.ini"));
         DerivedFieldController controller(fixture.hooks());
         auto* parent = new QWidget;
         auto* action = controller.createAction(parent);
@@ -226,7 +193,6 @@ int main(int argc, char** argv)
     // and an export writes the draft rather than the committed list.
     {
         Fixture fixture;
-        fixture.settingsPath = dir.filePath(QStringLiteral("io.ini"));
         DerivedFieldController controller(fixture.hooks());
         require(!controller.apply({{"speed", "density"}}).has_value(),
             "the starting list was refused");
@@ -334,11 +300,25 @@ int main(int argc, char** argv)
         delete parent;
     }
 
+    // Opening a different dataset forgets the list: a definition written
+    // against the last one's fields would otherwise refuse every later Apply,
+    // since the editor validates the whole list at once.
+    {
+        Fixture fixture;
+        DerivedFieldController controller(fixture.hooks());
+        require(!controller.apply({{"speed", "density"}}).has_value(),
+            "the starting list was refused");
+        controller.clear();
+        require(controller.definitions().empty(),
+            "clearing left definitions behind");
+        require(fixture.reloads == 1,
+            "clearing reloaded, which the open it belongs to does itself");
+    }
+
     // The report the host puts in the status bar when a dataset could not
     // provide some of the committed list.
     {
         Fixture fixture;
-        fixture.settingsPath = dir.filePath(QStringLiteral("skip.ini"));
         DerivedFieldController controller(fixture.hooks());
         require(controller.skippedReport({}).isEmpty(),
             "nothing skipped still produced a report");

--- a/tests/unit/test_derived_field_controller.cpp
+++ b/tests/unit/test_derived_field_controller.cpp
@@ -93,14 +93,13 @@ int main(int argc, char** argv)
     QTemporaryDir dir;
     require(dir.isValid(), "could not create a scratch directory");
 
-    // Validation, commit, persistence and the reload, which are the whole of
-    // what committing a list does.
+    // Validation, commit and the reload, which are the whole of what
+    // committing a list does.
     {
         Fixture fixture;
         DerivedFieldController controller(fixture.hooks());
 
-        // A refusal changes nothing: not the committed list, not the settings,
-        // and no reload.
+        // A refusal changes nothing: not the committed list, and no reload.
         const auto refusal = controller.apply({{"speed", "sqrt(absent)"}});
         require(refusal.has_value(), "an unresolvable definition was accepted");
         require(refusal->definitionIndex.has_value()
@@ -132,8 +131,7 @@ int main(int argc, char** argv)
         require(controller.definitions() == good,
             "a refused apply replaced the committed list");
 
-        // An empty list is a legitimate commit -- it clears the derived fields
-        // -- and takes the stored key with it.
+        // An empty list is a legitimate commit: it clears the derived fields.
         require(!controller.apply({}).has_value(),
             "clearing the list was refused");
         require(controller.definitions().empty() && fixture.reloads == 2,

--- a/tests/unit/test_derived_field_controller.cpp
+++ b/tests/unit/test_derived_field_controller.cpp
@@ -15,6 +15,7 @@
 #include <iostream>
 #include <memory>
 #include <optional>
+#include <string>
 #include <vector>
 
 namespace {
@@ -33,30 +34,6 @@ void require(bool condition, const char* message)
     }
 }
 
-// The stored fields a definition is validated against.
-amrvis::DatasetMetadata storedMetadata()
-{
-    amrvis::DatasetMetadata metadata;
-    metadata.dimension = 2;
-    metadata.finestLevel = 0;
-    metadata.hasPhysicalGeometry = true;
-    for (std::size_t axis = 0; axis < 3; ++axis) {
-        metadata.physicalDomain.lower[axis] = 0.0;
-        metadata.physicalDomain.upper[axis] = 1.0;
-    }
-    amrvis::LevelMetadata level;
-    level.cellSize = amrvis::Real3{{0.25, 0.25, 0.25}};
-    level.domain.upper = amrvis::Int3{{3, 3, 3}};
-    metadata.levels.push_back(level);
-    metadata.fields = {
-        amrvis::FieldMetadata{
-            .name = "density", .centering = {}, .componentNames = {}},
-        amrvis::FieldMetadata{
-            .name = "temperature", .centering = {}, .componentNames = {}},
-    };
-    return metadata;
-}
-
 struct Fixture {
     // Set to false to stand for a session that cannot take derived fields (a
     // remote one) or for no dataset at all.
@@ -70,13 +47,6 @@ struct Fixture {
     {
         return DerivedFieldController::Hooks{
             .available = [this] { return datasetOpen; },
-            .storedMetadata =
-                [this]() -> std::optional<amrvis::DatasetMetadata> {
-                if (!datasetOpen) {
-                    return std::nullopt;
-                }
-                return storedMetadata();
-            },
             .reload = [this] { ++reloads; },
             .chooseFile =
                 [this](QWidget*, bool forSaving) {
@@ -152,6 +122,30 @@ int main(int argc, char** argv)
         require(controller.definitions().empty()
                 && fixture.reloads == before + 1,
             "clearing the list did not commit and reload");
+    }
+
+    // A list longer than a dataset can install is refused whole. Committing
+    // it would install the first maximumDerivedFieldCount against every
+    // dataset and skip the rest, so every window would list what it had
+    // greyed out -- and an imported file is where such a length comes from.
+    {
+        Fixture fixture;
+        DerivedFieldStore store;
+        DerivedFieldController controller(fixture.hooks(), store);
+        std::vector<DerivedFieldDefinition> many;
+        many.reserve(amrvis::maximumDerivedFieldCount + 1);
+        for (std::size_t index = 0; index <= amrvis::maximumDerivedFieldCount;
+            ++index) {
+            many.push_back({"f" + std::to_string(index), "density"});
+        }
+        const auto refusal = controller.apply(many);
+        require(refusal.has_value() && !refusal->definitionIndex.has_value(),
+            "a list past the cap was accepted");
+        require(controller.definitions().empty() && fixture.reloads == 0,
+            "a refused list was committed");
+        many.pop_back();
+        require(!controller.apply(many).has_value(),
+            "a list at the cap was refused");
     }
 
     // With no dataset that can take derived fields, the action is disabled and
@@ -342,6 +336,62 @@ int main(int argc, char** argv)
         require(two.definitions().empty(), "the other window kept the list");
         require(second.reloads == 1,
             "a window with no usable dataset was reloaded");
+    }
+
+    // An editor open in another window: a definition committed next door
+    // reaches it, but never over work started here and not yet applied.
+    {
+        Fixture first;
+        Fixture second;
+        DerivedFieldStore store;
+        DerivedFieldController one(first.hooks(), store);
+        DerivedFieldController two(second.hooks(), store);
+
+        auto* parent = new QWidget;
+        two.showEditor(parent);
+        auto* peer = parent->findChild<ExpressionEditorDialog*>();
+        require(peer != nullptr, "the editor did not open");
+        const auto* notice =
+            peer->findChild<QLabel*>(QStringLiteral("expressionNotice"));
+        require(notice != nullptr && !notice->isVisible(),
+            "the editor opened on a notice");
+
+        // Nothing typed here, so the change is taken as it stands.
+        require(!one.apply({{"speed", "density"}}).has_value(),
+            "the list was refused");
+        require(peer->draft().size() == 1 && peer->draft()[0].name == "speed",
+            "an idle editor did not adopt the shared list");
+        require(!peer->hasUnappliedEdits(),
+            "an adopted list was left looking like an unapplied edit");
+        require(!notice->isVisible(), "an adopted change was announced");
+
+        // Now with a definition written here and not applied.
+        peer->findChild<QPushButton*>(QStringLiteral("newExpressionButton"))
+            ->click();
+        peer->findChild<QLineEdit*>(QStringLiteral("expressionName"))
+            ->setText(QStringLiteral("mine"));
+        peer->findChild<QPlainTextEdit*>(QStringLiteral("expressionSource"))
+            ->setPlainText(QStringLiteral("temperature"));
+        require(peer->hasUnappliedEdits(), "typing left no unapplied edit");
+        require(!one.apply({{"theirs", "density"}}).has_value(),
+            "the second list was refused");
+        require(peer->draft().size() == 2 && peer->draft()[1].name == "mine",
+            "a commit in another window discarded unapplied work");
+        require(notice->isVisible(),
+            "the editor was not told the shared list had moved");
+
+        // The kept edits are still the ones Apply commits, and committing
+        // them ends the notice rather than leaving it standing.
+        peer->findChild<QPushButton*>(
+                QStringLiteral("applyExpressionsButton"))
+            ->click();
+        require(store.definitions().size() == 2
+                && store.definitions()[1].name == "mine",
+            "applying the kept edits did not commit them");
+        require(!peer->hasUnappliedEdits(),
+            "an applied draft was still an unapplied edit");
+        require(!notice->isVisible(), "the notice outlived the apply");
+        delete parent;
     }
 
     std::cout << "derived field controller tests passed\n";

--- a/tests/unit/test_derived_field_controller.cpp
+++ b/tests/unit/test_derived_field_controller.cpp
@@ -1,0 +1,333 @@
+#include "DerivedFieldController.hpp"
+#include "ExpressionEditorDialog.hpp"
+
+#include <QApplication>
+#include <QFile>
+#include <QLabel>
+#include <QLineEdit>
+#include <QListWidget>
+#include <QPlainTextEdit>
+#include <QPushButton>
+#include <QSettings>
+#include <QTemporaryDir>
+
+#include <cstdlib>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <vector>
+
+namespace {
+
+using amrvis::DerivedFieldDefinition;
+using amrvis::DerivedFieldSkip;
+using amrvis::qt::DerivedFieldController;
+using amrvis::qt::ExpressionEditorDialog;
+
+void require(bool condition, const char* message)
+{
+    if (!condition) {
+        std::cerr << "FAILED: " << message << '\n';
+        std::exit(1);
+    }
+}
+
+// The stored fields a definition is validated against.
+amrvis::DatasetMetadata storedMetadata()
+{
+    amrvis::DatasetMetadata metadata;
+    metadata.dimension = 2;
+    metadata.finestLevel = 0;
+    metadata.hasPhysicalGeometry = true;
+    for (std::size_t axis = 0; axis < 3; ++axis) {
+        metadata.physicalDomain.lower[axis] = 0.0;
+        metadata.physicalDomain.upper[axis] = 1.0;
+    }
+    amrvis::LevelMetadata level;
+    level.cellSize = amrvis::Real3{{0.25, 0.25, 0.25}};
+    level.domain.upper = amrvis::Int3{{3, 3, 3}};
+    metadata.levels.push_back(level);
+    metadata.fields = {
+        amrvis::FieldMetadata{
+            .name = "density", .centering = {}, .componentNames = {}},
+        amrvis::FieldMetadata{
+            .name = "temperature", .centering = {}, .componentNames = {}},
+    };
+    return metadata;
+}
+
+struct Fixture {
+    // Set to false to stand for a session that cannot take derived fields (a
+    // remote one) or for no dataset at all.
+    bool datasetOpen = true;
+    int reloads = 0;
+    QString settingsPath;
+    // What the next chooseFile answers, and what it was asked for.
+    QString chosenPath;
+    std::optional<bool> lastChooseForSaving;
+
+    [[nodiscard]] DerivedFieldController::Hooks hooks()
+    {
+        return DerivedFieldController::Hooks{
+            .available = [this] { return datasetOpen; },
+            .storedMetadata =
+                [this]() -> std::optional<amrvis::DatasetMetadata> {
+                if (!datasetOpen) {
+                    return std::nullopt;
+                }
+                return storedMetadata();
+            },
+            .reload = [this] { ++reloads; },
+            .settings =
+                [this] {
+                    return std::make_unique<QSettings>(
+                        settingsPath, QSettings::IniFormat);
+                },
+            .chooseFile =
+                [this](QWidget*, bool forSaving) {
+                    lastChooseForSaving = forSaving;
+                    return chosenPath;
+                },
+        };
+    }
+};
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    QApplication application(argc, argv);
+    QTemporaryDir dir;
+    require(dir.isValid(), "could not create a scratch directory");
+
+    // Validation, commit, persistence and the reload, which are the whole of
+    // what committing a list does.
+    {
+        Fixture fixture;
+        fixture.settingsPath = dir.filePath(QStringLiteral("apply.ini"));
+        DerivedFieldController controller(fixture.hooks());
+        int changes = 0;
+        QObject::connect(&controller,
+            &DerivedFieldController::definitionsChanged, &application,
+            [&changes] { ++changes; });
+
+        // A refusal changes nothing: not the committed list, not the settings,
+        // and no reload.
+        const auto refusal = controller.apply({{"speed", "sqrt(absent)"}});
+        require(refusal.has_value(), "an unresolvable definition was accepted");
+        require(refusal->definitionIndex.has_value()
+                && *refusal->definitionIndex == 0,
+            "the refusal did not name the definition");
+        require(refusal->message.contains(QStringLiteral("absent")),
+            "the refusal does not say what was missing");
+        require(controller.definitions().empty() && changes == 0
+                && fixture.reloads == 0,
+            "a refused apply still changed the committed list");
+        require(!QFile::exists(fixture.settingsPath),
+            "a refused apply wrote settings");
+
+        // The second definition is what makes this more than a single-entry
+        // check: it reads the first, which only resolves because the list is
+        // installed in order.
+        const std::vector<DerivedFieldDefinition> good{
+            {"speed", "sqrt(density**2 + temperature**2)"},
+            {"twice", "2*speed"}};
+        require(!controller.apply(good).has_value(),
+            "a resolvable list was refused");
+        require(controller.definitions() == good && changes == 1
+                && fixture.reloads == 1,
+            "an accepted apply did not commit and reload exactly once");
+
+        // The reverse order cannot resolve: a definition may only read the
+        // ones before it.
+        const auto reversed = controller.apply({good[1], good[0]});
+        require(reversed.has_value() && reversed->definitionIndex == 0,
+            "a forward reference was accepted");
+        require(controller.definitions() == good,
+            "a refused apply replaced the committed list");
+
+        // Persisted, and restored into a fresh controller as the same list.
+        {
+            Fixture other;
+            other.settingsPath = fixture.settingsPath;
+            DerivedFieldController restored(other.hooks());
+            const QSettings settings(
+                fixture.settingsPath, QSettings::IniFormat);
+            restored.restore(settings);
+            require(restored.definitions() == good,
+                "the committed list did not survive a restore");
+            require(other.reloads == 0,
+                "restoring reloaded, which would reload nothing at startup");
+        }
+
+        // An empty list is a legitimate commit -- it clears the derived fields
+        // -- and takes the stored key with it.
+        require(!controller.apply({}).has_value(),
+            "clearing the list was refused");
+        require(controller.definitions().empty() && fixture.reloads == 2,
+            "clearing the list did not commit and reload");
+        {
+            const QSettings settings(
+                fixture.settingsPath, QSettings::IniFormat);
+            DerivedFieldController restored(fixture.hooks());
+            restored.restore(settings);
+            require(restored.definitions().empty(),
+                "a cleared list came back from the settings");
+        }
+    }
+
+    // With no dataset that can take derived fields, the action is disabled and
+    // apply refuses without touching anything.
+    {
+        Fixture fixture;
+        fixture.datasetOpen = false;
+        fixture.settingsPath = dir.filePath(QStringLiteral("closed.ini"));
+        DerivedFieldController controller(fixture.hooks());
+        auto* parent = new QWidget;
+        auto* action = controller.createAction(parent);
+        require(action != nullptr && !action->isEnabled(),
+            "the action is enabled with no dataset open");
+        require(controller.apply({{"speed", "density"}}).has_value(),
+            "apply succeeded with no dataset open");
+        require(fixture.reloads == 0, "a refused apply reloaded");
+        fixture.datasetOpen = true;
+        controller.refreshAvailability();
+        require(action->isEnabled(),
+            "the action stayed disabled after a dataset opened");
+        delete parent;
+    }
+
+    // The expression-list format, both directions, and the entries it refuses.
+    {
+        const std::vector<DerivedFieldDefinition> definitions{
+            {"speed", "sqrt(u**2 + v**2)"}, {"drag", "-${x-momentum}"}};
+        const auto json = amrvis::qt::writeExpressionList(definitions);
+        const auto parsed = amrvis::qt::parseExpressionList(json);
+        require(parsed.error.isEmpty() && parsed.definitions == definitions,
+            "an expression list did not round-trip");
+        // The format string is in every exported file, so renaming it is a
+        // file-format change rather than a tidy-up. A round trip cannot catch
+        // that -- both directions would move together -- so the spelling is
+        // pinned here, as test_palette pins the palette settings keys.
+        require(json.contains("\"amrexplorer-expression-list\"")
+                && json.contains("\"version\": 1"),
+            "the exported format identifier changed");
+        for (const auto* bad : {"", "[]", "{}",
+                 R"({"format":"other","version":1,"expressions":[]})",
+                 R"({"format":"amrexplorer-expression-list","version":2,)"
+                 R"("expressions":[]})",
+                 R"({"format":"amrexplorer-expression-list","version":1,)"
+                 R"("expressions":[3]})",
+                 R"({"format":"amrexplorer-expression-list","version":1,)"
+                 R"("expressions":[{"name":"a"}]})"}) {
+            const auto rejected = amrvis::qt::parseExpressionList(bad);
+            require(!rejected.error.isEmpty() && rejected.definitions.empty(),
+                "a malformed expression list was accepted");
+        }
+    }
+
+    // Import and export through the editor: an import replaces the draft only,
+    // and an export writes the draft rather than the committed list.
+    {
+        Fixture fixture;
+        fixture.settingsPath = dir.filePath(QStringLiteral("io.ini"));
+        DerivedFieldController controller(fixture.hooks());
+        require(!controller.apply({{"speed", "density"}}).has_value(),
+            "the starting list was refused");
+
+        const auto importPath = dir.filePath(QStringLiteral("in.json"));
+        {
+            QFile file(importPath);
+            require(file.open(QIODevice::WriteOnly), "could not write import");
+            const auto json = amrvis::qt::writeExpressionList(
+                {{"imported", "temperature"}});
+            require(file.write(json) == json.size(), "short import write");
+        }
+
+        auto* parent = new QWidget;
+        controller.showEditor(parent);
+        auto* dialog = parent->findChild<ExpressionEditorDialog*>();
+        require(dialog != nullptr, "the editor did not open");
+        require(dialog->draft().size() == 1
+                && dialog->draft()[0].name == "speed",
+            "the editor did not open on the committed list");
+
+        fixture.chosenPath = importPath;
+        dialog->findChild<QPushButton*>(
+                   QStringLiteral("importExpressionsButton"))
+            ->click();
+        require(fixture.lastChooseForSaving.has_value()
+                && !*fixture.lastChooseForSaving,
+            "the import did not ask for a file to read");
+        require(dialog->draft().size() == 1
+                && dialog->draft()[0].name == "imported",
+            "the import did not replace the draft");
+        require(controller.definitions().size() == 1
+                && controller.definitions()[0].name == "speed",
+            "the import committed without an apply");
+
+        const auto exportPath = dir.filePath(QStringLiteral("out.json"));
+        fixture.chosenPath = exportPath;
+        dialog->findChild<QPushButton*>(
+                   QStringLiteral("exportExpressionsButton"))
+            ->click();
+        require(fixture.lastChooseForSaving.has_value()
+                && *fixture.lastChooseForSaving,
+            "the export did not ask for a file to write");
+        {
+            QFile file(exportPath);
+            require(file.open(QIODevice::ReadOnly), "the export wrote nothing");
+            const auto written = amrvis::qt::parseExpressionList(file.readAll());
+            require(written.error.isEmpty() && written.definitions.size() == 1
+                    && written.definitions[0].name == "imported",
+                "the export wrote the committed list instead of the draft");
+        }
+
+        // Apply from the editor: the draft becomes the committed list and the
+        // host is asked to reload.
+        const auto reloadsBefore = fixture.reloads;
+        dialog->findChild<QPushButton*>(
+                   QStringLiteral("applyExpressionsButton"))
+            ->click();
+        require(controller.definitions().size() == 1
+                && controller.definitions()[0].name == "imported"
+                && fixture.reloads == reloadsBefore + 1,
+            "the editor's Apply did not commit the draft");
+        const auto* error =
+            dialog->findChild<QLabel*>(QStringLiteral("expressionError"));
+        require(error != nullptr && !error->isVisible(),
+            "an accepted apply left an error showing");
+
+        // And a refusal from the editor shows in place, keeping the committed
+        // list.
+        dialog->findChild<QPlainTextEdit*>(
+                   QStringLiteral("expressionSource"))
+            ->setPlainText(QStringLiteral("absent + 1"));
+        dialog->findChild<QPushButton*>(
+                   QStringLiteral("applyExpressionsButton"))
+            ->click();
+        require(error->isVisible() && !error->text().isEmpty(),
+            "a refusal was not shown in the editor");
+        require(controller.definitions()[0].expression == "temperature",
+            "a refused apply from the editor changed the committed list");
+        delete parent;
+    }
+
+    // The report the host puts in the status bar when a dataset could not
+    // provide some of the committed list.
+    {
+        Fixture fixture;
+        fixture.settingsPath = dir.filePath(QStringLiteral("skip.ini"));
+        DerivedFieldController controller(fixture.hooks());
+        require(controller.skippedReport({}).isEmpty(),
+            "nothing skipped still produced a report");
+        const auto report = controller.skippedReport(
+            {DerivedFieldSkip{0, "speed", "no field named 'u'"}});
+        require(report.contains(QStringLiteral("speed"))
+                && report.contains(QStringLiteral("no field named 'u'")),
+            "the skip report names neither the field nor the reason");
+    }
+
+    std::cout << "derived field controller tests passed\n";
+    return 0;
+}

--- a/tests/unit/test_derived_field_controller.cpp
+++ b/tests/unit/test_derived_field_controller.cpp
@@ -3,6 +3,7 @@
 #include "ExpressionEditorDialog.hpp"
 
 #include <QApplication>
+#include <QDialog>
 #include <QFile>
 #include <QLabel>
 #include <QLineEdit>
@@ -10,6 +11,7 @@
 #include <QPlainTextEdit>
 #include <QPushButton>
 #include <QTemporaryDir>
+#include <QTextDocument>
 
 #include <cstdlib>
 #include <iostream>
@@ -167,6 +169,23 @@ int main(int argc, char** argv)
         require(action->isEnabled(),
             "the action stayed disabled after a dataset opened");
 
+        // Close closes it. Nothing asserted this, which is how removing the
+        // button's connection -- on the belief that a parented
+        // QDialogButtonBox wires rejected() to its dialog, which it does not
+        // -- shipped as a dialog whose Close button did nothing.
+        controller.showEditor(parent);
+        auto* closable = parent->findChild<ExpressionEditorDialog*>();
+        require(closable != nullptr, "the editor did not open");
+        int finished = 0;
+        QObject::connect(closable, &QDialog::finished,
+            closable, [&finished](int) { ++finished; });
+        closable->findChild<QPushButton*>(
+                     QStringLiteral("closeExpressionsButton"))
+            ->click();
+        require(finished == 1 && !closable->isVisible(),
+            "the editor's Close button did not close it");
+        QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
+
         // An editor open when the dataset goes stays open: it edits the
         // session's list, not the dataset's, and File > Open leaves the
         // window without one for the whole of the load. Closing it would
@@ -183,6 +202,27 @@ int main(int argc, char** argv)
         require(parent->findChild<ExpressionEditorDialog*>() != nullptr,
             "losing the dataset closed the editor and its draft");
         delete parent;
+    }
+
+    // The tooltip format, which a GUI smoke test could only assert through a
+    // combo box: an expression is folded onto one line, escaped, and wrapped
+    // so Qt renders it as rich text whichever characters it happens to hold.
+    {
+        require(amrvis::qt::escapedExpression("density *\n    temperature")
+                == QStringLiteral("density * temperature"),
+            "the expression was not folded onto one line");
+        require(amrvis::qt::escapedExpression("${a<b} & ${c}")
+                == QStringLiteral("${a&lt;b} &amp; ${c}"),
+            "the expression was not escaped");
+        require(amrvis::qt::richTooltip(QStringLiteral("a &amp; b"))
+                == QStringLiteral("<qt>a &amp; b</qt>"),
+            "the tooltip was not wrapped as rich text");
+        // Which is the point of the wrapper: on its own, text escaped for
+        // markup is only *read* as markup when it holds an escaped `<`.
+        require(!Qt::mightBeRichText(QStringLiteral("a &amp; b"))
+                && Qt::mightBeRichText(
+                    amrvis::qt::richTooltip(QStringLiteral("a &amp; b"))),
+            "the wrapper does not make Qt read the tooltip as rich text");
     }
 
     // An imported list is bounded where its length is first seen, so an

--- a/tests/unit/test_derived_field_controller.cpp
+++ b/tests/unit/test_derived_field_controller.cpp
@@ -1,4 +1,5 @@
 #include "DerivedFieldController.hpp"
+#include "DerivedFieldStore.hpp"
 #include "ExpressionEditorDialog.hpp"
 
 #include <QApplication>
@@ -21,6 +22,7 @@ namespace {
 using amrvis::DerivedFieldDefinition;
 using amrvis::DerivedFieldSkip;
 using amrvis::qt::DerivedFieldController;
+using amrvis::qt::DerivedFieldStore;
 using amrvis::qt::ExpressionEditorDialog;
 
 void require(bool condition, const char* message)
@@ -97,16 +99,17 @@ int main(int argc, char** argv)
     // committing a list does.
     {
         Fixture fixture;
-        DerivedFieldController controller(fixture.hooks());
+        DerivedFieldStore store;
+        DerivedFieldController controller(fixture.hooks(), store);
 
         // A refusal changes nothing: not the committed list, and no reload.
-        const auto refusal = controller.apply({{"speed", "sqrt(absent)"}});
-        require(refusal.has_value(), "an unresolvable definition was accepted");
+        // What is refused is what is wrong whatever the data -- an expression
+        // that does not parse, an empty or repeated name.
+        const auto refusal = controller.apply({{"speed", "sqrt(absent"}});
+        require(refusal.has_value(), "an unparsable expression was accepted");
         require(refusal->definitionIndex.has_value()
                 && *refusal->definitionIndex == 0,
             "the refusal did not name the definition");
-        require(refusal->message.contains(QStringLiteral("absent")),
-            "the refusal does not say what was missing");
         require(controller.definitions().empty()
                 && fixture.reloads == 0,
             "a refused apply still changed the committed list");
@@ -123,18 +126,31 @@ int main(int argc, char** argv)
                 && fixture.reloads == 1,
             "an accepted apply did not commit and reload exactly once");
 
-        // The reverse order cannot resolve: a definition may only read the
-        // ones before it.
-        const auto reversed = controller.apply({good[1], good[0]});
-        require(reversed.has_value() && reversed->definitionIndex == 0,
-            "a forward reference was accepted");
-        require(controller.definitions() == good,
+        // A name this dataset does not have is not a refusal: the list is
+        // shared with windows that may have it, and it is shown greyed out
+        // where it does not apply.
+        auto withStranger = good;
+        withStranger.push_back({"stranger", "absent * 2"});
+        require(!controller.apply(withStranger).has_value(),
+            "a definition for another dataset was refused");
+        require(controller.definitions() == withStranger,
+            "the definition for another dataset was not committed");
+        // A repeated name is wrong whatever the data.
+        auto repeated = good;
+        repeated.push_back(good[0]);
+        const auto duplicate = controller.apply(repeated);
+        require(duplicate.has_value() && duplicate->definitionIndex == 2,
+            "a repeated name was accepted");
+        require(controller.definitions() == withStranger,
             "a refused apply replaced the committed list");
+        require(!controller.apply(good).has_value(), "restoring was refused");
 
         // An empty list is a legitimate commit: it clears the derived fields.
+        const auto before = fixture.reloads;
         require(!controller.apply({}).has_value(),
             "clearing the list was refused");
-        require(controller.definitions().empty() && fixture.reloads == 2,
+        require(controller.definitions().empty()
+                && fixture.reloads == before + 1,
             "clearing the list did not commit and reload");
     }
 
@@ -143,7 +159,8 @@ int main(int argc, char** argv)
     {
         Fixture fixture;
         fixture.datasetOpen = false;
-        DerivedFieldController controller(fixture.hooks());
+        DerivedFieldStore store;
+        DerivedFieldController controller(fixture.hooks(), store);
         auto* parent = new QWidget;
         auto* action = controller.createAction(parent);
         require(action != nullptr && !action->isEnabled(),
@@ -191,7 +208,8 @@ int main(int argc, char** argv)
     // and an export writes the draft rather than the committed list.
     {
         Fixture fixture;
-        DerivedFieldController controller(fixture.hooks());
+        DerivedFieldStore store;
+        DerivedFieldController controller(fixture.hooks(), store);
         require(!controller.apply({{"speed", "density"}}).has_value(),
             "the starting list was refused");
 
@@ -283,11 +301,12 @@ int main(int argc, char** argv)
                 "applying did not keep the draft it committed");
         }
 
-        // And a refusal from the editor shows in place, keeping the committed
-        // list.
+        // And a refusal from the editor -- an expression that does not parse,
+        // since a name this dataset lacks is no longer one -- shows in place,
+        // keeping the committed list.
         dialog->findChild<QPlainTextEdit*>(
                    QStringLiteral("expressionSource"))
-            ->setPlainText(QStringLiteral("absent + 1"));
+            ->setPlainText(QStringLiteral("absent +"));
         dialog->findChild<QPushButton*>(
                    QStringLiteral("applyExpressionsButton"))
             ->click();
@@ -298,33 +317,31 @@ int main(int argc, char** argv)
         delete parent;
     }
 
-    // Opening a different dataset forgets the list: a definition written
-    // against the last one's fields would otherwise refuse every later Apply,
-    // since the editor validates the whole list at once.
+    // Two windows, one store: a definition written in one is the other's too,
+    // and both reload so it reaches both field lists.
     {
-        Fixture fixture;
-        DerivedFieldController controller(fixture.hooks());
-        require(!controller.apply({{"speed", "density"}}).has_value(),
-            "the starting list was refused");
-        controller.clear();
-        require(controller.definitions().empty(),
-            "clearing left definitions behind");
-        require(fixture.reloads == 1,
-            "clearing reloaded, which the open it belongs to does itself");
-    }
-
-    // The report the host puts in the status bar when a dataset could not
-    // provide some of the committed list.
-    {
-        Fixture fixture;
-        DerivedFieldController controller(fixture.hooks());
-        require(controller.skippedReport({}).isEmpty(),
-            "nothing skipped still produced a report");
-        const auto report = controller.skippedReport(
-            {DerivedFieldSkip{0, "speed", "no field named 'u'"}});
-        require(report.contains(QStringLiteral("speed"))
-                && report.contains(QStringLiteral("no field named 'u'")),
-            "the skip report names neither the field nor the reason");
+        Fixture first;
+        Fixture second;
+        DerivedFieldStore store;
+        DerivedFieldController one(first.hooks(), store);
+        DerivedFieldController two(second.hooks(), store);
+        const std::vector<DerivedFieldDefinition> list{{"speed", "density"}};
+        require(!one.apply(list).has_value(), "the list was refused");
+        require(one.definitions() == list && two.definitions() == list,
+            "the other window did not see the definition");
+        require(first.reloads == 1 && second.reloads == 1,
+            "both windows should have reloaded exactly once");
+        // Applying what is already there moves nothing and reloads nobody.
+        require(!two.apply(list).has_value(), "re-applying was refused");
+        require(first.reloads == 1 && second.reloads == 1,
+            "an unchanged list reloaded a window");
+        // A window that cannot take derived fields is not reloaded, and still
+        // sees the list.
+        second.datasetOpen = false;
+        require(!one.apply({}).has_value(), "clearing was refused");
+        require(two.definitions().empty(), "the other window kept the list");
+        require(second.reloads == 1,
+            "a window with no usable dataset was reloaded");
     }
 
     std::cout << "derived field controller tests passed\n";

--- a/tests/unit/test_derived_field_controller.cpp
+++ b/tests/unit/test_derived_field_controller.cpp
@@ -298,6 +298,31 @@ int main(int argc, char** argv)
         require(error != nullptr && !error->isVisible(),
             "an accepted apply left an error showing");
 
+        // Applying leaves the user on the definition they were editing, not
+        // back at the first one.
+        {
+            auto* second = dialog->findChild<QPushButton*>(
+                QStringLiteral("newExpressionButton"));
+            second->click();
+            dialog->findChild<QLineEdit*>(QStringLiteral("expressionName"))
+                ->setText(QStringLiteral("later"));
+            dialog->findChild<QPlainTextEdit*>(
+                       QStringLiteral("expressionSource"))
+                ->setPlainText(QStringLiteral("density"));
+            require(dialog->selectedIndex().has_value()
+                    && *dialog->selectedIndex() == 1,
+                "the new definition was not the selected one");
+            dialog->findChild<QPushButton*>(
+                       QStringLiteral("applyExpressionsButton"))
+                ->click();
+            require(dialog->selectedIndex().has_value()
+                    && *dialog->selectedIndex() == 1,
+                "applying moved the editor off the row being edited");
+            require(dialog->draft().size() == 2
+                    && dialog->draft()[1].name == "later",
+                "applying did not keep the draft it committed");
+        }
+
         // And a refusal from the editor shows in place, keeping the committed
         // list.
         dialog->findChild<QPlainTextEdit*>(

--- a/tests/unit/test_derived_field_controller.cpp
+++ b/tests/unit/test_derived_field_controller.cpp
@@ -106,10 +106,6 @@ int main(int argc, char** argv)
         Fixture fixture;
         fixture.settingsPath = dir.filePath(QStringLiteral("apply.ini"));
         DerivedFieldController controller(fixture.hooks());
-        int changes = 0;
-        QObject::connect(&controller,
-            &DerivedFieldController::definitionsChanged, &application,
-            [&changes] { ++changes; });
 
         // A refusal changes nothing: not the committed list, not the settings,
         // and no reload.
@@ -120,7 +116,7 @@ int main(int argc, char** argv)
             "the refusal did not name the definition");
         require(refusal->message.contains(QStringLiteral("absent")),
             "the refusal does not say what was missing");
-        require(controller.definitions().empty() && changes == 0
+        require(controller.definitions().empty()
                 && fixture.reloads == 0,
             "a refused apply still changed the committed list");
         require(!QFile::exists(fixture.settingsPath),
@@ -134,7 +130,7 @@ int main(int argc, char** argv)
             {"twice", "2*speed"}};
         require(!controller.apply(good).has_value(),
             "a resolvable list was refused");
-        require(controller.definitions() == good && changes == 1
+        require(controller.definitions() == good
                 && fixture.reloads == 1,
             "an accepted apply did not commit and reload exactly once");
 

--- a/tests/unit/test_derived_field_controller.cpp
+++ b/tests/unit/test_derived_field_controller.cpp
@@ -380,6 +380,20 @@ int main(int argc, char** argv)
         require(notice->isVisible(),
             "the editor was not told the shared list had moved");
 
+        // A standing conflict, not a message about the last thing done here:
+        // adding a definition (or selecting another row, or a refused Apply)
+        // goes through the same clear as an error would, and must not take
+        // the warning away while the draft still overwrites the shared list.
+        auto* add =
+            peer->findChild<QPushButton*>(QStringLiteral("newExpressionButton"));
+        add->click();
+        require(notice->isVisible(),
+            "adding a definition cleared the peer-change notice");
+        peer->findChild<QPushButton*>(QStringLiteral("deleteExpressionButton"))
+            ->click();
+        require(notice->isVisible(),
+            "deleting a definition cleared the peer-change notice");
+
         // The kept edits are still the ones Apply commits, and committing
         // them ends the notice rather than leaving it standing.
         peer->findChild<QPushButton*>(

--- a/tests/unit/test_derived_field_controller.cpp
+++ b/tests/unit/test_derived_field_controller.cpp
@@ -166,7 +166,43 @@ int main(int argc, char** argv)
         controller.refreshAvailability();
         require(action->isEnabled(),
             "the action stayed disabled after a dataset opened");
+
+        // An editor open when the dataset goes stays open: it edits the
+        // session's list, not the dataset's, and File > Open leaves the
+        // window without one for the whole of the load. Closing it would
+        // take an unapplied draft -- an import, say -- with it.
+        controller.showEditor(parent);
+        require(parent->findChild<ExpressionEditorDialog*>() != nullptr,
+            "the editor did not open");
+        fixture.datasetOpen = false;
+        controller.refreshAvailability();
+        // The editor is WA_DeleteOnClose, so a close() would only schedule the
+        // deletion: without delivering that, this passes whether the editor
+        // was closed or not.
+        QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
+        require(parent->findChild<ExpressionEditorDialog*>() != nullptr,
+            "losing the dataset closed the editor and its draft");
         delete parent;
+    }
+
+    // An imported list is bounded where its length is first seen, so an
+    // oversized file never becomes a row per entry in the editor's list.
+    {
+        QByteArray entries;
+        for (std::size_t index = 0; index <= amrvis::maximumDerivedFieldCount;
+            ++index) {
+            entries += entries.isEmpty() ? "" : ",";
+            entries += QByteArray("{\"name\":\"f")
+                + QByteArray::number(static_cast<qulonglong>(index))
+                + "\",\"expression\":\"density\"}";
+        }
+        const auto json = QByteArray(
+                              "{\"format\":\"amrexplorer-expression-list\","
+                              "\"version\":1,\"expressions\":[")
+            + entries + "]}";
+        const auto parsed = amrvis::qt::parseExpressionList(json);
+        require(!parsed.error.isEmpty() && parsed.definitions.empty(),
+            "an expression list past the cap was parsed anyway");
     }
 
     // The expression-list format, both directions, and the entries it refuses.

--- a/tests/unit/test_expression.cpp
+++ b/tests/unit/test_expression.cpp
@@ -294,8 +294,12 @@ int main()
         }
 
         requireError("", 0, "expected expression");
-        requireError("1\n+2", 1, "newlines are not allowed");
-        requireError("1\r+2", 1, "newlines are not allowed");
+        // Line breaks are whitespace, so a long expression can be laid out.
+        require(close(evaluate("1\n+2"), 3.0), "a newline broke an expression");
+        require(close(evaluate("1\r\n+\n2"), 3.0),
+            "a CRLF break broke an expression");
+        require(close(evaluate("sqrt(\n  9\n)"), 3.0),
+            "a call broken across lines failed");
         requireError("2^3", 1, "unexpected token");
         // A byte that is not a character is quoted as hex, never spliced into
         // the message: the message is UTF-8 by the time a label shows it, and
@@ -336,6 +340,7 @@ int main()
         requireError("${}", 0, "names no field");
         // At the '$', like every other failure inside a braced name -- the
         // offset names the token, not the byte the scan happened to stop on.
+        // ...but not inside a name, where it is a typo rather than layout.
         requireError("${a\nb}", 0, "newlines are not allowed");
         // A token's own text is escaped as well: a ${...} name is verbatim, so
         // it can carry bytes that are not characters.

--- a/tests/unit/test_range_controller.cpp
+++ b/tests/unit/test_range_controller.cpp
@@ -200,17 +200,21 @@ int main(int argc, char* argv[])
         controller.createToolbarWidgets(&toolbar);
         controller.setControlsReady(true);
         const auto widgets = widgetsOf(toolbar);
-        require(controller.trackedField() == 0, "tracked field does not start at 0");
+        // Nothing is tracked until a field is selected, which a name can say
+        // and a field id could not.
+        require(controller.trackedField().isEmpty(),
+            "a fresh controller already tracks a field");
+        controller.setTrackedField(QStringLiteral("f0"));
         selectMode(*widgets.mode, RangeMode::User);
         widgets.minimum->setValue(10.0);
         widgets.maximum->setValue(20.0);
-        controller.switchField(3);
-        require(controller.trackedField() == 3
+        controller.switchField(QStringLiteral("f3"));
+        require(controller.trackedField() == QStringLiteral("f3")
                 && controller.mode() == RangeMode::File
                 && !controller.selection().userRange
                 && !widgets.minimum->isEnabled(),
             "an unknown field did not load the default");
-        controller.switchField(3);
+        controller.switchField(QStringLiteral("f3"));
         require(controller.mode() == RangeMode::File,
             "switching to the same field changed something");
         // Field 3 gets its own User range, different from field 0's, so each
@@ -221,32 +225,32 @@ int main(int argc, char* argv[])
         widgets.minimum->setValue(-5.0);
         widgets.maximum->setValue(5.0);
         const auto edits = observed.userRange;
-        controller.switchField(0);
-        require(controller.trackedField() == 0
+        controller.switchField(QStringLiteral("f0"));
+        require(controller.trackedField() == QStringLiteral("f0")
                 && controller.mode() == RangeMode::User
                 && controller.selection().userRange == std::pair{10.0, 20.0}
                 && widgets.minimum->isEnabled(),
             "switching back did not restore the field's User range");
-        controller.switchField(3);
+        controller.switchField(QStringLiteral("f3"));
         require(controller.selection().userRange == std::pair{-5.0, 5.0},
             "the other field's snapshot was not kept");
         require(observed.userRange == edits && observed.mode == 2,
             "a field switch announced a change");
         controller.setSelection({RangeMode::Visible, std::nullopt, false});
-        controller.setTrackedField(7);
-        controller.commitFieldRange(7);
-        controller.switchField(0);
-        controller.switchField(7);
+        controller.setTrackedField(QStringLiteral("f7"));
+        controller.commitFieldRange(QStringLiteral("f7"));
+        controller.switchField(QStringLiteral("f0"));
+        controller.switchField(QStringLiteral("f7"));
         require(controller.mode() == RangeMode::Visible,
             "commit did not record the field's mode");
         controller.reset();
-        require(controller.trackedField() == 0
+        require(controller.trackedField().isEmpty()
                 && controller.mode() == RangeMode::File
                 && widgets.minimum->value() == 0.0
                 && widgets.maximum->value() == 1.0
                 && !widgets.minimum->isEnabled(),
             "reset did not restore the defaults");
-        controller.switchField(3);
+        controller.switchField(QStringLiteral("f3"));
         require(controller.mode() == RangeMode::File,
             "reset did not forget the fields");
     }
@@ -268,7 +272,7 @@ int main(int argc, char* argv[])
             return model->item(widgets.mode->findData(static_cast<int>(mode)));
         };
         selectMode(*widgets.mode, RangeMode::Level);
-        controller.updateAvailability({.file = true, .level = false}, 0);
+        controller.updateAvailability({.file = true, .level = false}, QStringLiteral("f0"));
         require(!item(RangeMode::Level)->isEnabled()
                 && !item(RangeMode::Level)->toolTip().isEmpty()
                 && item(RangeMode::File)->isEnabled()
@@ -282,21 +286,51 @@ int main(int argc, char* argv[])
         require(observed.mode == 1,
             "the fallback announced a mode change (only the user's Level pick "
             "should have)");
-        controller.switchField(1);
-        controller.switchField(0);
+        controller.switchField(QStringLiteral("f1"));
+        controller.switchField(QStringLiteral("f0"));
         require(controller.mode() == RangeMode::Visible,
             "the fallback was not recorded in the field's snapshot");
-        controller.updateAvailability({.file = true, .level = true}, 0);
+        controller.updateAvailability({.file = true, .level = true}, QStringLiteral("f0"));
         require(item(RangeMode::Level)->isEnabled()
                 && item(RangeMode::Level)->toolTip().isEmpty()
                 && controller.mode() == RangeMode::Visible
                 && observed.statuses.size() == 1,
             "restored availability changed the mode or re-announced");
         selectMode(*widgets.mode, RangeMode::User);
-        controller.updateAvailability({.file = false, .level = false}, 0);
+        controller.updateAvailability({.file = false, .level = false}, QStringLiteral("f0"));
         require(controller.mode() == RangeMode::User
                 && widgets.minimum->isEnabled(),
             "User was disturbed by metadata modes going away");
+    }
+
+    {
+        // A field's remembered range follows its name, not its position. The
+        // ids move whenever the field list does -- a sequence frame that lists
+        // fewer fields, or a derived definition that one frame cannot resolve
+        // and leaves out -- and keyed by id the memory handed the range of
+        // whichever field used to sit at that number.
+        QToolBar toolbar;
+        RangeController controller;
+        controller.createToolbarWidgets(&toolbar);
+        controller.setControlsReady(true);
+        const auto widgets = widgetsOf(toolbar);
+
+        controller.setTrackedField(QStringLiteral("speed"));
+        selectMode(*widgets.mode, RangeMode::User);
+        widgets.minimum->setValue(3.0);
+        widgets.maximum->setValue(4.0);
+        controller.commitFieldRange(QStringLiteral("speed"));
+
+        // Another field, then back -- as a reload that renumbered the list
+        // would leave things.
+        controller.switchField(QStringLiteral("drag"));
+        require(controller.mode() == RangeMode::File,
+            "an unseen field inherited a remembered range");
+        controller.switchField(QStringLiteral("speed"));
+        require(controller.mode() == RangeMode::User
+                && widgets.minimum->value() == 3.0
+                && widgets.maximum->value() == 4.0,
+            "the field's own range did not come back with its name");
     }
 
     std::cout << "range controller tests passed\n";

--- a/tests/unit/test_range_controller.cpp
+++ b/tests/unit/test_range_controller.cpp
@@ -361,6 +361,17 @@ int main(int argc, char* argv[])
         require(controller.selection().userRange
                 != std::pair{1.0, 2.0},
             "a range was filed under the empty name and handed back");
+
+        // The same rule in the writer a restored spec goes through, which
+        // commits whatever trackedField() says.
+        selectMode(*widgets.mode, RangeMode::User);
+        widgets.minimum->setValue(3.0);
+        widgets.maximum->setValue(4.0);
+        controller.commitFieldRange(QString());
+        controller.switchField(QStringLiteral("temperature"));
+        controller.switchField(QString());
+        require(controller.selection().userRange != std::pair{3.0, 4.0},
+            "commitFieldRange filed a range under the empty name");
     }
 
     std::cout << "range controller tests passed\n";

--- a/tests/unit/test_range_controller.cpp
+++ b/tests/unit/test_range_controller.cpp
@@ -333,6 +333,36 @@ int main(int argc, char* argv[])
             "the field's own range did not come back with its name");
     }
 
+    // The empty name is not a field, so nothing may be filed under it: the
+    // memory is keyed by name now, and an unset name is what a controller has
+    // before a field is tracked.
+    {
+        QToolBar toolbar;
+        Observed observed;
+        RangeController controller;
+        observe(controller, observed);
+        controller.createToolbarWidgets(&toolbar);
+        controller.setControlsReady(true);
+        const auto widgets = widgetsOf(toolbar);
+        require(controller.trackedField().isEmpty(),
+            "a fresh controller already tracks a field");
+
+        // A switch away from nothing must not snapshot the widgets under the
+        // empty name.
+        selectMode(*widgets.mode, RangeMode::User);
+        widgets.minimum->setValue(1.0);
+        widgets.maximum->setValue(2.0);
+        controller.switchField(QStringLiteral("density"));
+
+        selectMode(*widgets.mode, RangeMode::User);
+        widgets.minimum->setValue(7.0);
+        widgets.maximum->setValue(8.0);
+        controller.switchField(QString());
+        require(controller.selection().userRange
+                != std::pair{1.0, 2.0},
+            "a range was filed under the empty name and handed back");
+    }
+
     std::cout << "range controller tests passed\n";
     return 0;
 }


### PR DESCRIPTION
The Expression Editor: a list of definitions, the name and expression of the selected one, Import/Export of the list as JSON, and an Apply that validates the whole list and reopens the dataset with it. The definitions persist, so they apply to whatever is opened next.

Whole-list validation, strictly, before anything reloads: a rename can invalidate a later definition that read the old name, and a refusal names the definition and points into the expression. It is reported in the editor rather than over a second dialog.

Apply reloads rather than opens: the ordinary open path ends the sequence and closes the line-plot, dataset and volume windows, so a reload goes through the same route a sequence frame switch takes, and a single dataset through requestInitialSlice with a new generation -- which both invalidates the in-flight work and gives the replacement session a dataset id of its own.

Modeless, because that reload is an ordinary dataset load: there is no nested event loop to hold playback and debounce timers back from.

The list reaches a dataset through the frame spec, including on a fresh open, whose spec is otherwise the default one -- a restored list would never be installed. Definitions a dataset could not provide are said once the slices are up: showSlice clears the status bar, so an earlier message would not survive the load it belongs to. Remote sessions cannot install them, so the action is disabled with a reason there.