### PR TITLE
offer derived fields over a remote dataset

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -91,7 +91,9 @@ implementations, interchangeable to everything above them:
 
 - **`LocalDatasetSession`** — reads plotfiles in-process via `src/io` and the
   `SliceQuery`/`LineQuery` layer, backed by the block cache.
-- **`RemoteDatasetSession`** — forwards each request over the wire (`src/remote`)
+- **`RemoteDatasetSession`** — forwards each request over the wire (`src/remote`),
+  including the derived-field definitions an open carries (protocol 1.4), which
+  the server installs on its own `LocalDatasetSession`
   to a server that itself runs a `LocalDatasetSession`.
 
 The GUI opens one or the other and is otherwise agnostic to where the data lives.

--- a/docs/remote-client-server-plan.md
+++ b/docs/remote-client-server-plan.md
@@ -317,6 +317,17 @@ really is older rather than one a test pretended was. Protocol 1.3's gate was
 checked this way: the control is greyed out and cleared, the volume still
 renders nearest, and returning to a session that can sample restores it.
 
+Protocol 1.4's derived-field gate is the same shape and wants the same check.
+`RemoteDatasetSession::supportsDerivedFields()` reports the *connection's*
+capability, so against a pre-1.4 server the Expression Editor is greyed with a
+reason rather than offering a list the peer cannot install. Two halves to
+confirm against a real older binary: the editor is unavailable, and an open
+carrying definitions is refused answerably -- `UnsupportedProtocol`, with the
+connection still up and other datasets on it untouched, rather than a
+teardown. The server half is covered in-process by the raw-socket cases in
+`test_remote_server.cpp`, including that a 1.3 peer is told about the version
+rather than about the list.
+
 ### 5.3 Handshake and capabilities
 
 The first request must be `HelloRequest`. It will carry:
@@ -350,7 +361,7 @@ The production schema will cover:
 | Request | Successful response | Purpose |
 |---|---|---|
 | `HelloRequest` | `HelloResponse` | Negotiate the session |
-| `OpenDatasetRequest` | `DatasetOpened` | Open a path and return catalog metadata |
+| `OpenDatasetRequest` | `DatasetOpened` | Open a path and return catalog metadata (derived-field definitions 1.4; the reply's derived count and skips 1.4) |
 | `CloseDatasetRequest` | `DatasetClosed` | Release one remote handle |
 | `ViewDataRequest` | `ViewDataResponse` | Return cells needed for one 1-D/2-D viewport |
 | `DatasetPageRequest` | `DatasetPageResponse` | Populate one visible Dataset-window page |

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -492,8 +492,13 @@ Other notes:
   list, which is how a set of definitions is kept for another session. An
   import replaces what the editor is showing; nothing reaches the dataset until
   you select **Apply**.
-- Derived fields are computed where the data is read, so they are not
-  available for a dataset opened from a remote server.
+- Derived fields are computed where the data is read. For a dataset opened from
+  a remote server that means on the server: the definitions travel with the
+  open, the slices come back already computed, and everything else -- the line
+  plot, the Dataset window, volume rendering -- sees the computed field as it
+  sees a stored one. This needs a server new enough to carry them (protocol
+  1.4); against an older one the **Expression Editor** is greyed out and says
+  so, and the fields the plotfile stores are unaffected.
 
 ## Ranges, logarithms, and palettes
 

--- a/include/amrexplorer/data/SessionValidation.hpp
+++ b/include/amrexplorer/data/SessionValidation.hpp
@@ -54,8 +54,11 @@ void validateSessionVolumeResult(const DatasetMetadata& metadata,
 // installed anything. The siblings above take the request and result objects
 // themselves, which is what makes them non-transposable; this one cannot,
 // because the reply it checks is a remote:: type and this header does not
-// depend on that layer. Naming them also makes leaving one out an error rather
-// than a zero, since a missing designated initializer is one here.
+// depend on that layer. Naming them does not by itself make leaving one out an
+// error: the counts have default initializers, which is what suppresses the
+// missing-initializer diagnostic, so an omitted count silently reads as zero
+// and passes every check below. Only skips, which has no default, is caught
+// that way. What the struct buys is that a swap has to be written down.
 struct SessionOpenedDerivedFields {
     // The reply's whole catalog, computed tail included.
     std::size_t fieldCount = 0;

--- a/src/data/SessionValidation.cpp
+++ b/src/data/SessionValidation.cpp
@@ -758,19 +758,15 @@ void validateSessionOpenedDerivedFields(
             "dataset catalog installs and skips more definitions than were "
             "requested");
     }
-    // Tracked rather than only bounded: without this a reply could skip one
-    // definition twice and leave the rest unaccounted for while every count
-    // above still added up, which is the state the comment on this function
-    // says cannot happen.
-    std::vector<bool> seen(requested, false);
+    // Duplicate indices are deliberately NOT refused. definition_index is a
+    // flatbuffers scalar whose default of 0 is left out of the buffer, so a
+    // conforming 1.4 peer that never populates it sends every skip with index
+    // 0 -- and no client code reads the field, since the rows are matched to
+    // skips by name. Refusing here would run inside refusingInvalidResponses
+    // and fail the open outright, spending a fatal reaction on a field whose
+    // only wrong value is invisible. The bound below stays: an index past the
+    // request is a reply describing a definition that was never sent.
     for (const auto& skip : reply.skips) {
-        if (skip.definitionIndex < requested) {
-            if (seen[skip.definitionIndex]) {
-                throw std::invalid_argument(
-                    "dataset catalog skips the same definition twice");
-            }
-            seen[skip.definitionIndex] = true;
-        }
         if (skip.definitionIndex >= requested) {
             throw std::invalid_argument(
                 "dataset catalog skips a definition that was not requested");

--- a/src/data/SessionValidation.cpp
+++ b/src/data/SessionValidation.cpp
@@ -758,7 +758,19 @@ void validateSessionOpenedDerivedFields(
             "dataset catalog installs and skips more definitions than were "
             "requested");
     }
+    // Tracked rather than only bounded: without this a reply could skip one
+    // definition twice and leave the rest unaccounted for while every count
+    // above still added up, which is the state the comment on this function
+    // says cannot happen.
+    std::vector<bool> seen(requested, false);
     for (const auto& skip : reply.skips) {
+        if (skip.definitionIndex < requested) {
+            if (seen[skip.definitionIndex]) {
+                throw std::invalid_argument(
+                    "dataset catalog skips the same definition twice");
+            }
+            seen[skip.definitionIndex] = true;
+        }
         if (skip.definitionIndex >= requested) {
             throw std::invalid_argument(
                 "dataset catalog skips a definition that was not requested");

--- a/src/qt/DerivedFieldController.cpp
+++ b/src/qt/DerivedFieldController.cpp
@@ -160,8 +160,9 @@ void DerivedFieldController::adoptStoreChange()
     }
     // Including the window whose Apply made the change: one path installs the
     // list, whoever asked for it. A window that cannot take derived fields --
-    // a remote session, or a FAB -- has nothing to reload, and will not show
-    // them either way.
+    // a FAB, or a session whose peer predates 1.4 -- has nothing to reload,
+    // and will not show them either way. (A remote session on a 1.4 peer very
+    // much does reload; that is what this protocol version is for.)
     if (m_hooks.reload && available()) {
         m_hooks.reload();
     }
@@ -271,7 +272,10 @@ std::optional<DerivedFieldController::Refusal> DerivedFieldController::apply(
     }
 
     // set() is what reloads -- here and in every other window -- and does
-    // nothing at all when the list has not moved.
+    // nothing at all when the list has not moved. That last part is deliberate
+    // and tested ("an unchanged list reloaded a window"), which is also why an
+    // Apply cannot serve as the retry for a reload that failed: see the note
+    // on the failure path in MainWindowDataset.
     m_store.set(std::move(definitions));
     return std::nullopt;
 }

--- a/src/qt/DerivedFieldController.cpp
+++ b/src/qt/DerivedFieldController.cpp
@@ -179,7 +179,10 @@ QAction* DerivedFieldController::createAction(QWidget* parent)
 
 void DerivedFieldController::refreshAvailability()
 {
-    const auto usable = available();
+    const auto reason = m_hooks.unavailableReason
+        ? m_hooks.unavailableReason()
+        : tr("Derived fields need a dataset.");
+    const auto usable = reason.isEmpty();
     if (m_action) {
         m_action->setEnabled(usable);
         // Never empty: the Variable menu shows tooltips (for the derived
@@ -187,7 +190,7 @@ void DerivedFieldController::refreshAvailability()
         // a tooltip repeating the entry's label.
         m_action->setToolTip(usable
                 ? tr("Define fields computed from the stored ones")
-                : tr("Derived fields need a local dataset."));
+                : reason);
     }
     // The editor stays open when the dataset does not. It edits the session's
     // list rather than the dataset's, and closing it would take with it a
@@ -203,9 +206,13 @@ std::optional<DerivedFieldController::Refusal> DerivedFieldController::apply(
     // The same question the action's enablement asks, not a weaker one: the
     // editor is modeless, so the window can enter a state it is disabled for
     // (a FAB drill-down) while it is still open in front of the user.
-    if (!available()) {
-        return Refusal{tr("No dataset that can take derived fields is open."),
-            std::nullopt};
+    if (const auto reason = m_hooks.unavailableReason
+            ? m_hooks.unavailableReason()
+            : tr("Derived fields need a dataset.");
+        !reason.isEmpty()) {
+        // The same words the greyed action carries, so the editor and the menu
+        // give one answer rather than two.
+        return Refusal{reason, std::nullopt};
     }
 
     // Bounded here as well as at installation, because this is where an

--- a/src/qt/DerivedFieldController.cpp
+++ b/src/qt/DerivedFieldController.cpp
@@ -273,10 +273,16 @@ std::optional<DerivedFieldController::Refusal> DerivedFieldController::apply(
 
     // set() is what reloads -- here and in every other window -- and does
     // nothing at all when the list has not moved. That last part is deliberate
-    // and tested ("an unchanged list reloaded a window"), which is also why an
-    // Apply cannot serve as the retry for a reload that failed: see the note
-    // on the failure path in MainWindowDataset.
+    // and tested ("an unchanged list reloaded a window"), so a list that has
+    // not moved is asked for again here instead, and only of this window: the
+    // reload that failed is the one the user is looking at, and the hook drops
+    // the ask where the session already carries the list, which is every
+    // window an unchanged Apply has nothing to do in.
+    const bool moved = definitions != m_store.definitions();
     m_store.set(std::move(definitions));
+    if (!moved && m_hooks.reloadIfMissing) {
+        m_hooks.reloadIfMissing();
+    }
     return std::nullopt;
 }
 

--- a/src/qt/DerivedFieldController.hpp
+++ b/src/qt/DerivedFieldController.hpp
@@ -70,10 +70,13 @@ class DerivedFieldController final : public QObject {
 
 public:
     struct Hooks {
-        // Whether a dataset that can take derived fields is open. Asked on
-        // every dataset load, so it answers from one pointer rather than by
-        // copying anything.
-        std::function<bool()> available;
+        // Empty while a dataset that can take derived fields is open, and
+        // otherwise why not, in the words the greyed action shows. A reason
+        // rather than a bool because there is more than one: no dataset, a FAB
+        // drilled out of a MultiFab, or a server too old for them -- and
+        // telling a remote user their dataset is not local would be a lie.
+        // Asked on every dataset load, so it answers without copying anything.
+        std::function<QString()> unavailableReason;
         // Reopen the open dataset with the committed definitions.
         std::function<void()> reload;
         // A path to import from (forSaving false) or export to (true); empty
@@ -100,7 +103,8 @@ public:
     // window but not the session it was opening.
     [[nodiscard]] bool available() const
     {
-        return m_hooks.available && m_hooks.available();
+        return m_hooks.unavailableReason
+            && m_hooks.unavailableReason().isEmpty();
     }
 
     [[nodiscard]] const std::vector<DerivedFieldDefinition>& definitions()

--- a/src/qt/DerivedFieldController.hpp
+++ b/src/qt/DerivedFieldController.hpp
@@ -79,6 +79,14 @@ public:
         std::function<QString()> unavailableReason;
         // Reopen the open dataset with the committed definitions.
         std::function<void()> reload;
+        // Reopen it only if it is not already showing them. What an Apply that
+        // changed nothing asks for: a reload that failed leaves the list
+        // committed and uninstalled, and the store emits nothing to ask again
+        // with, so without this the only ways back are editing the list to
+        // something else and back, or reopening the dataset. A window whose
+        // session already carries the list does nothing here, which is what
+        // keeps a merely redundant Apply from reloading anything.
+        std::function<void()> reloadIfMissing;
         // A path to import from (forSaving false) or export to (true); empty
         // cancels. The host runs the file dialog, as it does for palettes.
         std::function<QString(QWidget* parent, bool forSaving)> chooseFile;

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -635,6 +635,11 @@ MainWindow::MainWindow(QWidget* parent)
     connect(m_sequenceController, &SequenceController::frameLoadFailed,
         this, [this](const QString& message) {
             statusBar()->showMessage(tr("Frame load failed"));
+            // A reload handed to the sequence and then failed installs
+            // nothing, so the memo must not remember it as asked: the epoch
+            // has not moved, and Apply cannot ask again because the store does
+            // not emit for a list that has not moved.
+            m_reloadAskedFor.reset();
             // Stop playing. Playback wraps, so without this it comes back to
             // the same unreadable frame -- or the same disconnected server --
             // every cycle, raising a diagnostic each time. The user is left on

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -44,18 +44,31 @@ MainWindow::MainWindow(QWidget* parent)
     // buildFrameSpec is where the list reaches a dataset.
     m_derivedFields = new DerivedFieldController(
         DerivedFieldController::Hooks{
-            .available = [this] {
-                // Two questions, and both have to hold: whether the open
-                // session can take derived fields, and whether a load built
-                // now would carry them (derivedFieldsReachNextLoad). Not for a
-                // standalone FAB, drilled out of a MultiFab or opened straight
-                // from a file: applying reopens m_datasetPath, and what that
-                // entry describes -- a synthesised metadata, or one record of
-                // a multi-record file -- is not what re-reading the path
-                // produces.
-                return m_dataset && m_dataset->supportsDerivedFields()
-                    && !m_dataset->metadata().isFab
-                    && derivedFieldsReachNextLoad();
+            .unavailableReason = [this]() -> QString {
+                // Each answer names the thing the user would have to change.
+                // Not for a standalone FAB, drilled out of a MultiFab or opened
+                // straight from a file: applying reopens m_datasetPath, and
+                // what that entry describes -- a synthesised metadata, or one
+                // record of a multi-record file -- is not what re-reading the
+                // path produces.
+                if (!m_dataset) {
+                    return tr("Derived fields need an open dataset.");
+                }
+                if (m_dataset->metadata().isFab
+                    || !derivedFieldsReachNextLoad()) {
+                    return tr("Derived fields are not available for a FAB "
+                              "drilled out of a MultiFab.");
+                }
+                if (!m_dataset->supportsDerivedFields()) {
+                    // The one case a user can act on: their server is old.
+                    // A remote session says so in the words both layers share;
+                    // anything else cannot compute fields at all.
+                    return std::dynamic_pointer_cast<
+                               remote::RemoteDatasetSession>(m_dataset)
+                        ? tr(remote::derivedFieldsUnsupportedMessage)
+                        : tr("This dataset cannot compute fields.");
+                }
+                return {};
             },
             .reload = [this] { reloadCurrentDataset(); },
             .chooseFile =
@@ -1539,7 +1552,7 @@ void MainWindow::reloadCurrentDataset()
     // Not while closing: another window's Apply reaches every window, and a
     // worker started here would hold the I/O mutex against the quit. The
     // completion handler checks m_closing, but the read still runs.
-    if (m_closing || !m_dataset || m_datasetPath.empty()) {
+    if (m_closing || !m_dataset || m_datasetPath.empty() || !m_openMetadata) {
         return;
     }
     if (m_playbackMode == PlaybackMode::Sequence) {
@@ -1592,6 +1605,20 @@ void MainWindow::reloadCurrentDataset()
     // replayed against the new session by the next unrelated request.
     m_pendingAllViews = false;
     m_pendingViews.clear();
+    // A remote dataset is reopened on *its own* connection, not on whatever
+    // the session controller currently holds: server dataset ids come from a
+    // counter per connection, so a reload over a newer connection would
+    // restart them at 1 and let a cached display range alias a renumbered
+    // field. A connection that has gone fails the reload cleanly instead,
+    // which is the honest outcome.
+    if (const auto remote
+        = std::dynamic_pointer_cast<remote::RemoteDatasetSession>(m_dataset)) {
+        requestInitialSlice(m_datasetPath, generation, std::nullopt, {},
+            buildFrameSpec(),
+            SliceLoad{{}, RemoteOpen{remote->connection(),
+                           remote->remotePath()}});
+        return;
+    }
     // No prepared metadata and no data root: with none, the session derives
     // both from the path, which is what re-reading a plotfile means. A FAB
     // drilled out of a MultiFab cannot be reopened this way -- its metadata is

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -54,19 +54,34 @@ MainWindow::MainWindow(QWidget* parent)
                 if (!m_dataset) {
                     return tr("Derived fields need an open dataset.");
                 }
-                if (m_dataset->metadata().isFab
-                    || !derivedFieldsReachNextLoad()) {
-                    return tr("Derived fields are not available for a FAB "
-                              "drilled out of a MultiFab.");
-                }
+                // Asked before the shape of the next load, because
+                // derivedFieldsReachNextLoad() is also false for a remote
+                // sequence on a peer too old to install them -- and answering
+                // that with the FAB wording below tells the user their dataset
+                // is something it is not, which is the lie this reason exists
+                // to remove. The one case a user can act on is checked first.
                 if (!m_dataset->supportsDerivedFields()) {
-                    // The one case a user can act on: their server is old.
                     // A remote session says so in the words both layers share;
                     // anything else cannot compute fields at all.
                     return std::dynamic_pointer_cast<
                                remote::RemoteDatasetSession>(m_dataset)
                         ? tr(remote::derivedFieldsUnsupportedMessage)
                         : tr("This dataset cannot compute fields.");
+                }
+                // Both FABs, not just the drilled one: a standalone FAB opened
+                // straight from a file reopens no better than one drilled out
+                // of a MultiFab.
+                if (m_dataset->metadata().isFab
+                    || m_fabNavigator->fabMode()) {
+                    return tr("Derived fields are not available for a FAB.");
+                }
+                if (!derivedFieldsReachNextLoad()) {
+                    // What is left once the two above are ruled out. Kept so
+                    // every state the availability hook calls unavailable has
+                    // a reason to show, rather than a greyed control saying
+                    // nothing.
+                    return tr("Derived fields are not available for this "
+                              "remote sequence.");
                 }
                 return {};
             },
@@ -1547,13 +1562,13 @@ QString MainWindow::chooseExpressionListPath(QWidget* parent, bool forSaving)
     return path;
 }
 
-void MainWindow::reloadCurrentDataset()
+bool MainWindow::reloadCurrentDataset()
 {
     // Not while closing: another window's Apply reaches every window, and a
     // worker started here would hold the I/O mutex against the quit. The
     // completion handler checks m_closing, but the read still runs.
     if (m_closing || !m_dataset || m_datasetPath.empty() || !m_openMetadata) {
-        return;
+        return false;
     }
     if (m_playbackMode == PlaybackMode::Sequence) {
         // Mid-playback: reloading here would restart the frame under the user,
@@ -1568,14 +1583,17 @@ void MainWindow::reloadCurrentDataset()
         // definition uninstalled for good, with the editor reporting that it
         // had been applied.
         m_sequenceController->invalidatePrefetch();
-        return;
+        // Nothing was reloaded, which the caller has to know: a reload only
+        // asked for is not one that happened, and treating the two alike is
+        // how the definition would stay uninstalled for good.
+        return false;
     }
     if (m_sequenceController->hasSequence()) {
         // A prefetched frame was rendered against the previous field list.
         m_sequenceController->invalidatePrefetch();
         m_sequenceController->goToFrame(
             m_sequenceController->currentIndex(), true);
-        return;
+        return true;
     }
     // Not openDataset: that ends the sequence, drops the zoom and closes the
     // line-plot, dataset and volume windows. This is the same reload a
@@ -1617,7 +1635,7 @@ void MainWindow::reloadCurrentDataset()
             buildFrameSpec(),
             SliceLoad{{}, RemoteOpen{remote->connection(),
                            remote->remotePath()}});
-        return;
+        return true;
     }
     // No prepared metadata and no data root: with none, the session derives
     // both from the path, which is what re-reading a plotfile means. A FAB
@@ -1627,6 +1645,7 @@ void MainWindow::reloadCurrentDataset()
     // availability hook).
     requestInitialSlice(
         m_datasetPath, generation, std::nullopt, {}, buildFrameSpec());
+    return true;
 }
 
 void MainWindow::refreshMetadataDisplay()

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -86,6 +86,11 @@ MainWindow::MainWindow(QWidget* parent)
                 return {};
             },
             .reload = [this] { reloadCurrentDataset(); },
+            // Which asks nothing of a session that already carries the list,
+            // and remembers the ask it does make, so pressing Apply on an
+            // unchanged list repeatedly starts one reload rather than one
+            // each time.
+            .reloadIfMissing = [this] { reloadIfDefinitionsMoved(); },
             .chooseFile =
                 [this](QWidget*, bool forSaving) {
                     // Parented to the window, not to the editor that asked:

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -640,11 +640,17 @@ MainWindow::MainWindow(QWidget* parent)
     connect(m_sequenceController, &SequenceController::frameLoadFailed,
         this, [this](const QString& message) {
             statusBar()->showMessage(tr("Frame load failed"));
-            // A reload handed to the sequence and then failed installs
+            // Armed across the stop below and cleared after it. Stopping is
+            // where the frames' standing aside is made good -- setPlaybackMode
+            // asks for the reload once there is no next frame to read the list
+            // -- and asking from here would reopen the frame that just failed,
+            // against the same unreadable file or the same connection that has
+            // gone, for a second report of one failure. Cleared afterwards
+            // because a reload handed to the sequence and then failed installs
             // nothing, so the memo must not remember it as asked: the epoch
-            // has not moved, and Apply cannot ask again because the store does
-            // not emit for a list that has not moved.
-            m_reloadAskedFor.reset();
+            // has not moved, and without the clear the next load could not ask
+            // either.
+            m_reloadAskedFor = {m_derivedFields->definitions(), m_sessionEpoch};
             // Stop playing. Playback wraps, so without this it comes back to
             // the same unreadable frame -- or the same disconnected server --
             // every cycle, raising a diagnostic each time. The user is left on
@@ -654,6 +660,7 @@ MainWindow::MainWindow(QWidget* parent)
             if (m_playbackMode == PlaybackMode::Sequence) {
                 setPlaybackMode(PlaybackMode::None);
             }
+            m_reloadAskedFor.reset();
             // During animation export the failure is reported by the export
             // handler; avoid a second dialog.
             const bool wasExporting = m_animationExporter->active();

--- a/src/qt/MainWindow.hpp
+++ b/src/qt/MainWindow.hpp
@@ -151,6 +151,16 @@ public:
     // release build does not have is: the body cannot be inline here, where
     // AMREXPLORER_QT_TEST_ACCESS is not necessarily on.
     void setInitialSliceLaunchedHookForTest(std::function<void()> hook);
+    // Submits a slice for the active view the way an interaction does --
+    // synchronously, bumping the view's slice generation. Paired with the hook
+    // above it reproduces an interaction that lands while a reload is still
+    // replacing the session, which is the one ordering no arrival-side check
+    // can sort out on its own.
+    void requestActiveViewSliceForTest();
+    // Whether the raster on screen came from the session now installed. A
+    // reload leaves the outgoing session displayed while its replacement
+    // loads, so this is the invariant that says the two have converged.
+    [[nodiscard]] bool activeViewSliceMatchesSessionForTest() const;
     // The sequence frame waiting in the prefetch slot, if any.
     [[nodiscard]] std::optional<int> prefetchedSequenceFrameForTest() const;
     // The slot an idle frame-slider press-and-release lands in, which must not
@@ -1023,8 +1033,26 @@ private:
     // dataset once per event-loop turn -- a hung window, and a server past its
     // per-session dataset limit within a few seconds. With these, a mismatch
     // that survives a reload costs one wasted reload rather than a storm.
-    std::optional<std::vector<DerivedFieldDefinition>> m_reloadStartedFor;
-    bool m_reloadInFlight = false;
+    // Which session is installed. Bumped wherever m_dataset is replaced or
+    // cleared, and captured by a slice request at submission: an arrival whose
+    // stamp no longer matches was computed against a session that is gone, and
+    // the catalog, field list and colour bar on screen are the new one's.
+    //
+    // Note what this cannot do on its own. In the common ordering an
+    // interactive slice finishes *before* the reload installs, so its stamp
+    // still matches and it is rightly accepted -- it only goes stale a moment
+    // later. Acceptance is therefore only half the invariant; the other half is
+    // that a view whose display the reload skipped is re-sliced, so no view
+    // keeps a raster from a session that is no longer installed.
+    std::uint64_t m_sessionEpoch = 0;
+    // The list a reload has already been asked for, with the session epoch it
+    // was asked under. The epoch is what keeps it from getting stuck: any
+    // install makes the memo stale by itself, so it cannot suppress a reload
+    // for a different dataset or one that a later session could satisfy. It is
+    // cleared outright when a reload stands aside or a load fails, neither of
+    // which installs anything.
+    std::optional<std::pair<std::vector<DerivedFieldDefinition>, std::uint64_t>>
+        m_reloadAskedFor;
     QTreeWidget* m_metadataTree = nullptr;
     QDockWidget* m_metadataDock = nullptr;
     QDockWidget* m_diagnosticsDock = nullptr;

--- a/src/qt/MainWindow.hpp
+++ b/src/qt/MainWindow.hpp
@@ -151,6 +151,11 @@ public:
     // release build does not have is: the body cannot be inline here, where
     // AMREXPLORER_QT_TEST_ACCESS is not necessarily on.
     void setInitialSliceLaunchedHookForTest(std::function<void()> hook);
+    // Sends the next initial-slice completion down its failure arm, standing
+    // in for the reopen a server refuses or a connection that has gone. The
+    // one state a test cannot reach through the widgets, and the one the
+    // retry an unchanged Apply performs exists for.
+    void failNextInitialSliceForTest();
     // Submits a slice for the active view the way an interaction does --
     // synchronously, bumping the view's slice generation. Paired with the hook
     // above it reproduces an interaction that lands while a reload is still
@@ -1032,6 +1037,10 @@ private:
     // Test-only: run just after an initial-slice load is launched; see
     // setInitialSliceLaunchedHookForTest.
     std::function<void()> m_initialSliceLaunchedForTest;
+    // Test-only: consumed by the next initial-slice completion, which then
+    // throws where a load that failed would have. See
+    // failNextInitialSliceForTest.
+    bool m_failNextInitialSliceForTest = false;
     // Test-only: superseded visible-range sync outcomes dropped by the
     // rerun guard. Sole writer is that drop, so the overlapping-sync test can
     // assert an exact count. The DiagnosticsModel's stale count carries the

--- a/src/qt/MainWindow.hpp
+++ b/src/qt/MainWindow.hpp
@@ -577,7 +577,10 @@ private:
     // single dataset is reloaded straight through requestInitialSlice, whose
     // new generation both invalidates the in-flight work and gives the
     // replacement session a dataset id of its own.
-    void reloadCurrentDataset();
+    // Reopens the dataset on the list as it now stands. False when it stood
+    // aside without reloading -- mid-sequence playback, or nothing open --
+    // which is what reloadIfDefinitionsMoved's memo must not record as done.
+    bool reloadCurrentDataset();
     // The directory the last file dialog ended in, remembered across all of
     // them. The dialogs themselves stay separate -- one picks several
     // directories, one saves with a default suffix -- but this was copied into

--- a/src/qt/MainWindow.hpp
+++ b/src/qt/MainWindow.hpp
@@ -526,6 +526,13 @@ private:
         std::uint32_t cachedVectorVField = 0;
         int cachedContourCount = 0;
         StopSource stopSource;
+        // The session epoch `plane` was produced under. A reload replaces the
+        // session while the outgoing one is still displayed, so this is what
+        // says whether the raster on screen belongs to the session now
+        // installed. Derived state rather than a debt flag on purpose: a
+        // pending re-slice can be discarded by the next reload clearing the
+        // debounce, and a comparison cannot be.
+        std::uint64_t planeSessionEpoch = 0;
         std::uint64_t sliceGeneration = 0;
         // Bumped every time `plane` (and its contour companions) is rewritten:
         // each showSlice apply and each dataset reset. The 3-D visible-range
@@ -825,7 +832,16 @@ private:
     // arrival carries -- at the 4096 output cap a ScalarPlane is around 117 MB
     // and the ImageBuffer around 67 MB -- and a const& forced this function to
     // deep-copy them again into the shared_ptr snapshots it publishes.
-    void showSlice(PlaneViewState& state, SliceDisplayResult display);
+    // sessionEpoch is the epoch the display was computed under, stamped onto
+    // the view. No default: every caller has to say which session produced
+    // what it is showing, which is the whole point of the stamp.
+    void showSlice(PlaneViewState& state, SliceDisplayResult display,
+        std::uint64_t sessionEpoch);
+    // Re-slices every current view whose raster came from a session that is no
+    // longer installed. Called wherever a load settles -- including when it
+    // fails, since a failed reload leaves the previous session installed and
+    // its own display untouched.
+    void resliceReplacedViews();
     void updateOverlay(PlaneViewState& state);
     void updateOverlays();
     void updateGridBoxes(PlaneViewState& state);
@@ -1027,12 +1043,6 @@ private:
     // reason derivedFieldsReachNextLoad gives: frame 0's spec is built while
     // the outgoing dataset is still installed.
     bool m_remoteSequenceDerivedFields = false;
-    // The definition list a reload was last started for, and whether one is
-    // still in flight. A reload is asked for on every frame a sequence
-    // displays, so a list a load cannot install would otherwise reopen the
-    // dataset once per event-loop turn -- a hung window, and a server past its
-    // per-session dataset limit within a few seconds. With these, a mismatch
-    // that survives a reload costs one wasted reload rather than a storm.
     // Which session is installed. Bumped wherever m_dataset is replaced or
     // cleared, and captured by a slice request at submission: an arrival whose
     // stamp no longer matches was computed against a session that is gone, and
@@ -1046,7 +1056,13 @@ private:
     // keeps a raster from a session that is no longer installed.
     std::uint64_t m_sessionEpoch = 0;
     // The list a reload has already been asked for, with the session epoch it
-    // was asked under. The epoch is what keeps it from getting stuck: any
+    // was asked under. What bounds the reopens is no longer the memo itself:
+    // any install invalidates it, so the bound rests on no install ever leaving
+    // a mismatch. That holds because a session records the list it was asked
+    // for, and all three paths that filter the list before an open -- a pre-1.4
+    // connection, either !derivedFieldsReachNextLoad case, and a prepared
+    // session opened with the copied list -- make available() false, so this is
+    // never reached for them. The epoch is what keeps it from getting stuck: any
     // install makes the memo stale by itself, so it cannot suppress a reload
     // for a different dataset or one that a later session could satisfy. It is
     // cleared outright when a reload stands aside or a load fails, neither of

--- a/src/qt/MainWindow.hpp
+++ b/src/qt/MainWindow.hpp
@@ -60,6 +60,7 @@ struct DatasetMetadata;
 struct LineResult;
 namespace remote {
 class Connection;
+class RemoteDatasetSession;
 }
 enum class CompositionPolicy : std::uint8_t;
 }
@@ -621,6 +622,26 @@ private:
     // frame 1 would make them appear. A prepared session cannot take them
     // either, but that is a property of the load, not of the window, so
     // requestInitialSlice asks it there.
+    // Opens a remote session for one load and renders it. Shared by the
+    // sequence loader and the reload of a single remote dataset, so the
+    // connected() pre-check and -- the reason it exists -- the derived-field
+    // capability gate are written once. A peer that predates protocol 1.4 gets
+    // an open with no definitions rather than a refusal, so a session that
+    // cannot compute fields still shows the ones it stores.
+    // Opens a remote session for a load, sending only the definitions the peer
+    // can install. Not a refusal for an older peer: a list the user happens to
+    // have must not stop it from opening a plotfile, and the editor is greyed
+    // with the reason instead.
+    [[nodiscard]] static std::shared_ptr<remote::RemoteDatasetSession>
+    openRemoteSessionForLoad(
+        const std::shared_ptr<remote::Connection>& connection,
+        const std::string& remotePath,
+        const std::vector<DerivedFieldDefinition>& derivedFields,
+        StopToken cancellation);
+    [[nodiscard]] static InitialSliceResult loadRemoteFrame(
+        const std::shared_ptr<remote::Connection>& connection,
+        const std::string& remotePath, std::uint64_t connectionGeneration,
+        const FrameSliceSpec& spec, StopToken cancellation);
     [[nodiscard]] bool derivedFieldsReachNextLoad() const;
     // Whether the session on screen was opened with the list the editor now
     // holds. Asked of the session itself rather than inferred from when
@@ -840,12 +861,29 @@ private:
     void scheduleSliceRequest(PlaneViewState& state, bool rasterDirty = true);
     void flushSliceRequests();
     void requestSlice(PlaneViewState& state, bool rasterDirty);
+    // How requestInitialSlice is to get its session: one that is already open,
+    // or a remote endpoint to reopen. Exactly one applies, which is why they
+    // travel together rather than as two parameters that must not both be set.
+    // Both isRemote() and responseBytes() are asked *before* the worker runs --
+    // they size the output rasters and arm the post-load resize coalescing --
+    // so the reopen case has to be able to answer them without a session.
+    struct SliceLoad {
+        // Already open: the initial remote open, which needed the session on
+        // the GUI thread for its metadata.
+        std::shared_ptr<DatasetSession> session;
+        // To be opened on the worker: the quiet reload of a remote dataset,
+        // which must not tear the window down the way a fresh open does.
+        std::optional<RemoteOpen> reopen;
+        [[nodiscard]] bool isRemote() const;
+        // The negotiated frame size, which bounds a remote raster.
+        [[nodiscard]] std::optional<std::uint32_t> responseBytes() const;
+    };
     void requestInitialSlice(const std::filesystem::path& path,
         std::uint64_t generation,
         std::optional<PlotfileMetadataResult> preparedMetadata = std::nullopt,
         std::filesystem::path dataRoot = {},
         std::optional<FrameSliceSpec> initialSpec = std::nullopt,
-        std::shared_ptr<DatasetSession> preparedSession = {});
+        SliceLoad load = {});
     // The scale the toolbar button and the View > Scale radio group report.
     // They are one state shown twice, so there is one setter: picking "4x" from
     // the toolbar used to leave the View menu unchecked, and neither reset when
@@ -971,6 +1009,19 @@ private:
     // same event for the user-facing diagnostics panel.
     std::uint64_t m_visibleSyncStaleSkips = 0;
 #endif
+    // Whether the connection a remote sequence was opened on can install
+    // derived fields. Captured there rather than asked of m_dataset, for the
+    // reason derivedFieldsReachNextLoad gives: frame 0's spec is built while
+    // the outgoing dataset is still installed.
+    bool m_remoteSequenceDerivedFields = false;
+    // The definition list a reload was last started for, and whether one is
+    // still in flight. A reload is asked for on every frame a sequence
+    // displays, so a list a load cannot install would otherwise reopen the
+    // dataset once per event-loop turn -- a hung window, and a server past its
+    // per-session dataset limit within a few seconds. With these, a mismatch
+    // that survives a reload costs one wasted reload rather than a storm.
+    std::optional<std::vector<DerivedFieldDefinition>> m_reloadStartedFor;
+    bool m_reloadInFlight = false;
     QTreeWidget* m_metadataTree = nullptr;
     QDockWidget* m_metadataDock = nullptr;
     QDockWidget* m_diagnosticsDock = nullptr;

--- a/src/qt/MainWindowDataset.cpp
+++ b/src/qt/MainWindowDataset.cpp
@@ -1110,6 +1110,15 @@ void MainWindow::requestInitialSlice(
             }
             try {
                 auto result = watcher->future().takeResult();
+#ifdef AMREXPLORER_QT_TEST_ACCESS
+                // Before anything is installed, which is where a load that
+                // failed gives up: the session this one opened dies with
+                // `result` and the arm below finds the previous one still on
+                // screen. See failNextInitialSliceForTest.
+                if (std::exchange(m_failNextInitialSliceForTest, false)) {
+                    throw std::runtime_error("initial slice failed for test");
+                }
+#endif
                 if (generation == m_generation) {
                     const auto previousVectorFields = vectorFieldNames();
                     m_dataset = result.dataset;
@@ -1124,12 +1133,22 @@ void MainWindow::requestInitialSlice(
                     // selection. The controls are one per window, so once any
                     // view has been superseded the user's current state has to
                     // win for all of them.
-                    std::vector<std::size_t> superseded;
-                    for (std::size_t index = 0; index < views.size(); ++index) {
-                        if (views[index]->sliceGeneration
-                            != viewGenerations[index]) {
-                            superseded.push_back(index);
-                        }
+                    //
+                    // A request queued behind the debounce counts as much as
+                    // one already dispatched: an edit only starts that timer,
+                    // and sliceGeneration does not move until it flushes, so a
+                    // load completing inside the window between the two would
+                    // find nothing superseded and replay the spec over what
+                    // the user had just done -- and the flush that followed
+                    // would then render the replayed values. Every path that
+                    // launches a load empties the queue first, so anything in
+                    // it now was queued while this load ran.
+                    bool superseded
+                        = m_pendingAllViews || !m_pendingViews.empty();
+                    for (std::size_t index = 0;
+                        index < views.size() && !superseded; ++index) {
+                        superseded = views[index]->sliceGeneration
+                            != viewGenerations[index];
                     }
                     // By name, and before configureSliceControls below, which
                     // repopulates the selector and calls selectFieldItem(0):
@@ -1138,9 +1157,9 @@ void MainWindow::requestInitialSlice(
                     // load was *launched* with. Ids renumber across a reload
                     // when the derived tail changes, so the name is the only
                     // stable handle.
-                    const auto supersededField = superseded.empty()
-                        ? QString{}
-                        : m_fieldSelector->currentText();
+                    const auto supersededField = superseded
+                        ? m_fieldSelector->currentText()
+                        : QString{};
                     // The level and the range are read here for the same
                     // reason: configureSliceControls puts the level combo back
                     // to its first row, and the spec restore below writes both
@@ -1149,7 +1168,7 @@ void MainWindow::requestInitialSlice(
                     // the reloaded session need not offer the same rows.
                     std::optional<int> supersededLevel;
                     std::optional<RangeController::Selection> supersededRange;
-                    if (!superseded.empty()) {
+                    if (superseded) {
                         if (m_levelSelector->currentIndex() >= 0) {
                             supersededLevel
                                 = m_levelSelector->currentData().toInt();

--- a/src/qt/MainWindowDataset.cpp
+++ b/src/qt/MainWindowDataset.cpp
@@ -775,6 +775,10 @@ void MainWindow::openDatasetImpl(const std::filesystem::path& path,
         state->cachedVectorUField = 0;
         state->cachedVectorVField = 0;
         state->cachedContourCount = 0;
+        // Cleared, not stale: there is no raster to converge, and the open
+        // about to run will stamp whatever it displays. Set after the bump
+        // below would be too late -- resliceReplacedViews could run first.
+        state->planeSessionEpoch = m_sessionEpoch + 1;
     }
     m_initialStopSource.request_stop();
     m_linePlotStopSource.request_stop();
@@ -1110,6 +1114,34 @@ void MainWindow::requestInitialSlice(
                     const auto previousVectorFields = vectorFieldNames();
                     m_dataset = result.dataset;
                     ++m_sessionEpoch;
+                    // Which views a newer request has already claimed. Worked
+                    // out before anything below restores control state,
+                    // because that restoration replays the field, level and
+                    // range this load was launched with -- and if the user
+                    // moved any of them while it ran, replaying the old values
+                    // silently reverts what they did, and the re-slice this
+                    // load owes those views then renders the reverted
+                    // selection. The controls are one per window, so once any
+                    // view has been superseded the user's current state has to
+                    // win for all of them.
+                    std::vector<std::size_t> superseded;
+                    for (std::size_t index = 0; index < views.size(); ++index) {
+                        if (views[index]->sliceGeneration
+                            != viewGenerations[index]) {
+                            superseded.push_back(index);
+                        }
+                    }
+                    // By name, and before configureSliceControls below, which
+                    // repopulates the selector and calls selectFieldItem(0):
+                    // after that the user's choice is gone from the widget, and
+                    // the restore that follows would put back the field the
+                    // load was *launched* with. Ids renumber across a reload
+                    // when the derived tail changes, so the name is the only
+                    // stable handle. Level and range still come from the spec:
+                    // the field is what a user reads a reloading window with.
+                    const auto supersededField = superseded.empty()
+                        ? QString{}
+                        : m_fieldSelector->currentText();
                     restoreVectorFields(previousVectorFields);
                     m_particleController->setSamples(
                         std::move(result.particles));
@@ -1191,6 +1223,20 @@ void MainWindow::requestInitialSlice(
                         configureSlicePositionControls();
                         syncMenuChecks();
                     }
+                    // The user moved the field while this load ran, so theirs
+                    // is the selection that stands -- otherwise the re-slice
+                    // this load owes their view renders the field they left.
+                    if (!supersededField.isEmpty()) {
+                        const auto index
+                            = m_fieldSelector->findText(supersededField);
+                        if (index >= 0) {
+                            const QSignalBlocker blocker(m_fieldSelector);
+                            m_fieldSelector->setCurrentIndex(index);
+                            m_range->setTrackedField(
+                                m_fieldSelector->currentText());
+                            syncVariableMenu();
+                        }
+                    }
                     if (selectCacheFallbackLevel(
                             m_levelSelector, result.cacheFallbackToLevel)) {
                         configureSlicePositionControls();
@@ -1225,11 +1271,9 @@ void MainWindow::requestInitialSlice(
                     // this on its own: in the common ordering that newer
                     // request finished before this completion ran and was
                     // rightly accepted against the session then installed.
-                    std::vector<std::size_t> superseded;
                     for (std::size_t index = 0; index < views.size(); ++index) {
                         if (views[index]->sliceGeneration
                             != viewGenerations[index]) {
-                            superseded.push_back(index);
                             continue;
                         }
                         // A FAB round-trip preserved the zoom in restoredSpec and
@@ -1250,15 +1294,15 @@ void MainWindow::requestInitialSlice(
                                     result.displays[index].request.visibleRegion}
                                 : std::optional<RealBox>{};
                         }
-                        showSlice(*views[index], std::move(result.displays[index]));
+                        showSlice(*views[index],
+                            std::move(result.displays[index]), m_sessionEpoch);
                     }
-                    // Re-sliced against the session just installed, with
-                    // the view state as it now stands, which is what the newer
-                    // request was asking for anyway. Debounced, so a view that
-                    // the resize pass below also schedules is asked once.
-                    for (const auto index : superseded) {
-                        scheduleSliceRequest(*views[index]);
-                    }
+                    // Re-sliced against the session just installed. Driven
+                    // off each view's stamp rather than the list above, so a
+                    // debt survives the next reload clearing the debounce: if
+                    // that reload fails it re-checks the same stamps and the
+                    // view is asked again.
+                    resliceReplacedViews();
                     if (isRemote) {
                         // A resize during the initial worker cannot submit a
                         // slice yet because m_dataset is not published. Once
@@ -1323,6 +1367,12 @@ void MainWindow::requestInitialSlice(
                     // guards against: it runs when a load completes, not once
                     // per event-loop turn.
                     m_reloadAskedFor.reset();
+                    // The previous session is still installed and still fine,
+                    // so this does not wipe the display -- it asks any view
+                    // still showing an even older session's raster for one of
+                    // the installed session's. A reload dropped between the
+                    // debounce and this failure would otherwise be lost.
+                    resliceReplacedViews();
                     emit initialSliceFinished(false);
                 } else {
                     m_diagnosticsModel->noteStaleResult();

--- a/src/qt/MainWindowDataset.cpp
+++ b/src/qt/MainWindowDataset.cpp
@@ -1137,11 +1137,25 @@ void MainWindow::requestInitialSlice(
                     // the restore that follows would put back the field the
                     // load was *launched* with. Ids renumber across a reload
                     // when the derived tail changes, so the name is the only
-                    // stable handle. Level and range still come from the spec:
-                    // the field is what a user reads a reloading window with.
+                    // stable handle.
                     const auto supersededField = superseded.empty()
                         ? QString{}
                         : m_fieldSelector->currentText();
+                    // The level and the range are read here for the same
+                    // reason: configureSliceControls puts the level combo back
+                    // to its first row, and the spec restore below writes both
+                    // outright. The level travels as the combo's data rather
+                    // than its position, which is what the spec carries too --
+                    // the reloaded session need not offer the same rows.
+                    std::optional<int> supersededLevel;
+                    std::optional<RangeController::Selection> supersededRange;
+                    if (!superseded.empty()) {
+                        if (m_levelSelector->currentIndex() >= 0) {
+                            supersededLevel
+                                = m_levelSelector->currentData().toInt();
+                        }
+                        supersededRange = m_range->selection();
+                    }
                     restoreVectorFields(previousVectorFields);
                     m_particleController->setSamples(
                         std::move(result.particles));
@@ -1236,6 +1250,34 @@ void MainWindow::requestInitialSlice(
                                 m_fieldSelector->currentText());
                             syncVariableMenu();
                         }
+                    }
+                    // The level and the range that same interaction moved, put
+                    // back after the field: the range widgets represent the
+                    // selected field, and its name is the key commitFieldRange
+                    // files them under. Blocked, as the spec restore above is
+                    // -- the re-slice these views are owed comes from
+                    // resliceReplacedViews below, and a signal from here would
+                    // queue a second one for every view.
+                    if (supersededLevel) {
+                        const auto index
+                            = m_levelSelector->findData(*supersededLevel);
+                        if (index >= 0) {
+                            const QSignalBlocker blocker(m_levelSelector);
+                            m_levelSelector->setCurrentIndex(index);
+                            configureSlicePositionControls();
+                            syncMenuChecks();
+                        }
+                    }
+                    if (supersededRange) {
+                        m_range->setSelection(*supersededRange);
+                        m_range->commitFieldRange(m_range->trackedField());
+                    }
+                    if (supersededLevel || supersededRange) {
+                        // A mode the restored field and level cannot offer
+                        // falls back here rather than staying selected and
+                        // unavailable, which is what the spec restore's own
+                        // call does for the values it put back.
+                        updateRangeModeAvailability();
                     }
                     if (selectCacheFallbackLevel(
                             m_levelSelector, result.cacheFallbackToLevel)) {

--- a/src/qt/MainWindowDataset.cpp
+++ b/src/qt/MainWindowDataset.cpp
@@ -908,7 +908,7 @@ void MainWindow::openDatasetImpl(const std::filesystem::path& path,
                         requestInitialSlice(path, generation,
                             std::move(result.metadata), std::move(root),
                             std::move(initialSpec),
-                            std::move(result.session));
+                            SliceLoad{std::move(result.session), std::nullopt});
                     }
                 } else {
                     m_diagnosticsModel->noteStaleResult();
@@ -943,12 +943,15 @@ void MainWindow::openDatasetImpl(const std::filesystem::path& path,
     watcher->setFuture(QtConcurrent::run(
         [path, preparedMetadata = std::move(preparedMetadata),
             cancellation = metadataCancellation, preserveFabSelector,
-            remoteOpen = std::move(remoteOpen)]() mutable {
+            remoteOpen = std::move(remoteOpen),
+            // Copied here, on the GUI thread: the store has no locking and any
+            // window's Apply mutates it, so reading it inside the worker would
+            // race.
+            derivedFields = m_derivedFields->definitions()]() mutable {
         OpenedDataset opened;
         if (remoteOpen) {
-            opened.session = remote::RemoteDatasetSession::open(
-                std::move(remoteOpen->connection), remoteOpen->remotePath,
-                initialCacheBudget(), cancellation);
+            opened.session = openRemoteSessionForLoad(remoteOpen->connection,
+                remoteOpen->remotePath, derivedFields, cancellation);
             opened.metadata.metadata
                 = std::make_shared<const DatasetMetadata>(
                     opened.session->metadata());
@@ -972,12 +975,32 @@ void MainWindow::openDatasetImpl(const std::filesystem::path& path,
     }));
 }
 
+bool MainWindow::SliceLoad::isRemote() const
+{
+    return reopen.has_value()
+        || std::dynamic_pointer_cast<remote::RemoteDatasetSession>(session)
+            != nullptr;
+}
+
+std::optional<std::uint32_t> MainWindow::SliceLoad::responseBytes() const
+{
+    if (session) {
+        return session->maximumResponseBytes();
+    }
+    if (reopen && reopen->connection) {
+        // What the session would report once it exists: the frame size the
+        // connection negotiated.
+        return reopen->connection->serverInfo().maximumFrameBytes;
+    }
+    return std::nullopt;
+}
+
 void MainWindow::requestInitialSlice(
     const std::filesystem::path& path, std::uint64_t generation,
     std::optional<PlotfileMetadataResult> preparedMetadata,
     std::filesystem::path dataRoot,
     std::optional<FrameSliceSpec> initialSpec,
-    std::shared_ptr<DatasetSession> preparedSession)
+    SliceLoad load)
 {
     validateVectorMode();
     const auto& metadata = *m_openMetadata;
@@ -1028,7 +1051,7 @@ void MainWindow::requestInitialSlice(
         // sees it, which is a property of the load rather than of the window,
         // so it is asked here and the rest through the shared predicate.
         spec.derivedFields
-            = preparedSession || !derivedFieldsReachNextLoad()
+            = load.session || !derivedFieldsReachNextLoad()
             ? std::vector<DerivedFieldDefinition>{}
             : m_derivedFields->definitions();
         spec.palette = m_paletteController->palette();
@@ -1044,16 +1067,15 @@ void MainWindow::requestInitialSlice(
         spec.sphericalSupersample = m_sphericalSupersample;
         spec.sphericalDisplay = m_sphericalDisplay;
     }
-    const auto isRemote = std::dynamic_pointer_cast<
-        remote::RemoteDatasetSession>(preparedSession) != nullptr;
+    const auto isRemote = load.isRemote();
     if (spec.outputSizes.size() != views.size()) {
         spec.outputSizes.clear();
         spec.outputSizes.reserve(views.size());
         for (const auto* state : views) {
             auto outputSize = sliceOutputSize(*state, isRemote);
-            if (preparedSession) {
-                outputSize = frameBudgetBoundedOutputSize(outputSize,
-                    preparedSession->maximumResponseBytes());
+            if (const auto responseBytes = load.responseBytes()) {
+                outputSize
+                    = frameBudgetBoundedOutputSize(outputSize, responseBytes);
             }
             spec.outputSizes.push_back(outputSize);
         }
@@ -1251,9 +1273,20 @@ void MainWindow::requestInitialSlice(
                     // panels are still on the open's placeholder with nothing
                     // left in flight to replace it. The dataset name is known
                     // here, so say which one has no displayable slice.
-                    setAllViewPlaceholders(
-                        tr("Could not display %1")
-                            .arg(QString::fromStdString(m_datasetPath.string())));
+                    //
+                    // Only when nothing is installed, which is what tells an
+                    // open from a reload: a reload never resets m_dataset, so
+                    // the session on screen is still live and its rasters are
+                    // still what it produced. Wiping them because a reopen
+                    // failed -- a definition the server would not take, a
+                    // connection that went away -- would throw away a working
+                    // display over a change that simply did not happen.
+                    if (!m_dataset) {
+                        setAllViewPlaceholders(
+                            tr("Could not display %1")
+                                .arg(QString::fromStdString(
+                                    m_datasetPath.string())));
+                    }
                     emit initialSliceFinished(false);
                 } else {
                     m_diagnosticsModel->noteStaleResult();
@@ -1266,10 +1299,17 @@ void MainWindow::requestInitialSlice(
         [path, generation, spec = std::move(spec), cancellation,
             preparedMetadata = std::move(preparedMetadata),
             dataRoot = std::move(dataRoot),
-            preparedSession = std::move(preparedSession)]() mutable {
-        if (preparedSession) {
+            load = std::move(load)]() mutable {
+        if (load.session) {
             return executeSessionFrameLoad(
-                std::move(preparedSession), spec, cancellation);
+                std::move(load.session), spec, cancellation);
+        }
+        if (load.reopen) {
+            // The quiet reopen of a remote dataset: same loader the sequence
+            // frames use, so the connected() pre-check and the derived-field
+            // capability gate are the ones written once.
+            return loadRemoteFrame(load.reopen->connection,
+                load.reopen->remotePath, 0, spec, cancellation);
         }
         return executeFrameLoad(path, DatasetId{generation}, spec,
             initialCacheBudget(), cancellation,

--- a/src/qt/MainWindowDataset.cpp
+++ b/src/qt/MainWindowDataset.cpp
@@ -1287,6 +1287,16 @@ void MainWindow::requestInitialSlice(
                                 .arg(QString::fromStdString(
                                     m_datasetPath.string())));
                     }
+                    // A reload that started and then failed must not count as
+                    // one that happened: the list is still uninstalled, and
+                    // pressing Apply again cannot ask for it a second time
+                    // because DerivedFieldStore::set returns without emitting
+                    // for a list that has not moved. Left armed, the window
+                    // stayed on the older list for good while the editor
+                    // reported it applied. This cannot loop the way the memo
+                    // guards against: it runs when a load completes, not once
+                    // per event-loop turn.
+                    m_reloadStartedFor.reset();
                     emit initialSliceFinished(false);
                 } else {
                     m_diagnosticsModel->noteStaleResult();

--- a/src/qt/MainWindowDataset.cpp
+++ b/src/qt/MainWindowDataset.cpp
@@ -790,6 +790,9 @@ void MainWindow::openDatasetImpl(const std::filesystem::path& path,
     }
     m_activeView = nullptr;
     m_dataset.reset();
+    // Nothing is installed now, which is a change of session like any other:
+    // a slice still on a worker for the outgoing one must not be displayed.
+    ++m_sessionEpoch;
     // The dock's edge trigger is per dataset, not per session: an open is a new
     // context, so the next update re-asserts it. Without this the flags could
     // hold (false, true) straight across a 3-D -> 3-D open -- closeSequence
@@ -1106,6 +1109,7 @@ void MainWindow::requestInitialSlice(
                 if (generation == m_generation) {
                     const auto previousVectorFields = vectorFieldNames();
                     m_dataset = result.dataset;
+                    ++m_sessionEpoch;
                     restoreVectorFields(previousVectorFields);
                     m_particleController->setSamples(
                         std::move(result.particles));
@@ -1208,9 +1212,24 @@ void MainWindow::requestInitialSlice(
                     for (const auto& display : result.displays) {
                         requestedSizes.push_back(display.request.outputSize);
                     }
+                    // Views this load will not display, because a newer
+                    // request for them was submitted while it ran. Collected
+                    // rather than merely skipped: each is still showing a
+                    // raster produced by the session installed *before* this
+                    // one, while m_dataset, the field selector, the range
+                    // widgets and the colour bar have all just become the new
+                    // session's. Leaving them is the catalog-vs-pixels
+                    // mismatch -- after an edit that renumbers the derived
+                    // tail, values from the old expression under the new field
+                    // list -- and it is why an arrival-side check cannot close
+                    // this on its own: in the common ordering that newer
+                    // request finished before this completion ran and was
+                    // rightly accepted against the session then installed.
+                    std::vector<std::size_t> superseded;
                     for (std::size_t index = 0; index < views.size(); ++index) {
                         if (views[index]->sliceGeneration
                             != viewGenerations[index]) {
+                            superseded.push_back(index);
                             continue;
                         }
                         // A FAB round-trip preserved the zoom in restoredSpec and
@@ -1232,6 +1251,13 @@ void MainWindow::requestInitialSlice(
                                 : std::optional<RealBox>{};
                         }
                         showSlice(*views[index], std::move(result.displays[index]));
+                    }
+                    // Re-sliced against the session just installed, with
+                    // the view state as it now stands, which is what the newer
+                    // request was asking for anyway. Debounced, so a view that
+                    // the resize pass below also schedules is asked once.
+                    for (const auto index : superseded) {
+                        scheduleSliceRequest(*views[index]);
                     }
                     if (isRemote) {
                         // A resize during the initial worker cannot submit a
@@ -1296,7 +1322,7 @@ void MainWindow::requestInitialSlice(
                     // reported it applied. This cannot loop the way the memo
                     // guards against: it runs when a load completes, not once
                     // per event-loop turn.
-                    m_reloadStartedFor.reset();
+                    m_reloadAskedFor.reset();
                     emit initialSliceFinished(false);
                 } else {
                     m_diagnosticsModel->noteStaleResult();

--- a/src/qt/MainWindowDataset.cpp
+++ b/src/qt/MainWindowDataset.cpp
@@ -1259,16 +1259,36 @@ void MainWindow::requestInitialSlice(
                     // The user moved the field while this load ran, so theirs
                     // is the selection that stands -- otherwise the re-slice
                     // this load owes their view renders the field they left.
+                    bool fieldRestored = false;
                     if (!supersededField.isEmpty()) {
                         const auto index
                             = m_fieldSelector->findText(supersededField);
-                        if (index >= 0) {
+                        // Only a row that is a field. A definition this
+                        // session skipped is listed under the same name,
+                        // greyed and carrying no id, and setCurrentIndex takes
+                        // one as readily as any other -- leaving the combo,
+                        // the Variable menu and the range on that name while
+                        // every reader of currentData() renders field 0. Where
+                        // the user's field did not survive the reload there is
+                        // nothing of theirs to restore, and the field the load
+                        // rendered stands.
+                        if (index >= 0
+                            && m_fieldSelector->itemData(index).isValid()) {
                             const QSignalBlocker blocker(m_fieldSelector);
                             m_fieldSelector->setCurrentIndex(index);
                             m_range->setTrackedField(
                                 m_fieldSelector->currentText());
                             syncVariableMenu();
+                            fieldRestored = true;
                         }
+                    }
+                    if (!fieldRestored) {
+                        // A range belongs to the field it was set on, and the
+                        // memory is keyed by that field's name. Restoring it
+                        // over a field the user was not looking at would
+                        // render that field with their bounds and remember
+                        // them there.
+                        supersededRange.reset();
                     }
                     // The level and the range that same interaction moved, put
                     // back after the field: the range widgets represent the

--- a/src/qt/MainWindowSlice.cpp
+++ b/src/qt/MainWindowSlice.cpp
@@ -153,7 +153,13 @@ std::vector<MainWindow::DerivedFieldRow> MainWindow::derivedFieldRows() const
             [&definition](const DerivedFieldSkip& entry) {
                 return entry.name == definition.name;
             });
-        row.tooltip = richTooltip(reason != skipped.end()
+        // An empty reason falls back to the wording that promises none: the
+        // decoder accepts one (an absent wire string decodes as empty), and
+        // "unavailable here: " with nothing after the colon tells the user a
+        // reason exists while showing it to them blank.
+        const auto haveReason
+            = reason != skipped.end() && !reason->reason.empty();
+        row.tooltip = richTooltip(haveReason
                 ? tr("%1 -- unavailable here: %2")
                       .arg(expression,
                           QString::fromStdString(reason->reason)

--- a/src/qt/MainWindowSlice.cpp
+++ b/src/qt/MainWindowSlice.cpp
@@ -725,7 +725,7 @@ void MainWindow::requestSlice(PlaneViewState& state, bool rasterDirty)
                     // than reading them back off a moved-from result.
                     const auto fallbackToLevel = result.cacheFallbackToLevel;
                     const auto fallbackFromLevel = result.cacheFallbackFromLevel;
-                    showSlice(state, std::move(result));
+                    showSlice(state, std::move(result), sessionEpoch);
                     // Cache the full-domain range. In 3-D the store defers to
                     // the (async) shared-range sync's completion so the union
                     // across all panels is captured; 2-D has no later sync
@@ -1142,8 +1142,10 @@ std::optional<QRectF> MainWindow::sphericalReframe(
         visible.width() * sx, visible.height() * sy);
 }
 
-void MainWindow::showSlice(PlaneViewState& state, SliceDisplayResult display)
+void MainWindow::showSlice(PlaneViewState& state, SliceDisplayResult display,
+    std::uint64_t sessionEpoch)
 {
+    state.planeSessionEpoch = sessionEpoch;
     if (!display.rasterUnchanged) {
         if (!display.image.valid()) {
             throw std::runtime_error("renderer produced an invalid image");
@@ -1285,6 +1287,18 @@ void MainWindow::showSlice(PlaneViewState& state, SliceDisplayResult display)
     // scheduling call that fetched this plane ran while the previous one was
     // still displayed, and would have measured that.
     m_volumeController->regionChanged();
+}
+
+void MainWindow::resliceReplacedViews()
+{
+    if (!m_controlsReady || !m_dataset) {
+        return;
+    }
+    for (auto* state : currentViews()) {
+        if (state->planeSessionEpoch != m_sessionEpoch) {
+            scheduleSliceRequest(*state);
+        }
+    }
 }
 
 int MainWindow::slicesInFlight() const
@@ -1874,7 +1888,8 @@ void MainWindow::displayFrameResult(InitialSliceResult& result,
         throw std::runtime_error("frame slice count does not match the view set");
     }
     for (std::size_t index = 0; index < views.size(); ++index) {
-        showSlice(*views[index], std::move(result.displays[index]));
+        showSlice(*views[index], std::move(result.displays[index]),
+            m_sessionEpoch);
     }
     const auto cache = m_dataset->cacheMetrics();
     m_diagnosticsModel->setCacheMetrics(cache);

--- a/src/qt/MainWindowSlice.cpp
+++ b/src/qt/MainWindowSlice.cpp
@@ -670,8 +670,20 @@ void MainWindow::requestSlice(PlaneViewState& state, bool rasterDirty)
                 // the future and copying out of it duplicates every plane in
                 // the arrival before showSlice has even seen it.
                 auto result = watcher->future().takeResult();
+                // The session too, not just the two generations: a reload
+                // leaves the outgoing session installed while it runs (that is
+                // what keeps a working display up if the reopen fails), so an
+                // interaction meanwhile submits against the old session under
+                // the *new* m_generation. The reload then installs the new
+                // session and skips its own display for this view, because the
+                // interaction moved sliceGeneration past the value it captured
+                // -- and this slice would be accepted as current, leaving the
+                // catalog and the pixels from different datasets. After an edit
+                // that renumbers the derived tail, that is values from the old
+                // expression under the new field list.
                 if (generation == m_generation
-                    && sliceGeneration == state.sliceGeneration) {
+                    && sliceGeneration == state.sliceGeneration
+                    && dataset == m_dataset) {
                     // Cache the full-domain range whenever we get a non-zoomed
                     // Visible-range slice; reuse it for zoomed (subregion)
                     // slices so the color bar stays stable during pan and zoom.

--- a/src/qt/MainWindowSlice.cpp
+++ b/src/qt/MainWindowSlice.cpp
@@ -247,36 +247,35 @@ void MainWindow::reloadIfDefinitionsMoved()
         || openSessionHasCurrentDefinitions()) {
         return;
     }
-    // Once per list, and one at a time. This is asked on every frame a
-    // sequence displays, so a list the load cannot install -- a server that
-    // skips all of it, a path that forgets to pass it on -- would otherwise
-    // reopen the dataset on every event-loop turn until the session hit its
-    // dataset limit. A reload already started for this exact list is enough.
-    if (m_reloadInFlight
-        || (m_reloadStartedFor
-            && *m_reloadStartedFor == m_derivedFields->definitions())) {
+    // Once per list per session. This is asked on every frame a sequence
+    // displays, so without a memo a list the load cannot install would reopen
+    // the dataset on every event-loop turn until the session hit its dataset
+    // limit. Pairing the list with the session epoch is what keeps the memo
+    // from becoming a trap: installing anything at all makes it stale, so it
+    // can only ever suppress a retry that would be asking the same question of
+    // the same session. It also replaces the separate in-flight flag, which
+    // guarded a single event-loop turn rather than the reload.
+    if (m_reloadAskedFor
+        && m_reloadAskedFor->first == m_derivedFields->definitions()
+        && m_reloadAskedFor->second == m_sessionEpoch) {
         return;
     }
-    m_reloadInFlight = true;
+    m_reloadAskedFor = {m_derivedFields->definitions(), m_sessionEpoch};
     // Not now: the frame path is called from inside the sequence controller's
     // own load completion, which sets m_inFlight and emits frameDisplayed
     // after this returns -- starting a load from here would have it clobber
     // the load this reload starts.
     QTimer::singleShot(0, this, [this] {
-        m_reloadInFlight = false;
         if (m_closing || !m_derivedFields->available()
             || openSessionHasCurrentDefinitions()) {
             return;
         }
-        // Armed before the call, so a reload that asks for this one again
-        // from inside its own completion is still suppressed -- and dropped
-        // again if the reload stood aside, because mid-playback the frames
+        // Dropped again if the reload stood aside: mid-playback the frames
         // carry the list themselves and setPlaybackMode asks once more when
-        // they stop. Recording a reload that never ran is what left the
+        // they stop, so recording a reload that never ran is what left the
         // definition uninstalled with the editor reporting it applied.
-        m_reloadStartedFor = m_derivedFields->definitions();
         if (!reloadCurrentDataset()) {
-            m_reloadStartedFor.reset();
+            m_reloadAskedFor.reset();
         }
     });
 }
@@ -608,6 +607,10 @@ void MainWindow::requestSlice(PlaneViewState& state, bool rasterDirty)
     state.stopSource = StopSource{};
     const auto cancellation = state.stopSource.get_token();
     const auto generation = m_generation;
+    // The session this request is about to be computed against. A reload leaves
+    // the outgoing one installed while its replacement loads, so this is what
+    // tells an arrival apart from the session that is current when it lands.
+    const auto sessionEpoch = m_sessionEpoch;
     const auto sliceGeneration = ++state.sliceGeneration;
     ++state.pendingRequests;
     m_diagnosticsModel->adjustActivity(1);
@@ -657,8 +660,8 @@ void MainWindow::requestSlice(PlaneViewState& state, bool rasterDirty)
 
     auto* watcher = new QFutureWatcher<SliceDisplayResult>(this);
     connect(watcher, &QFutureWatcher<SliceDisplayResult>::finished, this,
-        [this, watcher, dataset, generation, sliceGeneration, cancellation,
-         &state, rangeMode] {
+        [this, watcher, dataset, generation, sliceGeneration, sessionEpoch,
+         cancellation, &state, rangeMode] {
             --state.pendingRequests;
             m_diagnosticsModel->adjustActivity(-1);
             if (m_closing) {
@@ -670,20 +673,20 @@ void MainWindow::requestSlice(PlaneViewState& state, bool rasterDirty)
                 // the future and copying out of it duplicates every plane in
                 // the arrival before showSlice has even seen it.
                 auto result = watcher->future().takeResult();
-                // The session too, not just the two generations: a reload
-                // leaves the outgoing session installed while it runs (that is
-                // what keeps a working display up if the reopen fails), so an
-                // interaction meanwhile submits against the old session under
-                // the *new* m_generation. The reload then installs the new
-                // session and skips its own display for this view, because the
-                // interaction moved sliceGeneration past the value it captured
-                // -- and this slice would be accepted as current, leaving the
-                // catalog and the pixels from different datasets. After an edit
-                // that renumbers the derived tail, that is values from the old
-                // expression under the new field list.
+                // The session too, by the epoch captured at submission
+                // rather than by comparing the pointer: `dataset == m_dataset`
+                // reads like a staleness test but is really a test of whether
+                // the reload's completion has run yet, since m_dataset is only
+                // swapped there. Both forms accept in the common ordering,
+                // where this slice finishes before the reload installs -- and
+                // it is right to, because that session is still the installed
+                // one. What makes the display consistent is the other half of
+                // the invariant: the reload re-slices the views whose display
+                // it skipped, so a raster stamped with a session that has since
+                // been replaced does not stay on screen.
                 if (generation == m_generation
                     && sliceGeneration == state.sliceGeneration
-                    && dataset == m_dataset) {
+                    && sessionEpoch == m_sessionEpoch) {
                     // Cache the full-domain range whenever we get a non-zoomed
                     // Visible-range slice; reuse it for zoomed (subregion)
                     // slices so the color bar stays stable during pan and zoom.
@@ -761,8 +764,14 @@ void MainWindow::requestSlice(PlaneViewState& state, bool rasterDirty)
                     m_diagnosticsModel->noteStaleResult();
                 }
             } catch (const std::exception& error) {
+                // The same three tests as the success arm: a slice the window
+                // has decided is not current must not raise an error either.
+                // A reopen that pushes the connection past a server limit, or
+                // a budget the outgoing session's cache cannot meet, would
+                // otherwise report a failure for work already superseded.
                 if (generation == m_generation
                     && sliceGeneration == state.sliceGeneration
+                    && sessionEpoch == m_sessionEpoch
                     && !cancellation.stop_requested()) {
                     reportBackgroundError(
                         tr("Cannot load slice: %1").arg(exceptionMessage(error)));
@@ -1834,6 +1843,7 @@ void MainWindow::displayFrameResult(InitialSliceResult& result,
     }
     const auto previousVectorFields = vectorFieldNames();
     m_dataset = result.dataset;
+    ++m_sessionEpoch;
     restoreVectorFields(previousVectorFields);
     m_particleController->setSamples(std::move(result.particles));
     m_particleController->configureForDataset(true);

--- a/src/qt/MainWindowSlice.cpp
+++ b/src/qt/MainWindowSlice.cpp
@@ -241,11 +241,24 @@ void MainWindow::reloadIfDefinitionsMoved()
         || openSessionHasCurrentDefinitions()) {
         return;
     }
+    // Once per list, and one at a time. This is asked on every frame a
+    // sequence displays, so a list the load cannot install -- a server that
+    // skips all of it, a path that forgets to pass it on -- would otherwise
+    // reopen the dataset on every event-loop turn until the session hit its
+    // dataset limit. A reload already started for this exact list is enough.
+    if (m_reloadInFlight
+        || (m_reloadStartedFor
+            && *m_reloadStartedFor == m_derivedFields->definitions())) {
+        return;
+    }
+    m_reloadStartedFor = m_derivedFields->definitions();
+    m_reloadInFlight = true;
     // Not now: the frame path is called from inside the sequence controller's
     // own load completion, which sets m_inFlight and emits frameDisplayed
     // after this returns -- starting a load from here would have it clobber
     // the load this reload starts.
     QTimer::singleShot(0, this, [this] {
+        m_reloadInFlight = false;
         if (m_closing || !m_derivedFields->available()
             || openSessionHasCurrentDefinitions()) {
             return;
@@ -254,12 +267,52 @@ void MainWindow::reloadIfDefinitionsMoved()
     });
 }
 
+std::shared_ptr<remote::RemoteDatasetSession>
+MainWindow::openRemoteSessionForLoad(
+    const std::shared_ptr<remote::Connection>& connection,
+    const std::string& remotePath,
+    const std::vector<DerivedFieldDefinition>& derivedFields,
+    StopToken cancellation)
+{
+    return remote::RemoteDatasetSession::open(connection, remotePath,
+        initialCacheBudget(), cancellation,
+        connection && connection->supportsDerivedFields()
+            ? derivedFields
+            : std::vector<DerivedFieldDefinition>{});
+}
+
+InitialSliceResult MainWindow::loadRemoteFrame(
+    const std::shared_ptr<remote::Connection>& connection,
+    const std::string& remotePath, std::uint64_t connectionGeneration,
+    const FrameSliceSpec& spec, StopToken cancellation)
+{
+    // Foreground loads and prefetches share the session's connection, which
+    // multiplexes their requests. There is no reconnect: the connection lives
+    // as long as the ssh session, and a lost session is reported to the user
+    // rather than silently re-established -- said here, because "not
+    // connected" is the message a user can act on and a bare transact failure
+    // is not.
+    if (!connection || !connection->connected()) {
+        throw std::runtime_error("remote session is not connected: "
+            + (connection ? connection->disconnectReason()
+                          : std::string("no connection")));
+    }
+    auto session = openRemoteSessionForLoad(
+        connection, remotePath, spec.derivedFields, cancellation);
+    auto result = executeSessionFrameLoad(
+        std::move(session), spec, cancellation);
+    result.connectionGeneration = connectionGeneration;
+    return result;
+}
+
 bool MainWindow::derivedFieldsReachNextLoad() const
 {
-    // A remote sequence fixes its field lists on the server, and a FAB
-    // drilled out of a MultiFab is what the editor is unavailable over -- for
-    // the same reason the reload cannot rebuild one.
-    return !m_remoteSequence && !m_fabNavigator->fabMode();
+    // A remote sequence carries them only when the server it was opened on can
+    // install them (protocol 1.4); a FAB drilled out of a MultiFab is what the
+    // editor is unavailable over -- for the same reason the reload cannot
+    // rebuild one.
+    return (!m_remoteSequence || m_remoteSequenceDerivedFields)
+        && !m_fabNavigator->fabMode();
 }
 
 std::array<std::string, 3> MainWindow::vectorFieldNames() const
@@ -1654,6 +1707,8 @@ void MainWindow::openRemoteSequence(
 
     prepareSequence(remotePaths.size());
     m_remoteSequence = true;
+    m_remoteSequenceDerivedFields
+        = connection && connection->supportsDerivedFields();
 
     std::vector<std::filesystem::path> frames;
     frames.reserve(remotePaths.size());
@@ -1668,16 +1723,8 @@ void MainWindow::openRemoteSequence(
                       generation = connectionGeneration](
                       const std::filesystem::path& path, DatasetId,
                       const FrameSliceSpec& spec, StopToken cancellation) {
-        if (!connection->connected()) {
-            throw std::runtime_error("remote session is not connected: "
-                + connection->disconnectReason());
-        }
-        auto session = remote::RemoteDatasetSession::open(
-            connection, path.string(), initialCacheBudget(), cancellation);
-        auto result = executeSessionFrameLoad(
-            std::move(session), spec, cancellation);
-        result.connectionGeneration = generation;
-        return result;
+        return loadRemoteFrame(
+            connection, path.string(), generation, spec, cancellation);
     };
     m_sequenceController->open(std::move(frames), std::move(loader));
 }

--- a/src/qt/MainWindowSlice.cpp
+++ b/src/qt/MainWindowSlice.cpp
@@ -1145,7 +1145,6 @@ std::optional<QRectF> MainWindow::sphericalReframe(
 void MainWindow::showSlice(PlaneViewState& state, SliceDisplayResult display,
     std::uint64_t sessionEpoch)
 {
-    state.planeSessionEpoch = sessionEpoch;
     if (!display.rasterUnchanged) {
         if (!display.image.valid()) {
             throw std::runtime_error("renderer produced an invalid image");
@@ -1204,6 +1203,13 @@ void MainWindow::showSlice(PlaneViewState& state, SliceDisplayResult display,
             state.rasterGeometry = incomingGeometry;
         }
     }
+    // Stamped once the view is showing this session's pixels, not on the way
+    // in: ahead of the validity check above, a view that threw before adopting
+    // anything still counted as the installed session's, and
+    // resliceReplacedViews -- which the failure arm calls for exactly this --
+    // would never ask for it again. Anything below that throws has already put
+    // the raster on screen, so the stamp belongs here rather than at the end.
+    state.planeSessionEpoch = sessionEpoch;
     // Fresh immutable snapshots: replace the pointers, never mutate the
     // pointees a cached-planes refresh worker may still be reading. The cache
     // fast path already holds the plane by shared_ptr, so adopt it directly;

--- a/src/qt/MainWindowSlice.cpp
+++ b/src/qt/MainWindowSlice.cpp
@@ -257,7 +257,6 @@ void MainWindow::reloadIfDefinitionsMoved()
             && *m_reloadStartedFor == m_derivedFields->definitions())) {
         return;
     }
-    m_reloadStartedFor = m_derivedFields->definitions();
     m_reloadInFlight = true;
     // Not now: the frame path is called from inside the sequence controller's
     // own load completion, which sets m_inFlight and emits frameDisplayed
@@ -269,7 +268,16 @@ void MainWindow::reloadIfDefinitionsMoved()
             || openSessionHasCurrentDefinitions()) {
             return;
         }
-        reloadCurrentDataset();
+        // Armed before the call, so a reload that asks for this one again
+        // from inside its own completion is still suppressed -- and dropped
+        // again if the reload stood aside, because mid-playback the frames
+        // carry the list themselves and setPlaybackMode asks once more when
+        // they stop. Recording a reload that never ran is what left the
+        // definition uninstalled with the editor reporting it applied.
+        m_reloadStartedFor = m_derivedFields->definitions();
+        if (!reloadCurrentDataset()) {
+            m_reloadStartedFor.reset();
+        }
     });
 }
 

--- a/src/qt/MainWindowTestAccess.cpp
+++ b/src/qt/MainWindowTestAccess.cpp
@@ -7,6 +7,27 @@ void MainWindow::setInitialSliceLaunchedHookForTest(std::function<void()> hook)
     m_initialSliceLaunchedForTest = std::move(hook);
 }
 
+void MainWindow::requestActiveViewSliceForTest()
+{
+    if (m_activeView != nullptr) {
+        requestSlice(*m_activeView, true);
+    }
+}
+
+bool MainWindow::activeViewSliceMatchesSessionForTest() const
+{
+    if (!m_dataset || m_activeView == nullptr
+        || !m_activeView->hasCachedRequest) {
+        return false;
+    }
+    // The id the displayed raster was queried under, against the id of the
+    // session now installed. A reload allocates a new id -- locally the load
+    // generation, remotely the server's per-connection counter -- so these
+    // disagree exactly when a view is still showing the outgoing session.
+    return m_activeView->cachedRequest.dataset.value
+        == m_dataset->id().value;
+}
+
 std::optional<int> MainWindow::prefetchedSequenceFrameForTest() const
 {
     return m_sequenceController->prefetchedFrameForTest();

--- a/src/qt/MainWindowTestAccess.cpp
+++ b/src/qt/MainWindowTestAccess.cpp
@@ -7,6 +7,11 @@ void MainWindow::setInitialSliceLaunchedHookForTest(std::function<void()> hook)
     m_initialSliceLaunchedForTest = std::move(hook);
 }
 
+void MainWindow::failNextInitialSliceForTest()
+{
+    m_failNextInitialSliceForTest = true;
+}
+
 void MainWindow::requestActiveViewSliceForTest()
 {
     if (m_activeView != nullptr) {

--- a/src/qt/SmokeHarnessDerived.cpp
+++ b/src/qt/SmokeHarnessDerived.cpp
@@ -394,6 +394,129 @@ void armReloadRaceChecks(amrvis::qt::MainWindow& window,
     timer->start();
 }
 
+// Arms the skipped-definition race: the user is displaying a derived field
+// when an edit arrives that this dataset cannot resolve. The reload lists that
+// definition greyed out -- same name, no field id -- while a view superseded
+// meanwhile has the completion restore the user's field *by that name*. Exit 0
+// if what ends up selected is a field; a nonzero code names the step that
+// failed.
+void armSkippedFieldChecks(
+    amrvis::qt::MainWindow& window, QApplication& application)
+{
+    auto phase = std::make_shared<int>(0);
+    auto loads = std::make_shared<int>(0);
+    auto ticks = std::make_shared<int>(0);
+    auto armed = std::make_shared<bool>(false);
+    QObject::connect(&window, &amrvis::qt::MainWindow::initialSliceFinished,
+        &application, [&application, loads](bool success) {
+            if (!success) {
+                application.exit(2);
+                return;
+            }
+            ++*loads;
+        });
+    window.setInitialSliceLaunchedHookForTest([&window, armed] {
+        if (!*armed) {
+            return;
+        }
+        *armed = false;
+        // Supersedes the reload's display for this view without touching the
+        // selection: the field the completion then restores is the one the
+        // user is on, which is the whole of what the restore is for.
+        window.requestActiveViewSliceForTest();
+    });
+
+    auto* timer = new QTimer(&window);
+    timer->setInterval(25);
+    QObject::connect(timer, &QTimer::timeout, &application,
+        [&window, &application, phase, loads, ticks, armed, timer] {
+            const auto finish = [&application, timer](int code) {
+                timer->stop();
+                application.exit(code);
+            };
+            ++*ticks;
+            if (*ticks > 400) {
+                qCritical("the skipped-definition scenario never settled");
+                finish(40);
+                return;
+            }
+            if (*loads == 0) {
+                return;
+            }
+            auto* selector = window.findChild<QComboBox*>(
+                QStringLiteral("fieldSelector"));
+            if (selector == nullptr) {
+                qCritical("the window has no field selector");
+                finish(41);
+                return;
+            }
+            const auto settled = [&window] {
+                return window.slicesInFlightForTest() == 0
+                    && !window.sliceRequestPendingForTest();
+            };
+            if (*phase == 0) {
+                amrvis::qt::DerivedFieldStore::session().set(
+                    {{"twice", "density * 2"}});
+                *phase = 1;
+                return;
+            }
+            if (*phase == 1) {
+                if (*loads < 2 || !settled()) {
+                    return;
+                }
+                const auto index = selector->findText(QStringLiteral("twice"));
+                if (index < 0 || !selector->itemData(index).isValid()) {
+                    qCritical("a definition this dataset can compute was not "
+                              "installed as a field");
+                    finish(42);
+                    return;
+                }
+                window.selectFieldItemForTest(index);
+                if (selector->currentText() != QStringLiteral("twice")) {
+                    qCritical("the derived field could not be selected");
+                    finish(42);
+                    return;
+                }
+                *phase = 2;
+                return;
+            }
+            if (*phase == 2) {
+                if (!settled()) {
+                    return;
+                }
+                // The same name, now reading a field this dataset does not
+                // have: the session skips it and the window lists it greyed.
+                *armed = true;
+                amrvis::qt::DerivedFieldStore::session().set(
+                    {{"twice", "nonesuch * 2"}});
+                *phase = 3;
+                return;
+            }
+            if (*phase == 3) {
+                if (*loads < 3 || !settled()) {
+                    return;
+                }
+                const auto index = selector->findText(QStringLiteral("twice"));
+                if (index < 0 || selector->itemData(index).isValid()) {
+                    qCritical("a definition this dataset cannot resolve is "
+                              "not listed greyed out");
+                    finish(43);
+                    return;
+                }
+                // The row carrying no id is exactly what setCurrentIndex will
+                // take and every reader of currentData() will call field 0.
+                if (!selector->currentData().isValid()) {
+                    qCritical("the reload selected a row that is not a field");
+                    finish(44);
+                    return;
+                }
+                finish(0);
+                return;
+            }
+        });
+    timer->start();
+}
+
 // Arms the retry scenario: a reload that fails leaves the list committed and
 // uninstalled, and the store emits nothing for a list that has not moved, so
 // the Apply the user presses again has to ask for the reload itself. Exit 0
@@ -1569,6 +1692,8 @@ Outcome dispatchDerived(Context& context)
         armReloadRaceChecks(window, application, false);
     } else if (option == "--derived-field-reload-retry-smoke-test") {
         armReloadRetryChecks(window, application);
+    } else if (option == "--derived-field-skipped-race-smoke-test") {
+        armSkippedFieldChecks(window, application);
     } else if (option == "--derived-field-playback-smoke-test") {
         armPlaybackChecks(window, application, path);
     } else if (option == "--remote-derived-field-smoke-test") {

--- a/src/qt/SmokeHarnessDerived.cpp
+++ b/src/qt/SmokeHarnessDerived.cpp
@@ -3,6 +3,8 @@
 #include "DerivedFieldStore.hpp"
 #include "ExpressionEditorDialog.hpp"
 #include "MainWindow.hpp"
+
+#include <amrexplorer/remote/Server.hpp>
 #include "RangeController.hpp"
 
 #include <QAction>
@@ -1035,6 +1037,174 @@ void armPlaybackChecks(amrvis::qt::MainWindow& window,
     QTimer::singleShot(30000, &application, [&application] { application.exit(13); });
 }
 
+// Arms the remote scenario. Everything the local one checks, but with the
+// session on the far side of the protocol: the editor is available over a
+// remote dataset (which it was not before 1.4), Apply reopens the dataset on
+// its own connection with the definitions, the computed field arrives as the
+// tail of the catalog and renders, and a definition the plotfile cannot
+// satisfy comes back greyed with the *server's* reason.
+void armRemoteDerivedChecks(
+    amrvis::qt::MainWindow& window, QApplication& application)
+{
+    auto phase = std::make_shared<int>(0);
+    auto loads = std::make_shared<int>(0);
+    auto ticks = std::make_shared<int>(0);
+    QObject::connect(&window, &amrvis::qt::MainWindow::initialSliceFinished,
+        &application, [&application, loads](bool success) {
+            if (!success) {
+                application.exit(2);
+                return;
+            }
+            ++*loads;
+        });
+
+    auto* timer = new QTimer(&window);
+    timer->setInterval(25);
+    QObject::connect(timer, &QTimer::timeout, &application,
+        [&window, &application, phase, loads, ticks, timer] {
+            const auto finish = [&application, timer](int code) {
+                timer->stop();
+                application.exit(code);
+            };
+            ++*ticks;
+            if (*loads == 0) {
+                return;  // the remote dataset is still opening
+            }
+            auto* selector = window.findChild<QComboBox*>(
+                QStringLiteral("fieldSelector"));
+            auto* action = window.findChild<QAction*>(
+                QStringLiteral("expressionEditorAction"));
+            if (selector == nullptr || action == nullptr) {
+                qCritical("the window is missing its field selector or action");
+                finish(3);
+                return;
+            }
+            auto* dialog =
+                window.findChild<amrvis::qt::ExpressionEditorDialog*>();
+            if (*phase == 0) {
+                if (fieldNames(window)
+                    != QStringList{QStringLiteral("density"),
+                        QStringLiteral("temperature")}) {
+                    qCritical("the remote dataset lists: %s",
+                        qPrintable(fieldNames(window).join(
+                            QStringLiteral(", "))));
+                    finish(4);
+                    return;
+                }
+                // The whole point of 1.4: over a remote session this used to
+                // be disabled, saying derived fields needed a local dataset.
+                if (!action->isEnabled()) {
+                    qCritical("the Expression Editor is unavailable over a "
+                              "remote dataset: %s",
+                        qPrintable(action->toolTip()));
+                    finish(5);
+                    return;
+                }
+                action->trigger();
+                *phase = 1;
+                return;
+            }
+            if (*phase == 1) {
+                if (dialog == nullptr
+                    || !writeDefinition(*dialog, QStringLiteral("product"),
+                        QStringLiteral("density * temperature"))
+                    || !appendDefinition(*dialog,
+                        QStringLiteral("elsewhere"),
+                        QStringLiteral("nonesuch * 2"))
+                    || !clickApply(*dialog) || errorShown(*dialog)) {
+                    qCritical("the editor refused the definitions");
+                    finish(6);
+                    return;
+                }
+                *ticks = 0;
+                *phase = 2;
+                return;
+            }
+            if (*phase == 2) {
+                // Apply reopens the remote dataset on its own connection.
+                if (!fieldNames(window).contains(QStringLiteral("product"))) {
+                    if (*ticks > 400) {
+                        qCritical("applying over a remote session never "
+                                  "reached the field list: %s",
+                            qPrintable(fieldNames(window).join(
+                                QStringLiteral(", "))));
+                        finish(7);
+                        return;
+                    }
+                    return;
+                }
+                // The one the plotfile cannot satisfy is listed, greyed, with
+                // the server's own reason on it.
+                const auto unavailable
+                    = selector->findText(QStringLiteral("elsewhere"));
+                if (unavailable < 0
+                    || selector->itemData(unavailable).isValid()) {
+                    qCritical("the unavailable definition is not listed, or "
+                              "is listed as a field");
+                    finish(8);
+                    return;
+                }
+                if (!selector->itemData(unavailable, Qt::ToolTipRole)
+                        .toString()
+                        .contains(QStringLiteral("unavailable"))) {
+                    qCritical("the dimmed entry does not say why");
+                    finish(9);
+                    return;
+                }
+                const auto product
+                    = selector->findText(QStringLiteral("product"));
+                selector->setCurrentIndex(product);
+                *ticks = 0;
+                *phase = 3;
+                return;
+            }
+            if (*phase == 3) {
+                if (window.sliceRequestPendingForTest()
+                    || window.slicesInFlightForTest() != 0) {
+                    if (*ticks > 400) {
+                        qCritical("the computed field never finished slicing");
+                        finish(10);
+                        return;
+                    }
+                    return;
+                }
+                const auto size = window.activeViewImageSizeForTest();
+                if (size[0] <= 0 || size[1] <= 0) {
+                    qCritical("the computed field rendered nothing");
+                    finish(11);
+                    return;
+                }
+                if (window.backgroundErrorCountForTest() != 0) {
+                    qCritical("the remote computed field reported an error");
+                    finish(12);
+                    return;
+                }
+                // And the reload settled: one Apply must not leave the window
+                // reopening the dataset for ever, which is what would happen
+                // if the session and the editor disagreed about the list.
+                *ticks = 0;
+                *phase = 4;
+                return;
+            }
+            if (*phase == 4) {
+                // A few idle turns with nothing in flight: a reload loop shows
+                // up here as loads climbing without anything asking.
+                const auto settled = *loads;
+                if (*ticks < 20) {
+                    return;
+                }
+                if (*loads != settled) {
+                    qCritical("the window is still reopening the dataset");
+                    finish(13);
+                    return;
+                }
+                finish(0);
+            }
+        });
+    timer->start();
+    QTimer::singleShot(40000, &application, [&application] { application.exit(14); });
+}
+
 Outcome dispatchDerivedSequence(Context& context)
 {
     if (context.argc != 4) {
@@ -1078,6 +1248,20 @@ Outcome dispatchDerived(Context& context)
         armDerivedChecks(window, application);
     } else if (option == "--derived-field-playback-smoke-test") {
         armPlaybackChecks(window, application, path);
+    } else if (option == "--remote-derived-field-smoke-test") {
+        // The in-process loopback server, as the remote theme starts one: the
+        // handshake takes milliseconds and runs on the GUI thread.
+        context.server = std::make_shared<amrvis::remote::Server>();
+        context.serverThread.emplace(
+            [server = context.server] { server->run(); });
+        armRemoteDerivedChecks(window, application);
+        QTimer::singleShot(0, &window,
+            [&window, remotePath = path.string(),
+                server = context.server] {
+                attachSmokeServer(window, server);
+                window.openRemoteDataset(remotePath);
+            });
+        return {true, std::nullopt};
     } else {
         return {false, std::nullopt};
     }

--- a/src/qt/SmokeHarnessDerived.cpp
+++ b/src/qt/SmokeHarnessDerived.cpp
@@ -232,6 +232,11 @@ void armReloadRaceChecks(
     // completion queued behind this call, which is the only moment a test can
     // submit against the session on its way out.
     auto injected = std::make_shared<bool>(false);
+    // The field the injected interaction switches to. The reload's completion
+    // replays the field, level and range the load was launched with, so if it
+    // does that after the user has moved the selection, the change is reverted
+    // and the re-slice this load owes renders the old field.
+    auto chosenField = std::make_shared<QString>();
     QObject::connect(&window, &amrvis::qt::MainWindow::initialSliceFinished,
         &application, [&application, loads](bool success) {
             if (!success) {
@@ -240,18 +245,32 @@ void armReloadRaceChecks(
             }
             ++*loads;
         });
-    window.setInitialSliceLaunchedHookForTest([&window, loads, injected] {
-        if (*loads == 0 || *injected) {
-            return;
-        }
-        *injected = true;
-        window.requestActiveViewSliceForTest();
-    });
+    window.setInitialSliceLaunchedHookForTest(
+        [&window, loads, injected, chosenField] {
+            if (*loads == 0 || *injected) {
+                return;
+            }
+            *injected = true;
+            // Move the field, as a user reading a reloading window would, and
+            // then submit for it. Both matter: the submission is what
+            // supersedes the reload's display for this view, and the selection
+            // is what the completion must not roll back.
+            auto* selector = window.findChild<QComboBox*>(
+                QStringLiteral("fieldSelector"));
+            if (selector == nullptr || selector->count() < 2) {
+                return;
+            }
+            const auto next = selector->currentIndex() == 0 ? 1 : 0;
+            window.selectFieldItemForTest(next);
+            *chosenField = selector->currentText();
+            window.requestActiveViewSliceForTest();
+        });
 
     auto* timer = new QTimer(&window);
     timer->setInterval(25);
     QObject::connect(timer, &QTimer::timeout, &application,
-        [&window, &application, phase, loads, ticks, injected, timer] {
+        [&window, &application, phase, loads, ticks, injected, chosenField,
+            timer] {
             const auto finish = [&application, timer](int code) {
                 timer->stop();
                 application.exit(code);
@@ -276,10 +295,16 @@ void armReloadRaceChecks(
                 return;
             }
             if (*phase == 1) {
-                // Wait for the injection to have happened and everything it
-                // started to drain, including the re-slice the reload owes any
-                // view whose display it skipped.
-                if (!*injected || window.slicesInFlightForTest() != 0
+                // Wait for the reload's own load to have finished, not just
+                // for the view queues to be quiet: slicesInFlightForTest sums
+                // per-view pendingRequests and does not count the initial-slice
+                // worker, so without the load count this tick can fire while
+                // the reload is still running -- and then the outgoing session
+                // is still installed and the comparison below is against
+                // itself, which passes whatever the code does. `loads` is 1
+                // after the open and 2 once the reload has installed.
+                if (!*injected || *loads < 2
+                    || window.slicesInFlightForTest() != 0
                     || window.sliceRequestPendingForTest()) {
                     return;
                 }
@@ -293,6 +318,17 @@ void armReloadRaceChecks(
                 if (!window.activeViewSliceMatchesSessionForTest()) {
                     qCritical("the displayed slice outlived its session");
                     finish(23);
+                    return;
+                }
+                // And the interaction that superseded the reload was not
+                // quietly undone by the reload's own control restoration.
+                auto* selector = window.findChild<QComboBox*>(
+                    QStringLiteral("fieldSelector"));
+                if (selector == nullptr
+                    || (!chosenField->isEmpty()
+                        && selector->currentText() != *chosenField)) {
+                    qCritical("the reload reverted the field the user chose");
+                    finish(24);
                     return;
                 }
                 finish(0);

--- a/src/qt/SmokeHarnessDerived.cpp
+++ b/src/qt/SmokeHarnessDerived.cpp
@@ -25,6 +25,7 @@
 
 #include <filesystem>
 #include <memory>
+#include <optional>
 #include <string_view>
 #include <vector>
 
@@ -232,11 +233,17 @@ void armReloadRaceChecks(
     // completion queued behind this call, which is the only moment a test can
     // submit against the session on its way out.
     auto injected = std::make_shared<bool>(false);
-    // The field the injected interaction switches to. The reload's completion
+    // What the injected interaction switches to. The reload's completion
     // replays the field, level and range the load was launched with, so if it
-    // does that after the user has moved the selection, the change is reverted
-    // and the re-slice this load owes renders the old field.
+    // does that after the user has moved them, the change is reverted and the
+    // re-slice this load owes renders what they left. All three, because the
+    // controls are one set per window: an interaction that supersedes the
+    // reload can have moved any of them, and each is restored from the same
+    // launch-time spec. Empty for a control the dataset gave nothing to move
+    // to, which the checks below then skip.
     auto chosenField = std::make_shared<QString>();
+    auto chosenLevel = std::make_shared<std::optional<int>>();
+    auto chosenRangeMode = std::make_shared<std::optional<int>>();
     QObject::connect(&window, &amrvis::qt::MainWindow::initialSliceFinished,
         &application, [&application, loads](bool success) {
             if (!success) {
@@ -246,15 +253,16 @@ void armReloadRaceChecks(
             ++*loads;
         });
     window.setInitialSliceLaunchedHookForTest(
-        [&window, loads, injected, chosenField] {
+        [&window, loads, injected, chosenField, chosenLevel,
+            chosenRangeMode] {
             if (*loads == 0 || *injected) {
                 return;
             }
             *injected = true;
-            // Move the field, as a user reading a reloading window would, and
-            // then submit for it. Both matter: the submission is what
-            // supersedes the reload's display for this view, and the selection
-            // is what the completion must not roll back.
+            // Move the controls, as a user reading a reloading window would,
+            // and then submit for them. Both matter: the submission is what
+            // supersedes the reload's display for this view, and the
+            // selections are what the completion must not roll back.
             auto* selector = window.findChild<QComboBox*>(
                 QStringLiteral("fieldSelector"));
             if (selector == nullptr || selector->count() < 2) {
@@ -263,6 +271,26 @@ void armReloadRaceChecks(
             const auto next = selector->currentIndex() == 0 ? 1 : 0;
             window.selectFieldItemForTest(next);
             *chosenField = selector->currentText();
+            // Through the widgets, which is what a user's click reaches: the
+            // level combo carries its selection as item data (the position
+            // means nothing across a repopulate), and the range mode goes to
+            // Visible, the one mode no dataset can leave unavailable.
+            auto* levels = window.findChild<QComboBox*>(
+                QStringLiteral("levelSelector"));
+            if (levels != nullptr && levels->count() > 1) {
+                levels->setCurrentIndex(levels->currentIndex() == 0 ? 1 : 0);
+                *chosenLevel = levels->currentData().toInt();
+            }
+            auto* modes = window.findChild<QComboBox*>(
+                QStringLiteral("rangeModeSelector"));
+            if (modes != nullptr) {
+                const auto visible = modes->findData(
+                    static_cast<int>(amrvis::qt::RangeMode::Visible));
+                if (visible >= 0 && modes->currentIndex() != visible) {
+                    modes->setCurrentIndex(visible);
+                    *chosenRangeMode = modes->currentData().toInt();
+                }
+            }
             window.requestActiveViewSliceForTest();
         });
 
@@ -270,7 +298,7 @@ void armReloadRaceChecks(
     timer->setInterval(25);
     QObject::connect(timer, &QTimer::timeout, &application,
         [&window, &application, phase, loads, ticks, injected, chosenField,
-            timer] {
+            chosenLevel, chosenRangeMode, timer] {
             const auto finish = [&application, timer](int code) {
                 timer->stop();
                 application.exit(code);
@@ -329,6 +357,26 @@ void armReloadRaceChecks(
                         && selector->currentText() != *chosenField)) {
                     qCritical("the reload reverted the field the user chose");
                     finish(24);
+                    return;
+                }
+                auto* levels = window.findChild<QComboBox*>(
+                    QStringLiteral("levelSelector"));
+                if (chosenLevel->has_value()
+                    && (levels == nullptr
+                        || levels->currentData().toInt() != **chosenLevel)) {
+                    qCritical("the reload reverted the level the user chose");
+                    finish(25);
+                    return;
+                }
+                auto* modes = window.findChild<QComboBox*>(
+                    QStringLiteral("rangeModeSelector"));
+                if (chosenRangeMode->has_value()
+                    && (modes == nullptr
+                        || modes->currentData().toInt()
+                            != **chosenRangeMode)) {
+                    qCritical(
+                        "the reload reverted the range mode the user chose");
+                    finish(26);
                     return;
                 }
                 finish(0);

--- a/src/qt/SmokeHarnessDerived.cpp
+++ b/src/qt/SmokeHarnessDerived.cpp
@@ -1049,6 +1049,10 @@ void armRemoteDerivedChecks(
     auto phase = std::make_shared<int>(0);
     auto loads = std::make_shared<int>(0);
     auto ticks = std::make_shared<int>(0);
+    // The load count when the Apply settled, so the idle turns that follow can
+    // be told from the loads the Apply itself caused. Read on every tick it
+    // would compare against itself and never fail.
+    auto loadsAtSettle = std::make_shared<int>(0);
     QObject::connect(&window, &amrvis::qt::MainWindow::initialSliceFinished,
         &application, [&application, loads](bool success) {
             if (!success) {
@@ -1061,7 +1065,7 @@ void armRemoteDerivedChecks(
     auto* timer = new QTimer(&window);
     timer->setInterval(25);
     QObject::connect(timer, &QTimer::timeout, &application,
-        [&window, &application, phase, loads, ticks, timer] {
+        [&window, &application, phase, loads, ticks, loadsAtSettle, timer] {
             const auto finish = [&application, timer](int code) {
                 timer->stop();
                 application.exit(code);
@@ -1182,6 +1186,7 @@ void armRemoteDerivedChecks(
                 // And the reload settled: one Apply must not leave the window
                 // reopening the dataset for ever, which is what would happen
                 // if the session and the editor disagreed about the list.
+                *loadsAtSettle = *loads;
                 *ticks = 0;
                 *phase = 4;
                 return;
@@ -1189,11 +1194,10 @@ void armRemoteDerivedChecks(
             if (*phase == 4) {
                 // A few idle turns with nothing in flight: a reload loop shows
                 // up here as loads climbing without anything asking.
-                const auto settled = *loads;
                 if (*ticks < 20) {
                     return;
                 }
-                if (*loads != settled) {
+                if (*loads != *loadsAtSettle) {
                     qCritical("the window is still reopening the dataset");
                     finish(13);
                     return;

--- a/src/qt/SmokeHarnessDerived.cpp
+++ b/src/qt/SmokeHarnessDerived.cpp
@@ -214,6 +214,94 @@ void armRangeMemoryChecks(
     QTimer::singleShot(30000, &application, [&application] { application.exit(13); });
 }
 
+// Arms the one ordering that reading this code kept missing: an interaction
+// that lands while a reload is still replacing the session. The reload skips
+// its own display for that view, because a newer request for it exists, and
+// the interaction's own raster came from the session being replaced -- so
+// unless something re-slices, the window keeps the outgoing session's pixels
+// while its catalog, field list and colour bar are the new session's. Exit 0
+// once the raster on screen and the installed session agree again.
+void armReloadRaceChecks(
+    amrvis::qt::MainWindow& window, QApplication& application)
+{
+    auto phase = std::make_shared<int>(0);
+    auto loads = std::make_shared<int>(0);
+    auto ticks = std::make_shared<int>(0);
+    // Fired once, on the reload's load rather than the opening one: the hook
+    // runs inside requestInitialSlice with the work already dispatched and the
+    // completion queued behind this call, which is the only moment a test can
+    // submit against the session on its way out.
+    auto injected = std::make_shared<bool>(false);
+    QObject::connect(&window, &amrvis::qt::MainWindow::initialSliceFinished,
+        &application, [&application, loads](bool success) {
+            if (!success) {
+                application.exit(2);
+                return;
+            }
+            ++*loads;
+        });
+    window.setInitialSliceLaunchedHookForTest([&window, loads, injected] {
+        if (*loads == 0 || *injected) {
+            return;
+        }
+        *injected = true;
+        window.requestActiveViewSliceForTest();
+    });
+
+    auto* timer = new QTimer(&window);
+    timer->setInterval(25);
+    QObject::connect(timer, &QTimer::timeout, &application,
+        [&window, &application, phase, loads, ticks, injected, timer] {
+            const auto finish = [&application, timer](int code) {
+                timer->stop();
+                application.exit(code);
+            };
+            ++*ticks;
+            if (*ticks > 400) {
+                qCritical("the reload race scenario never settled");
+                finish(20);
+                return;
+            }
+            if (*loads == 0) {
+                return;
+            }
+            if (*phase == 0) {
+                // A definition every 2-D plotfile here can compute, so the
+                // reload it triggers succeeds and installs a new session. Set
+                // on the shared store, which is what an Apply in any window
+                // does and what makes every window reload.
+                amrvis::qt::DerivedFieldStore::session().set(
+                    {{"twice", "density * 2"}});
+                *phase = 1;
+                return;
+            }
+            if (*phase == 1) {
+                // Wait for the injection to have happened and everything it
+                // started to drain, including the re-slice the reload owes any
+                // view whose display it skipped.
+                if (!*injected || window.slicesInFlightForTest() != 0
+                    || window.sliceRequestPendingForTest()) {
+                    return;
+                }
+                if (window.backgroundErrorCountForTest() != 0) {
+                    qCritical("the reload race reported an error");
+                    finish(22);
+                    return;
+                }
+                // The invariant: no view keeps a raster from a session that is
+                // no longer installed.
+                if (!window.activeViewSliceMatchesSessionForTest()) {
+                    qCritical("the displayed slice outlived its session");
+                    finish(23);
+                    return;
+                }
+                finish(0);
+                return;
+            }
+        });
+    timer->start();
+}
+
 // Arms the scenario on `window`: exit 0 once a derived field has been
 // refused, accepted, and rendered; a nonzero code names the step that failed.
 void armDerivedChecks(amrvis::qt::MainWindow& window, QApplication& application)
@@ -1250,6 +1338,8 @@ Outcome dispatchDerived(Context& context)
         armRangeMemoryChecks(window, application);
     } else if (option == "--derived-field-smoke-test") {
         armDerivedChecks(window, application);
+    } else if (option == "--derived-field-reload-race-smoke-test") {
+        armReloadRaceChecks(window, application);
     } else if (option == "--derived-field-playback-smoke-test") {
         armPlaybackChecks(window, application, path);
     } else if (option == "--remote-derived-field-smoke-test") {

--- a/src/qt/SmokeHarnessDerived.cpp
+++ b/src/qt/SmokeHarnessDerived.cpp
@@ -222,8 +222,14 @@ void armRangeMemoryChecks(
 // unless something re-slices, the window keeps the outgoing session's pixels
 // while its catalog, field list and colour bar are the new session's. Exit 0
 // once the raster on screen and the installed session agree again.
-void armReloadRaceChecks(
-    amrvis::qt::MainWindow& window, QApplication& application)
+// `dispatch` decides how the injected interaction reaches the slice pipeline.
+// True submits for the view there and then, which is the ordering an
+// arrival-side check cannot sort out: the view is showing a raster the
+// outgoing session produced. False leaves the request queued behind the
+// debounce, as a real click does -- sliceGeneration has not moved when the
+// reload completes, so only the queue says the user has been here.
+void armReloadRaceChecks(amrvis::qt::MainWindow& window,
+    QApplication& application, bool dispatch)
 {
     auto phase = std::make_shared<int>(0);
     auto loads = std::make_shared<int>(0);
@@ -253,8 +259,8 @@ void armReloadRaceChecks(
             ++*loads;
         });
     window.setInitialSliceLaunchedHookForTest(
-        [&window, loads, injected, chosenField, chosenLevel,
-            chosenRangeMode] {
+        [&window, loads, injected, chosenField, chosenLevel, chosenRangeMode,
+            dispatch] {
             if (*loads == 0 || *injected) {
                 return;
             }
@@ -291,7 +297,9 @@ void armReloadRaceChecks(
                     *chosenRangeMode = modes->currentData().toInt();
                 }
             }
-            window.requestActiveViewSliceForTest();
+            if (dispatch) {
+                window.requestActiveViewSliceForTest();
+            }
         });
 
     auto* timer = new QTimer(&window);
@@ -380,6 +388,139 @@ void armReloadRaceChecks(
                     return;
                 }
                 finish(0);
+                return;
+            }
+        });
+    timer->start();
+}
+
+// Arms the retry scenario: a reload that fails leaves the list committed and
+// uninstalled, and the store emits nothing for a list that has not moved, so
+// the Apply the user presses again has to ask for the reload itself. Exit 0
+// once the definition the first Apply could not install is on the field list;
+// a nonzero code names the step that failed.
+void armReloadRetryChecks(
+    amrvis::qt::MainWindow& window, QApplication& application)
+{
+    auto phase = std::make_shared<int>(0);
+    auto loads = std::make_shared<int>(0);
+    auto failures = std::make_shared<int>(0);
+    auto ticks = std::make_shared<int>(0);
+    // The tick the retry was pressed on, so the wait for it to land is bounded
+    // by itself rather than by the scenario's own budget -- what the bug looks
+    // like is nothing happening, and it should say so in those words.
+    auto retryTick = std::make_shared<int>(0);
+    QObject::connect(&window, &amrvis::qt::MainWindow::initialSliceFinished,
+        &application, [loads, failures](bool success) {
+            if (success) {
+                ++*loads;
+            } else {
+                ++*failures;
+            }
+        });
+
+    auto* timer = new QTimer(&window);
+    timer->setInterval(25);
+    QObject::connect(timer, &QTimer::timeout, &application,
+        [&window, &application, phase, loads, failures, ticks, retryTick,
+            timer] {
+            const auto finish = [&application, timer](int code) {
+                timer->stop();
+                application.exit(code);
+            };
+            ++*ticks;
+            if (*ticks > 400) {
+                qCritical("the reload retry scenario never settled");
+                finish(30);
+                return;
+            }
+            if (*loads == 0) {
+                return;
+            }
+            auto* dialog =
+                window.findChild<amrvis::qt::ExpressionEditorDialog*>();
+            if (*phase == 0) {
+                auto* action = window.findChild<QAction*>(
+                    QStringLiteral("expressionEditorAction"));
+                if (action == nullptr || !action->isEnabled()) {
+                    qCritical("the Expression Editor action is not available");
+                    finish(31);
+                    return;
+                }
+                action->trigger();
+                *phase = 1;
+                return;
+            }
+            if (*phase == 1) {
+                if (dialog == nullptr) {
+                    qCritical("the Expression Editor did not open");
+                    finish(32);
+                    return;
+                }
+                // The reload this Apply starts goes down its failure arm,
+                // which is what a server refusing the reopen -- or a
+                // connection that has gone -- leaves behind: the list
+                // committed, the previous session still installed, and the
+                // editor reporting a definition that never arrived.
+                window.failNextInitialSliceForTest();
+                if (!writeDefinition(*dialog, QStringLiteral("twice"),
+                        QStringLiteral("density * 2"))
+                    || !clickApply(*dialog)) {
+                    qCritical("the editor did not take the definition");
+                    finish(33);
+                    return;
+                }
+                if (errorShown(*dialog)) {
+                    qCritical("a definition this dataset can compute was "
+                              "refused");
+                    finish(33);
+                    return;
+                }
+                *phase = 2;
+                return;
+            }
+            if (*phase == 2) {
+                if (*failures == 0) {
+                    return;  // the reload is still running
+                }
+                if (fieldNames(window).contains(QStringLiteral("twice"))) {
+                    qCritical("a failed reload installed the definition");
+                    finish(34);
+                    return;
+                }
+                if (dialog == nullptr) {
+                    qCritical("the editor closed over a failed reload");
+                    finish(35);
+                    return;
+                }
+                // The same list a second time, which the store does not emit
+                // for. Nothing else in the window can ask for that reload
+                // again, so without the Apply doing it the definition stays
+                // uninstalled for good.
+                if (!clickApply(*dialog)) {
+                    qCritical("the editor has no Apply button");
+                    finish(35);
+                    return;
+                }
+                *retryTick = *ticks;
+                *phase = 3;
+                return;
+            }
+            if (*phase == 3) {
+                if (fieldNames(window).contains(QStringLiteral("twice"))) {
+                    if (window.slicesInFlightForTest() != 0
+                        || window.sliceRequestPendingForTest()) {
+                        return;
+                    }
+                    finish(0);
+                    return;
+                }
+                if (*ticks - *retryTick > 120) {
+                    qCritical("an unchanged Apply did not retry the reload "
+                              "that failed");
+                    finish(36);
+                    return;
+                }
                 return;
             }
         });
@@ -1423,7 +1564,11 @@ Outcome dispatchDerived(Context& context)
     } else if (option == "--derived-field-smoke-test") {
         armDerivedChecks(window, application);
     } else if (option == "--derived-field-reload-race-smoke-test") {
-        armReloadRaceChecks(window, application);
+        armReloadRaceChecks(window, application, true);
+    } else if (option == "--derived-field-reload-debounce-smoke-test") {
+        armReloadRaceChecks(window, application, false);
+    } else if (option == "--derived-field-reload-retry-smoke-test") {
+        armReloadRetryChecks(window, application);
     } else if (option == "--derived-field-playback-smoke-test") {
         armPlaybackChecks(window, application, path);
     } else if (option == "--remote-derived-field-smoke-test") {

--- a/src/remote/Codec.cpp
+++ b/src/remote/Codec.cpp
@@ -377,6 +377,11 @@ bool vectorsAligned(std::span<const std::uint8_t> bytes)
 std::string boundedReason(const std::string& reason)
 {
     constexpr std::string_view continued = "...";
+    // The bound is expression/Expression.hpp's, which is about expression
+    // source rather than about messages -- nothing here owns it. Were it ever
+    // set below the marker, the subtraction would wrap and the index below
+    // would read off the end of the string before substr could clamp it.
+    static_assert(maximumExpressionBytes > continued.size());
     if (reason.size() <= maximumExpressionBytes) {
         return reason;
     }

--- a/src/remote/Server.cpp
+++ b/src/remote/Server.cpp
@@ -604,19 +604,22 @@ private:
         if (request == nullptr || request->path.empty()) {
             throw std::invalid_argument("dataset path is empty");
         }
-        // Decoded here, before the reservation below: this is what bounds the
-        // definition list a client sent (codec::fromWire), and an over-cap list
-        // should be refused before anything is reserved or allocated for it.
-        auto open = codec::fromWire(*request);
-        // Also before the reservation, so an early return need not know that
-        // bookkeeping. Not theatre: encode() stamps the envelope's version but
-        // filters no fields, so a 1.3-negotiated envelope can physically carry
-        // this vector -- and a client that read our Hello knows better, so this
-        // is answerable rather than fatal.
-        if (!open.derivedFields.empty() && m_selectedMinorVersion < 4) {
+        // Before the decode, so a peer too old to send a list at all is told
+        // that rather than what is wrong with the list: fromWire's bounds
+        // would otherwise answer an over-cap list from a 1.3 peer with advice
+        // about shortening one it was never allowed to send. Tested on the
+        // unpacked request for the same reason. Not theatre: encode() stamps
+        // the envelope's version but filters no fields, so a 1.3-negotiated
+        // envelope can physically carry this vector -- and a client that read
+        // our Hello knows better, so this is answerable rather than fatal.
+        if (!request->derived_fields.empty() && m_selectedMinorVersion < 4) {
             throw RemoteError(ErrorCode::UnsupportedProtocol,
                 "derived fields require protocol 1.4");
         }
+        // Decoded before the reservation below: this is what bounds the
+        // definition list a client sent (codec::fromWire), and an over-cap list
+        // should be refused before anything is reserved or allocated for it.
+        auto open = codec::fromWire(*request);
         {
             std::scoped_lock lock(m_stateMutex);
             if (m_stopping.load() || cancellation.stop_requested()) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1341,6 +1341,23 @@ if(TARGET amrexplorer_qt)
     )
     set_tests_properties(qt_derived_field_playback_smoke PROPERTIES TIMEOUT 60)
 
+    # Derived fields over the protocol (1.4): the editor is available over a
+    # remote dataset, Apply reopens it on its own connection with the
+    # definitions, the computed field arrives as the tail of the catalog and
+    # renders, one the plotfile cannot satisfy is greyed with the server's own
+    # reason, and the reload settles instead of looping. The server runs
+    # in-process, so the "remote" path is the materialized fixture.
+    add_test(
+        NAME qt_remote_derived_field_smoke
+        COMMAND "$<TARGET_FILE:amrexplorer_qt>"
+            --remote-derived-field-smoke-test
+            "${CMAKE_CURRENT_BINARY_DIR}/fixtures_remote_server"
+    )
+    set_tests_properties(qt_remote_derived_field_smoke PROPERTIES
+        ENVIRONMENT "QT_QPA_PLATFORM=offscreen"
+        FIXTURES_REQUIRED remote_server_materialized
+        TIMEOUT 90)
+
     # Applying a definition while a plotfile sequence is open: the frame on
     # screen reloads with it and the sequence is still navigable afterwards,
     # which is what separates the reload from an ordinary dataset open.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1324,6 +1324,24 @@ if(TARGET amrexplorer_qt)
     )
     set_tests_properties(qt_derived_field_smoke PROPERTIES TIMEOUT 60)
 
+    # An interaction that lands while a reload is still replacing the session.
+    # The reload skips its own display for that view and the interaction's
+    # raster came from the session being replaced, so without the re-slice the
+    # reload owes it, the window keeps the outgoing session's pixels under the
+    # new catalog.
+    add_test(
+        NAME qt_derived_field_reload_race_smoke
+        COMMAND "${CMAKE_COMMAND}"
+            "-DMATERIALIZER=$<TARGET_FILE:fixture_materializer>"
+            "-DAMREXPLORER_QT=$<TARGET_FILE:amrexplorer_qt>"
+            "-DSOURCE=${CMAKE_CURRENT_SOURCE_DIR}/data/plotfile_2d"
+            "-DWORK=${CMAKE_CURRENT_BINARY_DIR}/fixtures_derived_reload_race"
+            -DMODE=derived-field-reload-race
+            -P "${CMAKE_CURRENT_SOURCE_DIR}/qt_smoke_driver.cmake"
+    )
+    set_tests_properties(
+        qt_derived_field_reload_race_smoke PROPERTIES TIMEOUT 60)
+
     # The two ways a committed definition can miss the session on screen: an
     # Apply during a plane sweep, which never reopens the dataset of its own
     # accord, and a list changed while this window is opening one, when it

--- a/tests/fuzz/fuzz_wire_codec.cpp
+++ b/tests/fuzz/fuzz_wire_codec.cpp
@@ -144,12 +144,13 @@ void checkConverted(
                  "faithfully");
         }
         // Equality unless the decoder was entitled to clamp: an over-long
-        // reason comes back at the bound, and that is the only change it may
-        // make to one.
+        // reason comes back no longer than the bound. Not *at* the bound --
+        // the clamp backs off a partial UTF-8 sequence, so a legitimate one
+        // lands a byte or two under it.
         const auto reasonKept
             = entry->reason.size() <= amrvis::maximumExpressionBytes
             ? skip.reason == entry->reason
-            : skip.reason.size() == amrvis::maximumExpressionBytes;
+            : skip.reason.size() <= amrvis::maximumExpressionBytes;
         if (skip.name != entry->name
             || skip.definitionIndex != entry->definition_index || !reasonKept) {
             fail("DatasetOpened derived-field skip did not convert "

--- a/tests/fuzz/fuzz_wire_codec.cpp
+++ b/tests/fuzz/fuzz_wire_codec.cpp
@@ -128,6 +128,34 @@ void checkConverted(
             fail("DatasetOpened converter accepted an inconsistent level");
         }
     }
+    // The 1.4 tail, checked like the request's definitions are. This compares
+    // the buffer against what fromWire made of it, so it is the decode that is
+    // pinned: one that dropped the count, or that transposed a skip's name and
+    // reason, would otherwise pass every iteration.
+    if (result.derivedFieldCount != wire.derived_field_count
+        || result.derivedFieldSkips.size() != wire.derived_field_skips.size()) {
+        fail("DatasetOpened derived fields did not convert faithfully");
+    }
+    for (std::size_t i = 0; i < result.derivedFieldSkips.size(); ++i) {
+        const auto& entry = wire.derived_field_skips[i];
+        const auto& skip = result.derivedFieldSkips[i];
+        if (!entry) {
+            fail("DatasetOpened derived-field skip did not convert "
+                 "faithfully");
+        }
+        // Equality unless the decoder was entitled to clamp: an over-long
+        // reason comes back at the bound, and that is the only change it may
+        // make to one.
+        const auto reasonKept
+            = entry->reason.size() <= amrvis::maximumExpressionBytes
+            ? skip.reason == entry->reason
+            : skip.reason.size() == amrvis::maximumExpressionBytes;
+        if (skip.name != entry->name
+            || skip.definitionIndex != entry->definition_index || !reasonKept) {
+            fail("DatasetOpened derived-field skip did not convert "
+                 "faithfully");
+        }
+    }
 }
 
 void checkConverted(
@@ -604,6 +632,18 @@ std::vector<std::vector<std::uint8_t>> wireSeeds()
         opened.level_range_available = {1, 0, 1, 1};
         opened.metadata_metrics = std::make_unique<fb::MetadataReadMetricsT>();
         opened.cache = std::make_unique<fb::CacheStateT>();
+        // Protocol 1.4, and non-default on purpose, for the same reason the
+        // request seed carries definitions: 0 and an empty vector are the
+        // schema defaults and are left out of the buffer, so a seed without
+        // them would be byte-identical to a pre-1.4 reply and would reach
+        // none of the reply-side bounds. One of the two fields is derived,
+        // and one skip so the vector is present for the mutator to grow.
+        opened.derived_field_count = 1;
+        auto skip = std::make_unique<fb::DerivedFieldSkipT>();
+        skip->definition_index = 1;
+        skip->name = "twice";
+        skip->reason = "no field or coordinate is named 'speed'";
+        opened.derived_field_skips.push_back(std::move(skip));
         add(std::move(opened));
     }
     {

--- a/tests/fuzz/fuzz_wire_codec.cpp
+++ b/tests/fuzz/fuzz_wire_codec.cpp
@@ -143,14 +143,27 @@ void checkConverted(
             fail("DatasetOpened derived-field skip did not convert "
                  "faithfully");
         }
-        // Equality unless the decoder was entitled to clamp: an over-long
-        // reason comes back no longer than the bound. Not *at* the bound --
-        // the clamp backs off a partial UTF-8 sequence, so a legitimate one
-        // lands a byte or two under it.
+        // Equality unless the decoder was entitled to clamp. What survives a
+        // clamp is a shape, not a length: a prefix of what was sent followed
+        // by the marker. A bare length bound would be satisfied by an empty
+        // reason or a transposed field, which is what this check exists to
+        // catch; an exact length would reject the legitimate case, since the
+        // clamp backs off a partial UTF-8 sequence and lands under the bound.
+        // No length lower bound either -- an input of continuation bytes drives
+        // the backoff to zero, leaving just the marker.
+        auto clamped = [&] {
+            if (skip.reason.size() > amrvis::maximumExpressionBytes
+                || !skip.reason.ends_with("...")) {
+                return false;
+            }
+            const auto kept = std::string_view{skip.reason}.substr(
+                0, skip.reason.size() - 3);
+            return entry->reason.starts_with(kept);
+        };
         const auto reasonKept
             = entry->reason.size() <= amrvis::maximumExpressionBytes
             ? skip.reason == entry->reason
-            : skip.reason.size() <= amrvis::maximumExpressionBytes;
+            : clamped();
         if (skip.name != entry->name
             || skip.definitionIndex != entry->definition_index || !reasonKept) {
             fail("DatasetOpened derived-field skip did not convert "

--- a/tests/integration/test_remote_server.cpp
+++ b/tests/integration/test_remote_server.cpp
@@ -618,6 +618,29 @@ int main(int argc, char* argv[])
         require(olderError.code == ErrorCode::UnsupportedProtocol,
             "a 1.3 peer derived-field open returned the wrong error");
 
+        // And the same answer for a list fromWire would refuse on its own
+        // merits: the version gate runs first, so a peer too old to send a
+        // list at all is told that, not how to shorten one it was never
+        // allowed to send.
+        {
+            OpenDatasetData overCap{std::filesystem::path(argv[1]).string(),
+                16ULL * 1024ULL * 1024ULL, {}};
+            for (std::size_t index = 0; index <= maximumDerivedFieldCount;
+                ++index) {
+                overCap.derivedFields.push_back(
+                    {"f" + std::to_string(index), "density"});
+            }
+            olderEnvelope = exchange(olderSocket, 4, codec::toWire(overCap),
+                olderInfo.maximumFrameBytes, 3);
+            require(codec::inspect(*olderEnvelope).payload
+                    == PayloadKind::ErrorResponse,
+                "a 1.3 peer over-cap derived-field open was not refused");
+            require(codec::fromWire(*olderEnvelope->payload.AsErrorResponse())
+                        .code
+                    == ErrorCode::UnsupportedProtocol,
+                "a 1.3 peer was told about the list instead of the version");
+        }
+
         // And the session survives it: an open without definitions still works.
         olderEnvelope = exchange(olderSocket, 3,
             codec::toWire(OpenDatasetData{

--- a/tests/qt_smoke_driver.cmake
+++ b/tests/qt_smoke_driver.cmake
@@ -68,6 +68,10 @@ elseif(MODE STREQUAL "derived-field")
     run_or_die("${AMREXPLORER_QT}" --derived-field-smoke-test "${WORK}/plt")
     run_or_die("${AMREXPLORER_QT}" --field-range-memory-smoke-test
         "${WORK}/plt")
+elseif(MODE STREQUAL "derived-field-reload-race")
+    run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt")
+    run_or_die("${AMREXPLORER_QT}" --derived-field-reload-race-smoke-test
+        "${WORK}/plt")
 elseif(MODE STREQUAL "derived-field-frames")
     # Two frames that do not list the same fields: the second drops the one a
     # definition reads, so that definition is left out of it and every id after

--- a/tests/qt_smoke_driver.cmake
+++ b/tests/qt_smoke_driver.cmake
@@ -82,6 +82,11 @@ elseif(MODE STREQUAL "derived-field-reload-race")
     # uninstalled, and only the Apply pressed again can ask for it.
     run_or_die("${AMREXPLORER_QT}" --derived-field-reload-retry-smoke-test
         "${WORK}/plt")
+    # And the same race over a definition the reload cannot resolve: it is
+    # listed under the user's field name, greyed and carrying no id, which is
+    # what the restore must not select.
+    run_or_die("${AMREXPLORER_QT}" --derived-field-skipped-race-smoke-test
+        "${WORK}/plt")
 elseif(MODE STREQUAL "derived-field-frames")
     # Two frames that do not list the same fields: the second drops the one a
     # definition reads, so that definition is left out of it and every id after

--- a/tests/qt_smoke_driver.cmake
+++ b/tests/qt_smoke_driver.cmake
@@ -73,6 +73,15 @@ elseif(MODE STREQUAL "derived-field-reload-race")
     run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt")
     run_or_die("${AMREXPLORER_QT}" --derived-field-reload-race-smoke-test
         "${WORK}/plt")
+    # The same interaction left queued behind the slice debounce, which is what
+    # a click actually does: no slice generation has moved when the reload
+    # completes, so only the queue says the user has changed anything.
+    run_or_die("${AMREXPLORER_QT}" --derived-field-reload-debounce-smoke-test
+        "${WORK}/plt")
+    # And the way back from a reload that failed: the list is committed and
+    # uninstalled, and only the Apply pressed again can ask for it.
+    run_or_die("${AMREXPLORER_QT}" --derived-field-reload-retry-smoke-test
+        "${WORK}/plt")
 elseif(MODE STREQUAL "derived-field-frames")
     # Two frames that do not list the same fields: the second drops the one a
     # definition reads, so that definition is left out of it and every id after

--- a/tests/qt_smoke_driver.cmake
+++ b/tests/qt_smoke_driver.cmake
@@ -6,6 +6,7 @@
 #   SOURCE        fixture source directory (e.g. tests/data/plotfile_2d)
 #   WORK          directory the materialized copies are written into
 #   MODE          slice | sequence | sequence-after-fab |
+#                 derived-field-reload-race |
 #                 remote-sequence-after-fab | missing-range |
 #                 non-finite | raw-fab |
 #                 multifab-fab | quit | quit-on-failure | window-close-pool |

--- a/tests/unit/test_derived_field_controller.cpp
+++ b/tests/unit/test_derived_field_controller.cpp
@@ -41,24 +41,48 @@ struct Fixture {
     // remote one) or for no dataset at all.
     bool datasetOpen = true;
     int reloads = 0;
+    // The list this window's session is showing. A reload installs whatever is
+    // committed, unless reloadFails stands in for the reopen a server refuses
+    // or a connection that has gone -- which leaves the list committed here
+    // and installed nowhere.
+    std::vector<DerivedFieldDefinition> installed;
+    bool reloadFails = false;
     // What the next chooseFile answers, and what it was asked for.
     QString chosenPath;
     std::optional<bool> lastChooseForSaving;
 
-    [[nodiscard]] DerivedFieldController::Hooks hooks()
+    [[nodiscard]] DerivedFieldController::Hooks hooks(
+        const DerivedFieldStore& store)
     {
         return DerivedFieldController::Hooks{
             .unavailableReason = [this]() -> QString {
                 return datasetOpen ? QString()
                                    : QStringLiteral("no dataset here");
             },
-            .reload = [this] { ++reloads; },
+            .reload = [this, &store] { reload(store); },
+            // As the host does: reopen only where the session is not already
+            // showing the list. That is what makes an unchanged Apply the
+            // retry for a reload that failed, and a no-op everywhere else.
+            .reloadIfMissing =
+                [this, &store] {
+                    if (installed != store.definitions()) {
+                        reload(store);
+                    }
+                },
             .chooseFile =
                 [this](QWidget*, bool forSaving) {
                     lastChooseForSaving = forSaving;
                     return chosenPath;
                 },
         };
+    }
+
+    void reload(const DerivedFieldStore& store)
+    {
+        ++reloads;
+        if (!reloadFails) {
+            installed = store.definitions();
+        }
     }
 };
 
@@ -75,7 +99,7 @@ int main(int argc, char** argv)
     {
         Fixture fixture;
         DerivedFieldStore store;
-        DerivedFieldController controller(fixture.hooks(), store);
+        DerivedFieldController controller(fixture.hooks(store), store);
 
         // A refusal changes nothing: not the committed list, and no reload.
         // What is refused is what is wrong whatever the data -- an expression
@@ -129,6 +153,35 @@ int main(int argc, char** argv)
             "clearing the list did not commit and reload");
     }
 
+    // A reload that fails leaves the list committed here and installed
+    // nowhere, and the store emits nothing for a list that has not moved -- so
+    // the Apply pressed again is the only thing left that can ask for it.
+    {
+        Fixture fixture;
+        DerivedFieldStore store;
+        DerivedFieldController controller(fixture.hooks(store), store);
+        const std::vector<DerivedFieldDefinition> list{{"twice", "2*density"}};
+
+        fixture.reloadFails = true;
+        require(!controller.apply(list).has_value(),
+            "a resolvable list was refused");
+        require(fixture.reloads == 1 && fixture.installed.empty(),
+            "a failed reload installed the list");
+
+        fixture.reloadFails = false;
+        require(!controller.apply(list).has_value(), "the retry was refused");
+        require(fixture.reloads == 2 && fixture.installed == list,
+            "an unchanged apply did not retry the reload that failed");
+
+        // And once it is installed, pressing Apply again asks for nothing:
+        // the ask goes to the one hook that drops it where the session
+        // already carries the list.
+        require(!controller.apply(list).has_value(),
+            "a redundant apply was refused");
+        require(fixture.reloads == 2,
+            "an unchanged apply reloaded a window already showing the list");
+    }
+
     // A list longer than a dataset can install is refused whole. Committing
     // it would install the first maximumDerivedFieldCount against every
     // dataset and skip the rest, so every window would list what it had
@@ -136,7 +189,7 @@ int main(int argc, char** argv)
     {
         Fixture fixture;
         DerivedFieldStore store;
-        DerivedFieldController controller(fixture.hooks(), store);
+        DerivedFieldController controller(fixture.hooks(store), store);
         std::vector<DerivedFieldDefinition> many;
         many.reserve(amrvis::maximumDerivedFieldCount + 1);
         for (std::size_t index = 0; index <= amrvis::maximumDerivedFieldCount;
@@ -159,7 +212,7 @@ int main(int argc, char** argv)
         Fixture fixture;
         fixture.datasetOpen = false;
         DerivedFieldStore store;
-        DerivedFieldController controller(fixture.hooks(), store);
+        DerivedFieldController controller(fixture.hooks(store), store);
         auto* parent = new QWidget;
         auto* action = controller.createAction(parent);
         require(action != nullptr && !action->isEnabled(),
@@ -282,7 +335,7 @@ int main(int argc, char** argv)
     {
         Fixture fixture;
         DerivedFieldStore store;
-        DerivedFieldController controller(fixture.hooks(), store);
+        DerivedFieldController controller(fixture.hooks(store), store);
         require(!controller.apply({{"speed", "density"}}).has_value(),
             "the starting list was refused");
 
@@ -396,8 +449,8 @@ int main(int argc, char** argv)
         Fixture first;
         Fixture second;
         DerivedFieldStore store;
-        DerivedFieldController one(first.hooks(), store);
-        DerivedFieldController two(second.hooks(), store);
+        DerivedFieldController one(first.hooks(store), store);
+        DerivedFieldController two(second.hooks(store), store);
         const std::vector<DerivedFieldDefinition> list{{"speed", "density"}};
         require(!one.apply(list).has_value(), "the list was refused");
         require(one.definitions() == list && two.definitions() == list,
@@ -423,8 +476,8 @@ int main(int argc, char** argv)
         Fixture first;
         Fixture second;
         DerivedFieldStore store;
-        DerivedFieldController one(first.hooks(), store);
-        DerivedFieldController two(second.hooks(), store);
+        DerivedFieldController one(first.hooks(store), store);
+        DerivedFieldController two(second.hooks(store), store);
 
         auto* parent = new QWidget;
         two.showEditor(parent);

--- a/tests/unit/test_derived_field_controller.cpp
+++ b/tests/unit/test_derived_field_controller.cpp
@@ -48,7 +48,10 @@ struct Fixture {
     [[nodiscard]] DerivedFieldController::Hooks hooks()
     {
         return DerivedFieldController::Hooks{
-            .available = [this] { return datasetOpen; },
+            .unavailableReason = [this]() -> QString {
+                return datasetOpen ? QString()
+                                   : QStringLiteral("no dataset here");
+            },
             .reload = [this] { ++reloads; },
             .chooseFile =
                 [this](QWidget*, bool forSaving) {

--- a/tests/unit/test_session_validation.cpp
+++ b/tests/unit/test_session_validation.cpp
@@ -1061,19 +1061,19 @@ int main()
         }, "installs and skips",
             "a reply accounting for more definitions than were sent was "
             "accepted");
-        // Two skips naming the same definition: every count above still adds
-        // up, so nothing else here would catch it.
+        // Two skips naming the same definition are accepted on purpose: a
+        // peer that leaves definition_index at its default sends all zeroes,
+        // and nothing reads the field. See the note in the validator.
         const std::vector<amrvis::DerivedFieldSkip> twiceSkipped{
             {0, "a", "why"}, {0, "a", "why again"}};
-        requireRejectedWith([&] {
+        requireAccepted([&] {
             amrvis::validateSessionOpenedDerivedFields({
                 .fieldCount = 5,
                 .derivedFieldCount = 0,
                 .skips = twiceSkipped,
                 .requestedCount = 3,
             });
-        }, "the same definition twice",
-            "a reply skipping one definition twice was accepted");
+        }, "a peer that left definition_index at its default was refused");
         const std::vector<amrvis::DerivedFieldSkip> straySkip{
             {7, "stray", "why"}};
         requireRejectedWith([&] {

--- a/tests/unit/test_session_validation.cpp
+++ b/tests/unit/test_session_validation.cpp
@@ -1061,6 +1061,19 @@ int main()
         }, "installs and skips",
             "a reply accounting for more definitions than were sent was "
             "accepted");
+        // Two skips naming the same definition: every count above still adds
+        // up, so nothing else here would catch it.
+        const std::vector<amrvis::DerivedFieldSkip> twiceSkipped{
+            {0, "a", "why"}, {0, "a", "why again"}};
+        requireRejectedWith([&] {
+            amrvis::validateSessionOpenedDerivedFields({
+                .fieldCount = 5,
+                .derivedFieldCount = 0,
+                .skips = twiceSkipped,
+                .requestedCount = 3,
+            });
+        }, "the same definition twice",
+            "a reply skipping one definition twice was accepted");
         const std::vector<amrvis::DerivedFieldSkip> straySkip{
             {7, "stray", "why"}};
         requireRejectedWith([&] {


### PR DESCRIPTION
One helper opens a remote session for a load and sends only the definitions the peer can install, so a sequence frame and a reload cannot disagree about an older server. requestInitialSlice takes either an open session or an endpoint to reopen, which lets a remote dataset reload quietly instead of trying to open its server-side path locally -- on the session's own connection, since dataset ids restart per connection and a newer one would let a cached range alias a renumbered field.

The reload now coalesces, because it is asked for on every frame a sequence displays. The greyed editor gives a reason, since telling a remote user their dataset is not local was about to become a lie.