### PR TITLE
carry derived fields over the remote protocol (1.4)

### DIFF
--- a/include/amrexplorer/data/SessionValidation.hpp
+++ b/include/amrexplorer/data/SessionValidation.hpp
@@ -1,8 +1,11 @@
 #pragma once
 
+#include <amrexplorer/core/DerivedField.hpp>
 #include <amrexplorer/data/DatasetPage.hpp>
 #include <amrexplorer/data/DatasetSession.hpp>
 
+#include <cstddef>
+#include <span>
 #include <string>
 
 namespace amrvis {
@@ -43,8 +46,27 @@ void validateSessionVolumeResult(const DatasetMetadata& metadata,
 // them than were asked for, and cannot skip a definition that was never sent
 // or report more skips than there were definitions -- and a definition cannot
 // be both installed and skipped, which is what the counts add up to.
-void validateSessionOpenedDerivedFields(std::size_t fieldCount,
-    std::uint32_t derivedFieldCount,
-    const std::vector<DerivedFieldSkip>& skips, std::size_t requestedCount);
+//
+// Gathered into one named argument rather than passed as four: fieldCount and
+// requestedCount are both counts of the same type, and positionally a caller
+// that swapped them would still compile and still satisfy every check on any
+// reply whose catalog is larger than its request -- which is every reply that
+// installed anything. The siblings above take the request and result objects
+// themselves, which is what makes them non-transposable; this one cannot,
+// because the reply it checks is a remote:: type and this header does not
+// depend on that layer. Naming them also makes leaving one out an error rather
+// than a zero, since a missing designated initializer is one here.
+struct SessionOpenedDerivedFields {
+    // The reply's whole catalog, computed tail included.
+    std::size_t fieldCount = 0;
+    // How many of that tail the reply claims it installed.
+    std::size_t derivedFieldCount = 0;
+    // The definitions it reports it could not.
+    std::span<const DerivedFieldSkip> skips;
+    // How many definitions the request carried.
+    std::size_t requestedCount = 0;
+};
+void validateSessionOpenedDerivedFields(
+    const SessionOpenedDerivedFields& reply);
 
 } // namespace amrvis

--- a/include/amrexplorer/data/SessionValidation.hpp
+++ b/include/amrexplorer/data/SessionValidation.hpp
@@ -37,5 +37,14 @@ void validateSessionParticleSampleResult(
 // and sampling metrics the dataset and the request's budget could produce.
 void validateSessionVolumeResult(const DatasetMetadata& metadata,
     const VolumeRenderRequest& request, const VolumeFrame& frame);
+// The derived-field half of an open reply, which the wire decoder cannot check
+// on its own: it does not know how many definitions the request carried. A
+// catalog cannot hold more derived fields than fields, cannot report more of
+// them than were asked for, and cannot skip a definition that was never sent
+// or report more skips than there were definitions -- and a definition cannot
+// be both installed and skipped, which is what the counts add up to.
+void validateSessionOpenedDerivedFields(std::size_t fieldCount,
+    std::uint32_t derivedFieldCount,
+    const std::vector<DerivedFieldSkip>& skips, std::size_t requestedCount);
 
 } // namespace amrvis

--- a/include/amrexplorer/remote/Connection.hpp
+++ b/include/amrexplorer/remote/Connection.hpp
@@ -42,6 +42,12 @@ inline constexpr const char* volumeSamplingUnsupportedMessage
     = "the remote server predates smooth volume sampling (protocol 1.3) and "
       "samples each ray at the nearest voxel; install a current "
       "amrexplorer-server";
+// And for derived fields, which a 1.3 server would not read off an open
+// request at all -- so it would answer a catalog of stored fields while the
+// client believed the definitions had been installed.
+inline constexpr const char* derivedFieldsUnsupportedMessage
+    = "the remote server predates derived fields (protocol 1.4); install a "
+      "current amrexplorer-server";
 
 class Connection : public std::enable_shared_from_this<Connection> {
 public:
@@ -62,8 +68,13 @@ public:
     [[nodiscard]] bool connected() const;
     [[nodiscard]] std::string disconnectReason() const;
 
+    // `derivedFields` are installed by the server on the session it opens
+    // (protocol 1.4). Ask supportsDerivedFields() first: a non-empty list
+    // against an older peer throws, because a peer that cannot read the field
+    // would answer a catalog of stored fields alone.
     [[nodiscard]] OpenedDataset openDataset(const std::string& path,
-        std::uint64_t cacheBudgetBytes, StopToken cancellation = {});
+        std::uint64_t cacheBudgetBytes, StopToken cancellation = {},
+        std::vector<DerivedFieldDefinition> derivedFields = {});
     // Lists the subdirectories of a server-side directory (protocol 1.1);
     // an empty path is the server's home. Throws when the server negotiated
     // protocol 1.0, i.e. predates browsing.
@@ -76,6 +87,10 @@ public:
     // Whether the negotiated protocol carries the volume march's sampling
     // policy (1.3). A 1.2 peer renders volumes but always sampled nearest.
     [[nodiscard]] bool supportsVolumeSampling() const noexcept;
+    // Whether the negotiated protocol carries derived-field definitions on an
+    // open request (1.4). A 1.3 peer opens datasets perfectly well; it just
+    // cannot be asked to compute a field.
+    [[nodiscard]] bool supportsDerivedFields() const noexcept;
     // Renders a volume on the server and returns the frame (protocol 1.2).
     // Ask supportsVolumeRendering() first: this throws when the server
     // negotiated an older protocol.

--- a/include/amrexplorer/remote/Protocol.hpp
+++ b/include/amrexplorer/remote/Protocol.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <amrexplorer/cache/CacheMetrics.hpp>
+#include <amrexplorer/core/DerivedField.hpp>
 #include <amrexplorer/core/Metadata.hpp>
 #include <amrexplorer/core/Request.hpp>
 #include <amrexplorer/data/DatasetPage.hpp>
@@ -19,14 +20,21 @@ namespace amrvis::remote {
 
 inline constexpr std::uint16_t protocolMajor = 1;
 // 1.1 added directory browsing; 1.2 adds volume rendering (RenderedFrame*);
-// 1.3 adds the volume march's sampling policy (RenderedFrameRequest.sampling).
+// 1.3 adds the volume march's sampling policy (RenderedFrameRequest.sampling);
+// 1.4 adds derived fields (OpenDatasetRequest.derived_fields, and the derived
+// count and skip reasons on DatasetOpened).
 //
 // 1.3 is a version rather than a bare appended field because the field changes
 // the picture. A 1.2 server ignores what it cannot read and renders nearest,
 // so a client that simply sent it would offer a control that silently did
 // nothing there -- the defect this codebase keeps designing against. The
 // version lets the client ask first and say so instead.
-inline constexpr std::uint16_t protocolMinorVersion = 3;
+//
+// 1.4 is a version for the same reason, one step worse: a 1.3 server would
+// answer a plain catalog, so the client would show an Expression Editor whose
+// Apply reported success while every slice kept coming back from the stored
+// fields alone.
+inline constexpr std::uint16_t protocolMinorVersion = 4;
 
 enum class PayloadKind : std::uint8_t {
     None = 0,
@@ -108,6 +116,11 @@ struct HelloResponseData {
 struct OpenDatasetData {
     std::string path;
     std::uint64_t cacheBudgetBytes = 0;
+    // Protocol 1.4. The fields the session should compute as well as read; the
+    // server installs them under DerivedFieldPolicy::Skip, so one it cannot
+    // resolve comes back in OpenedDataset::derivedFieldSkips rather than
+    // failing the open.
+    std::vector<DerivedFieldDefinition> derivedFields;
 };
 
 // One subdirectory of a listed directory. Only directories are listed:
@@ -148,6 +161,12 @@ struct OpenedDataset {
     std::vector<std::uint8_t> fileRangeAvailable;
     std::vector<std::uint8_t> levelRangeAvailable;
     CacheMetrics cache;
+    // Protocol 1.4. How many of catalog.fields are computed rather than stored
+    // (the last ones, in definition order), and the definitions the server
+    // could not install. Zero and empty for a server that was sent none -- and
+    // for one too old to have been sent any.
+    std::uint32_t derivedFieldCount = 0;
+    std::vector<DerivedFieldSkip> derivedFieldSkips;
 };
 
 struct ErrorData {

--- a/include/amrexplorer/remote/RemoteDatasetSession.hpp
+++ b/include/amrexplorer/remote/RemoteDatasetSession.hpp
@@ -16,9 +16,14 @@ namespace amrvis::remote {
 
 class RemoteDatasetSession final : public DatasetSession {
 public:
+    // `derivedFields` are installed by the server on the session it opens
+    // (protocol 1.4). A non-empty list against a peer that predates it is
+    // refused here, before the connection is used, so the refusal cannot be
+    // mistaken for a peer that stopped speaking the protocol.
     [[nodiscard]] static std::shared_ptr<RemoteDatasetSession> open(
         std::shared_ptr<Connection> connection, const std::string& path,
-        std::uint64_t cacheBudgetBytes, StopToken cancellation = {});
+        std::uint64_t cacheBudgetBytes, StopToken cancellation = {},
+        std::vector<DerivedFieldDefinition> derivedFields = {});
 
     ~RemoteDatasetSession() override;
 
@@ -38,6 +43,15 @@ public:
     // plotfile; the frame comes back rendered, validated against the request.
     [[nodiscard]] bool supportsVolumeRendering() const noexcept override;
     [[nodiscard]] bool supportsVolumeSampling() const noexcept override;
+    // True when the server speaks protocol 1.4 -- which is also the only way
+    // this session could have installed the list it was opened with, which is
+    // what the GUI's reload loop relies on (see DatasetSession).
+    [[nodiscard]] bool supportsDerivedFields() const noexcept override;
+    [[nodiscard]] std::size_t storedFieldCount() const noexcept override;
+    [[nodiscard]] std::vector<DerivedFieldSkip> skippedDerivedFields()
+        const override;
+    [[nodiscard]] std::vector<DerivedFieldDefinition> derivedFieldDefinitions()
+        const override;
     [[nodiscard]] VolumeFrame renderVolume(const VolumeRenderRequest& request,
         StopToken cancellation = {}) override;
     [[nodiscard]] DatasetPage requestDatasetPage(
@@ -60,7 +74,8 @@ public:
 
 private:
     RemoteDatasetSession(std::shared_ptr<Connection> connection,
-        std::string path, OpenedDataset opened);
+        std::string path, OpenedDataset opened,
+        std::vector<DerivedFieldDefinition> derivedFields);
     void requireOpen() const;
 
     // A range is immutable for a (dataset, field, level, composition, scope),
@@ -84,6 +99,14 @@ private:
     std::vector<ParticleSpeciesMetadata> m_particleSpecies;
     std::vector<std::uint8_t> m_fileRangeAvailable;
     std::vector<std::uint8_t> m_levelRangeAvailable;
+    // The list this session was opened with, kept as it was sent rather than
+    // rebuilt from the reply: a caller comparing its own list against this one
+    // is asking what this session was built from, and a reply-borne copy would
+    // differ from it in ways nothing here could see (an absent wire string
+    // decodes as an empty one).
+    std::vector<DerivedFieldDefinition> m_derivedFieldDefinitions;
+    std::size_t m_storedFieldCount = 0;
+    std::vector<DerivedFieldSkip> m_derivedFieldSkips;
     mutable std::mutex m_mutex;
     bool m_open = true;
 

--- a/schemas/amrexplorer_wire.fbs
+++ b/schemas/amrexplorer_wire.fbs
@@ -92,9 +92,30 @@ table HelloResponse {
   capabilities:[ulong] (id: 7);
 }
 
+// One derived-field definition: a name and the expression that produces it
+// (core/DerivedField.hpp). Carried on an open request, so the session the
+// server builds computes these fields alongside the ones the plotfile stores.
+table DerivedFieldDefinition {
+  name:string (id: 0);
+  expression:string (id: 1);
+}
+
+// A definition the server could not install, and why (DerivedFieldPolicy::Skip).
+// The index is into the definition list the client sent, which is what lets an
+// editor select the row the reason belongs to.
+table DerivedFieldSkip {
+  definition_index:uint (id: 0);
+  name:string (id: 1);
+  reason:string (id: 2);
+}
+
 table OpenDatasetRequest {
   path:string (id: 0);
   cache_budget_bytes:ulong (id: 1);
+  // Protocol 1.4. A peer that negotiated less refuses a non-empty list rather
+  // than dropping it: the field it cannot read would leave the client offering
+  // an editor whose Apply silently did nothing.
+  derived_fields:[DerivedFieldDefinition] (id: 2);
 }
 
 table FieldCatalog {
@@ -145,6 +166,13 @@ table DatasetOpened {
   metadata_metrics:MetadataReadMetrics (id: 13);
   file_version:string (id: 14);
   cache:CacheState (id: 15);
+  // Protocol 1.4. How many of `fields` are computed rather than stored; they
+  // are the last ones, in the order their definitions were given. The *derived*
+  // count rather than the stored one because flatbuffers reads an absent uint
+  // as 0, and 0 derived fields is the truth about a server that installed none
+  // -- while a stored count of 0 would empty the client's field list.
+  derived_field_count:uint (id: 16);
+  derived_field_skips:[DerivedFieldSkip] (id: 17);
 }
 
 table CloseDatasetRequest {

--- a/src/data/SessionValidation.cpp
+++ b/src/data/SessionValidation.cpp
@@ -733,33 +733,33 @@ void validateSessionParticleSampleResult(
     }
 }
 
-void validateSessionOpenedDerivedFields(std::size_t fieldCount,
-    std::uint32_t derivedFieldCount, const std::vector<DerivedFieldSkip>& skips,
-    std::size_t requestedCount)
+void validateSessionOpenedDerivedFields(
+    const SessionOpenedDerivedFields& reply)
 {
-    const auto derived = static_cast<std::size_t>(derivedFieldCount);
-    if (derived > fieldCount) {
+    const auto derived = reply.derivedFieldCount;
+    const auto requested = reply.requestedCount;
+    if (derived > reply.fieldCount) {
         throw std::invalid_argument(
             "dataset catalog claims more derived fields than it has fields");
     }
-    if (derived > requestedCount) {
+    if (derived > requested) {
         throw std::invalid_argument(
             "dataset catalog reports more derived fields than were requested");
     }
-    if (skips.size() > requestedCount) {
+    if (reply.skips.size() > requested) {
         throw std::invalid_argument(
             "dataset catalog skips more definitions than were requested");
     }
     // Every definition was either installed or skipped, so the two cannot add
     // up to more than were sent. Fewer is legal: nothing says a server must
     // account for each one separately, only that it cannot invent them.
-    if (derived + skips.size() > requestedCount) {
+    if (derived + reply.skips.size() > requested) {
         throw std::invalid_argument(
             "dataset catalog installs and skips more definitions than were "
             "requested");
     }
-    for (const auto& skip : skips) {
-        if (skip.definitionIndex >= requestedCount) {
+    for (const auto& skip : reply.skips) {
+        if (skip.definitionIndex >= requested) {
             throw std::invalid_argument(
                 "dataset catalog skips a definition that was not requested");
         }

--- a/src/data/SessionValidation.cpp
+++ b/src/data/SessionValidation.cpp
@@ -733,4 +733,37 @@ void validateSessionParticleSampleResult(
     }
 }
 
+void validateSessionOpenedDerivedFields(std::size_t fieldCount,
+    std::uint32_t derivedFieldCount, const std::vector<DerivedFieldSkip>& skips,
+    std::size_t requestedCount)
+{
+    const auto derived = static_cast<std::size_t>(derivedFieldCount);
+    if (derived > fieldCount) {
+        throw std::invalid_argument(
+            "dataset catalog claims more derived fields than it has fields");
+    }
+    if (derived > requestedCount) {
+        throw std::invalid_argument(
+            "dataset catalog reports more derived fields than were requested");
+    }
+    if (skips.size() > requestedCount) {
+        throw std::invalid_argument(
+            "dataset catalog skips more definitions than were requested");
+    }
+    // Every definition was either installed or skipped, so the two cannot add
+    // up to more than were sent. Fewer is legal: nothing says a server must
+    // account for each one separately, only that it cannot invent them.
+    if (derived + skips.size() > requestedCount) {
+        throw std::invalid_argument(
+            "dataset catalog installs and skips more definitions than were "
+            "requested");
+    }
+    for (const auto& skip : skips) {
+        if (skip.definitionIndex >= requestedCount) {
+            throw std::invalid_argument(
+                "dataset catalog skips a definition that was not requested");
+        }
+    }
+}
+
 } // namespace amrvis

--- a/src/remote/Codec.cpp
+++ b/src/remote/Codec.cpp
@@ -2,6 +2,8 @@
 
 #include "amrexplorer_wire_bfbs_generated.h"
 
+#include <amrexplorer/expression/Expression.hpp>
+
 #include <flatbuffers/reflection.h>
 #include <flatbuffers/verifier.h>
 
@@ -620,12 +622,48 @@ fb::OpenDatasetRequestT toWire(const OpenDatasetData& value)
     fb::OpenDatasetRequestT wire;
     wire.path = value.path;
     wire.cache_budget_bytes = value.cacheBudgetBytes;
+    wire.derived_fields.reserve(value.derivedFields.size());
+    for (const auto& definition : value.derivedFields) {
+        auto entry = std::make_unique<fb::DerivedFieldDefinitionT>();
+        entry->name = definition.name;
+        entry->expression = definition.expression;
+        wire.derived_fields.push_back(std::move(entry));
+    }
     return wire;
 }
 
 OpenDatasetData fromWire(const fb::OpenDatasetRequestT& value)
 {
-    return {value.path, value.cache_budget_bytes};
+    // The definition list arrives from a client, so it is bounded here rather
+    // than left to installation: installDerivedFields caps the programs it
+    // *installs*, so a list whose first maximumDerivedFieldCount entries all
+    // fail would otherwise still compile every entry after them, bounded only
+    // by the frame size. Same shape as the directory-listing cap above.
+    if (value.derived_fields.size() > maximumDerivedFieldCount) {
+        throw std::invalid_argument(
+            "wire open request carries too many derived-field definitions");
+    }
+    OpenDatasetData result;
+    result.path = value.path;
+    result.cacheBudgetBytes = value.cache_budget_bytes;
+    result.derivedFields.reserve(value.derived_fields.size());
+    for (const auto& entry : value.derived_fields) {
+        if (!entry) {
+            throw std::invalid_argument(
+                "wire derived-field definition is missing");
+        }
+        if (entry->name.empty()) {
+            throw std::invalid_argument(
+                "wire derived-field definition has no name");
+        }
+        if (entry->expression.size() > maximumExpressionBytes) {
+            throw std::invalid_argument(
+                "wire derived-field expression is too long");
+        }
+        result.derivedFields.push_back(
+            DerivedFieldDefinition{entry->name, entry->expression});
+    }
+    return result;
 }
 
 fb::DatasetOpenedT toWire(const OpenedDataset& value)
@@ -681,6 +719,16 @@ fb::DatasetOpenedT toWire(const OpenedDataset& value)
         = value.metadataMetrics.payloadBytesRead;
     wire.file_version = value.fileVersion;
     wire.cache = toWire(value.cache);
+    wire.derived_field_count = value.derivedFieldCount;
+    wire.derived_field_skips.reserve(value.derivedFieldSkips.size());
+    for (const auto& skip : value.derivedFieldSkips) {
+        auto converted = std::make_unique<fb::DerivedFieldSkipT>();
+        converted->definition_index
+            = static_cast<std::uint32_t>(skip.definitionIndex);
+        converted->name = skip.name;
+        converted->reason = skip.reason;
+        wire.derived_field_skips.push_back(std::move(converted));
+    }
     return wire;
 }
 
@@ -820,6 +868,41 @@ OpenedDataset fromWire(const fb::DatasetOpenedT& value)
             throw std::invalid_argument(
                 "wire particle species component count is outside its bounds");
         }
+    }
+    // The derived fields are the tail of the catalog, so a count past its
+    // length would leave the client splitting the list at an index that is not
+    // in it. What the count cannot be checked against here is the number of
+    // definitions the client sent -- the decoder does not know it -- which is
+    // what validateSessionOpenedDerivedFields is for.
+    result.derivedFieldCount = value.derived_field_count;
+    if (result.derivedFieldCount > result.catalog.fields.size()) {
+        throw std::invalid_argument(
+            "wire dataset catalog claims more derived fields than it has "
+            "fields");
+    }
+    if (value.derived_field_skips.size() > maximumDerivedFieldCount) {
+        throw std::invalid_argument(
+            "wire dataset catalog carries too many derived-field skips");
+    }
+    result.derivedFieldSkips.reserve(value.derived_field_skips.size());
+    for (const auto& skip : value.derived_field_skips) {
+        if (!skip) {
+            throw std::invalid_argument(
+                "wire derived-field skip is missing");
+        }
+        if (skip->name.empty()) {
+            throw std::invalid_argument(
+                "wire derived-field skip has no name");
+        }
+        if (skip->reason.size() > maximumExpressionBytes) {
+            // Rendered into a tooltip, so bounded like the expression it is
+            // about rather than left to whatever a peer cares to send.
+            throw std::invalid_argument(
+                "wire derived-field skip reason is too long");
+        }
+        result.derivedFieldSkips.push_back(
+            DerivedFieldSkip{skip->definition_index, skip->name,
+                skip->reason});
     }
     return result;
 }

--- a/src/remote/Codec.cpp
+++ b/src/remote/Codec.cpp
@@ -634,11 +634,17 @@ fb::OpenDatasetRequestT toWire(const OpenDatasetData& value)
 
 OpenDatasetData fromWire(const fb::OpenDatasetRequestT& value)
 {
-    // The definition list arrives from a client, so it is bounded here rather
-    // than left to installation: installDerivedFields caps the programs it
-    // *installs*, so a list whose first maximumDerivedFieldCount entries all
-    // fail would otherwise still compile every entry after them, bounded only
-    // by the frame size. Same shape as the directory-listing cap above.
+    // Only what a skip cannot express is refused here. The server installs
+    // this list under DerivedFieldPolicy::Skip, so a definition it cannot
+    // resolve comes back as one greyed row instead of an open that failed, and
+    // a check repeated here would turn that row into a refusal the same list
+    // never gets from a local dataset.
+    //
+    // These two are the exceptions, because the reply has no way to carry
+    // them: a skip is reported by name, so a nameless definition cannot be
+    // named back, and the reply's vector of skips is bounded by this same
+    // maximumDerivedFieldCount, so a list past the cap could only be answered
+    // with a reply this decoder would itself reject.
     if (value.derived_fields.size() > maximumDerivedFieldCount) {
         throw std::invalid_argument(
             "wire open request carries too many derived-field definitions");
@@ -656,10 +662,10 @@ OpenDatasetData fromWire(const fb::OpenDatasetRequestT& value)
             throw std::invalid_argument(
                 "wire derived-field definition has no name");
         }
-        if (entry->expression.size() > maximumExpressionBytes) {
-            throw std::invalid_argument(
-                "wire derived-field expression is too long");
-        }
+        // The expression's length is not checked: CompiledExpression::compile
+        // refuses one past maximumExpressionBytes before it parses anything, so
+        // installation already skips it with a bounded reason, which is what a
+        // local dataset does with the same definition.
         result.derivedFields.push_back(
             DerivedFieldDefinition{entry->name, entry->expression});
     }

--- a/src/remote/Codec.cpp
+++ b/src/remote/Codec.cpp
@@ -13,6 +13,7 @@
 #include <limits>
 #include <memory>
 #include <stdexcept>
+#include <string>
 #include <string_view>
 #include <utility>
 
@@ -364,6 +365,29 @@ bool vectorsAligned(std::span<const std::uint8_t> bytes)
         = *reflection::GetSchema(fb::EnvelopeBinarySchema::data());
     return VectorAlignmentWalk(schema, bytes.data())
         .aligned(*schema.root_table(), *flatbuffers::GetAnyRoot(bytes.data()));
+}
+
+// A skip's reason is written by installation, which quotes a symbol out of the
+// expression it could not resolve -- so it runs to the expression's own bound
+// plus the words around it, which is longer than the bound fromWire enforces
+// on the way back in. Bounded here rather than left to disagree: a decoder
+// that refused its own encoder's output would take the throw inside
+// refusingInvalidResponses and close the connection, losing every other
+// dataset on it over a reply the server was right to send.
+std::string boundedReason(const std::string& reason)
+{
+    constexpr std::string_view continued = "...";
+    if (reason.size() <= maximumExpressionBytes) {
+        return reason;
+    }
+    auto kept = maximumExpressionBytes - continued.size();
+    // Not mid-character: splitting a UTF-8 sequence would put bytes on the
+    // wire that no longer read as text in the tooltip this ends up in.
+    while (kept > 0
+        && (static_cast<unsigned char>(reason[kept]) & 0xC0U) == 0x80U) {
+        --kept;
+    }
+    return reason.substr(0, kept) + std::string(continued);
 }
 
 } // namespace
@@ -732,7 +756,7 @@ fb::DatasetOpenedT toWire(const OpenedDataset& value)
         converted->definition_index
             = static_cast<std::uint32_t>(skip.definitionIndex);
         converted->name = skip.name;
-        converted->reason = skip.reason;
+        converted->reason = boundedReason(skip.reason);
         wire.derived_field_skips.push_back(std::move(converted));
     }
     return wire;
@@ -902,7 +926,9 @@ OpenedDataset fromWire(const fb::DatasetOpenedT& value)
         }
         if (skip->reason.size() > maximumExpressionBytes) {
             // Rendered into a tooltip, so bounded like the expression it is
-            // about rather than left to whatever a peer cares to send.
+            // about rather than left to whatever a peer cares to send. What
+            // our own encoder sends is held to this same bound by
+            // boundedReason, so reaching this throw means the peer sent it.
             throw std::invalid_argument(
                 "wire derived-field skip reason is too long");
         }

--- a/src/remote/Codec.cpp
+++ b/src/remote/Codec.cpp
@@ -924,17 +924,18 @@ OpenedDataset fromWire(const fb::DatasetOpenedT& value)
             throw std::invalid_argument(
                 "wire derived-field skip has no name");
         }
-        if (skip->reason.size() > maximumExpressionBytes) {
-            // Rendered into a tooltip, so bounded like the expression it is
-            // about rather than left to whatever a peer cares to send. What
-            // our own encoder sends is held to this same bound by
-            // boundedReason, so reaching this throw means the peer sent it.
-            throw std::invalid_argument(
-                "wire derived-field skip reason is too long");
-        }
+        // Clamped rather than refused. A reason over the bound is what a
+        // *correct* peer produces -- installation quotes the symbol it could
+        // not resolve, so the reason runs to the expression's own bound plus
+        // the words around it -- and protocol 1.4 cannot tell a peer that
+        // bounds it from one that does not. This decode runs inside
+        // refusingInvalidResponses, where a throw closes the connection and
+        // takes every other dataset on it, so display-only text must not be
+        // able to do that. Our encoder bounds what we send; this is what
+        // makes a peer built from any other 1.4 commit safe to talk to.
         result.derivedFieldSkips.push_back(
             DerivedFieldSkip{skip->definition_index, skip->name,
-                skip->reason});
+                boundedReason(skip->reason)});
     }
     return result;
 }

--- a/src/remote/Connection.cpp
+++ b/src/remote/Connection.cpp
@@ -234,10 +234,19 @@ public:
     }
 
     OpenedDataset openDataset(const std::string& path,
-        std::uint64_t cacheBudgetBytes, StopToken cancellation)
+        std::uint64_t cacheBudgetBytes, StopToken cancellation,
+        std::vector<DerivedFieldDefinition> derivedFields)
     {
+        // Refused here as well as in RemoteDatasetSession, for the reason
+        // renderVolume gives: this class is public, this is where the
+        // negotiated version lives, and a caller that did not ask first must
+        // not have its request answered by a different rule than the one it
+        // named. A caller that did ask never reaches this.
+        if (!derivedFields.empty() && !supportsDerivedFields()) {
+            throw std::runtime_error(derivedFieldsUnsupportedMessage);
+        }
         const auto response = transact(codec::toWire(
-            OpenDatasetData{path, cacheBudgetBytes}),
+            OpenDatasetData{path, cacheBudgetBytes, std::move(derivedFields)}),
             PayloadKind::DatasetOpened, cancellation,
             ResponseWait::Indefinite);
         const auto* payload = response->payload.AsDatasetOpened();
@@ -284,6 +293,13 @@ public:
     [[nodiscard]] bool supportsVolumeSampling() const noexcept
     {
         return m_selectedMinorVersion >= 3;
+    }
+
+    // Likewise: a 1.3 server opens datasets perfectly well, it just cannot be
+    // asked to compute a field from an expression.
+    [[nodiscard]] bool supportsDerivedFields() const noexcept
+    {
+        return m_selectedMinorVersion >= 4;
     }
 
     VolumeFrame renderVolume(
@@ -779,9 +795,11 @@ std::string Connection::disconnectReason() const
 }
 
 OpenedDataset Connection::openDataset(const std::string& path,
-    std::uint64_t cacheBudgetBytes, StopToken cancellation)
+    std::uint64_t cacheBudgetBytes, StopToken cancellation,
+    std::vector<DerivedFieldDefinition> derivedFields)
 {
-    return m_impl->openDataset(path, cacheBudgetBytes, cancellation);
+    return m_impl->openDataset(
+        path, cacheBudgetBytes, cancellation, std::move(derivedFields));
 }
 
 RemoteDirectoryListing Connection::listDirectory(
@@ -798,6 +816,11 @@ bool Connection::supportsVolumeRendering() const noexcept
 bool Connection::supportsVolumeSampling() const noexcept
 {
     return m_impl->supportsVolumeSampling();
+}
+
+bool Connection::supportsDerivedFields() const noexcept
+{
+    return m_impl->supportsDerivedFields();
 }
 
 VolumeFrame Connection::renderVolume(

--- a/src/remote/RemoteDatasetSession.cpp
+++ b/src/remote/RemoteDatasetSession.cpp
@@ -69,9 +69,12 @@ std::shared_ptr<RemoteDatasetSession> RemoteDatasetSession::open(
         // What the decoder could not check: it does not know how many
         // definitions were sent. A reply that disagrees with the request is a
         // peer that stopped speaking the protocol, so it belongs in here.
-        validateSessionOpenedDerivedFields(
-            answer.catalog.fields.size(), answer.derivedFieldCount,
-            answer.derivedFieldSkips, derivedFields.size());
+        validateSessionOpenedDerivedFields({
+            .fieldCount = answer.catalog.fields.size(),
+            .derivedFieldCount = answer.derivedFieldCount,
+            .skips = answer.derivedFieldSkips,
+            .requestedCount = derivedFields.size(),
+        });
         return answer;
     });
     return std::shared_ptr<RemoteDatasetSession>(

--- a/src/remote/RemoteDatasetSession.cpp
+++ b/src/remote/RemoteDatasetSession.cpp
@@ -47,25 +47,41 @@ decltype(auto) refusingInvalidResponses(
 
 std::shared_ptr<RemoteDatasetSession> RemoteDatasetSession::open(
     std::shared_ptr<Connection> connection, const std::string& path,
-    std::uint64_t cacheBudgetBytes, StopToken cancellation)
+    std::uint64_t cacheBudgetBytes, StopToken cancellation,
+    std::vector<DerivedFieldDefinition> derivedFields)
 {
     if (!connection) {
         throw std::invalid_argument(
             "remote dataset requires a connection");
     }
+    // Outside refusingInvalidResponses below, whose catch(...) closes the
+    // connection: a peer too old to compute a field is not a peer that has
+    // stopped speaking the protocol, and closing here would take every other
+    // dataset on the connection with it. Same placement as renderVolume's.
+    if (!derivedFields.empty() && !connection->supportsDerivedFields()) {
+        throw std::runtime_error(derivedFieldsUnsupportedMessage);
+    }
     // The catalog is validated while it is decoded, so an impossible one throws
     // in here rather than at a later call.
     auto opened = refusingInvalidResponses(*connection, [&] {
-        return connection->openDataset(path, cacheBudgetBytes, cancellation);
+        auto answer = connection->openDataset(
+            path, cacheBudgetBytes, cancellation, derivedFields);
+        // What the decoder could not check: it does not know how many
+        // definitions were sent. A reply that disagrees with the request is a
+        // peer that stopped speaking the protocol, so it belongs in here.
+        validateSessionOpenedDerivedFields(
+            answer.catalog.fields.size(), answer.derivedFieldCount,
+            answer.derivedFieldSkips, derivedFields.size());
+        return answer;
     });
     return std::shared_ptr<RemoteDatasetSession>(
-        new RemoteDatasetSession(
-            std::move(connection), path, std::move(opened)));
+        new RemoteDatasetSession(std::move(connection), path,
+            std::move(opened), std::move(derivedFields)));
 }
 
 RemoteDatasetSession::RemoteDatasetSession(
     std::shared_ptr<Connection> connection, std::string path,
-    OpenedDataset opened)
+    OpenedDataset opened, std::vector<DerivedFieldDefinition> derivedFields)
     : m_connection(std::move(connection))
     , m_path(std::move(path))
     , m_id(opened.id)
@@ -75,6 +91,12 @@ RemoteDatasetSession::RemoteDatasetSession(
     , m_particleSpecies(std::move(opened.particleSpecies))
     , m_fileRangeAvailable(std::move(opened.fileRangeAvailable))
     , m_levelRangeAvailable(std::move(opened.levelRangeAvailable))
+    , m_derivedFieldDefinitions(std::move(derivedFields))
+    // The stored fields are what is left when the derived tail is taken off;
+    // the decoder has already refused a count past the field list's length.
+    , m_storedFieldCount(
+          m_metadata.fields.size() - opened.derivedFieldCount)
+    , m_derivedFieldSkips(std::move(opened.derivedFieldSkips))
 {
 }
 
@@ -135,6 +157,30 @@ bool RemoteDatasetSession::supportsVolumeRendering() const noexcept
     // refusals can name its own cause.
     return m_connection->supportsVolumeRendering()
         && datasetSupportsVolumeRendering(m_metadata);
+}
+
+bool RemoteDatasetSession::supportsDerivedFields() const noexcept
+{
+    // The one answer that keeps the GUI's reload loop terminating: a session
+    // that could not have installed the list it was handed must say so, and a
+    // pre-1.4 peer never received one.
+    return m_connection && m_connection->supportsDerivedFields();
+}
+
+std::size_t RemoteDatasetSession::storedFieldCount() const noexcept
+{
+    return m_storedFieldCount;
+}
+
+std::vector<DerivedFieldSkip> RemoteDatasetSession::skippedDerivedFields() const
+{
+    return m_derivedFieldSkips;
+}
+
+std::vector<DerivedFieldDefinition>
+RemoteDatasetSession::derivedFieldDefinitions() const
+{
+    return m_derivedFieldDefinitions;
 }
 
 bool RemoteDatasetSession::supportsVolumeSampling() const noexcept

--- a/src/remote/Server.cpp
+++ b/src/remote/Server.cpp
@@ -604,6 +604,19 @@ private:
         if (request == nullptr || request->path.empty()) {
             throw std::invalid_argument("dataset path is empty");
         }
+        // Decoded here, before the reservation below: this is what bounds the
+        // definition list a client sent (codec::fromWire), and an over-cap list
+        // should be refused before anything is reserved or allocated for it.
+        auto open = codec::fromWire(*request);
+        // Also before the reservation, so an early return need not know that
+        // bookkeeping. Not theatre: encode() stamps the envelope's version but
+        // filters no fields, so a 1.3-negotiated envelope can physically carry
+        // this vector -- and a client that read our Hello knows better, so this
+        // is answerable rather than fatal.
+        if (!open.derivedFields.empty() && m_selectedMinorVersion < 4) {
+            throw RemoteError(ErrorCode::UnsupportedProtocol,
+                "derived fields require protocol 1.4");
+        }
         {
             std::scoped_lock lock(m_stateMutex);
             if (m_stopping.load() || cancellation.stop_requested()) {
@@ -621,9 +634,13 @@ private:
         std::shared_ptr<LocalDatasetSession> dataset;
         bool reservationActive = true;
         try {
+            // The definitions are installed under DerivedFieldPolicy::Skip,
+            // so one this plotfile cannot resolve is reported back rather than
+            // failing the open -- a list written for another dataset must not
+            // make this one unopenable.
             dataset = std::make_shared<LocalDatasetSession>(
-                resolveDatasetPath(request->path), id,
-                request->cache_budget_bytes, cancellation);
+                resolveDatasetPath(open.path), id, open.cacheBudgetBytes,
+                cancellation, std::move(open.derivedFields));
             // The operator's number, on its own. The constructor has just
             // seeded the grid pool from cache_budget_bytes, which is the
             // client's *block* cache budget -- a different pool holding
@@ -645,6 +662,12 @@ private:
             opened.metadataMetrics = dataset->metadataReadMetrics();
             opened.fileVersion = dataset->fileVersion();
             opened.particleSpecies = dataset->particleSpecies();
+            // The derived tail of the catalog, and what could not be
+            // installed. Both come from the session just built, so the client
+            // is told exactly what it is looking at.
+            opened.derivedFieldCount = static_cast<std::uint32_t>(
+                opened.catalog.fields.size() - dataset->storedFieldCount());
+            opened.derivedFieldSkips = dataset->skippedDerivedFields();
             opened.fileRangeAvailable.reserve(opened.catalog.fields.size());
             opened.levelRangeAvailable.reserve(opened.catalog.fields.size()
                 * opened.catalog.levels.size());

--- a/tests/fuzz/fuzz_wire_codec.cpp
+++ b/tests/fuzz/fuzz_wire_codec.cpp
@@ -91,8 +91,17 @@ void checkConverted(const fb::OpenDatasetRequestT& wire,
     const amrvis::remote::OpenDatasetData& result)
 {
     if (result.path != wire.path
-        || result.cacheBudgetBytes != wire.cache_budget_bytes) {
+        || result.cacheBudgetBytes != wire.cache_budget_bytes
+        || result.derivedFields.size() != wire.derived_fields.size()) {
         fail("OpenDatasetRequest did not convert faithfully");
+    }
+    for (std::size_t index = 0; index < result.derivedFields.size(); ++index) {
+        const auto& entry = wire.derived_fields[index];
+        if (!entry || result.derivedFields[index].name != entry->name
+            || result.derivedFields[index].expression != entry->expression) {
+            fail("OpenDatasetRequest derived field did not convert "
+                 "faithfully");
+        }
     }
 }
 
@@ -533,6 +542,19 @@ std::vector<std::vector<std::uint8_t>> wireSeeds()
         fb::OpenDatasetRequestT open;
         open.path = "/plt00000";
         open.cache_budget_bytes = 1 << 20;
+        // Protocol 1.4, and non-empty on purpose: an absent vector is the
+        // schema default and is left out of the buffer, so a seed without one
+        // would be byte-identical to a pre-1.4 request and would reach none of
+        // the definition bounds. Two entries so the mutator can corrupt one
+        // while the other stays well formed.
+        auto first = std::make_unique<fb::DerivedFieldDefinitionT>();
+        first->name = "speed";
+        first->expression = "sqrt(u**2 + v**2)";
+        open.derived_fields.push_back(std::move(first));
+        auto second = std::make_unique<fb::DerivedFieldDefinitionT>();
+        second->name = "twice";
+        second->expression = "2*speed";
+        open.derived_fields.push_back(std::move(second));
         add(std::move(open));
     }
     {

--- a/tests/integration/test_remote_server.cpp
+++ b/tests/integration/test_remote_server.cpp
@@ -104,11 +104,13 @@ private:
 template <typename Payload>
 std::unique_ptr<amrvis::remote::codec::NativeEnvelope> exchange(
     const amrvis::remote::Socket& socket, std::uint64_t requestId,
-    Payload payload, std::uint32_t maximumFrameBytes)
+    Payload payload, std::uint32_t maximumFrameBytes,
+    std::uint16_t minorVersion = amrvis::remote::protocolMinorVersion)
 {
     using namespace amrvis::remote;
     writeFrame(socket,
-        codec::encode(requestId, std::move(payload)), maximumFrameBytes);
+        codec::encode(requestId, std::move(payload), minorVersion),
+        maximumFrameBytes);
     const auto response = readFrame(socket, maximumFrameBytes);
     require(response.has_value(), "server closed before sending a response");
     auto envelope = codec::decode(*response);
@@ -309,7 +311,7 @@ int main(int argc, char* argv[])
     envelope = exchange(socket, 2,
         codec::toWire(OpenDatasetData{
             std::filesystem::path(argv[1]).string(),
-            16ULL * 1024ULL * 1024ULL}),
+            16ULL * 1024ULL * 1024ULL, {}}),
         hello.maximumFrameBytes);
     require(codec::inspect(*envelope).payload == PayloadKind::DatasetOpened,
         "server did not open the materialized plotfile");
@@ -318,6 +320,50 @@ int main(int argc, char* argv[])
     require(opened.catalog.dimension == 2
             && opened.catalog.levels.size() == 2,
         "server returned an incomplete dataset catalog");
+    require(opened.derivedFieldCount == 0 && opened.derivedFieldSkips.empty(),
+        "server reported derived fields for a request that carried none");
+    const auto storedFields = opened.catalog.fields.size();
+
+    // Protocol 1.4: the definitions are installed on the session the server
+    // opens, so the catalog comes back with the computed field appended and the
+    // client is told how many of the fields are computed. A definition this
+    // plotfile cannot resolve is skipped with its reason rather than failing
+    // the open, and the skip names the definition it belongs to by index.
+    envelope = exchange(socket, 16,
+        codec::toWire(OpenDatasetData{
+            std::filesystem::path(argv[1]).string(),
+            16ULL * 1024ULL * 1024ULL,
+            {{"product", "density * temperature"},
+                {"elsewhere", "nonesuch * 2"}}}),
+        hello.maximumFrameBytes);
+    require(codec::inspect(*envelope).payload == PayloadKind::DatasetOpened,
+        "server refused an open carrying derived fields");
+    const auto derivedOpen = codec::fromWire(
+        *envelope->payload.AsDatasetOpened());
+    require(derivedOpen.catalog.fields.size() == storedFields + 1
+            && derivedOpen.catalog.fields.back().name == "product",
+        "the computed field is not the tail of the catalog");
+    require(derivedOpen.derivedFieldCount == 1,
+        "server did not report exactly one field as computed");
+    require(derivedOpen.derivedFieldSkips.size() == 1
+            && derivedOpen.derivedFieldSkips.front().definitionIndex == 1
+            && derivedOpen.derivedFieldSkips.front().name == "elsewhere"
+            && !derivedOpen.derivedFieldSkips.front().reason.empty(),
+        "the unresolvable definition did not come back as a skip");
+    // A derived field has no stored statistics, so the server reports no File
+    // range for it -- the same answer a local session gives.
+    require(derivedOpen.fileRangeAvailable.size()
+                == derivedOpen.catalog.fields.size()
+            && derivedOpen.fileRangeAvailable.back() == 0,
+        "server claimed a File range for a computed field");
+    // Released again: this session's dataset limit is 2, and the cases below
+    // need the slot.
+    codec::fb::CloseDatasetRequestT closeDerived;
+    closeDerived.dataset_id = derivedOpen.id.value;
+    envelope = exchange(socket, 17, std::move(closeDerived),
+        hello.maximumFrameBytes);
+    require(codec::inspect(*envelope).payload == PayloadKind::DatasetClosed,
+        "server did not close the dataset opened with derived fields");
 
     DatasetPageRequest smallPage;
     smallPage.dataset = opened.id;
@@ -426,7 +472,7 @@ int main(int argc, char* argv[])
         envelope = exchange(socket, 14,
             codec::toWire(OpenDatasetData{
                 (std::filesystem::path(argv[1]) / "CraftedHeader").string(),
-                16ULL * 1024ULL * 1024ULL}),
+                16ULL * 1024ULL * 1024ULL, {}}),
             hello.maximumFrameBytes);
         require(codec::inspect(*envelope).payload == PayloadKind::ErrorResponse,
             "a crafted plotfile Header was opened as a dataset");
@@ -489,7 +535,7 @@ int main(int argc, char* argv[])
     envelope = exchange(socket, 5,
         codec::toWire(OpenDatasetData{
             std::filesystem::path(argv[1]).string(),
-            16ULL * 1024ULL * 1024ULL}),
+            16ULL * 1024ULL * 1024ULL, {}}),
         hello.maximumFrameBytes);
     require(codec::inspect(*envelope).payload == PayloadKind::DatasetOpened,
         "server rejected the second allowed dataset");
@@ -499,7 +545,7 @@ int main(int argc, char* argv[])
     envelope = exchange(socket, 6,
         codec::toWire(OpenDatasetData{
             std::filesystem::path(argv[1]).string(),
-            16ULL * 1024ULL * 1024ULL}),
+            16ULL * 1024ULL * 1024ULL, {}}),
         hello.maximumFrameBytes);
     require(codec::inspect(*envelope).payload == PayloadKind::ErrorResponse
             && codec::fromWire(*envelope->payload.AsErrorResponse()).code
@@ -512,6 +558,50 @@ int main(int argc, char* argv[])
         hello.maximumFrameBytes);
     require(codec::inspect(*envelope).payload == PayloadKind::DatasetClosed,
         "server did not close the second dataset");
+
+    // A peer that negotiated 1.3 asking for derived fields anyway. encode()
+    // stamps the envelope's version but filters no fields, so the request can
+    // physically carry the vector -- the server's guard is the only thing that
+    // refuses it, and it must refuse answerably: a capability the peer is too
+    // old for is not a peer that has stopped speaking the protocol.
+    {
+        auto olderSocket = connectTo("127.0.0.1", server.port());
+        auto olderHello = helloRequest(server.token());
+        olderHello.maximumMinorVersion = 3;
+        auto olderEnvelope = exchange(olderSocket, 1,
+            codec::toWire(olderHello), defaultMaximumFrameBytes, 3);
+        require(codec::inspect(*olderEnvelope).payload
+                == PayloadKind::HelloResponse,
+            "server rejected a 1.3 handshake");
+        const auto olderInfo = codec::fromWire(
+            *olderEnvelope->payload.AsHelloResponse());
+        require(olderInfo.selectedMinorVersion == 3,
+            "server did not negotiate down to the peer maximum");
+
+        olderEnvelope = exchange(olderSocket, 2,
+            codec::toWire(OpenDatasetData{
+                std::filesystem::path(argv[1]).string(),
+                16ULL * 1024ULL * 1024ULL,
+                {{"product", "density * temperature"}}}),
+            olderInfo.maximumFrameBytes, 3);
+        require(codec::inspect(*olderEnvelope).payload
+                == PayloadKind::ErrorResponse,
+            "a 1.3 peer derived-field open was not refused");
+        const auto olderError = codec::fromWire(
+            *olderEnvelope->payload.AsErrorResponse());
+        require(olderError.code == ErrorCode::UnsupportedProtocol,
+            "a 1.3 peer derived-field open returned the wrong error");
+
+        // And the session survives it: an open without definitions still works.
+        olderEnvelope = exchange(olderSocket, 3,
+            codec::toWire(OpenDatasetData{
+                std::filesystem::path(argv[1]).string(),
+                16ULL * 1024ULL * 1024ULL, {}}),
+            olderInfo.maximumFrameBytes, 3);
+        require(codec::inspect(*olderEnvelope).payload
+                == PayloadKind::DatasetOpened,
+            "the refusal closed a session that should have survived it");
+    }
 
     ServerOptions duplicateOptions;
     duplicateOptions.workerCount = 2;
@@ -531,7 +621,7 @@ int main(int argc, char* argv[])
         *envelope->payload.AsHelloResponse());
     const OpenDatasetData duplicateOpen{
         std::filesystem::path(argv[1]).string(),
-        16ULL * 1024ULL * 1024ULL};
+        16ULL * 1024ULL * 1024ULL, {}};
     envelope = exchange(duplicateSocket, 2, codec::toWire(duplicateOpen),
         duplicateHello.maximumFrameBytes);
     require(codec::inspect(*envelope).payload == PayloadKind::DatasetOpened,
@@ -775,7 +865,7 @@ int main(int argc, char* argv[])
         codec::toWire(OpenDatasetData{
             std::string(
                 handshakeFrameOptions.maximumHandshakeFrameBytes * 2U, 'x'),
-            16ULL * 1024ULL * 1024ULL}),
+            16ULL * 1024ULL * 1024ULL, {}}),
         defaultMaximumFrameBytes);
     require(codec::inspect(*envelope).payload == PayloadKind::ErrorResponse,
         "server retained the handshake frame cap after authentication");
@@ -799,7 +889,7 @@ int main(int argc, char* argv[])
         envelope = exchange(boundedSocket, requestId,
             codec::toWire(OpenDatasetData{
                 std::filesystem::path(argv[1]).string(),
-                16ULL * 1024ULL * 1024ULL}),
+                16ULL * 1024ULL * 1024ULL, {}}),
             boundedOptions.maximumFrameBytes);
         require(codec::inspect(*envelope).payload
                     == PayloadKind::ErrorResponse
@@ -864,7 +954,7 @@ int main(int argc, char* argv[])
         envelope = exchange(slow, 2,
             codec::toWire(OpenDatasetData{
                 std::filesystem::path(argv[1]).string(),
-                16ULL * 1024ULL * 1024ULL}),
+                16ULL * 1024ULL * 1024ULL, {}}),
             defaultMaximumFrameBytes);
         require(codec::inspect(*envelope).payload
                 == PayloadKind::DatasetOpened,
@@ -931,7 +1021,7 @@ int main(int argc, char* argv[])
         envelope = exchange(neighbour, 2,
             codec::toWire(OpenDatasetData{
                 std::filesystem::path(argv[1]).string(),
-                16ULL * 1024ULL * 1024ULL}),
+                16ULL * 1024ULL * 1024ULL, {}}),
             defaultMaximumFrameBytes);
         require(codec::inspect(*envelope).payload
                 == PayloadKind::DatasetOpened,

--- a/tests/integration/test_remote_server.cpp
+++ b/tests/integration/test_remote_server.cpp
@@ -329,12 +329,16 @@ int main(int argc, char* argv[])
     // client is told how many of the fields are computed. A definition this
     // plotfile cannot resolve is skipped with its reason rather than failing
     // the open, and the skip names the definition it belongs to by index.
+    // An expression past maximumExpressionBytes is one of those rather than a
+    // refusal: compile() bounds it before parsing anything, so the remote
+    // answer for such a list is the one a local dataset gives.
     envelope = exchange(socket, 16,
         codec::toWire(OpenDatasetData{
             std::filesystem::path(argv[1]).string(),
             16ULL * 1024ULL * 1024ULL,
             {{"product", "density * temperature"},
-                {"elsewhere", "nonesuch * 2"}}}),
+                {"elsewhere", "nonesuch * 2"},
+                {"overlong", std::string(maximumExpressionBytes + 1, 'x')}}}),
         hello.maximumFrameBytes);
     require(codec::inspect(*envelope).payload == PayloadKind::DatasetOpened,
         "server refused an open carrying derived fields");
@@ -345,11 +349,19 @@ int main(int argc, char* argv[])
         "the computed field is not the tail of the catalog");
     require(derivedOpen.derivedFieldCount == 1,
         "server did not report exactly one field as computed");
-    require(derivedOpen.derivedFieldSkips.size() == 1
+    require(derivedOpen.derivedFieldSkips.size() == 2
             && derivedOpen.derivedFieldSkips.front().definitionIndex == 1
             && derivedOpen.derivedFieldSkips.front().name == "elsewhere"
             && !derivedOpen.derivedFieldSkips.front().reason.empty(),
         "the unresolvable definition did not come back as a skip");
+    // Reported, not refused -- and the reason is the bounded one compile()
+    // gives, not the expression it is about.
+    require(derivedOpen.derivedFieldSkips.back().definitionIndex == 2
+            && derivedOpen.derivedFieldSkips.back().name == "overlong"
+            && !derivedOpen.derivedFieldSkips.back().reason.empty()
+            && derivedOpen.derivedFieldSkips.back().reason.size()
+                <= maximumExpressionBytes,
+        "the over-long expression did not come back as a bounded skip");
     // A derived field has no stored statistics, so the server reports no File
     // range for it -- the same answer a local session gives.
     require(derivedOpen.fileRangeAvailable.size()

--- a/tests/integration/test_remote_server.cpp
+++ b/tests/integration/test_remote_server.cpp
@@ -331,14 +331,19 @@ int main(int argc, char* argv[])
     // the open, and the skip names the definition it belongs to by index.
     // An expression past maximumExpressionBytes is one of those rather than a
     // refusal: compile() bounds it before parsing anything, so the remote
-    // answer for such a list is the one a local dataset gives.
+    // answer for such a list is the one a local dataset gives. The last
+    // definition is the other side of that bound -- long enough to name a
+    // symbol installation must quote back, so the reason it produces is longer
+    // than the reason bound, and the reply only decodes because toWire holds
+    // it to that bound.
     envelope = exchange(socket, 16,
         codec::toWire(OpenDatasetData{
             std::filesystem::path(argv[1]).string(),
             16ULL * 1024ULL * 1024ULL,
             {{"product", "density * temperature"},
                 {"elsewhere", "nonesuch * 2"},
-                {"overlong", std::string(maximumExpressionBytes + 1, 'x')}}}),
+                {"overlong", std::string(maximumExpressionBytes + 1, 'x')},
+                {"longreason", std::string(maximumExpressionBytes - 6, 'a')}}}),
         hello.maximumFrameBytes);
     require(codec::inspect(*envelope).payload == PayloadKind::DatasetOpened,
         "server refused an open carrying derived fields");
@@ -349,19 +354,28 @@ int main(int argc, char* argv[])
         "the computed field is not the tail of the catalog");
     require(derivedOpen.derivedFieldCount == 1,
         "server did not report exactly one field as computed");
-    require(derivedOpen.derivedFieldSkips.size() == 2
-            && derivedOpen.derivedFieldSkips.front().definitionIndex == 1
-            && derivedOpen.derivedFieldSkips.front().name == "elsewhere"
-            && !derivedOpen.derivedFieldSkips.front().reason.empty(),
+    require(derivedOpen.derivedFieldSkips.size() == 3
+            && derivedOpen.derivedFieldSkips[0].definitionIndex == 1
+            && derivedOpen.derivedFieldSkips[0].name == "elsewhere"
+            && !derivedOpen.derivedFieldSkips[0].reason.empty(),
         "the unresolvable definition did not come back as a skip");
-    // Reported, not refused -- and the reason is the bounded one compile()
-    // gives, not the expression it is about.
-    require(derivedOpen.derivedFieldSkips.back().definitionIndex == 2
-            && derivedOpen.derivedFieldSkips.back().name == "overlong"
-            && !derivedOpen.derivedFieldSkips.back().reason.empty()
-            && derivedOpen.derivedFieldSkips.back().reason.size()
-                <= maximumExpressionBytes,
+    // Reported, not refused -- and the reason is the short one compile() gives,
+    // not the expression it is about.
+    require(derivedOpen.derivedFieldSkips[1].definitionIndex == 2
+            && derivedOpen.derivedFieldSkips[1].name == "overlong"
+            && !derivedOpen.derivedFieldSkips[1].reason.empty()
+            && derivedOpen.derivedFieldSkips[1].reason.size()
+                < maximumExpressionBytes,
         "the over-long expression did not come back as a bounded skip");
+    // The reason installation produced for this one is longer than the bound
+    // fromWire enforces, so reaching this line at all is the point: before
+    // toWire bounded it, the decode above threw and the connection closed.
+    // The marker is what proves it was truncated rather than merely short.
+    const auto& longest = derivedOpen.derivedFieldSkips[2];
+    require(longest.definitionIndex == 3 && longest.name == "longreason"
+            && longest.reason.size() == maximumExpressionBytes
+            && longest.reason.ends_with("..."),
+        "an over-long skip reason was not bounded on the way out");
     // A derived field has no stored statistics, so the server reports no File
     // range for it -- the same answer a local session gives.
     require(derivedOpen.fileRangeAvailable.size()

--- a/tests/integration/test_remote_session.cpp
+++ b/tests/integration/test_remote_session.cpp
@@ -153,6 +153,74 @@ int main(int argc, char* argv[])
                 && slice.plane.physicalRegion
                     == localSlice.plane.physicalRegion,
             "local and remote slice values differ");
+
+        // Protocol 1.4: a field computed on the server must be the same field
+        // a local session computes. The definitions are installed in the same
+        // order at both ends, so the derived field takes the same id, and the
+        // slice through it must match value for value -- which is the check
+        // that catches a server-side install that silently differs.
+        {
+            const std::vector<amrvis::DerivedFieldDefinition> definitions{
+                {"product", "density * temperature"},
+                {"elsewhere", "nonesuch * 2"}};
+            auto derivedRemote = amrvis::remote::RemoteDatasetSession::open(
+                connection, std::filesystem::path(argv[1]).string(),
+                16ULL * 1024ULL * 1024ULL, {}, definitions);
+            amrvis::LocalDatasetSession derivedLocal(
+                std::filesystem::path(argv[1]), amrvis::DatasetId{1002},
+                16ULL * 1024ULL * 1024ULL, {}, definitions);
+
+            require(derivedRemote->supportsDerivedFields(),
+                "a 1.4 session does not report derived-field support");
+            require(derivedRemote->storedFieldCount()
+                    == derivedLocal.storedFieldCount(),
+                "local and remote disagree on how many fields are stored");
+            require(derivedRemote->metadata().fields.size()
+                    == derivedLocal.metadata().fields.size(),
+                "local and remote installed a different number of fields");
+            require(derivedRemote->derivedFieldDefinitions() == definitions,
+                "the session did not report the list it was opened with");
+
+            // The one this plotfile cannot resolve, reported the same way at
+            // both ends including the index of the definition it belongs to.
+            const auto remoteSkips = derivedRemote->skippedDerivedFields();
+            const auto localSkips = derivedLocal.skippedDerivedFields();
+            require(remoteSkips.size() == localSkips.size()
+                    && remoteSkips.size() == 1
+                    && remoteSkips.front().definitionIndex
+                        == localSkips.front().definitionIndex
+                    && remoteSkips.front().name == localSkips.front().name
+                    && remoteSkips.front().reason == localSkips.front().reason,
+                "local and remote report the skipped definition differently");
+
+            const auto derivedField = amrvis::FieldId{
+                static_cast<std::uint32_t>(derivedRemote->storedFieldCount())};
+            auto remoteDerivedRequest = sliceRequest(*derivedRemote, 8, 6);
+            remoteDerivedRequest.field = derivedField;
+            auto localDerivedRequest = sliceRequest(derivedLocal, 8, 6);
+            localDerivedRequest.field = derivedField;
+            const auto remoteDerivedSlice = std::get<amrvis::SliceQueryResult>(
+                derivedRemote->requestView(remoteDerivedRequest));
+            const auto localDerivedSlice = std::get<amrvis::SliceQueryResult>(
+                derivedLocal.requestView(localDerivedRequest));
+            require(remoteDerivedSlice.plane.values
+                        == localDerivedSlice.plane.values
+                    && remoteDerivedSlice.plane.valid
+                        == localDerivedSlice.plane.valid,
+                "a computed field differs between a local and a remote session");
+            // And it is genuinely the product, not a copy of a stored field.
+            require(remoteDerivedSlice.plane.values != slice.plane.values,
+                "the computed slice is identical to the stored field's");
+
+            // A derived field has no stored statistics at either end.
+            const amrvis::RangeRequest derivedRange{derivedField,
+                derivedRemote->metadata().finestLevel,
+                amrvis::CompositionPolicy::FinestAvailable,
+                amrvis::RangeScope::File};
+            require(derivedRemote->rangeAvailable(derivedRange)
+                    == derivedLocal.rangeAvailable(derivedRange),
+                "local and remote disagree on a computed field's File range");
+        }
         require(slice.gridBoxesIncluded && !slice.gridBoxes.empty(),
             "remote slice omitted view-local grid geometry");
         for (const auto& box : slice.gridBoxes) {

--- a/tests/unit/test_remote_codec.cpp
+++ b/tests/unit/test_remote_codec.cpp
@@ -317,6 +317,87 @@ int main()
                         codec::fromWire(inconsistent)); },
         "inconsistent slice vectors were accepted");
 
+    // Protocol 1.4, on the wire rather than through a round trip: the request
+    // carries the definitions in order, and the reply carries the *derived*
+    // count (not the stored one) plus a skip per definition it could not
+    // install. A converter that transposed name and expression, or that sent
+    // the stored count, round-trips cleanly here and mislabels every field
+    // against a real peer.
+    {
+        OpenDatasetData open;
+        open.path = "/plt";
+        open.cacheBudgetBytes = 1024;
+        open.derivedFields = {{"speed", "sqrt(u**2 + v**2)"}, {"twice", "2*speed"}};
+        const auto openWire = codec::toWire(open);
+        require(openWire.derived_fields.size() == 2
+                && openWire.derived_fields[0]->name == "speed"
+                && openWire.derived_fields[0]->expression == "sqrt(u**2 + v**2)"
+                && openWire.derived_fields[1]->name == "twice",
+            "the derived-field definitions are not on the wire in order");
+        require(codec::fromWire(openWire).derivedFields == open.derivedFields,
+            "the derived-field definitions did not survive the wire");
+
+        auto derived = opened;
+        derived.catalog.fields.push_back(FieldMetadata{
+            .name = "speed", .centering = {}, .componentNames = {}});
+        derived.fileRangeAvailable.push_back(0);
+        derived.levelRangeAvailable.push_back(0);
+        derived.derivedFieldCount = 1;
+        derived.derivedFieldSkips = {DerivedFieldSkip{1, "twice",
+            "no field or coordinate is named 'speed'"}};
+        const auto derivedWire = codec::toWire(derived);
+        require(derivedWire.derived_field_count == 1,
+            "the derived field count is not on the wire");
+        require(derivedWire.derived_field_skips.size() == 1
+                && derivedWire.derived_field_skips[0]->definition_index == 1
+                && derivedWire.derived_field_skips[0]->name == "twice",
+            "a skip's definition index and name are not on the wire");
+        const auto derivedBack = codec::fromWire(derivedWire);
+        require(derivedBack.derivedFieldCount == 1
+                && derivedBack.derivedFieldSkips.size() == 1
+                && derivedBack.derivedFieldSkips[0].definitionIndex == 1,
+            "the derived reply did not survive the wire");
+
+        // Rejections, one per new bound.
+        auto tooMany = openWire;
+        tooMany.derived_fields.clear();
+        for (std::size_t index = 0; index <= maximumDerivedFieldCount; ++index) {
+            auto entry = std::make_unique<
+                amrexplorer::wire::DerivedFieldDefinitionT>();
+            entry->name = "f" + std::to_string(index);
+            entry->expression = "density";
+            tooMany.derived_fields.push_back(std::move(entry));
+        }
+        requireRejected([&] { static_cast<void>(codec::fromWire(tooMany)); },
+            "a definition list past the cap was accepted");
+
+        auto longExpression = codec::toWire(open);
+        longExpression.derived_fields[0]->expression
+            = std::string(maximumExpressionBytes + 1, 'x');
+        requireRejected(
+            [&] { static_cast<void>(codec::fromWire(longExpression)); },
+            "an over-long expression was accepted");
+
+        auto namelessDefinition = codec::toWire(open);
+        namelessDefinition.derived_fields[0]->name.clear();
+        requireRejected(
+            [&] { static_cast<void>(codec::fromWire(namelessDefinition)); },
+            "a definition with no name was accepted");
+
+        auto tooManyDerived = derivedWire;
+        tooManyDerived.derived_field_count
+            = static_cast<std::uint32_t>(derived.catalog.fields.size() + 1);
+        requireRejected(
+            [&] { static_cast<void>(codec::fromWire(tooManyDerived)); },
+            "a derived count past the field list was accepted");
+
+        auto namelessSkip = codec::toWire(derived);
+        namelessSkip.derived_field_skips[0]->name.clear();
+        requireRejected(
+            [&] { static_cast<void>(codec::fromWire(namelessSkip)); },
+            "a skip with no name was accepted");
+    }
+
     auto openedWire = codec::toWire(opened);
     openedWire.dimension = 4;
     requireRejected([&] { static_cast<void>(codec::fromWire(openedWire)); },

--- a/tests/unit/test_remote_codec.cpp
+++ b/tests/unit/test_remote_codec.cpp
@@ -371,12 +371,16 @@ int main()
         requireRejected([&] { static_cast<void>(codec::fromWire(tooMany)); },
             "a definition list past the cap was accepted");
 
+        // Not a rejection, and deliberately so: compile() refuses an
+        // expression past maximumExpressionBytes, so installation reports one
+        // as a skip. Refusing it here would fail an open that the very same
+        // definition list opens locally.
         auto longExpression = codec::toWire(open);
-        longExpression.derived_fields[0]->expression
-            = std::string(maximumExpressionBytes + 1, 'x');
-        requireRejected(
-            [&] { static_cast<void>(codec::fromWire(longExpression)); },
-            "an over-long expression was accepted");
+        const auto overLong = std::string(maximumExpressionBytes + 1, 'x');
+        longExpression.derived_fields[0]->expression = overLong;
+        require(codec::fromWire(longExpression).derivedFields.front().expression
+                == overLong,
+            "an over-long expression did not survive the wire");
 
         auto namelessDefinition = codec::toWire(open);
         namelessDefinition.derived_fields[0]->name.clear();

--- a/tests/unit/test_remote_codec.cpp
+++ b/tests/unit/test_remote_codec.cpp
@@ -413,6 +413,28 @@ int main()
                 == maximumExpressionBytes,
             "a bounded skip reason did not survive the wire");
 
+        // A peer built from any other 1.4 commit sends the reason
+        // installation produced, unbounded -- and 1.4 cannot tell it from a
+        // peer that bounds it. Clamped on the way in, not refused: this decode
+        // runs inside refusingInvalidResponses, where a throw would close the
+        // connection and take every other dataset on it.
+        auto unboundedPeer = codec::toWire(derived);
+        // Every character three bytes wide, so a clean cut is a multiple of
+        // three: a ${...} symbol is taken verbatim, so a reason really can
+        // carry multi-byte text, and the clamp must not leave half of one.
+        std::string wide;
+        while (wide.size() < maximumExpressionBytes + 64) {
+            wide += "\xe2\x82\xac";
+        }
+        unboundedPeer.derived_field_skips[0]->reason = wide;
+        const auto clamped
+            = codec::fromWire(unboundedPeer).derivedFieldSkips[0].reason;
+        require(clamped.size() <= maximumExpressionBytes
+                && clamped.ends_with("..."),
+            "an over-long reason from a peer was not clamped on the way in");
+        require((clamped.size() - 3) % 3 == 0,
+            "the clamp cut a multi-byte sequence in half");
+
         auto namelessSkip = codec::toWire(derived);
         namelessSkip.derived_field_skips[0]->name.clear();
         requireRejected(

--- a/tests/unit/test_remote_codec.cpp
+++ b/tests/unit/test_remote_codec.cpp
@@ -395,6 +395,24 @@ int main()
             [&] { static_cast<void>(codec::fromWire(tooManyDerived)); },
             "a derived count past the field list was accepted");
 
+        // The encoder holds a reason to the bound the decoder enforces, so
+        // the codec cannot refuse its own output. Installation quotes an
+        // unresolved symbol into the reason, so one longer than the bound is
+        // what a *correct* server produces, not a malformed one.
+        auto longReason = derived;
+        longReason.derivedFieldSkips[0].reason
+            = std::string(maximumExpressionBytes + 500, 'r');
+        const auto longReasonWire = codec::toWire(longReason);
+        require(longReasonWire.derived_field_skips[0]->reason.size()
+                    == maximumExpressionBytes
+                && longReasonWire.derived_field_skips[0]->reason.ends_with(
+                    "..."),
+            "an over-long skip reason was not bounded on the way out");
+        require(codec::fromWire(longReasonWire).derivedFieldSkips[0].reason
+                    .size()
+                == maximumExpressionBytes,
+            "a bounded skip reason did not survive the wire");
+
         auto namelessSkip = codec::toWire(derived);
         namelessSkip.derived_field_skips[0]->name.clear();
         requireRejected(

--- a/tests/unit/test_session_validation.cpp
+++ b/tests/unit/test_session_validation.cpp
@@ -1002,5 +1002,87 @@ int main()
         }
         require(cancelled, "a cancelled Visible range scan did not throw");
     }
+    {
+        // The derived-field half of an open reply. The catalog is larger than
+        // the request in every case below and each refusal is matched on its
+        // own message, so a call site that swapped fieldCount for
+        // requestedCount fails here instead of passing silently.
+        const std::vector<amrvis::DerivedFieldSkip> noSkips;
+        const std::vector<amrvis::DerivedFieldSkip> oneSkip{
+            {1, "twice", "no field or coordinate is named 'speed'"}};
+        requireAccepted([&] {
+            amrvis::validateSessionOpenedDerivedFields({
+                .fieldCount = 5,
+                .derivedFieldCount = 1,
+                .skips = oneSkip,
+                .requestedCount = 2,
+            });
+        }, "a well-formed derived-field reply was rejected");
+        requireRejectedWith([&] {
+            amrvis::validateSessionOpenedDerivedFields({
+                .fieldCount = 1,
+                .derivedFieldCount = 2,
+                .skips = noSkips,
+                .requestedCount = 2,
+            });
+        }, "than it has fields",
+            "a catalog claiming more derived fields than fields was accepted");
+        requireRejectedWith([&] {
+            amrvis::validateSessionOpenedDerivedFields({
+                .fieldCount = 5,
+                .derivedFieldCount = 3,
+                .skips = noSkips,
+                .requestedCount = 2,
+            });
+        }, "reports more derived fields",
+            "a reply installing more definitions than were sent was accepted");
+        const std::vector<amrvis::DerivedFieldSkip> threeSkips{
+            {0, "a", "why"}, {1, "b", "why"}, {2, "c", "why"}};
+        requireRejectedWith([&] {
+            amrvis::validateSessionOpenedDerivedFields({
+                .fieldCount = 5,
+                .derivedFieldCount = 0,
+                .skips = threeSkips,
+                .requestedCount = 2,
+            });
+        }, "skips more definitions",
+            "a reply skipping more definitions than were sent was accepted");
+        // The sum, which is the only check the two above cannot stand in for:
+        // neither count alone is past the request.
+        const std::vector<amrvis::DerivedFieldSkip> twoSkips{
+            {0, "a", "why"}, {1, "b", "why"}};
+        requireRejectedWith([&] {
+            amrvis::validateSessionOpenedDerivedFields({
+                .fieldCount = 5,
+                .derivedFieldCount = 2,
+                .skips = twoSkips,
+                .requestedCount = 3,
+            });
+        }, "installs and skips",
+            "a reply accounting for more definitions than were sent was "
+            "accepted");
+        const std::vector<amrvis::DerivedFieldSkip> straySkip{
+            {7, "stray", "why"}};
+        requireRejectedWith([&] {
+            amrvis::validateSessionOpenedDerivedFields({
+                .fieldCount = 5,
+                .derivedFieldCount = 0,
+                .skips = straySkip,
+                .requestedCount = 2,
+            });
+        }, "was not requested",
+            "a skip naming a definition that was never sent was accepted");
+        // A peer that installed none is not a peer that lied: the reply a
+        // pre-1.4 server sends decodes to zeroes, and an empty request is
+        // answered the same way.
+        requireAccepted([&] {
+            amrvis::validateSessionOpenedDerivedFields({
+                .fieldCount = 5,
+                .derivedFieldCount = 0,
+                .skips = noSkips,
+                .requestedCount = 0,
+            });
+        }, "a reply carrying no derived fields was rejected");
+    }
     return 0;
 }


### PR DESCRIPTION
The open request carries the definitions and the server installs them on the session it opens, so slices arrive already computed and nothing in the query path changes. The reply carries the derived count rather than the stored one: flatbuffers reads an absent uint as 0, which is the truth about a server that installed none, while a stored 0 would empty the client's field list.

A peer that predates 1.4 is refused above the wrapper that closes the connection, and the session keeps its list as sent, which is what makes the client's reload comparison converge.