### PR TITLE
say what a definition cannot do here while it is being written

### DIFF
--- a/src/qt/DerivedFieldController.cpp
+++ b/src/qt/DerivedFieldController.cpp
@@ -321,33 +321,48 @@ void DerivedFieldController::refreshDraftDiagnostics()
 
 bool DerivedFieldController::failureIsInherited(
     const std::vector<DerivedFieldDefinition>& definitions, std::size_t index,
-    const std::vector<DerivedFieldSkip>& skipped)
+    const std::vector<DerivedFieldSkip>& skipped) const
 {
-    if (index >= definitions.size()) {
+    if (index >= definitions.size() || !m_hooks.resolveAgainstOpenDataset) {
         return false;
     }
-    std::optional<CompiledExpression> expression;
-    try {
-        expression = CompiledExpression::compile(definitions[index].expression);
-    } catch (const ExpressionError&) {
-        // It does not parse, which is its own fault and reported as such.
-        return false;
-    }
-    for (const auto& symbol : expression->symbols()) {
-        for (std::size_t earlier = 0; earlier < index; ++earlier) {
-            if (definitions[earlier].name != symbol) {
-                continue;
-            }
-            const auto lost = std::find_if(skipped.begin(), skipped.end(),
-                [earlier](const DerivedFieldSkip& skip) {
-                    return skip.definitionIndex == earlier;
-                });
-            if (lost != skipped.end()) {
-                return true;
-            }
+    const auto lost = [&skipped](std::size_t row) {
+        return std::find_if(skipped.begin(), skipped.end(),
+                   [row](const DerivedFieldSkip& skip) {
+                       return skip.definitionIndex == row;
+                   })
+            != skipped.end();
+    };
+    // The rows above that this dataset could not provide, made into something
+    // it always can. A constant resolves wherever anything does, so what comes
+    // back is this row's standing with its dependencies restored and nothing
+    // else about the list changed.
+    std::vector<DerivedFieldDefinition> probe(
+        definitions.begin(), definitions.begin() + static_cast<std::ptrdiff_t>(index) + 1);
+    bool substituted = false;
+    for (std::size_t earlier = 0; earlier < index; ++earlier) {
+        if (lost(earlier)) {
+            probe[earlier].expression = "0";
+            substituted = true;
         }
     }
-    return false;
+    if (!substituted) {
+        // Nothing above it was lost, so nothing above it can be the reason.
+        return false;
+    }
+    // Still skipped with its dependencies made good: the fault is its own.
+    // A probe that somehow fails for a reason of its own leaves this false,
+    // which refuses the row -- the safe direction, since the alternative is
+    // committing a definition nothing checked.
+    return !lost(index)
+        || [&] {
+               const auto again = m_hooks.resolveAgainstOpenDataset(probe);
+               return std::find_if(again.begin(), again.end(),
+                          [index](const DerivedFieldSkip& skip) {
+                              return skip.definitionIndex == index;
+                          })
+                   == again.end();
+           }();
 }
 
 std::optional<DerivedFieldController::Refusal>

--- a/src/qt/DerivedFieldController.cpp
+++ b/src/qt/DerivedFieldController.cpp
@@ -206,16 +206,10 @@ void DerivedFieldController::refreshAvailability()
         // the reload an Apply of its own started -- so what follows must cost
         // nothing when the dataset's vocabulary has not moved. Which it has
         // not, for either of those.
-        // The reason rides along with the shape. Every unavailable state
-        // renders the same empty shape -- no dataset, a FAB, a peer too old --
-        // so without it a refusal naming one of them survives the arrival of
-        // another, and the editor reports that derived fields need an open
-        // dataset while one is open.
         const auto moved = m_dialog->setStoredFields(
             m_hooks.storedFieldNames ? m_hooks.storedFieldNames()
                                      : QStringList{},
-            reason + QLatin1Char('\n')
-                + (m_hooks.datasetShape ? m_hooks.datasetShape() : QString{}));
+            datasetKey(reason));
         if (moved) {
             // Everything standing described a vocabulary that has gone: the
             // advisory, and the refusal whose "Apply anyway" would otherwise
@@ -241,6 +235,12 @@ void DerivedFieldController::refreshAvailability()
             }
         }
     }
+}
+
+QString DerivedFieldController::datasetKey(const QString& reason) const
+{
+    return reason + QLatin1Char('\n')
+        + (m_hooks.datasetShape ? m_hooks.datasetShape() : QString{});
 }
 
 void DerivedFieldController::refreshDraftDiagnostics()
@@ -483,7 +483,7 @@ std::optional<DerivedFieldController::Refusal> DerivedFieldController::apply(
         !reason.isEmpty()) {
         // The same words the greyed action carries, so the editor and the menu
         // give one answer rather than two.
-        return Refusal{reason, std::nullopt};
+        return Refusal{reason, std::nullopt, false, true};
     }
 
     if (const auto fault = definitionFault(definitions)) {
@@ -500,7 +500,7 @@ std::optional<DerivedFieldController::Refusal> DerivedFieldController::apply(
         std::sort(mustResolveHere.begin(), mustResolveHere.end());
         for (const auto index : mustResolveHere) {
             if (auto refusal = datasetRefusalFor(definitions, index, skipped)) {
-                return Refusal{*std::move(refusal), index, true};
+                return Refusal{*std::move(refusal), index, true, true};
             }
         }
     }
@@ -530,9 +530,13 @@ void DerivedFieldController::showEditor(QWidget* parent)
     auto* dialog =
         new ExpressionEditorDialog(m_store.definitions(), parent);
     dialog->setAttribute(Qt::WA_DeleteOnClose);
+    // The same key refreshAvailability composes. Spelled differently here, the
+    // first session installed after the editor opened read as a change of
+    // dataset and took down a verdict that was still true of it.
     dialog->setStoredFields(
         m_hooks.storedFieldNames ? m_hooks.storedFieldNames() : QStringList{},
-        m_hooks.datasetShape ? m_hooks.datasetShape() : QString{});
+        datasetKey(m_hooks.unavailableReason ? m_hooks.unavailableReason()
+                                             : QString{}));
     // Owned by the dialog, so it goes when the dialog does and cannot fire
     // into a m_dialog that has been destroyed. Single-shot and restarted by
     // each edit: what the user wants is the verdict on what they have
@@ -580,7 +584,7 @@ void DerivedFieldController::showEditor(QWidget* parent)
         }
         if (const auto refusal = apply(dialog->draft(), std::move(written))) {
             dialog->showError(refusal->message, refusal->definitionIndex,
-                refusal->confirmable);
+                refusal->confirmable, refusal->dependsOnDataset);
             return;
         }
         // The draft is now the committed list, which is what later edits are

--- a/src/qt/DerivedFieldController.cpp
+++ b/src/qt/DerivedFieldController.cpp
@@ -235,6 +235,14 @@ void DerivedFieldController::refreshDraftDiagnostics()
         return;
     }
     const auto& draft = m_dialog->draft();
+    // Nothing to say about a row still being written. An empty name or
+    // expression is not a verdict on anything, and saying so a quarter of a
+    // second after the first character is a complaint about the user not
+    // having finished a sentence. Apply asks for both, where it belongs.
+    if (draft[*index].name.empty() || draft[*index].expression.empty()) {
+        m_dialog->showResolutionWarning({});
+        return;
+    }
     // A fault in the definition first, and in its own words. It is wrong
     // wherever it is installed, so calling it unavailable *in this dataset*
     // would send the user looking for a plotfile that has the field when what
@@ -243,16 +251,33 @@ void DerivedFieldController::refreshDraftDiagnostics()
         m_dialog->showResolutionWarning(fault->message);
         return;
     }
+    // A row *above* this one that cannot be installed makes any verdict below
+    // it unreliable: installation is ordered, so this definition may read the
+    // ones before it, and what a dataset then makes of this row follows from
+    // that fault rather than from the data. Rows after it cannot affect it.
+    for (std::size_t earlier = 0; earlier < *index; ++earlier) {
+        if (definitionFaultAt(draft, earlier)) {
+            m_dialog->showResolutionWarning({});
+            return;
+        }
+    }
     // And the faults that belong to the list rather than to a row -- an
     // expression reading more fields than one evaluation may pin, a chain
     // deeper than it may recurse -- where they name this one. Safe over a
     // draft that does not compile: the check answers nullopt for that rather
     // than throwing, leaving the row's own fault above to have spoken first.
-    if (const auto fault = validateDerivedFieldGraph(draft)) {
-        // Only the first fault is reported, so one naming another row leaves
-        // this one's standing unknown -- and whatever the dataset would then
-        // say about it follows from that other fault rather than from the
-        // data. Nothing is the honest answer; Apply names the real one.
+    // The faults that belong to the list rather than to a row -- an expression
+    // reading more fields than one evaluation may pin, a chain deeper than it
+    // may recurse -- asked of the rows up to and including this one. Of the
+    // prefix and not the whole list, because the check reports only its first
+    // fault and gives up entirely on the first row that will not compile: a
+    // half-written row *below* this one would otherwise answer for it, and
+    // this row's own fault would reach the dataset wording it must never
+    // wear. Everything above is known installable by the loop just above, so
+    // a fault here is this row's.
+    const std::vector<DerivedFieldDefinition> upto(draft.begin(),
+        draft.begin() + static_cast<std::ptrdiff_t>(*index) + 1);
+    if (const auto fault = validateDerivedFieldGraph(upto)) {
         m_dialog->showResolutionWarning(fault->definitionIndex == *index
                 ? QString::fromStdString(fault->message)
                 : QString{});

--- a/src/qt/DerivedFieldController.cpp
+++ b/src/qt/DerivedFieldController.cpp
@@ -17,6 +17,7 @@
 #include <QWidget>
 
 #include <algorithm>
+#include <span>
 #include <utility>
 
 namespace amrvis::qt {
@@ -281,13 +282,14 @@ void DerivedFieldController::refreshDraftDiagnostics()
     // this row's own fault would reach the dataset wording it must never
     // wear. Everything above is known installable by the loop just above, so
     // a fault here is this row's.
-    const std::vector<DerivedFieldDefinition> upto(draft.begin(),
-        draft.begin() + static_cast<std::ptrdiff_t>(*index) + 1);
-    if (const auto fault = validateDerivedFieldGraph(upto)) {
-        m_dialog->showResolutionWarning(fault->definitionIndex == *index
-                ? QString::fromStdString(fault->message)
-                : QString{},
-            true);
+    if (const auto fault = validateDerivedFieldGraph(
+            std::span(draft).first(*index + 1))) {
+        // Whichever row it names. It is a fault of the list, so the wording
+        // does not blame the data, and Apply will refuse it -- saying nothing
+        // because it belongs to a row above would leave the advisory silent
+        // about something that is about to stop the user.
+        m_dialog->showResolutionWarning(
+            QString::fromStdString(fault->message), true);
         return;
     }
     if (!m_hooks.resolveAgainstOpenDataset) {

--- a/src/qt/DerivedFieldController.cpp
+++ b/src/qt/DerivedFieldController.cpp
@@ -298,25 +298,29 @@ void DerivedFieldController::refreshDraftDiagnostics()
     // written above it, so what this one resolves to depends on them, and one
     // of them failing is why this one cannot be had either.
     const auto skipped = m_hooks.resolveAgainstOpenDataset(draft);
+    const auto refusal = datasetRefusalFor(draft, *index, skipped);
+    m_dialog->showResolutionWarning(refusal.value_or(QString{}));
+}
+
+std::optional<QString> DerivedFieldController::datasetRefusalFor(
+    const std::vector<DerivedFieldDefinition>& definitions, std::size_t index,
+    const std::vector<DerivedFieldSkip>& skipped) const
+{
     const auto entry = std::find_if(skipped.begin(), skipped.end(),
         [index](const DerivedFieldSkip& skip) {
-            return skip.definitionIndex == *index;
+            return skip.definitionIndex == index;
         });
     if (entry == skipped.end()
-        || failureIsInherited(draft, *index, skipped)) {
-        // Inherited failures say nothing here for the same reason apply does
-        // not refuse them: the row above is what this dataset could not
-        // provide, and it is shown greyed out in the field list saying so.
-        m_dialog->showResolutionWarning({});
-        return;
+        || failureIsInherited(definitions, index, skipped)) {
+        return std::nullopt;
     }
-    // An empty reason takes the wording that promises none: a skip decoded
-    // off the wire may carry one, and "...: " with nothing after the colon
-    // tells the user a reason exists while showing it to them blank.
-    m_dialog->showResolutionWarning(entry->reason.empty()
-            ? tr("This dataset cannot provide this field.")
-            : tr("Unavailable in this dataset: %1")
-                  .arg(QString::fromStdString(entry->reason)));
+    // An empty reason takes the wording that promises none: a skip decoded off
+    // the wire may carry one, and "...: " with nothing after the colon tells
+    // the user a reason exists while showing it to them blank.
+    return entry->reason.empty()
+        ? tr("This dataset cannot provide this field.")
+        : tr("Unavailable in this dataset: %1")
+              .arg(QString::fromStdString(entry->reason));
 }
 
 bool DerivedFieldController::failureIsInherited(
@@ -473,19 +477,9 @@ std::optional<DerivedFieldController::Refusal> DerivedFieldController::apply(
         const auto skipped = m_hooks.resolveAgainstOpenDataset(definitions);
         std::sort(mustResolveHere.begin(), mustResolveHere.end());
         for (const auto index : mustResolveHere) {
-            const auto entry = std::find_if(skipped.begin(), skipped.end(),
-                [index](const DerivedFieldSkip& skip) {
-                    return skip.definitionIndex == index;
-                });
-            if (entry == skipped.end()
-                || failureIsInherited(definitions, index, skipped)) {
-                continue;
+            if (auto refusal = datasetRefusalFor(definitions, index, skipped)) {
+                return Refusal{*std::move(refusal), index, true};
             }
-            return Refusal{entry->reason.empty()
-                    ? tr("This dataset cannot provide this field.")
-                    : tr("Unavailable in this dataset: %1")
-                          .arg(QString::fromStdString(entry->reason)),
-                index, true};
         }
     }
 

--- a/src/qt/DerivedFieldController.cpp
+++ b/src/qt/DerivedFieldController.cpp
@@ -302,7 +302,11 @@ void DerivedFieldController::refreshDraftDiagnostics()
         [index](const DerivedFieldSkip& skip) {
             return skip.definitionIndex == *index;
         });
-    if (entry == skipped.end()) {
+    if (entry == skipped.end()
+        || failureIsInherited(draft, *index, skipped)) {
+        // Inherited failures say nothing here for the same reason apply does
+        // not refuse them: the row above is what this dataset could not
+        // provide, and it is shown greyed out in the field list saying so.
         m_dialog->showResolutionWarning({});
         return;
     }
@@ -313,6 +317,37 @@ void DerivedFieldController::refreshDraftDiagnostics()
             ? tr("This dataset cannot provide this field.")
             : tr("Unavailable in this dataset: %1")
                   .arg(QString::fromStdString(entry->reason)));
+}
+
+bool DerivedFieldController::failureIsInherited(
+    const std::vector<DerivedFieldDefinition>& definitions, std::size_t index,
+    const std::vector<DerivedFieldSkip>& skipped)
+{
+    if (index >= definitions.size()) {
+        return false;
+    }
+    std::optional<CompiledExpression> expression;
+    try {
+        expression = CompiledExpression::compile(definitions[index].expression);
+    } catch (const ExpressionError&) {
+        // It does not parse, which is its own fault and reported as such.
+        return false;
+    }
+    for (const auto& symbol : expression->symbols()) {
+        for (std::size_t earlier = 0; earlier < index; ++earlier) {
+            if (definitions[earlier].name != symbol) {
+                continue;
+            }
+            const auto lost = std::find_if(skipped.begin(), skipped.end(),
+                [earlier](const DerivedFieldSkip& skip) {
+                    return skip.definitionIndex == earlier;
+                });
+            if (lost != skipped.end()) {
+                return true;
+            }
+        }
+    }
+    return false;
 }
 
 std::optional<DerivedFieldController::Refusal>
@@ -427,7 +462,8 @@ std::optional<DerivedFieldController::Refusal> DerivedFieldController::apply(
                 [index](const DerivedFieldSkip& skip) {
                     return skip.definitionIndex == index;
                 });
-            if (entry == skipped.end()) {
+            if (entry == skipped.end()
+                || failureIsInherited(definitions, index, skipped)) {
                 continue;
             }
             return Refusal{entry->reason.empty()

--- a/src/qt/DerivedFieldController.cpp
+++ b/src/qt/DerivedFieldController.cpp
@@ -229,7 +229,9 @@ void DerivedFieldController::refreshDraftDiagnostics()
     // leaves a timer running whose answer is about something they never
     // touched -- and the one thing the warning must not do is complain about
     // a definition they merely carried here.
-    if (!index || m_diagnosticsRow != index || !m_dialog->handEdited(*index)) {
+    if (!index || m_diagnosticsRow != index
+        || m_diagnosticsRevision != m_dialog->draftRevision()
+        || !m_dialog->handEdited(*index)) {
         return;
     }
     const auto& draft = m_dialog->draft();
@@ -237,9 +239,19 @@ void DerivedFieldController::refreshDraftDiagnostics()
     // wherever it is installed, so calling it unavailable *in this dataset*
     // would send the user looking for a plotfile that has the field when what
     // they have is a typo.
-    if (const auto fault = definitionFault(draft);
-        fault && fault->definitionIndex == index) {
+    if (const auto fault = definitionFaultAt(draft, *index)) {
         m_dialog->showResolutionWarning(fault->message);
+        return;
+    }
+    // And the faults that belong to the list rather than to a row -- an
+    // expression reading more fields than one evaluation may pin, a chain
+    // deeper than it may recurse -- where they name this one. Safe over a
+    // draft that does not compile: the check answers nullopt for that rather
+    // than throwing, leaving the row's own fault above to have spoken first.
+    if (const auto fault = validateDerivedFieldGraph(draft);
+        fault && fault->definitionIndex == *index) {
+        m_dialog->showResolutionWarning(
+            QString::fromStdString(fault->message));
         return;
     }
     if (!m_hooks.resolveAgainstOpenDataset) {
@@ -265,6 +277,41 @@ void DerivedFieldController::refreshDraftDiagnostics()
             ? tr("This dataset cannot provide this field.")
             : tr("Unavailable in this dataset: %1")
                   .arg(QString::fromStdString(entry->reason)));
+}
+
+std::optional<DerivedFieldController::Refusal>
+DerivedFieldController::definitionFaultAt(
+    const std::vector<DerivedFieldDefinition>& definitions,
+    std::size_t index) const
+{
+    if (index >= definitions.size()) {
+        return std::nullopt;
+    }
+    const auto& definition = definitions[index];
+    if (definition.name.empty()) {
+        return Refusal{tr("A derived field needs a name."), index};
+    }
+    // Against the rows before it only, which is the order installation
+    // resolves in: a name is a duplicate of an earlier one, never of a later.
+    const auto upto = definitions.begin() + static_cast<std::ptrdiff_t>(index);
+    if (std::find_if(definitions.begin(), upto,
+            [&definition](const DerivedFieldDefinition& earlier) {
+                return earlier.name == definition.name;
+            })
+        != upto) {
+        return Refusal{tr("Another derived field is already called \"%1\".")
+                           .arg(QString::fromStdString(definition.name)),
+            index};
+    }
+    if (definition.expression.empty()) {
+        return Refusal{tr("A derived field needs an expression."), index};
+    }
+    try {
+        static_cast<void>(CompiledExpression::compile(definition.expression));
+    } catch (const ExpressionError& error) {
+        return Refusal{QString::fromUtf8(error.what()), index};
+    }
+    return std::nullopt;
 }
 
 // What is wrong with a list whatever the data it is installed against. Asked
@@ -294,30 +341,8 @@ DerivedFieldController::definitionFault(
     // field out. One list is shared by windows showing different data, so only
     // what is wrong whatever the data is can be refused.
     for (std::size_t index = 0; index < definitions.size(); ++index) {
-        const auto& definition = definitions[index];
-        if (definition.name.empty()) {
-            return Refusal{tr("A derived field needs a name."), index};
-        }
-        const auto upto =
-            definitions.begin() + static_cast<std::ptrdiff_t>(index);
-        if (std::find_if(definitions.begin(), upto,
-                [&definition](const DerivedFieldDefinition& earlier) {
-                    return earlier.name == definition.name;
-                })
-            != upto) {
-            return Refusal{
-                tr("Another derived field is already called \"%1\".")
-                    .arg(QString::fromStdString(definition.name)),
-                index};
-        }
-        if (definition.expression.empty()) {
-            return Refusal{tr("A derived field needs an expression."), index};
-        }
-        try {
-            static_cast<void>(
-                CompiledExpression::compile(definition.expression));
-        } catch (const ExpressionError& error) {
-            return Refusal{QString::fromUtf8(error.what()), index};
+        if (auto fault = definitionFaultAt(definitions, index)) {
+            return fault;
         }
     }
 
@@ -420,6 +445,8 @@ void DerivedFieldController::showEditor(QWidget* parent)
         [this] {
             m_diagnosticsRow = m_dialog ? m_dialog->selectedIndex()
                                         : std::nullopt;
+            m_diagnosticsRevision =
+                m_dialog ? m_dialog->draftRevision() : 0;
             m_diagnostics->start();
         });
     connect(dialog, &QObject::destroyed, this, [this] {

--- a/src/qt/DerivedFieldController.cpp
+++ b/src/qt/DerivedFieldController.cpp
@@ -248,10 +248,14 @@ void DerivedFieldController::refreshDraftDiagnostics()
     // deeper than it may recurse -- where they name this one. Safe over a
     // draft that does not compile: the check answers nullopt for that rather
     // than throwing, leaving the row's own fault above to have spoken first.
-    if (const auto fault = validateDerivedFieldGraph(draft);
-        fault && fault->definitionIndex == *index) {
-        m_dialog->showResolutionWarning(
-            QString::fromStdString(fault->message));
+    if (const auto fault = validateDerivedFieldGraph(draft)) {
+        // Only the first fault is reported, so one naming another row leaves
+        // this one's standing unknown -- and whatever the dataset would then
+        // say about it follows from that other fault rather than from the
+        // data. Nothing is the honest answer; Apply names the real one.
+        m_dialog->showResolutionWarning(fault->definitionIndex == *index
+                ? QString::fromStdString(fault->message)
+                : QString{});
         return;
     }
     if (!m_hooks.resolveAgainstOpenDataset) {
@@ -454,6 +458,14 @@ void DerivedFieldController::showEditor(QWidget* parent)
     });
     connect(dialog, &ExpressionEditorDialog::applyRequested, dialog,
         [this, dialog] {
+            // Whatever the debounce was about, Apply has overtaken it: left
+            // armed, a refusal within the 250 ms would be joined a moment
+            // later by the advisory it just replaced, in amber beside the red.
+            // A commit clears it by moving the draft on; a refusal moves
+            // nothing, so it is stopped here for both.
+            if (m_diagnostics != nullptr) {
+                m_diagnostics->stop();
+            }
             // The rows the user has typed into, which are the ones Apply
             // holds to this dataset.
             std::vector<std::size_t> handEdited;

--- a/src/qt/DerivedFieldController.cpp
+++ b/src/qt/DerivedFieldController.cpp
@@ -206,17 +206,29 @@ void DerivedFieldController::refreshAvailability()
         // the reload an Apply of its own started -- so what follows must cost
         // nothing when the dataset's vocabulary has not moved. Which it has
         // not, for either of those.
+        // The reason rides along with the shape. Every unavailable state
+        // renders the same empty shape -- no dataset, a FAB, a peer too old --
+        // so without it a refusal naming one of them survives the arrival of
+        // another, and the editor reports that derived fields need an open
+        // dataset while one is open.
         const auto moved = m_dialog->setStoredFields(
             m_hooks.storedFieldNames ? m_hooks.storedFieldNames()
                                      : QStringList{},
-            m_hooks.datasetGeometry ? m_hooks.datasetGeometry() : QString{});
+            reason + QLatin1Char('\n')
+                + (m_hooks.datasetShape ? m_hooks.datasetShape() : QString{}));
         if (moved) {
             // Everything standing described a vocabulary that has gone: the
             // advisory, and the refusal whose "Apply anyway" would otherwise
             // offer to overrule a verdict computed against data that is not
             // open any more.
             m_dialog->showResolutionWarning({});
-            m_dialog->clearRefusal();
+            // Only a verdict about the data. A fault in the definition itself
+            // is still true whatever is open, and nothing would say it again:
+            // the advisory speaks only about the selected row, and says
+            // nothing at all about one still being written -- so wiping "a
+            // derived field needs a name" leaves a clean-looking editor whose
+            // Apply still refuses.
+            m_dialog->clearDataRefusal();
             // And the answer is owed again. Re-armed rather than left to the
             // next keystroke, because a File > Open passes through a moment
             // with no dataset at all: a diagnostic armed before it would fire
@@ -520,7 +532,7 @@ void DerivedFieldController::showEditor(QWidget* parent)
     dialog->setAttribute(Qt::WA_DeleteOnClose);
     dialog->setStoredFields(
         m_hooks.storedFieldNames ? m_hooks.storedFieldNames() : QStringList{},
-        m_hooks.datasetGeometry ? m_hooks.datasetGeometry() : QString{});
+        m_hooks.datasetShape ? m_hooks.datasetShape() : QString{});
     // Owned by the dialog, so it goes when the dialog does and cannot fire
     // into a m_dialog that has been destroyed. Single-shot and restarted by
     // each edit: what the user wants is the verdict on what they have

--- a/src/qt/DerivedFieldController.cpp
+++ b/src/qt/DerivedFieldController.cpp
@@ -212,6 +212,10 @@ void DerivedFieldController::refreshAvailability()
         // those out, and repeating it here would read as a correction being
         // demanded. Only what is being typed is measured against the data.
         m_dialog->showResolutionWarning({});
+        // And the refusal, which named the dataset that has just been
+        // replaced -- with an offer to overrule a verdict computed against
+        // data that is gone, where a plain Apply might now succeed.
+        m_dialog->clearRefusal();
         if (m_diagnostics) {
             m_diagnostics->stop();
         }
@@ -255,7 +259,7 @@ void DerivedFieldController::refreshDraftDiagnostics()
     // would send the user looking for a plotfile that has the field when what
     // they have is a typo.
     if (const auto fault = definitionFaultAt(draft, *index)) {
-        m_dialog->showResolutionWarning(fault->message);
+        m_dialog->showResolutionWarning(fault->message, true);
         return;
     }
     // A row *above* this one that cannot be installed makes any verdict below
@@ -282,7 +286,8 @@ void DerivedFieldController::refreshDraftDiagnostics()
     if (const auto fault = validateDerivedFieldGraph(upto)) {
         m_dialog->showResolutionWarning(fault->definitionIndex == *index
                 ? QString::fromStdString(fault->message)
-                : QString{});
+                : QString{},
+            true);
         return;
     }
     if (!m_hooks.resolveAgainstOpenDataset) {

--- a/src/qt/DerivedFieldController.cpp
+++ b/src/qt/DerivedFieldController.cpp
@@ -230,8 +230,15 @@ void DerivedFieldController::refreshDraftDiagnostics()
     // touched -- and the one thing the warning must not do is complain about
     // a definition they merely carried here.
     if (!index || m_diagnosticsRow != index
-        || m_diagnosticsRevision != m_dialog->draftRevision()
-        || !m_dialog->handEdited(*index)) {
+        || m_diagnosticsRevision != m_dialog->draftRevision()) {
+        // Stale: it belongs to a moment that has passed, and whatever is on
+        // screen now was put there by that moment's own answer.
+        return;
+    }
+    if (!m_dialog->handEdited(*index)) {
+        // Put back the way it arrived while this was in flight. There is no
+        // claim left to answer, so the answer to the old one goes too.
+        m_dialog->showResolutionWarning({});
         return;
     }
     const auto& draft = m_dialog->draft();
@@ -261,11 +268,6 @@ void DerivedFieldController::refreshDraftDiagnostics()
             return;
         }
     }
-    // And the faults that belong to the list rather than to a row -- an
-    // expression reading more fields than one evaluation may pin, a chain
-    // deeper than it may recurse -- where they name this one. Safe over a
-    // draft that does not compile: the check answers nullopt for that rather
-    // than throwing, leaving the row's own fault above to have spoken first.
     // The faults that belong to the list rather than to a row -- an expression
     // reading more fields than one evaluation may pin, a chain deeper than it
     // may recurse -- asked of the rows up to and including this one. Of the
@@ -364,7 +366,6 @@ DerivedFieldController::definitionFault(
             std::nullopt};
     }
 
-
     // Checked without reference to any dataset: whether a definition applies
     // *here* is decided when a dataset installs it, and shown by greying the
     // field out. One list is shared by windows showing different data, so only
@@ -428,7 +429,7 @@ std::optional<DerivedFieldController::Refusal> DerivedFieldController::apply(
                     ? tr("This dataset cannot provide this field.")
                     : tr("Unavailable in this dataset: %1")
                           .arg(QString::fromStdString(entry->reason)),
-                index};
+                index, true};
         }
     }
 
@@ -481,44 +482,48 @@ void DerivedFieldController::showEditor(QWidget* parent)
     connect(dialog, &QObject::destroyed, this, [this] {
         m_diagnostics = nullptr;
     });
-    connect(dialog, &ExpressionEditorDialog::applyRequested, dialog,
-        [this, dialog] {
-            // Whatever the debounce was about, Apply has overtaken it: left
-            // armed, a refusal within the 250 ms would be joined a moment
-            // later by the advisory it just replaced, in amber beside the red.
-            // A commit clears it by moving the draft on; a refusal moves
-            // nothing, so it is stopped here for both.
-            if (m_diagnostics != nullptr) {
-                m_diagnostics->stop();
-            }
-            // The rows the user has typed into, which are the ones Apply
-            // holds to this dataset.
-            std::vector<std::size_t> handEdited;
+    // One path for both buttons: Apply holds what the user wrote to the open
+    // dataset, "Apply anyway" commits the same draft without that. Everything
+    // after the check is identical, and it is the part that must not drift.
+    const auto commit = [this, dialog](bool holdToDataset) {
+        // Whatever the debounce was about, this has overtaken it: left armed,
+        // a refusal within the 250 ms would be joined a moment later by the
+        // advisory it just replaced, in amber beside the red. A commit clears
+        // it by moving the draft on; a refusal moves nothing, so it is
+        // stopped here for both.
+        if (m_diagnostics != nullptr) {
+            m_diagnostics->stop();
+        }
+        // The rows the user has written, which are the ones Apply holds to
+        // this dataset. Empty when they have chosen to commit regardless.
+        std::vector<std::size_t> written;
+        if (holdToDataset) {
             for (std::size_t index = 0; index < dialog->draft().size();
                 ++index) {
                 if (dialog->handEdited(index)) {
-                    handEdited.push_back(index);
+                    written.push_back(index);
                 }
             }
-            const auto refusal =
-                apply(dialog->draft(), std::move(handEdited));
-            if (refusal) {
-                dialog->showError(
-                    refusal->message, refusal->definitionIndex);
-                return;
-            }
-            // The draft is now the committed list, which is what later
-            // edits are measured against -- and what a change arriving from
-            // another window may replace without asking. Same content, so
-            // nothing on screen moves but the row the user was editing, which
-            // is kept.
-            dialog->setCommitted(
-                m_store.definitions(), dialog->selectedIndex());
-            // Not a status message: apply() has already started the reload,
-            // and showSlice clears the status bar when its slices land. The
-            // editor is in front of the user anyway, so it says so itself.
-            dialog->showApplied(m_store.definitions().size());
-        });
+        }
+        if (const auto refusal = apply(dialog->draft(), std::move(written))) {
+            dialog->showError(refusal->message, refusal->definitionIndex,
+                refusal->confirmable);
+            return;
+        }
+        // The draft is now the committed list, which is what later edits are
+        // measured against -- and what a change arriving from another window
+        // may replace without asking. Same content, so nothing on screen moves
+        // but the row the user was editing, which is kept.
+        dialog->setCommitted(m_store.definitions(), dialog->selectedIndex());
+        // Not a status message: apply() has already started the reload, and
+        // showSlice clears the status bar when its slices land. The editor is
+        // in front of the user anyway, so it says so itself.
+        dialog->showApplied(m_store.definitions().size());
+    };
+    connect(dialog, &ExpressionEditorDialog::applyRequested, dialog,
+        [commit] { commit(true); });
+    connect(dialog, &ExpressionEditorDialog::applyAnywayRequested, dialog,
+        [commit] { commit(false); });
     connect(dialog, &ExpressionEditorDialog::importRequested, dialog,
         [this, dialog] {
             if (!m_hooks.chooseFile) {

--- a/src/qt/DerivedFieldController.cpp
+++ b/src/qt/DerivedFieldController.cpp
@@ -13,6 +13,7 @@
 #include <QJsonValue>
 #include <QPointer>
 #include <QSaveFile>
+#include <QTimer>
 #include <QWidget>
 
 #include <algorithm>
@@ -199,6 +200,53 @@ void DerivedFieldController::refreshAvailability()
     // ordinary File > Open, which resets the dataset for the whole of the
     // load. Apply refuses meanwhile, saying why, and starts working again by
     // itself when a dataset it can install into arrives.
+    if (m_dialog) {
+        // The fields on offer are this dataset's, so they follow it.
+        m_dialog->setStoredFields(
+            m_hooks.storedFieldNames ? m_hooks.storedFieldNames()
+                                     : QStringList{});
+        // The warning is dropped rather than recomputed against the new
+        // dataset. A session may open a plotfile of an entirely different
+        // shape, which makes definitions written for the last one
+        // unresolvable through no fault of the user's; the field list greys
+        // those out, and repeating it here would read as a correction being
+        // demanded. Only what is being typed is measured against the data.
+        m_dialog->showResolutionWarning({});
+        if (m_diagnostics) {
+            m_diagnostics->stop();
+        }
+    }
+}
+
+void DerivedFieldController::refreshDraftDiagnostics()
+{
+    if (!m_dialog || !m_hooks.resolveAgainstOpenDataset) {
+        return;
+    }
+    const auto index = m_dialog->selectedIndex();
+    if (!index) {
+        m_dialog->showResolutionWarning({});
+        return;
+    }
+    // The whole draft, not the one definition: a definition may read the ones
+    // written above it, so what this one resolves to depends on them, and one
+    // of them failing is why this one cannot be had either.
+    const auto skipped = m_hooks.resolveAgainstOpenDataset(m_dialog->draft());
+    const auto entry = std::find_if(skipped.begin(), skipped.end(),
+        [index](const DerivedFieldSkip& skip) {
+            return skip.definitionIndex == *index;
+        });
+    if (entry == skipped.end()) {
+        m_dialog->showResolutionWarning({});
+        return;
+    }
+    // Named as what it is: this dataset cannot provide the field, which is not
+    // the same as the definition being wrong. The wording says which, so a
+    // user who meant it for other data knows nothing needs fixing.
+    // Worded as the field list words it, so the same fact reads the same in
+    // both places.
+    m_dialog->showResolutionWarning(tr("Unavailable in this dataset: %1")
+            .arg(QString::fromStdString(entry->reason)));
 }
 
 std::optional<DerivedFieldController::Refusal> DerivedFieldController::apply(
@@ -296,6 +344,24 @@ void DerivedFieldController::showEditor(QWidget* parent)
     auto* dialog =
         new ExpressionEditorDialog(m_store.definitions(), parent);
     dialog->setAttribute(Qt::WA_DeleteOnClose);
+    dialog->setStoredFields(
+        m_hooks.storedFieldNames ? m_hooks.storedFieldNames() : QStringList{});
+    // Owned by the dialog, so it goes when the dialog does and cannot fire
+    // into a m_dialog that has been destroyed. Single-shot and restarted by
+    // each edit: what the user wants is the verdict on what they have
+    // finished typing, not one per keystroke.
+    if (m_diagnostics == nullptr) {
+        m_diagnostics = new QTimer(dialog);
+        m_diagnostics->setSingleShot(true);
+        m_diagnostics->setInterval(250);
+        connect(m_diagnostics, &QTimer::timeout, this,
+            [this] { refreshDraftDiagnostics(); });
+    }
+    connect(dialog, &ExpressionEditorDialog::draftEdited, dialog,
+        [this] { m_diagnostics->start(); });
+    connect(dialog, &QObject::destroyed, this, [this] {
+        m_diagnostics = nullptr;
+    });
     connect(dialog, &ExpressionEditorDialog::applyRequested, dialog,
         [this, dialog] {
             const auto refusal = apply(dialog->draft());

--- a/src/qt/DerivedFieldController.cpp
+++ b/src/qt/DerivedFieldController.cpp
@@ -220,18 +220,36 @@ void DerivedFieldController::refreshAvailability()
 
 void DerivedFieldController::refreshDraftDiagnostics()
 {
-    if (!m_dialog || !m_hooks.resolveAgainstOpenDataset) {
+    if (!m_dialog) {
         return;
     }
     const auto index = m_dialog->selectedIndex();
-    if (!index) {
+    // Only the row this was armed for, and only while it is still the user's
+    // own writing. A selection that moved on, or a draft an import replaced,
+    // leaves a timer running whose answer is about something they never
+    // touched -- and the one thing the warning must not do is complain about
+    // a definition they merely carried here.
+    if (!index || m_diagnosticsRow != index || !m_dialog->handEdited(*index)) {
+        return;
+    }
+    const auto& draft = m_dialog->draft();
+    // A fault in the definition first, and in its own words. It is wrong
+    // wherever it is installed, so calling it unavailable *in this dataset*
+    // would send the user looking for a plotfile that has the field when what
+    // they have is a typo.
+    if (const auto fault = definitionFault(draft);
+        fault && fault->definitionIndex == index) {
+        m_dialog->showResolutionWarning(fault->message);
+        return;
+    }
+    if (!m_hooks.resolveAgainstOpenDataset) {
         m_dialog->showResolutionWarning({});
         return;
     }
     // The whole draft, not the one definition: a definition may read the ones
     // written above it, so what this one resolves to depends on them, and one
     // of them failing is why this one cannot be had either.
-    const auto skipped = m_hooks.resolveAgainstOpenDataset(m_dialog->draft());
+    const auto skipped = m_hooks.resolveAgainstOpenDataset(draft);
     const auto entry = std::find_if(skipped.begin(), skipped.end(),
         [index](const DerivedFieldSkip& skip) {
             return skip.definitionIndex == *index;
@@ -240,30 +258,24 @@ void DerivedFieldController::refreshDraftDiagnostics()
         m_dialog->showResolutionWarning({});
         return;
     }
-    // Named as what it is: this dataset cannot provide the field, which is not
-    // the same as the definition being wrong. The wording says which, so a
-    // user who meant it for other data knows nothing needs fixing.
-    // Worded as the field list words it, so the same fact reads the same in
-    // both places.
-    m_dialog->showResolutionWarning(tr("Unavailable in this dataset: %1")
-            .arg(QString::fromStdString(entry->reason)));
+    // An empty reason takes the wording that promises none: a skip decoded
+    // off the wire may carry one, and "...: " with nothing after the colon
+    // tells the user a reason exists while showing it to them blank.
+    m_dialog->showResolutionWarning(entry->reason.empty()
+            ? tr("This dataset cannot provide this field.")
+            : tr("Unavailable in this dataset: %1")
+                  .arg(QString::fromStdString(entry->reason)));
 }
 
-std::optional<DerivedFieldController::Refusal> DerivedFieldController::apply(
-    std::vector<DerivedFieldDefinition> definitions)
+// What is wrong with a list whatever the data it is installed against. Asked
+// by apply before it commits, and by the live diagnostics to tell a fault in
+// the definition from a field this dataset happens not to have -- the two read
+// alike in a DerivedFieldSkip's reason, and only the first is the user's to
+// fix wherever they are.
+std::optional<DerivedFieldController::Refusal>
+DerivedFieldController::definitionFault(
+    const std::vector<DerivedFieldDefinition>& definitions) const
 {
-    // The same question the action's enablement asks, not a weaker one: the
-    // editor is modeless, so the window can enter a state it is disabled for
-    // (a FAB drill-down) while it is still open in front of the user.
-    if (const auto reason = m_hooks.unavailableReason
-            ? m_hooks.unavailableReason()
-            : tr("Derived fields need a dataset.");
-        !reason.isEmpty()) {
-        // The same words the greyed action carries, so the editor and the menu
-        // give one answer rather than two.
-        return Refusal{reason, std::nullopt};
-    }
-
     // Bounded here as well as at installation, because this is where an
     // imported file's length is first seen: past the cap every dataset would
     // install the first 256 and skip the rest, so each window would list
@@ -319,6 +331,53 @@ std::optional<DerivedFieldController::Refusal> DerivedFieldController::apply(
             fault->definitionIndex};
     }
 
+    return std::nullopt;
+}
+
+std::optional<DerivedFieldController::Refusal> DerivedFieldController::apply(
+    std::vector<DerivedFieldDefinition> definitions,
+    std::vector<std::size_t> mustResolveHere)
+{
+    // The same question the action's enablement asks, not a weaker one: the
+    // editor is modeless, so the window can enter a state it is disabled for
+    // (a FAB drill-down) while it is still open in front of the user.
+    if (const auto reason = m_hooks.unavailableReason
+            ? m_hooks.unavailableReason()
+            : tr("Derived fields need a dataset.");
+        !reason.isEmpty()) {
+        // The same words the greyed action carries, so the editor and the menu
+        // give one answer rather than two.
+        return Refusal{reason, std::nullopt};
+    }
+
+    if (const auto fault = definitionFault(definitions)) {
+        return *fault;
+    }
+
+    // What the user has written must work on the data in front of them. Only
+    // what they wrote: the rest of the list may be theirs from another
+    // plotfile or somebody else's from a file, and neither is a claim about
+    // this dataset -- those install where they can and grey out where they
+    // cannot, which is what makes one list usable across plotfiles at all.
+    if (!mustResolveHere.empty() && m_hooks.resolveAgainstOpenDataset) {
+        const auto skipped = m_hooks.resolveAgainstOpenDataset(definitions);
+        std::sort(mustResolveHere.begin(), mustResolveHere.end());
+        for (const auto index : mustResolveHere) {
+            const auto entry = std::find_if(skipped.begin(), skipped.end(),
+                [index](const DerivedFieldSkip& skip) {
+                    return skip.definitionIndex == index;
+                });
+            if (entry == skipped.end()) {
+                continue;
+            }
+            return Refusal{entry->reason.empty()
+                    ? tr("This dataset cannot provide this field.")
+                    : tr("Unavailable in this dataset: %1")
+                          .arg(QString::fromStdString(entry->reason)),
+                index};
+        }
+    }
+
     // set() is what reloads -- here and in every other window -- and does
     // nothing at all when the list has not moved. That last part is deliberate
     // and tested ("an unchanged list reloaded a window"), so a list that has
@@ -358,13 +417,27 @@ void DerivedFieldController::showEditor(QWidget* parent)
             [this] { refreshDraftDiagnostics(); });
     }
     connect(dialog, &ExpressionEditorDialog::draftEdited, dialog,
-        [this] { m_diagnostics->start(); });
+        [this] {
+            m_diagnosticsRow = m_dialog ? m_dialog->selectedIndex()
+                                        : std::nullopt;
+            m_diagnostics->start();
+        });
     connect(dialog, &QObject::destroyed, this, [this] {
         m_diagnostics = nullptr;
     });
     connect(dialog, &ExpressionEditorDialog::applyRequested, dialog,
         [this, dialog] {
-            const auto refusal = apply(dialog->draft());
+            // The rows the user has typed into, which are the ones Apply
+            // holds to this dataset.
+            std::vector<std::size_t> handEdited;
+            for (std::size_t index = 0; index < dialog->draft().size();
+                ++index) {
+                if (dialog->handEdited(index)) {
+                    handEdited.push_back(index);
+                }
+            }
+            const auto refusal =
+                apply(dialog->draft(), std::move(handEdited));
             if (refusal) {
                 dialog->showError(
                     refusal->message, refusal->definitionIndex);

--- a/src/qt/DerivedFieldController.cpp
+++ b/src/qt/DerivedFieldController.cpp
@@ -202,23 +202,31 @@ void DerivedFieldController::refreshAvailability()
     // load. Apply refuses meanwhile, saying why, and starts working again by
     // itself when a dataset it can install into arrives.
     if (m_dialog) {
-        // The fields on offer are this dataset's, so they follow it.
-        m_dialog->setStoredFields(
+        // Asked on every installed session -- every frame of a sequence, and
+        // the reload an Apply of its own started -- so what follows must cost
+        // nothing when the dataset's vocabulary has not moved. Which it has
+        // not, for either of those.
+        const auto moved = m_dialog->setStoredFields(
             m_hooks.storedFieldNames ? m_hooks.storedFieldNames()
-                                     : QStringList{});
-        // The warning is dropped rather than recomputed against the new
-        // dataset. A session may open a plotfile of an entirely different
-        // shape, which makes definitions written for the last one
-        // unresolvable through no fault of the user's; the field list greys
-        // those out, and repeating it here would read as a correction being
-        // demanded. Only what is being typed is measured against the data.
-        m_dialog->showResolutionWarning({});
-        // And the refusal, which named the dataset that has just been
-        // replaced -- with an offer to overrule a verdict computed against
-        // data that is gone, where a plain Apply might now succeed.
-        m_dialog->clearRefusal();
-        if (m_diagnostics) {
-            m_diagnostics->stop();
+                                     : QStringList{},
+            m_hooks.datasetGeometry ? m_hooks.datasetGeometry() : QString{});
+        if (moved) {
+            // Everything standing described a vocabulary that has gone: the
+            // advisory, and the refusal whose "Apply anyway" would otherwise
+            // offer to overrule a verdict computed against data that is not
+            // open any more.
+            m_dialog->showResolutionWarning({});
+            m_dialog->clearRefusal();
+            // And the answer is owed again. Re-armed rather than left to the
+            // next keystroke, because a File > Open passes through a moment
+            // with no dataset at all: a diagnostic armed before it would fire
+            // during that gap, resolve against nothing, and take itself down,
+            // leaving a row the user wrote with nothing said about it.
+            if (m_diagnostics != nullptr) {
+                m_diagnosticsRow = m_dialog->selectedIndex();
+                m_diagnosticsRevision = m_dialog->draftRevision();
+                m_diagnostics->start();
+            }
         }
     }
 }
@@ -511,7 +519,8 @@ void DerivedFieldController::showEditor(QWidget* parent)
         new ExpressionEditorDialog(m_store.definitions(), parent);
     dialog->setAttribute(Qt::WA_DeleteOnClose);
     dialog->setStoredFields(
-        m_hooks.storedFieldNames ? m_hooks.storedFieldNames() : QStringList{});
+        m_hooks.storedFieldNames ? m_hooks.storedFieldNames() : QStringList{},
+        m_hooks.datasetGeometry ? m_hooks.datasetGeometry() : QString{});
     // Owned by the dialog, so it goes when the dialog does and cannot fire
     // into a m_dialog that has been destroyed. Single-shot and restarted by
     // each edit: what the user wants is the verdict on what they have

--- a/src/qt/DerivedFieldController.hpp
+++ b/src/qt/DerivedFieldController.hpp
@@ -97,6 +97,11 @@ public:
         // for the editor to list beside the expression being written. Empty
         // with no dataset open.
         std::function<QStringList()> storedFieldNames;
+        // The rest of what decides whether an expression resolves, besides
+        // the field names: the dimension, and whether there is physical
+        // geometry for x, y and z to mean anything. Any short rendering will
+        // do -- it is only ever compared with itself.
+        std::function<QString()> datasetGeometry;
         // Resolves `definitions` against the open dataset the way opening it
         // would (DerivedFieldPolicy::Skip) and answers with what could not be
         // installed and why. The host does it because only it holds the

--- a/src/qt/DerivedFieldController.hpp
+++ b/src/qt/DerivedFieldController.hpp
@@ -97,11 +97,14 @@ public:
         // for the editor to list beside the expression being written. Empty
         // with no dataset open.
         std::function<QStringList()> storedFieldNames;
-        // The rest of what decides whether an expression resolves, besides
-        // the field names: the dimension, and whether there is physical
-        // geometry for x, y and z to mean anything. Any short rendering will
-        // do -- it is only ever compared with itself.
-        std::function<QString()> datasetGeometry;
+        // The rest of what decides whether an expression resolves, besides the
+        // field names: the dimension and whether there is physical geometry
+        // (so x, y and z mean something), and each stored field's centering,
+        // since an expression may not mix centerings. Any short rendering will
+        // do -- it is only ever compared with itself. Everything installation
+        // consults has to be in here, or the editor keeps saying things about
+        // a dataset that has been replaced.
+        std::function<QString()> datasetShape;
         // Resolves `definitions` against the open dataset the way opening it
         // would (DerivedFieldPolicy::Skip) and answers with what could not be
         // installed and why. The host does it because only it holds the

--- a/src/qt/DerivedFieldController.hpp
+++ b/src/qt/DerivedFieldController.hpp
@@ -156,6 +156,12 @@ public:
         // plotfile they are about to open is worth committing. Everything
         // else is wrong wherever it is installed and is not offered.
         bool confirmable = false;
+        // Whether it stops being true when another dataset opens -- which is
+        // not the same question. A refusal that derived fields need an open
+        // dataset, or are not available for a FAB, is about the data and must
+        // not outlive it, but there is nothing to overrule: no expression
+        // could have been written that this one would take.
+        bool dependsOnDataset = false;
     };
 
     // Checks the list and, if it holds, commits it to the store -- from which
@@ -199,6 +205,13 @@ private:
     // by m_diagnostics: it answers a keystroke, and resolving a list costs
     // time in its own length squared.
     void refreshDraftDiagnostics();
+    // What the editor compares to know whether anything it has said could
+    // have stopped being true: why derived fields are unavailable, if they
+    // are, and the shape of the dataset otherwise. Composed in one place
+    // because the editor opening and a session installing have to agree --
+    // two spellings of it made the first refresh after opening look like a
+    // change of dataset.
+    [[nodiscard]] QString datasetKey(const QString& reason) const;
     // What is wrong with a list whatever the data, which is what apply may
     // refuse outright and what the live warning must not blame a dataset for.
     [[nodiscard]] std::optional<Refusal> definitionFault(

--- a/src/qt/DerivedFieldController.hpp
+++ b/src/qt/DerivedFieldController.hpp
@@ -154,8 +154,18 @@ public:
     // business -- one list is shared by windows showing different data, so a
     // definition simply does not apply in some of them, and is shown greyed
     // out there rather than refused everywhere.
+    //
+    // `mustResolveHere` names the definitions the caller vouches for as the
+    // user's own writing -- what the editor has been typed into. Those are
+    // additionally required to resolve against the open dataset, because
+    // writing one is a claim that it works on the data in front of you.
+    // Everything else is committed whether this dataset can provide it or
+    // not: a list carried from another plotfile, or imported whole, is not
+    // that claim, and greying it out in the field list is the whole of what
+    // should happen to it.
     [[nodiscard]] std::optional<Refusal> apply(
-        std::vector<DerivedFieldDefinition> definitions);
+        std::vector<DerivedFieldDefinition> definitions,
+        std::vector<std::size_t> mustResolveHere = {});
 
     // Opens the editor (or raises it if it is already open) on the committed
     // list. Modeless: the reload an Apply triggers is an ordinary dataset load,
@@ -174,12 +184,21 @@ private:
     // by m_diagnostics: it answers a keystroke, and resolving a list costs
     // time in its own length squared.
     void refreshDraftDiagnostics();
+    // What is wrong with a list whatever the data, which is what apply may
+    // refuse outright and what the live warning must not blame a dataset for.
+    [[nodiscard]] std::optional<Refusal> definitionFault(
+        const std::vector<DerivedFieldDefinition>& definitions) const;
 
     Hooks m_hooks;
     DerivedFieldStore& m_store;
     QPointer<QAction> m_action;
     QPointer<ExpressionEditorDialog> m_dialog;
     QTimer* m_diagnostics = nullptr;
+    // The row the pending diagnostic was armed for. A timer that outlives the
+    // edit it belongs to -- the selection moved, or an import replaced the
+    // draft -- would otherwise answer about a definition the user never
+    // touched, which is the one thing the warning must never do.
+    std::optional<std::size_t> m_diagnosticsRow;
 };
 
 } // namespace amrvis::qt

--- a/src/qt/DerivedFieldController.hpp
+++ b/src/qt/DerivedFieldController.hpp
@@ -212,6 +212,16 @@ private:
     // its own and is the user's to answer for. Guessing from the symbol list
     // cannot tell the two apart -- a row naming both a lost definition and a
     // field that was never there reads as inherited and commits unchecked.
+    // Why this dataset cannot provide `definitions[index]`, or nothing where it
+    // can -- or where the failure belongs to a row above it, which
+    // failureIsInherited answers. One place because the advisory and the
+    // refusal must carry the same sentence: showError takes the advisory down
+    // on the strength of them matching, and two copies of the wording is how
+    // that quietly stops being true.
+    [[nodiscard]] std::optional<QString> datasetRefusalFor(
+        const std::vector<DerivedFieldDefinition>& definitions,
+        std::size_t index,
+        const std::vector<DerivedFieldSkip>& skipped) const;
     [[nodiscard]] bool failureIsInherited(
         const std::vector<DerivedFieldDefinition>& definitions,
         std::size_t index,

--- a/src/qt/DerivedFieldController.hpp
+++ b/src/qt/DerivedFieldController.hpp
@@ -7,6 +7,7 @@
 #include <QObject>
 #include <QPointer>
 #include <QString>
+#include <QStringList>
 
 #include <cstddef>
 #include <string>
@@ -16,6 +17,7 @@
 
 class QAction;
 class QByteArray;
+class QTimer;
 class QWidget;
 
 namespace amrvis::qt {
@@ -90,6 +92,20 @@ public:
         // A path to import from (forSaving false) or export to (true); empty
         // cancels. The host runs the file dialog, as it does for palettes.
         std::function<QString(QWidget* parent, bool forSaving)> chooseFile;
+        // The names of the fields the open dataset stores, in its own order,
+        // for the editor to list beside the expression being written. Empty
+        // with no dataset open.
+        std::function<QStringList()> storedFieldNames;
+        // Resolves `definitions` against the open dataset the way opening it
+        // would (DerivedFieldPolicy::Skip) and answers with what could not be
+        // installed and why. The host does it because only it holds the
+        // dataset; this is asked again whenever the draft changes, so it must
+        // not be expensive enough to be felt while typing. Empty where every
+        // definition resolves, and where there is no dataset to resolve
+        // against -- the editor has nothing to say about either.
+        std::function<std::vector<DerivedFieldSkip>(
+            const std::vector<DerivedFieldDefinition>&)>
+            resolveAgainstOpenDataset;
     };
 
     // `store` outlives the controller: the session's own, or a test's. Every
@@ -153,11 +169,17 @@ private:
     // Re-reads the store: refreshes an open editor, and asks the host to
     // reload so the change reaches this window's field list too.
     void adoptStoreChange();
+    // Resolves the open editor's draft against the open dataset and tells it
+    // what this dataset cannot make of the definition being typed. Debounced
+    // by m_diagnostics: it answers a keystroke, and resolving a list costs
+    // time in its own length squared.
+    void refreshDraftDiagnostics();
 
     Hooks m_hooks;
     DerivedFieldStore& m_store;
     QPointer<QAction> m_action;
     QPointer<ExpressionEditorDialog> m_dialog;
+    QTimer* m_diagnostics = nullptr;
 };
 
 } // namespace amrvis::qt

--- a/src/qt/DerivedFieldController.hpp
+++ b/src/qt/DerivedFieldController.hpp
@@ -200,6 +200,15 @@ private:
     // wrong question when the caller is asking about the definition someone is
     // typing: a broken row above it would otherwise leave that one's own
     // syntax error to be explained as something the dataset lacks.
+    // Whether this definition failed only because one written above it did:
+    // it reads a name this dataset could not provide a field for, so what it
+    // is missing is that definition's field and not anything in the data.
+    // Holding the user to it would refuse the row they wrote while naming a
+    // field they can see defined one line up, and commit the row that
+    // actually broke it without comment.
+    [[nodiscard]] static bool failureIsInherited(
+        const std::vector<DerivedFieldDefinition>& definitions,
+        std::size_t index, const std::vector<DerivedFieldSkip>& skipped);
     [[nodiscard]] std::optional<Refusal> definitionFaultAt(
         const std::vector<DerivedFieldDefinition>& definitions,
         std::size_t index) const;

--- a/src/qt/DerivedFieldController.hpp
+++ b/src/qt/DerivedFieldController.hpp
@@ -142,6 +142,12 @@ public:
         QString message;
         // The definition the refusal belongs to, when it is about one.
         std::optional<std::size_t> definitionIndex;
+        // Whether the user may overrule it. True only for "this dataset
+        // cannot provide it", which is a fact about the data rather than
+        // about the definition: the list is shared, and one written for the
+        // plotfile they are about to open is worth committing. Everything
+        // else is wrong wherever it is installed and is not offered.
+        bool confirmable = false;
     };
 
     // Checks the list and, if it holds, commits it to the store -- from which

--- a/src/qt/DerivedFieldController.hpp
+++ b/src/qt/DerivedFieldController.hpp
@@ -200,15 +200,22 @@ private:
     // wrong question when the caller is asking about the definition someone is
     // typing: a broken row above it would otherwise leave that one's own
     // syntax error to be explained as something the dataset lacks.
-    // Whether this definition failed only because one written above it did:
-    // it reads a name this dataset could not provide a field for, so what it
-    // is missing is that definition's field and not anything in the data.
-    // Holding the user to it would refuse the row they wrote while naming a
-    // field they can see defined one line up, and commit the row that
+    // Whether this definition failed *only* because one written above it did.
+    // Holding the user to such a row would refuse what they wrote while naming
+    // a field they can see defined one line up, and commit the row that
     // actually broke it without comment.
-    [[nodiscard]] static bool failureIsInherited(
+    //
+    // Asked of the resolver rather than reasoned about here: the rows above
+    // that this dataset could not provide are made trivially resolvable and
+    // the prefix is resolved again. If this row comes back installable, those
+    // rows were the whole of its problem; if it still fails, the failure is
+    // its own and is the user's to answer for. Guessing from the symbol list
+    // cannot tell the two apart -- a row naming both a lost definition and a
+    // field that was never there reads as inherited and commits unchecked.
+    [[nodiscard]] bool failureIsInherited(
         const std::vector<DerivedFieldDefinition>& definitions,
-        std::size_t index, const std::vector<DerivedFieldSkip>& skipped);
+        std::size_t index,
+        const std::vector<DerivedFieldSkip>& skipped) const;
     [[nodiscard]] std::optional<Refusal> definitionFaultAt(
         const std::vector<DerivedFieldDefinition>& definitions,
         std::size_t index) const;

--- a/src/qt/DerivedFieldController.hpp
+++ b/src/qt/DerivedFieldController.hpp
@@ -10,6 +10,7 @@
 #include <QStringList>
 
 #include <cstddef>
+#include <cstdint>
 #include <string>
 #include <functional>
 #include <optional>
@@ -188,17 +189,29 @@ private:
     // refuse outright and what the live warning must not blame a dataset for.
     [[nodiscard]] std::optional<Refusal> definitionFault(
         const std::vector<DerivedFieldDefinition>& definitions) const;
+    // The same, for one row in the context of the rows before it. definitionFault
+    // answers for the list and so reports only its first fault, which is the
+    // wrong question when the caller is asking about the definition someone is
+    // typing: a broken row above it would otherwise leave that one's own
+    // syntax error to be explained as something the dataset lacks.
+    [[nodiscard]] std::optional<Refusal> definitionFaultAt(
+        const std::vector<DerivedFieldDefinition>& definitions,
+        std::size_t index) const;
 
     Hooks m_hooks;
     DerivedFieldStore& m_store;
     QPointer<QAction> m_action;
     QPointer<ExpressionEditorDialog> m_dialog;
     QTimer* m_diagnostics = nullptr;
-    // The row the pending diagnostic was armed for. A timer that outlives the
-    // edit it belongs to -- the selection moved, or an import replaced the
-    // draft -- would otherwise answer about a definition the user never
-    // touched, which is the one thing the warning must never do.
+    // The row the pending diagnostic was armed for, and the draft it was armed
+    // against. A timer that outlives the edit it belongs to -- the selection
+    // moved, an import replaced the draft, a row above was deleted -- would
+    // otherwise answer about a definition the user never touched, which is the
+    // one thing the warning must never do. The revision is what makes the row
+    // number an identity: deleting a row slides its successor into it, and a
+    // successor that had been edited too passes every other guard.
     std::optional<std::size_t> m_diagnosticsRow;
+    std::uint64_t m_diagnosticsRevision = 0;
 };
 
 } // namespace amrvis::qt

--- a/src/qt/ExpressionEditorDialog.cpp
+++ b/src/qt/ExpressionEditorDialog.cpp
@@ -9,6 +9,7 @@
 #include <QPlainTextEdit>
 #include <QPushButton>
 #include <QSignalBlocker>
+#include <QtGlobal>
 #include <QTextCursor>
 #include <QVBoxLayout>
 
@@ -492,8 +493,12 @@ void ExpressionEditorDialog::removeSelected()
     }
     clearError();
     m_draft.erase(m_draft.begin() + static_cast<std::ptrdiff_t>(*index));
-    m_baseline.erase(
-        m_baseline.begin() + static_cast<std::ptrdiff_t>(*index));
+    // In step with the draft, which handEdited asserts and depends on.
+    Q_ASSERT(*index < m_baseline.size());
+    if (*index < m_baseline.size()) {
+        m_baseline.erase(
+            m_baseline.begin() + static_cast<std::ptrdiff_t>(*index));
+    }
     ++m_draftRevision;
     // Deleting the last definition leaves nothing selected, and rebuildList
     // reaches that by writing -1 over a current row the clear() already set
@@ -506,13 +511,23 @@ void ExpressionEditorDialog::removeSelected()
 
 bool ExpressionEditorDialog::handEdited(std::size_t index) const
 {
+    // The baseline moves with the draft at every mutation, which is what makes
+    // this a comparison rather than a flag to be kept in step.
+    Q_ASSERT(m_baseline.size() == m_draft.size());
     if (index >= m_draft.size()) {
         return false;
     }
-    // Computed rather than remembered: there is no flag to fall out of step
-    // with the rows, and putting a definition back the way it arrived takes
-    // the claim back with it.
-    return index >= m_baseline.size() || m_draft[index] != m_baseline[index];
+    // Were they ever to diverge, this would be reading a baseline that
+    // describes some other row -- and the wrong answer in *that* direction is
+    // the one that matters: "not written here" drops the definition from the
+    // ones Apply holds to the open dataset, and commits unchecked what the
+    // user typed. So a divergence answers "written here", which only ever
+    // costs an extra check. The release build has no assertion to catch it,
+    // which is exactly why the fallback errs rather than indexing anyway.
+    if (m_baseline.size() != m_draft.size()) {
+        return true;
+    }
+    return m_draft[index] != m_baseline[index];
 }
 
 std::optional<std::size_t> ExpressionEditorDialog::selectedIndex() const

--- a/src/qt/ExpressionEditorDialog.cpp
+++ b/src/qt/ExpressionEditorDialog.cpp
@@ -206,12 +206,21 @@ ExpressionEditorDialog::ExpressionEditorDialog(
             // straight onto an identifier the two lex as one unknown symbol,
             // which is the same silent corruption as inserting at the front.
             // A space is safe after anything, operators included.
-            const auto before = m_expression->toPlainText().left(
-                m_expression->textCursor().position());
+            const auto text = m_expression->toPlainText();
+            const auto at = m_expression->textCursor().position();
+            const auto before = text.left(at);
+            const auto after = text.mid(at);
+            auto written = asSymbol(item->text());
             if (!before.isEmpty() && !before.back().isSpace()) {
-                m_expression->insertPlainText(QStringLiteral(" "));
+                written.prepend(QLatin1Char(' '));
             }
-            m_expression->insertPlainText(asSymbol(item->text()));
+            // And on the right: dropped into the middle of an identifier the
+            // name would merge with its tail instead of its head, which is the
+            // same silent corruption facing the other way.
+            if (!after.isEmpty() && !after.front().isSpace()) {
+                written.append(QLatin1Char(' '));
+            }
+            m_expression->insertPlainText(written);
             m_expression->setFocus();
         });
     connect(add, &QPushButton::clicked, this, [this] { addDefinition(); });
@@ -227,6 +236,10 @@ ExpressionEditorDialog::ExpressionEditorDialog(
             return;
         }
         m_draft[*index].name = text.trimmed().toStdString();
+        // The refusal was about the draft as it stood; it is not about this
+        // one. Left up it would sit in red beside the advisory this edit is
+        // about to raise, and its offer would commit rows nothing examined.
+        clearError();
         ++m_draftRevision;
         m_list->item(static_cast<int>(*index))
             ->setText(displayName(m_draft[*index]));
@@ -241,6 +254,7 @@ ExpressionEditorDialog::ExpressionEditorDialog(
         }
         m_draft[*index].expression =
             m_expression->toPlainText().trimmed().toStdString();
+        clearError();
         ++m_draftRevision;
         emit draftEdited();
     });
@@ -249,8 +263,16 @@ ExpressionEditorDialog::ExpressionEditorDialog(
         emit applyRequested();
     });
     connect(m_applyAnyway, &QPushButton::clicked, this, [this] {
+        // Only for the draft the refusal was computed against. Every edit
+        // clears the refusal, so this should be unreachable -- it is the
+        // check that makes "should" into "cannot", because what it guards is
+        // committing rows the dataset was never asked about.
+        const auto offered = m_refusalRevision.has_value()
+            && *m_refusalRevision == m_draftRevision;
         clearError();
-        emit applyAnywayRequested();
+        if (offered) {
+            emit applyAnywayRequested();
+        }
     });
     // Explicitly: a QDialogButtonBox parented to a dialog does *not* have its
     // rejected() wired to that dialog's reject() -- probed, not assumed --
@@ -296,8 +318,20 @@ void ExpressionEditorDialog::setStoredFields(const QStringList& names)
     m_fieldsCaption->setVisible(any);
 }
 
-void ExpressionEditorDialog::showResolutionWarning(const QString& message)
+void ExpressionEditorDialog::clearRefusal()
 {
+    clearError();
+}
+
+void ExpressionEditorDialog::showResolutionWarning(
+    const QString& message, bool blocking)
+{
+    // Red for what Apply will refuse, amber for what only this dataset cannot
+    // do. Set with the text rather than once at construction, because the one
+    // label carries both and the colour is the whole of what tells them apart.
+    m_warning->setStyleSheet(blocking
+            ? QStringLiteral("QLabel { color: red; }")
+            : QStringLiteral("QLabel { color: #b8860b; }"));
     m_warning->setText(message);
     m_warning->setVisible(!message.isEmpty());
 }
@@ -312,6 +346,10 @@ void ExpressionEditorDialog::markDraftCommitted()
     // The draft's meaning moved even though its rows did not, and the
     // revision is what an asynchronous reader compares against.
     ++m_draftRevision;
+    // Nothing standing about the old reading survives it: the refusal, its
+    // offer, and the advisory were all about a draft that was the user's.
+    clearError();
+    showResolutionWarning({});
     m_notice->clear();
     m_notice->setVisible(false);
 }
@@ -332,14 +370,18 @@ void ExpressionEditorDialog::setCommitted(
 void ExpressionEditorDialog::showError(const QString& message,
     std::optional<std::size_t> definitionIndex, bool offerAnyway)
 {
-    m_applyAnyway->setVisible(offerAnyway);
-    m_applied->clear();
-    m_applied->setVisible(false);
+    // Before anything is shown: selecting a different row runs the selection
+    // handler, which clears the error box -- so a refusal set up first would
+    // be taken down again on its way in, and the offer with it.
     if (definitionIndex && *definitionIndex < m_draft.size()) {
         m_list->setCurrentRow(static_cast<int>(*definitionIndex));
     }
+    m_applied->clear();
+    m_applied->setVisible(false);
     m_error->setText(message);
     m_error->setVisible(true);
+    m_applyAnyway->setVisible(offerAnyway);
+    m_refusalRevision = m_draftRevision;
     // The refusal supersedes the advisory: they carry the same sentence when
     // Apply refuses what the warning was about, and showing it twice -- once
     // in red, once in amber -- says the advisory did not stop anything at the
@@ -376,6 +418,7 @@ void ExpressionEditorDialog::clearError()
     m_error->clear();
     m_error->setVisible(false);
     m_applyAnyway->setVisible(false);
+    m_refusalRevision.reset();
     m_applied->clear();
     m_applied->setVisible(false);
 }

--- a/src/qt/ExpressionEditorDialog.cpp
+++ b/src/qt/ExpressionEditorDialog.cpp
@@ -307,8 +307,19 @@ void ExpressionEditorDialog::setDraft(
     showResolutionWarning({});
 }
 
-void ExpressionEditorDialog::setStoredFields(const QStringList& names)
+bool ExpressionEditorDialog::setStoredFields(
+    const QStringList& names, const QString& geometry)
 {
+    if (m_storedFieldsSet && names == m_storedFields
+        && geometry == m_storedGeometry) {
+        // Nothing an expression can resolve against has moved, so nothing the
+        // editor has already said about it needs revisiting -- and rebuilding
+        // the list would throw away where the user had scrolled to.
+        return false;
+    }
+    m_storedFields = names;
+    m_storedGeometry = geometry;
+    m_storedFieldsSet = true;
     m_fields->clear();
     m_fields->addItems(names);
     // Hidden rather than shown empty: an empty box beside the expression
@@ -317,6 +328,7 @@ void ExpressionEditorDialog::setStoredFields(const QStringList& names)
     const auto any = !names.isEmpty();
     m_fields->setVisible(any);
     m_fieldsCaption->setVisible(any);
+    return true;
 }
 
 void ExpressionEditorDialog::clearRefusal()

--- a/src/qt/ExpressionEditorDialog.cpp
+++ b/src/qt/ExpressionEditorDialog.cpp
@@ -332,10 +332,15 @@ void ExpressionEditorDialog::showResolutionWarning(
 {
     // Red for what Apply will refuse, amber for what only this dataset cannot
     // do. Set with the text rather than once at construction, because the one
-    // label carries both and the colour is the whole of what tells them apart.
-    m_warning->setStyleSheet(blocking
-            ? QStringLiteral("QLabel { color: red; }")
-            : QStringLiteral("QLabel { color: #b8860b; }"));
+    // label carries both and the colour is the whole of what tells them apart
+    // -- but only when there is text, since setStyleSheet reinstalls the
+    // style and repolishes the widget even for an identical string, and most
+    // calls here only clear the label.
+    if (!message.isEmpty()) {
+        m_warning->setStyleSheet(blocking
+                ? QStringLiteral("QLabel { color: red; }")
+                : QStringLiteral("QLabel { color: #b8860b; }"));
+    }
     m_warning->setText(message);
     m_warning->setVisible(!message.isEmpty());
 }

--- a/src/qt/ExpressionEditorDialog.cpp
+++ b/src/qt/ExpressionEditorDialog.cpp
@@ -320,7 +320,10 @@ void ExpressionEditorDialog::setStoredFields(const QStringList& names)
 
 void ExpressionEditorDialog::clearRefusal()
 {
-    clearError();
+    m_error->clear();
+    m_error->setVisible(false);
+    m_applyAnyway->setVisible(false);
+    m_refusalRevision.reset();
 }
 
 void ExpressionEditorDialog::showResolutionWarning(
@@ -415,10 +418,13 @@ void ExpressionEditorDialog::clearError()
     // definition or pressing Apply all come through here, and any of them
     // taking the warning away would leave a draft that still overwrites the
     // shared list with nothing on screen saying so. setCommitted ends it.
-    m_error->clear();
-    m_error->setVisible(false);
-    m_applyAnyway->setVisible(false);
-    m_refusalRevision.reset();
+    clearRefusal();
+    // And the confirmation, which every caller of this one wants gone: they
+    // are the acts that make "Applied 3 derived fields." describe something
+    // the user has since moved on from. clearRefusal is the narrower door,
+    // for a host taking down a verdict without touching what was applied --
+    // the reload an Apply starts comes back through here, and this label
+    // exists because the status bar could not survive it either.
     m_applied->clear();
     m_applied->setVisible(false);
 }

--- a/src/qt/ExpressionEditorDialog.cpp
+++ b/src/qt/ExpressionEditorDialog.cpp
@@ -49,6 +49,7 @@ ExpressionEditorDialog::ExpressionEditorDialog(
     : QDialog(parent)
     , m_draft(std::move(definitions))
     , m_committed(m_draft)
+    , m_handEdited(m_draft.size(), false)
 {
     setObjectName(QStringLiteral("expressionEditor"));
     setWindowTitle(tr("Expression Editor"));
@@ -204,6 +205,7 @@ ExpressionEditorDialog::ExpressionEditorDialog(
             return;
         }
         m_draft[*index].name = text.trimmed().toStdString();
+        m_handEdited[*index] = true;
         m_list->item(static_cast<int>(*index))
             ->setText(displayName(m_draft[*index]));
         // A rename moves what the definitions after this one can read, so the
@@ -217,6 +219,7 @@ ExpressionEditorDialog::ExpressionEditorDialog(
         }
         m_draft[*index].expression =
             m_expression->toPlainText().trimmed().toStdString();
+        m_handEdited[*index] = true;
         emit draftEdited();
     });
     connect(m_apply, &QPushButton::clicked, this, [this] {
@@ -240,6 +243,9 @@ void ExpressionEditorDialog::setDraft(
     std::optional<std::size_t> select)
 {
     m_draft = std::move(definitions);
+    // None of it is the user's writing: an import is carried, and a commit is
+    // already answered for.
+    m_handEdited.assign(m_draft.size(), false);
     clearError();
     rebuildList(select);
     // Explicitly, rather than leaving it to the row change rebuildList makes:
@@ -271,6 +277,10 @@ void ExpressionEditorDialog::showResolutionWarning(const QString& message)
 void ExpressionEditorDialog::markDraftCommitted()
 {
     m_committed = m_draft;
+    // As setDraft does for the path that replaces the rows: what was the
+    // user's own writing has been answered for, and holding it to this
+    // dataset a second time would refuse a list that is already installed.
+    m_handEdited.assign(m_draft.size(), false);
     m_notice->clear();
     m_notice->setVisible(false);
 }
@@ -374,6 +384,7 @@ void ExpressionEditorDialog::addDefinition()
 {
     clearError();
     m_draft.push_back({});
+    m_handEdited.push_back(false);
     rebuildList(m_draft.size() - 1);
     m_name->setFocus();
 }
@@ -386,8 +397,15 @@ void ExpressionEditorDialog::removeSelected()
     }
     clearError();
     m_draft.erase(m_draft.begin() + static_cast<std::ptrdiff_t>(*index));
+    m_handEdited.erase(
+        m_handEdited.begin() + static_cast<std::ptrdiff_t>(*index));
     rebuildList(*index == 0 ? std::optional<std::size_t>{0}
                             : std::optional<std::size_t>{*index - 1});
+}
+
+bool ExpressionEditorDialog::handEdited(std::size_t index) const
+{
+    return index < m_handEdited.size() && m_handEdited[index];
 }
 
 std::optional<std::size_t> ExpressionEditorDialog::selectedIndex() const

--- a/src/qt/ExpressionEditorDialog.cpp
+++ b/src/qt/ExpressionEditorDialog.cpp
@@ -9,6 +9,7 @@
 #include <QPlainTextEdit>
 #include <QPushButton>
 #include <QSignalBlocker>
+#include <QTextCursor>
 #include <QVBoxLayout>
 
 #include <algorithm>
@@ -205,7 +206,7 @@ ExpressionEditorDialog::ExpressionEditorDialog(
             return;
         }
         m_draft[*index].name = text.trimmed().toStdString();
-        m_handEdited[*index] = true;
+        markEdited(*index);
         ++m_draftRevision;
         m_list->item(static_cast<int>(*index))
             ->setText(displayName(m_draft[*index]));
@@ -220,7 +221,7 @@ ExpressionEditorDialog::ExpressionEditorDialog(
         }
         m_draft[*index].expression =
             m_expression->toPlainText().trimmed().toStdString();
-        m_handEdited[*index] = true;
+        markEdited(*index);
         ++m_draftRevision;
         emit draftEdited();
     });
@@ -378,6 +379,11 @@ void ExpressionEditorDialog::showSelected()
         m_name->setText(QString::fromStdString(m_draft[*index].name));
         m_expression->setPlainText(
             QString::fromStdString(m_draft[*index].expression));
+        // setPlainText parks the cursor at the start of the document, so a
+        // field written in from the list would go *before* what is already
+        // there -- silently, and reading as one unknown symbol. The end is
+        // where someone who just selected a row would carry on.
+        m_expression->moveCursor(QTextCursor::End);
     } else {
         m_name->clear();
         m_expression->clear();
@@ -416,6 +422,16 @@ void ExpressionEditorDialog::removeSelected()
     showResolutionWarning({});
     rebuildList(*index == 0 ? std::optional<std::size_t>{0}
                             : std::optional<std::size_t>{*index - 1});
+}
+
+void ExpressionEditorDialog::markEdited(std::size_t index)
+{
+    // Measured, not latched. A row typed into and then put back the way it was
+    // is not something the user is claiming about this dataset, and a latch
+    // would hold every later Apply to a definition they merely brushed
+    // against -- with nothing inside the editor able to clear it again.
+    m_handEdited[index] = index >= m_committed.size()
+        || m_draft[index] != m_committed[index];
 }
 
 bool ExpressionEditorDialog::handEdited(std::size_t index) const

--- a/src/qt/ExpressionEditorDialog.cpp
+++ b/src/qt/ExpressionEditorDialog.cpp
@@ -24,6 +24,24 @@ QString displayName(const DerivedFieldDefinition& definition)
         : QString::fromStdString(definition.name);
 }
 
+// A field name as an expression writes it: bare when it is a plain
+// identifier, and in ${...} otherwise -- which is the grammar's own escape for
+// a name holding anything else, and the rule the help text states.
+QString asSymbol(const QString& name)
+{
+    const auto plain = !name.isEmpty()
+        && (name.front().isLetter() || name.front() == QLatin1Char('_'))
+        && std::all_of(name.cbegin(), name.cend(), [](QChar character) {
+               return character.isLetterOrNumber()
+                   || character == QLatin1Char('_');
+           });
+    // isLetterOrNumber accepts non-ASCII letters, which the grammar's
+    // identifier rule does not, so anything outside ASCII takes the escape.
+    const auto ascii = std::all_of(name.cbegin(), name.cend(),
+        [](QChar character) { return character.unicode() < 128; });
+    return plain && ascii ? name : QStringLiteral("${%1}").arg(name);
+}
+
 } // namespace
 
 ExpressionEditorDialog::ExpressionEditorDialog(
@@ -91,6 +109,25 @@ ExpressionEditorDialog::ExpressionEditorDialog(
     m_notice->setWordWrap(true);
     m_notice->setVisible(false);
 
+    m_warning = new QLabel(this);
+    m_warning->setObjectName(QStringLiteral("expressionWarning"));
+    m_warning->setWordWrap(true);
+    m_warning->setVisible(false);
+    // Quotes the user's own text, as the error does.
+    m_warning->setTextFormat(Qt::PlainText);
+    // Not the error's red: this one does not stop anything, and colouring the
+    // two alike would say the definition had been refused when it has not.
+    m_warning->setStyleSheet(QStringLiteral("QLabel { color: #b8860b; }"));
+
+    m_fieldsCaption = new QLabel(tr("Fields in this dataset"), this);
+    m_fields = new QListWidget(this);
+    m_fields->setObjectName(QStringLiteral("storedFieldList"));
+    m_fields->setSelectionMode(QAbstractItemView::SingleSelection);
+    m_fields->setMinimumWidth(160);
+    m_fields->setToolTip(
+        tr("The fields this dataset stores. Double-click one to write it into "
+           "the expression."));
+
     auto* buttons = new QDialogButtonBox(this);
     m_apply = buttons->addButton(QDialogButtonBox::Apply);
     m_apply->setObjectName(QStringLiteral("applyExpressionsButton"));
@@ -116,13 +153,19 @@ ExpressionEditorDialog::ExpressionEditorDialog(
     editor->addLayout(form);
     editor->addWidget(help);
     editor->addWidget(m_error);
+    editor->addWidget(m_warning);
     editor->addWidget(m_applied);
     editor->addWidget(m_notice);
     editor->addStretch(1);
 
+    auto* fields = new QVBoxLayout;
+    fields->addWidget(m_fieldsCaption);
+    fields->addWidget(m_fields, 1);
+
     auto* columns = new QHBoxLayout;
     columns->addLayout(sidebar);
     columns->addLayout(editor, 1);
+    columns->addLayout(fields);
     auto* root = new QVBoxLayout(this);
     root->addLayout(columns, 1);
     root->addWidget(buttons);
@@ -130,7 +173,24 @@ ExpressionEditorDialog::ExpressionEditorDialog(
     connect(m_list, &QListWidget::currentRowChanged, this, [this] {
         clearError();
         showSelected();
+        // Cleared, not recomputed. The warning answers "does what you are
+        // writing work here", so it belongs to an edit and not to a row: a
+        // definition written against another plotfile is unresolvable here by
+        // design, and saying so every time the user looks at it would be
+        // nagging about something that is not wrong.
+        showResolutionWarning({});
     });
+    connect(m_fields, &QListWidget::itemDoubleClicked, this,
+        [this](QListWidgetItem* item) {
+            if (item == nullptr || !selectedIndex()) {
+                return;
+            }
+            // Into the expression at the cursor, and leave the focus there:
+            // the point of the list is to save typing a name, not to take the
+            // user out of what they were writing.
+            m_expression->insertPlainText(asSymbol(item->text()));
+            m_expression->setFocus();
+        });
     connect(add, &QPushButton::clicked, this, [this] { addDefinition(); });
     connect(
         m_remove, &QPushButton::clicked, this, [this] { removeSelected(); });
@@ -146,6 +206,9 @@ ExpressionEditorDialog::ExpressionEditorDialog(
         m_draft[*index].name = text.trimmed().toStdString();
         m_list->item(static_cast<int>(*index))
             ->setText(displayName(m_draft[*index]));
+        // A rename moves what the definitions after this one can read, so the
+        // whole draft is re-resolved, not just this row.
+        emit draftEdited();
     });
     connect(m_expression, &QPlainTextEdit::textChanged, this, [this] {
         const auto index = selectedIndex();
@@ -154,6 +217,7 @@ ExpressionEditorDialog::ExpressionEditorDialog(
         }
         m_draft[*index].expression =
             m_expression->toPlainText().trimmed().toStdString();
+        emit draftEdited();
     });
     connect(m_apply, &QPushButton::clicked, this, [this] {
         clearError();
@@ -165,7 +229,10 @@ ExpressionEditorDialog::ExpressionEditorDialog(
     connect(buttons, &QDialogButtonBox::rejected, this, &QDialog::reject);
 
     rebuildList(m_draft.empty() ? std::nullopt : std::optional<std::size_t>{0});
-    resize(720, 420);
+    // Wide enough for the three columns at their minimums (180 + 360 + 160)
+    // plus the layout's own spacing; at 720 the field list arrived squeezing
+    // the expression box rather than sitting beside it.
+    resize(900, 440);
 }
 
 void ExpressionEditorDialog::setDraft(
@@ -175,6 +242,30 @@ void ExpressionEditorDialog::setDraft(
     m_draft = std::move(definitions);
     clearError();
     rebuildList(select);
+    // Explicitly, rather than leaving it to the row change rebuildList makes:
+    // an import that lands on the row already selected changes no row at all.
+    // Cleared and not recomputed -- an imported list is tolerated whole, and
+    // what this dataset cannot provide of it is shown greyed in the field
+    // list rather than complained about here.
+    showResolutionWarning({});
+}
+
+void ExpressionEditorDialog::setStoredFields(const QStringList& names)
+{
+    m_fields->clear();
+    m_fields->addItems(names);
+    // Hidden rather than shown empty: an empty box beside the expression
+    // reads as "this dataset stores no fields", which is not what no open
+    // dataset means.
+    const auto any = !names.isEmpty();
+    m_fields->setVisible(any);
+    m_fieldsCaption->setVisible(any);
+}
+
+void ExpressionEditorDialog::showResolutionWarning(const QString& message)
+{
+    m_warning->setText(message);
+    m_warning->setVisible(!message.isEmpty());
 }
 
 void ExpressionEditorDialog::markDraftCommitted()

--- a/src/qt/ExpressionEditorDialog.cpp
+++ b/src/qt/ExpressionEditorDialog.cpp
@@ -206,6 +206,7 @@ ExpressionEditorDialog::ExpressionEditorDialog(
         }
         m_draft[*index].name = text.trimmed().toStdString();
         m_handEdited[*index] = true;
+        ++m_draftRevision;
         m_list->item(static_cast<int>(*index))
             ->setText(displayName(m_draft[*index]));
         // A rename moves what the definitions after this one can read, so the
@@ -220,6 +221,7 @@ ExpressionEditorDialog::ExpressionEditorDialog(
         m_draft[*index].expression =
             m_expression->toPlainText().trimmed().toStdString();
         m_handEdited[*index] = true;
+        ++m_draftRevision;
         emit draftEdited();
     });
     connect(m_apply, &QPushButton::clicked, this, [this] {
@@ -246,6 +248,7 @@ void ExpressionEditorDialog::setDraft(
     // None of it is the user's writing: an import is carried, and a commit is
     // already answered for.
     m_handEdited.assign(m_draft.size(), false);
+    ++m_draftRevision;
     clearError();
     rebuildList(select);
     // Explicitly, rather than leaving it to the row change rebuildList makes:
@@ -308,6 +311,11 @@ void ExpressionEditorDialog::showError(
     }
     m_error->setText(message);
     m_error->setVisible(true);
+    // The refusal supersedes the advisory: they carry the same sentence when
+    // Apply refuses what the warning was about, and showing it twice -- once
+    // in red, once in amber -- says the advisory did not stop anything at the
+    // moment it did.
+    showResolutionWarning({});
 }
 
 void ExpressionEditorDialog::showApplied(std::size_t count)
@@ -385,6 +393,7 @@ void ExpressionEditorDialog::addDefinition()
     clearError();
     m_draft.push_back({});
     m_handEdited.push_back(false);
+    ++m_draftRevision;
     rebuildList(m_draft.size() - 1);
     m_name->setFocus();
 }
@@ -399,6 +408,12 @@ void ExpressionEditorDialog::removeSelected()
     m_draft.erase(m_draft.begin() + static_cast<std::ptrdiff_t>(*index));
     m_handEdited.erase(
         m_handEdited.begin() + static_cast<std::ptrdiff_t>(*index));
+    ++m_draftRevision;
+    // Deleting the last definition leaves nothing selected, and rebuildList
+    // reaches that by writing -1 over a current row the clear() already set
+    // to -1 -- no row changes, so the selection path that would have taken
+    // the warning down never runs. Said here rather than relied on there.
+    showResolutionWarning({});
     rebuildList(*index == 0 ? std::optional<std::size_t>{0}
                             : std::optional<std::size_t>{*index - 1});
 }

--- a/src/qt/ExpressionEditorDialog.cpp
+++ b/src/qt/ExpressionEditorDialog.cpp
@@ -397,7 +397,8 @@ void ExpressionEditorDialog::setCommitted(
 }
 
 void ExpressionEditorDialog::showError(const QString& message,
-    std::optional<std::size_t> definitionIndex, bool offerAnyway)
+    std::optional<std::size_t> definitionIndex, bool offerAnyway,
+    bool dependsOnDataset)
 {
     // Before anything is shown: selecting a different row runs the selection
     // handler, which clears the error box -- so a refusal set up first would
@@ -411,7 +412,7 @@ void ExpressionEditorDialog::showError(const QString& message,
     m_error->setVisible(true);
     m_applyAnyway->setVisible(offerAnyway);
     m_refusalRevision = m_draftRevision;
-    m_refusalAboutData = offerAnyway;
+    m_refusalAboutData = dependsOnDataset;
     // The refusal supersedes the advisory: they carry the same sentence when
     // Apply refuses what the warning was about, and showing it twice -- once
     // in red, once in amber -- says the advisory did not stop anything at the

--- a/src/qt/ExpressionEditorDialog.cpp
+++ b/src/qt/ExpressionEditorDialog.cpp
@@ -50,7 +50,7 @@ ExpressionEditorDialog::ExpressionEditorDialog(
     : QDialog(parent)
     , m_draft(std::move(definitions))
     , m_committed(m_draft)
-    , m_handEdited(m_draft.size(), false)
+    , m_baseline(m_draft)
 {
     setObjectName(QStringLiteral("expressionEditor"));
     setWindowTitle(tr("Expression Editor"));
@@ -100,6 +100,10 @@ ExpressionEditorDialog::ExpressionEditorDialog(
     m_error->setTextFormat(Qt::PlainText);
     // As SetContoursDialog styles its own warning.
     m_error->setStyleSheet(QStringLiteral("QLabel { color: red; }"));
+
+    m_applyAnyway = new QPushButton(tr("Apply &anyway"), this);
+    m_applyAnyway->setObjectName(QStringLiteral("applyAnywayButton"));
+    m_applyAnyway->setVisible(false);
 
     m_applied = new QLabel(this);
     m_applied->setObjectName(QStringLiteral("expressionApplied"));
@@ -155,6 +159,14 @@ ExpressionEditorDialog::ExpressionEditorDialog(
     editor->addLayout(form);
     editor->addWidget(help);
     editor->addWidget(m_error);
+    {
+        // Left-aligned under the refusal it belongs to, rather than stretched
+        // across the column as a label would be.
+        auto* row = new QHBoxLayout;
+        row->addWidget(m_applyAnyway);
+        row->addStretch(1);
+        editor->addLayout(row);
+    }
     editor->addWidget(m_warning);
     editor->addWidget(m_applied);
     editor->addWidget(m_notice);
@@ -190,6 +202,15 @@ ExpressionEditorDialog::ExpressionEditorDialog(
             // Into the expression at the cursor, and leave the focus there:
             // the point of the list is to save typing a name, not to take the
             // user out of what they were writing.
+            // Separated from whatever the cursor sits after: written
+            // straight onto an identifier the two lex as one unknown symbol,
+            // which is the same silent corruption as inserting at the front.
+            // A space is safe after anything, operators included.
+            const auto before = m_expression->toPlainText().left(
+                m_expression->textCursor().position());
+            if (!before.isEmpty() && !before.back().isSpace()) {
+                m_expression->insertPlainText(QStringLiteral(" "));
+            }
             m_expression->insertPlainText(asSymbol(item->text()));
             m_expression->setFocus();
         });
@@ -206,7 +227,6 @@ ExpressionEditorDialog::ExpressionEditorDialog(
             return;
         }
         m_draft[*index].name = text.trimmed().toStdString();
-        markEdited(*index);
         ++m_draftRevision;
         m_list->item(static_cast<int>(*index))
             ->setText(displayName(m_draft[*index]));
@@ -221,13 +241,16 @@ ExpressionEditorDialog::ExpressionEditorDialog(
         }
         m_draft[*index].expression =
             m_expression->toPlainText().trimmed().toStdString();
-        markEdited(*index);
         ++m_draftRevision;
         emit draftEdited();
     });
     connect(m_apply, &QPushButton::clicked, this, [this] {
         clearError();
         emit applyRequested();
+    });
+    connect(m_applyAnyway, &QPushButton::clicked, this, [this] {
+        clearError();
+        emit applyAnywayRequested();
     });
     // Explicitly: a QDialogButtonBox parented to a dialog does *not* have its
     // rejected() wired to that dialog's reject() -- probed, not assumed --
@@ -246,9 +269,10 @@ void ExpressionEditorDialog::setDraft(
     std::optional<std::size_t> select)
 {
     m_draft = std::move(definitions);
-    // None of it is the user's writing: an import is carried, and a commit is
-    // already answered for.
-    m_handEdited.assign(m_draft.size(), false);
+    // None of it is the user's writing yet: an import is carried, and a commit
+    // is already answered for. Whatever they change from here is measured
+    // against this.
+    m_baseline = m_draft;
     ++m_draftRevision;
     clearError();
     rebuildList(select);
@@ -284,7 +308,10 @@ void ExpressionEditorDialog::markDraftCommitted()
     // As setDraft does for the path that replaces the rows: what was the
     // user's own writing has been answered for, and holding it to this
     // dataset a second time would refuse a list that is already installed.
-    m_handEdited.assign(m_draft.size(), false);
+    m_baseline = m_draft;
+    // The draft's meaning moved even though its rows did not, and the
+    // revision is what an asynchronous reader compares against.
+    ++m_draftRevision;
     m_notice->clear();
     m_notice->setVisible(false);
 }
@@ -302,9 +329,10 @@ void ExpressionEditorDialog::setCommitted(
     m_notice->setVisible(false);
 }
 
-void ExpressionEditorDialog::showError(
-    const QString& message, std::optional<std::size_t> definitionIndex)
+void ExpressionEditorDialog::showError(const QString& message,
+    std::optional<std::size_t> definitionIndex, bool offerAnyway)
 {
+    m_applyAnyway->setVisible(offerAnyway);
     m_applied->clear();
     m_applied->setVisible(false);
     if (definitionIndex && *definitionIndex < m_draft.size()) {
@@ -347,6 +375,7 @@ void ExpressionEditorDialog::clearError()
     // shared list with nothing on screen saying so. setCommitted ends it.
     m_error->clear();
     m_error->setVisible(false);
+    m_applyAnyway->setVisible(false);
     m_applied->clear();
     m_applied->setVisible(false);
 }
@@ -398,7 +427,9 @@ void ExpressionEditorDialog::addDefinition()
 {
     clearError();
     m_draft.push_back({});
-    m_handEdited.push_back(false);
+    // Nothing to carry: a row that did not arrive from anywhere is the user's
+    // the moment they write in it.
+    m_baseline.push_back({});
     ++m_draftRevision;
     rebuildList(m_draft.size() - 1);
     m_name->setFocus();
@@ -412,8 +443,8 @@ void ExpressionEditorDialog::removeSelected()
     }
     clearError();
     m_draft.erase(m_draft.begin() + static_cast<std::ptrdiff_t>(*index));
-    m_handEdited.erase(
-        m_handEdited.begin() + static_cast<std::ptrdiff_t>(*index));
+    m_baseline.erase(
+        m_baseline.begin() + static_cast<std::ptrdiff_t>(*index));
     ++m_draftRevision;
     // Deleting the last definition leaves nothing selected, and rebuildList
     // reaches that by writing -1 over a current row the clear() already set
@@ -424,19 +455,15 @@ void ExpressionEditorDialog::removeSelected()
                             : std::optional<std::size_t>{*index - 1});
 }
 
-void ExpressionEditorDialog::markEdited(std::size_t index)
-{
-    // Measured, not latched. A row typed into and then put back the way it was
-    // is not something the user is claiming about this dataset, and a latch
-    // would hold every later Apply to a definition they merely brushed
-    // against -- with nothing inside the editor able to clear it again.
-    m_handEdited[index] = index >= m_committed.size()
-        || m_draft[index] != m_committed[index];
-}
-
 bool ExpressionEditorDialog::handEdited(std::size_t index) const
 {
-    return index < m_handEdited.size() && m_handEdited[index];
+    if (index >= m_draft.size()) {
+        return false;
+    }
+    // Computed rather than remembered: there is no flag to fall out of step
+    // with the rows, and putting a definition back the way it arrived takes
+    // the claim back with it.
+    return index >= m_baseline.size() || m_draft[index] != m_baseline[index];
 }
 
 std::optional<std::size_t> ExpressionEditorDialog::selectedIndex() const

--- a/src/qt/ExpressionEditorDialog.cpp
+++ b/src/qt/ExpressionEditorDialog.cpp
@@ -331,8 +331,16 @@ bool ExpressionEditorDialog::setStoredFields(
     return true;
 }
 
+void ExpressionEditorDialog::clearDataRefusal()
+{
+    if (m_refusalAboutData) {
+        clearRefusal();
+    }
+}
+
 void ExpressionEditorDialog::clearRefusal()
 {
+    m_refusalAboutData = false;
     m_error->clear();
     m_error->setVisible(false);
     m_applyAnyway->setVisible(false);
@@ -403,6 +411,7 @@ void ExpressionEditorDialog::showError(const QString& message,
     m_error->setVisible(true);
     m_applyAnyway->setVisible(offerAnyway);
     m_refusalRevision = m_draftRevision;
+    m_refusalAboutData = offerAnyway;
     // The refusal supersedes the advisory: they carry the same sentence when
     // Apply refuses what the warning was about, and showing it twice -- once
     // in red, once in amber -- says the advisory did not stop anything at the

--- a/src/qt/ExpressionEditorDialog.hpp
+++ b/src/qt/ExpressionEditorDialog.hpp
@@ -4,6 +4,7 @@
 
 #include <QDialog>
 #include <QString>
+#include <QStringList>
 
 #include <cstddef>
 #include <optional>
@@ -27,6 +28,12 @@ namespace amrvis::qt {
 //
 // Names are kept as typed. An empty one is shown as "(unnamed)" in the list
 // and refused by the host, which is where every rule about a definition lives.
+//
+// It shows two things about the open dataset without knowing anything about
+// it: the stored field names an expression may use (setStoredFields) and,
+// while a definition is being written, why this dataset could not provide it
+// (showResolutionWarning). Both are handed in by the host, which resolves the
+// draft as it changes -- draftEdited says when that is.
 class ExpressionEditorDialog final : public QDialog {
     Q_OBJECT
 
@@ -76,12 +83,35 @@ public:
     // equivalent list can leave the user where they were.
     [[nodiscard]] std::optional<std::size_t> selectedIndex() const;
 
+    // The fields the open dataset stores, in its own order, listed beside the
+    // expression so they need not be hunted for in the Variable menu. Double
+    // -clicking one writes it into the expression at the cursor. Empty hides
+    // the list, which is what no open dataset looks like.
+    void setStoredFields(const QStringList& names);
+    // Why the open dataset could not provide the definition the user is
+    // *writing*, as the host's resolution of the draft reports it. An empty
+    // message clears it.
+    //
+    // Advisory, not a refusal: the list is shared by windows showing different
+    // data, and a session may open a plotfile of another shape entirely, so a
+    // definition that means nothing here is still committed -- and shown
+    // greyed in the field list -- rather than blocked. That is also why it is
+    // cleared and never recomputed when the selection moves, when a list is
+    // imported, or when a dataset opens: only a definition being typed is
+    // measured against the data, because only then is the user asking.
+    void showResolutionWarning(const QString& message);
+
 signals:
     // The draft is offered for validation; the host accepts it (setDraft, and
     // usually accept()) or refuses it (showError).
     void applyRequested();
     void importRequested();
     void exportRequested();
+    // The user typed into the selected definition's name or expression. What
+    // the host resolves on to answer with showResolutionWarning. Only hand
+    // editing: an import, a row change and a dataset opening all clear the
+    // warning instead, for the reason given there.
+    void draftEdited();
 
 private:
     void clearError();
@@ -96,6 +126,10 @@ private:
     // taking it back leaves nothing to protect.
     std::vector<DerivedFieldDefinition> m_committed;
     QListWidget* m_list = nullptr;
+    // The stored fields, and the caption over them: both hidden together when
+    // there is nothing to list.
+    QListWidget* m_fields = nullptr;
+    QLabel* m_fieldsCaption = nullptr;
     QLineEdit* m_name = nullptr;
     QPlainTextEdit* m_expression = nullptr;
     QLabel* m_error = nullptr;
@@ -106,6 +140,10 @@ private:
     // list that moved elsewhere. Its own widget for the same reason m_applied
     // is one.
     QLabel* m_notice = nullptr;
+    // What this dataset cannot make of the definition being edited. Standing
+    // rather than momentary -- it describes the draft, not the last thing
+    // done -- so clearError leaves it alone, as it does the notice.
+    QLabel* m_warning = nullptr;
     QPushButton* m_remove = nullptr;
     QPushButton* m_apply = nullptr;
     // Set while the widgets are being written from the draft, so the edit

--- a/src/qt/ExpressionEditorDialog.hpp
+++ b/src/qt/ExpressionEditorDialog.hpp
@@ -80,10 +80,11 @@ public:
     // refusal stays readable while they decide.
     void showError(const QString& message,
         std::optional<std::size_t> definitionIndex, bool offerAnyway = false);
-    // Takes a standing refusal and its offer down. The host calls it when the
-    // dataset the verdict was about is replaced; every change to the draft
-    // does it from in here, for the same reason.
-    void clearRefusal();
+    // Takes down a standing refusal only if it was about the data -- the kind
+    // showError was told the user may overrule. A fault in the definition is
+    // true of every dataset, and nothing here would say it a second time.
+    // What the host calls when the dataset a verdict was about is replaced.
+    void clearDataRefusal();
     // Confirms an accepted Apply in the same place a refusal appears. Said
     // here rather than in the status bar, which the reload this announces
     // clears as soon as its slices arrive.
@@ -179,6 +180,10 @@ signals:
 
 private:
     void clearError();
+    // Takes any standing refusal and its offer down, whatever it was about.
+    // Every change to the draft does this: the verdict was about a list that
+    // has moved.
+    void clearRefusal();
     void rebuildList(std::optional<std::size_t> select);
     void showSelected();
     void addDefinition();
@@ -231,6 +236,10 @@ private:
     // the draft clears the refusal, and this is what makes that a guarantee
     // rather than a promise kept at each site.
     std::optional<std::uint64_t> m_refusalRevision;
+    // Whether the standing refusal was one the user may overrule, which is
+    // also what makes it a verdict about the data rather than about the
+    // definition.
+    bool m_refusalAboutData = false;
     // Set while the widgets are being written from the draft, so the edit
     // signals do not write straight back into it.
     bool m_loading = false;

--- a/src/qt/ExpressionEditorDialog.hpp
+++ b/src/qt/ExpressionEditorDialog.hpp
@@ -126,7 +126,18 @@ public:
     // expression so they need not be hunted for in the Variable menu. Double
     // -clicking one writes it into the expression at the cursor. Empty hides
     // the list, which is what no open dataset looks like.
-    void setStoredFields(const QStringList& names);
+    //
+    // `geometry` is the rest of what decides whether an expression resolves --
+    // the dimension, and whether there is physical geometry for x, y and z to
+    // mean anything. Together with the names it is the dataset's whole
+    // vocabulary, and the return says whether that moved since the last call.
+    //
+    // The host asks on every installed session, which includes every frame of
+    // a sequence and the reload its own Apply started. Answering false there
+    // is what lets it leave the field list alone -- so a scroll position
+    // survives an Apply -- and leave standing what it has already said, since
+    // two datasets with one vocabulary resolve every definition alike.
+    bool setStoredFields(const QStringList& names, const QString& geometry);
     // Why the open dataset could not provide the definition the user is
     // *writing*, as the host's resolution of the draft reports it. An empty
     // message clears it.
@@ -136,11 +147,14 @@ public:
     // definition that means nothing here is still committed -- and shown
     // greyed in the field list -- rather than blocked. That is also why it is
     // cleared and never recomputed when the selection moves, when a list is
-    // imported, when a definition is deleted, or when a dataset opens: only a
-    // definition being typed is measured against the data, because only then
-    // is the user asking. A refusal replaces it too -- the same sentence in
-    // red and in amber says the advisory did not stop anything while it just
-    // did.
+    // imported, or when a definition is deleted: only a definition being typed
+    // is measured against the data, because only then is the user asking. A
+    // refusal replaces it too -- the same sentence in red and in amber says
+    // the advisory did not stop anything while it just did.
+    //
+    // A dataset opening clears it as well, but there it *is* recomputed: what
+    // was said described a vocabulary that has gone, and the row is still one
+    // the user wrote, so the answer is owed again against the data now open.
     //
     // `blocking` says the message is a fault Apply will refuse rather than a
     // limit of the data. The two read differently on purpose -- the advisory
@@ -186,6 +200,13 @@ private:
     // there is nothing to list.
     QListWidget* m_fields = nullptr;
     QLabel* m_fieldsCaption = nullptr;
+    // The vocabulary the field list was last built from. Held here rather than
+    // by the host because the host skips this call entirely while the editor
+    // is closed, and would then compare against something the dialog on screen
+    // never saw.
+    QStringList m_storedFields;
+    QString m_storedGeometry;
+    bool m_storedFieldsSet = false;
     QLineEdit* m_name = nullptr;
     QPlainTextEdit* m_expression = nullptr;
     QLabel* m_error = nullptr;

--- a/src/qt/ExpressionEditorDialog.hpp
+++ b/src/qt/ExpressionEditorDialog.hpp
@@ -140,6 +140,9 @@ signals:
 
 private:
     void clearError();
+    // Records whether row `index` now differs from what was committed, which
+    // is what handEdited answers.
+    void markEdited(std::size_t index);
     void rebuildList(std::optional<std::size_t> select);
     void showSelected();
     void addDefinition();

--- a/src/qt/ExpressionEditorDialog.hpp
+++ b/src/qt/ExpressionEditorDialog.hpp
@@ -83,6 +83,17 @@ public:
     // equivalent list can leave the user where they were.
     [[nodiscard]] std::optional<std::size_t> selectedIndex() const;
 
+    // Whether the user has typed into this definition's name or expression
+    // since the draft was last replaced -- by a commit, or by an import.
+    //
+    // This is what separates a definition the user is writing from one they
+    // are merely carrying: a list written for another plotfile, or imported
+    // whole, holds definitions this dataset may be unable to provide through
+    // no fault of anyone's, and those are committed and greyed out. One being
+    // written is a different claim -- that it works on the data in front of
+    // them -- and the host holds it to that.
+    [[nodiscard]] bool handEdited(std::size_t index) const;
+
     // The fields the open dataset stores, in its own order, listed beside the
     // expression so they need not be hunted for in the Variable menu. Double
     // -clicking one writes it into the expression at the cursor. Empty hides
@@ -125,6 +136,11 @@ private:
     // edit unapplied: compared rather than flagged, so typing something and
     // taking it back leaves nothing to protect.
     std::vector<DerivedFieldDefinition> m_committed;
+    // One flag per draft row: has the user typed into it. Kept beside m_draft
+    // rather than derived from m_committed, because "differs from what was
+    // committed" is also true of every row of an imported list, which is the
+    // case this has to tell apart. Cleared whenever the draft is replaced.
+    std::vector<bool> m_handEdited;
     QListWidget* m_list = nullptr;
     // The stored fields, and the caption over them: both hidden together when
     // there is nothing to list.

--- a/src/qt/ExpressionEditorDialog.hpp
+++ b/src/qt/ExpressionEditorDialog.hpp
@@ -71,8 +71,15 @@ public:
 
     // Reports a refusal in place rather than over a second dialog, and selects
     // the definition it belongs to so the user is looking at what failed.
-    void showError(
-        const QString& message, std::optional<std::size_t> definitionIndex);
+    //
+    // `offerAnyway` puts an "Apply anyway" button beside it, for a refusal the
+    // user is entitled to overrule: a definition this dataset cannot provide
+    // is still worth committing for the plotfile they are about to open, and
+    // without it the editor would have no way to write one at all. Beside the
+    // message rather than over a modal, so it interrupts nothing and the
+    // refusal stays readable while they decide.
+    void showError(const QString& message,
+        std::optional<std::size_t> definitionIndex, bool offerAnyway = false);
     // Confirms an accepted Apply in the same place a refusal appears. Said
     // here rather than in the status bar, which the reload this announces
     // clears as soon as its slices arrive.
@@ -84,8 +91,8 @@ public:
     // equivalent list can leave the user where they were.
     [[nodiscard]] std::optional<std::size_t> selectedIndex() const;
 
-    // Whether the user has typed into this definition's name or expression
-    // since the draft was last replaced -- by a commit, or by an import.
+    // Whether this definition differs from what it was when the draft was
+    // last replaced -- by a commit, or by an import.
     //
     // This is what separates a definition the user is writing from one they
     // are merely carrying: a list written for another plotfile, or imported
@@ -93,6 +100,12 @@ public:
     // no fault of anyone's, and those are committed and greyed out. One being
     // written is a different claim -- that it works on the data in front of
     // them -- and the host holds it to that.
+    //
+    // Measured against a baseline kept per row, not against the committed list
+    // by position: a row deleted above this one, or a list imported over it,
+    // moves what any given index means, and comparing across that both locks
+    // the user out of a list they only brushed against and lets a definition
+    // they typed from scratch pass as carried.
     [[nodiscard]] bool handEdited(std::size_t index) const;
 
     // Bumped by every change to the draft: a keystroke, a row added or
@@ -137,12 +150,12 @@ signals:
     // editing: an import, a row change and a dataset opening all clear the
     // warning instead, for the reason given there.
     void draftEdited();
+    // "Apply anyway" was pressed on a refusal that offered it: the same draft
+    // is to be committed without being held to the open dataset.
+    void applyAnywayRequested();
 
 private:
     void clearError();
-    // Records whether row `index` now differs from what was committed, which
-    // is what handEdited answers.
-    void markEdited(std::size_t index);
     void rebuildList(std::optional<std::size_t> select);
     void showSelected();
     void addDefinition();
@@ -153,11 +166,11 @@ private:
     // edit unapplied: compared rather than flagged, so typing something and
     // taking it back leaves nothing to protect.
     std::vector<DerivedFieldDefinition> m_committed;
-    // One flag per draft row: has the user typed into it. Kept beside m_draft
-    // rather than derived from m_committed, because "differs from what was
-    // committed" is also true of every row of an imported list, which is the
-    // case this has to tell apart. Cleared whenever the draft is replaced.
-    std::vector<bool> m_handEdited;
+    // What each draft row was when the draft was last replaced, one entry per
+    // row and moved with them. handEdited is the comparison against this: a
+    // row added since has an empty baseline, so anything written into it
+    // counts, and a row put back the way it arrived stops counting.
+    std::vector<DerivedFieldDefinition> m_baseline;
     std::uint64_t m_draftRevision = 0;
     QListWidget* m_list = nullptr;
     // The stored fields, and the caption over them: both hidden together when
@@ -180,6 +193,7 @@ private:
     QLabel* m_warning = nullptr;
     QPushButton* m_remove = nullptr;
     QPushButton* m_apply = nullptr;
+    QPushButton* m_applyAnyway = nullptr;
     // Set while the widgets are being written from the draft, so the edit
     // signals do not write straight back into it.
     bool m_loading = false;

--- a/src/qt/ExpressionEditorDialog.hpp
+++ b/src/qt/ExpressionEditorDialog.hpp
@@ -78,8 +78,14 @@ public:
     // without it the editor would have no way to write one at all. Beside the
     // message rather than over a modal, so it interrupts nothing and the
     // refusal stays readable while they decide.
+    //
+    // `dependsOnDataset` says the verdict stops being true when another dataset
+    // opens, which is a different question from whether the user may overrule
+    // it: "derived fields are not available for a FAB" is about the data and
+    // must not outlive it, but there is nothing to overrule.
     void showError(const QString& message,
-        std::optional<std::size_t> definitionIndex, bool offerAnyway = false);
+        std::optional<std::size_t> definitionIndex, bool offerAnyway = false,
+        bool dependsOnDataset = false);
     // Takes down a standing refusal only if it was about the data -- the kind
     // showError was told the user may overrule. A fault in the definition is
     // true of every dataset, and nothing here would say it a second time.
@@ -236,9 +242,9 @@ private:
     // the draft clears the refusal, and this is what makes that a guarantee
     // rather than a promise kept at each site.
     std::optional<std::uint64_t> m_refusalRevision;
-    // Whether the standing refusal was one the user may overrule, which is
-    // also what makes it a verdict about the data rather than about the
-    // definition.
+    // Whether the standing refusal stops being true when another dataset
+    // opens. Not the same as overrulable: an availability refusal is about the
+    // data and offers nothing.
     bool m_refusalAboutData = false;
     // Set while the widgets are being written from the draft, so the edit
     // signals do not write straight back into it.

--- a/src/qt/ExpressionEditorDialog.hpp
+++ b/src/qt/ExpressionEditorDialog.hpp
@@ -7,6 +7,7 @@
 #include <QStringList>
 
 #include <cstddef>
+#include <cstdint>
 #include <optional>
 #include <vector>
 
@@ -94,6 +95,16 @@ public:
     // them -- and the host holds it to that.
     [[nodiscard]] bool handEdited(std::size_t index) const;
 
+    // Bumped by every change to the draft: a keystroke, a row added or
+    // deleted, a list imported or committed. A host that answers a question
+    // about the draft asynchronously captures this when it asks and compares
+    // it when it answers -- a row index alone is not an identity, because
+    // deleting a row slides its successor into the same number.
+    [[nodiscard]] std::uint64_t draftRevision() const noexcept
+    {
+        return m_draftRevision;
+    }
+
     // The fields the open dataset stores, in its own order, listed beside the
     // expression so they need not be hunted for in the Variable menu. Double
     // -clicking one writes it into the expression at the cursor. Empty hides
@@ -108,8 +119,11 @@ public:
     // definition that means nothing here is still committed -- and shown
     // greyed in the field list -- rather than blocked. That is also why it is
     // cleared and never recomputed when the selection moves, when a list is
-    // imported, or when a dataset opens: only a definition being typed is
-    // measured against the data, because only then is the user asking.
+    // imported, when a definition is deleted, or when a dataset opens: only a
+    // definition being typed is measured against the data, because only then
+    // is the user asking. A refusal replaces it too -- the same sentence in
+    // red and in amber says the advisory did not stop anything while it just
+    // did.
     void showResolutionWarning(const QString& message);
 
 signals:
@@ -141,6 +155,7 @@ private:
     // committed" is also true of every row of an imported list, which is the
     // case this has to tell apart. Cleared whenever the draft is replaced.
     std::vector<bool> m_handEdited;
+    std::uint64_t m_draftRevision = 0;
     QListWidget* m_list = nullptr;
     // The stored fields, and the caption over them: both hidden together when
     // there is nothing to list.

--- a/src/qt/ExpressionEditorDialog.hpp
+++ b/src/qt/ExpressionEditorDialog.hpp
@@ -80,6 +80,10 @@ public:
     // refusal stays readable while they decide.
     void showError(const QString& message,
         std::optional<std::size_t> definitionIndex, bool offerAnyway = false);
+    // Takes a standing refusal and its offer down. The host calls it when the
+    // dataset the verdict was about is replaced; every change to the draft
+    // does it from in here, for the same reason.
+    void clearRefusal();
     // Confirms an accepted Apply in the same place a refusal appears. Said
     // here rather than in the status bar, which the reload this announces
     // clears as soon as its slices arrive.
@@ -137,7 +141,12 @@ public:
     // is the user asking. A refusal replaces it too -- the same sentence in
     // red and in amber says the advisory did not stop anything while it just
     // did.
-    void showResolutionWarning(const QString& message);
+    //
+    // `blocking` says the message is a fault Apply will refuse rather than a
+    // limit of the data. The two read differently on purpose -- the advisory
+    // is deliberately not the error's red -- so a syntax error must not wear
+    // the colour that promises nothing was stopped.
+    void showResolutionWarning(const QString& message, bool blocking = false);
 
 signals:
     // The draft is offered for validation; the host accepts it (setDraft, and
@@ -194,6 +203,13 @@ private:
     QPushButton* m_remove = nullptr;
     QPushButton* m_apply = nullptr;
     QPushButton* m_applyAnyway = nullptr;
+    // The draft revision the standing refusal was computed against, when one
+    // is standing. An offer to overrule a verdict means nothing once the draft
+    // has moved -- the verdict was about a list that no longer exists, and
+    // acting on it would commit rows nothing ever examined. Every change to
+    // the draft clears the refusal, and this is what makes that a guarantee
+    // rather than a promise kept at each site.
+    std::optional<std::uint64_t> m_refusalRevision;
     // Set while the widgets are being written from the draft, so the edit
     // signals do not write straight back into it.
     bool m_loading = false;

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -103,7 +103,13 @@ MainWindow::MainWindow(QWidget* parent)
             .storedFieldNames =
                 [this] {
                     QStringList names;
-                    if (!m_dataset) {
+                    // The same gate derivedFieldRows applies, not a weaker
+                    // one: where no definition can be installed at all -- a
+                    // FAB, a peer that predates 1.4 -- offering the fields as
+                    // material tells the user they may write against them,
+                    // and the refusal then comes from somewhere else
+                    // entirely. available() is that one question, asked once.
+                    if (!m_dataset || !m_derivedFields->available()) {
                         return names;
                     }
                     const auto& fields = m_dataset->metadata().fields;
@@ -123,7 +129,12 @@ MainWindow::MainWindow(QWidget* parent)
             .resolveAgainstOpenDataset =
                 [this](const std::vector<DerivedFieldDefinition>& definitions) {
                     std::vector<DerivedFieldSkip> skipped;
-                    if (!m_dataset) {
+                    // As above. Answering here would be worse than saying
+                    // nothing: a remote session on an old peer reports every
+                    // field as stored, so every definition resolves and the
+                    // editor would report that it works -- right up until
+                    // Apply refuses it for a reason of its own.
+                    if (!m_dataset || !m_derivedFields->available()) {
                         return skipped;
                     }
                     // The session's metadata with the derived tail cut back

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -136,17 +136,31 @@ MainWindow::MainWindow(QWidget* parent)
                     if (!m_dataset || !m_derivedFields->available()) {
                         return skipped;
                     }
-                    // The session's metadata with the derived tail cut back
-                    // off: installDerivedFields appends what it resolves, so
-                    // handing it a list that already holds the last
-                    // installation's fields would resolve every definition
-                    // against itself. The whole metadata is copied rather
-                    // than a made-up subset of it, so this asks the question
-                    // exactly as opening the dataset asks it -- the box lists
-                    // ride along, which the debounce is what pays for.
-                    auto metadata = m_dataset->metadata();
+                    // Only what installDerivedFields consults, which is
+                    // exhaustively: `fields` (and of those only `.name` and
+                    // `.centering`), `hasPhysicalGeometry` and `dimension`
+                    // -- see src/core/DerivedField.cpp. The whole metadata
+                    // used to be copied so this asked the question exactly as
+                    // an open asks it, but that copies every level's box list
+                    // on every pause in typing and again on every Apply.
+                    //
+                    // If that function ever grows a fourth dependency it has
+                    // to be added here too: until it is, the editor's verdict
+                    // silently stops matching what an open actually installs.
+                    // That tripwire is the price of not copying the hierarchy.
+                    //
+                    // The derived tail is cut off because installDerivedFields
+                    // appends what it resolves -- handing it a list that
+                    // already holds the last installation's fields would
+                    // resolve every definition against itself.
+                    const auto& open = m_dataset->metadata();
                     const auto stored = storedFieldCount();
-                    metadata.fields.resize(stored);
+                    DatasetMetadata metadata;
+                    metadata.dimension = open.dimension;
+                    metadata.hasPhysicalGeometry = open.hasPhysicalGeometry;
+                    metadata.fields.assign(open.fields.begin(),
+                        open.fields.begin()
+                            + static_cast<std::ptrdiff_t>(stored));
                     try {
                         return installDerivedFields(metadata, definitions,
                             DerivedFieldPolicy::Skip)

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -100,6 +100,56 @@ MainWindow::MainWindow(QWidget* parent)
                     // parents to the window for the same reason.
                     return chooseExpressionListPath(this, forSaving);
                 },
+            .storedFieldNames =
+                [this] {
+                    QStringList names;
+                    if (!m_dataset) {
+                        return names;
+                    }
+                    const auto& fields = m_dataset->metadata().fields;
+                    // The stored ones alone. The derived tail is what the
+                    // editor is for writing, and offering it back as material
+                    // would suggest a definition may read one written below
+                    // it, which installation does not allow.
+                    const auto stored = std::min(
+                        m_dataset->storedFieldCount(), fields.size());
+                    names.reserve(static_cast<qsizetype>(stored));
+                    for (std::size_t field = 0; field < stored; ++field) {
+                        names.append(
+                            QString::fromStdString(fields[field].name));
+                    }
+                    return names;
+                },
+            .resolveAgainstOpenDataset =
+                [this](const std::vector<DerivedFieldDefinition>& definitions) {
+                    std::vector<DerivedFieldSkip> skipped;
+                    if (!m_dataset) {
+                        return skipped;
+                    }
+                    // The session's metadata with the derived tail cut back
+                    // off: installDerivedFields appends what it resolves, so
+                    // handing it a list that already holds the last
+                    // installation's fields would resolve every definition
+                    // against itself. The whole metadata is copied rather
+                    // than a made-up subset of it, so this asks the question
+                    // exactly as opening the dataset asks it -- the box lists
+                    // ride along, which the debounce is what pays for.
+                    auto metadata = m_dataset->metadata();
+                    const auto stored = std::min(
+                        m_dataset->storedFieldCount(), metadata.fields.size());
+                    metadata.fields.resize(stored);
+                    try {
+                        return installDerivedFields(metadata, definitions,
+                            DerivedFieldPolicy::Skip)
+                            .skipped;
+                    } catch (const std::exception&) {
+                        // Skip resolves every definition it can and records
+                        // the rest, so nothing here should throw -- but this
+                        // runs while the user types, and a diagnostic is not
+                        // worth taking the editor down for.
+                        return skipped;
+                    }
+                },
         },
         DerivedFieldStore::session(), this);
     connect(m_derivedFields, &DerivedFieldController::statusMessage, this,

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -125,17 +125,28 @@ MainWindow::MainWindow(QWidget* parent)
                     }
                     return names;
                 },
-            .datasetGeometry =
+            .datasetShape =
                 [this] {
                     if (!m_dataset || !m_derivedFields->available()) {
                         return QString{};
                     }
                     const auto& metadata = m_dataset->metadata();
-                    return QStringLiteral("%1d%2")
+                    // The centerings as well as the geometry: two plotfiles
+                    // can share every field name and still resolve an
+                    // expression differently, because installation refuses one
+                    // that mixes them (DerivedField.cpp, "is not centered like
+                    // the other fields the expression reads").
+                    QString shape = QStringLiteral("%1d%2:")
                         .arg(metadata.dimension)
                         .arg(metadata.hasPhysicalGeometry
                                 ? QStringLiteral("+geo")
                                 : QString{});
+                    const auto stored = storedFieldCount();
+                    for (std::size_t field = 0; field < stored; ++field) {
+                        shape += QString::number(
+                            static_cast<int>(metadata.fields[field].centering));
+                    }
+                    return shape;
                 },
             .resolveAgainstOpenDataset =
                 [this](const std::vector<DerivedFieldDefinition>& definitions) {

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -125,6 +125,18 @@ MainWindow::MainWindow(QWidget* parent)
                     }
                     return names;
                 },
+            .datasetGeometry =
+                [this] {
+                    if (!m_dataset || !m_derivedFields->available()) {
+                        return QString{};
+                    }
+                    const auto& metadata = m_dataset->metadata();
+                    return QStringLiteral("%1d%2")
+                        .arg(metadata.dimension)
+                        .arg(metadata.hasPhysicalGeometry
+                                ? QStringLiteral("+geo")
+                                : QString{});
+                },
             .resolveAgainstOpenDataset =
                 [this](const std::vector<DerivedFieldDefinition>& definitions) {
                     std::vector<DerivedFieldSkip> skipped;

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -117,8 +117,7 @@ MainWindow::MainWindow(QWidget* parent)
                     // editor is for writing, and offering it back as material
                     // would suggest a definition may read one written below
                     // it, which installation does not allow.
-                    const auto stored = std::min(
-                        m_dataset->storedFieldCount(), fields.size());
+                    const auto stored = storedFieldCount();
                     names.reserve(static_cast<qsizetype>(stored));
                     for (std::size_t field = 0; field < stored; ++field) {
                         names.append(
@@ -146,8 +145,7 @@ MainWindow::MainWindow(QWidget* parent)
                     // exactly as opening the dataset asks it -- the box lists
                     // ride along, which the debounce is what pays for.
                     auto metadata = m_dataset->metadata();
-                    const auto stored = std::min(
-                        m_dataset->storedFieldCount(), metadata.fields.size());
+                    const auto stored = storedFieldCount();
                     metadata.fields.resize(stored);
                     try {
                         return installDerivedFields(metadata, definitions,
@@ -1512,8 +1510,7 @@ void MainWindow::rebuildVariableMenu(const std::vector<DerivedFieldRow>& rows)
     const auto& metadata = m_dataset->metadata();
     const auto currentField = m_fieldSelector->currentIndex() >= 0
         ? m_fieldSelector->currentData().toUInt() : 0;
-    const auto stored =
-        std::min(m_dataset->storedFieldCount(), metadata.fields.size());
+    const auto stored = storedFieldCount();
     const auto addField = [this, currentField](
                               const QString& name, std::size_t field) {
         auto* action = m_variableMenu->addAction(name);

--- a/src/qt/MainWindow.hpp
+++ b/src/qt/MainWindow.hpp
@@ -633,6 +633,12 @@ private:
     // The session's definitions as rows to list, in the order they were
     // written. The field selector and the Variable menu are the same list
     // shown twice, and the comment saying so kept them in step by hand.
+    // Where the stored fields end and the derived tail begins, clamped to what
+    // the metadata actually holds. Five places used to decide this
+    // independently -- the field selector, the Variable menu, the derived rows,
+    // and both editor hooks -- and the clamp is what guards a session whose
+    // count outruns the field list it carries.
+    [[nodiscard]] std::size_t storedFieldCount() const;
     [[nodiscard]] std::vector<DerivedFieldRow> derivedFieldRows() const;
     // Adds a listed-but-unchoosable row to the field selector. False when the
     // combo's model is not one whose item flags can be set, in which case no

--- a/src/qt/MainWindowSlice.cpp
+++ b/src/qt/MainWindowSlice.cpp
@@ -112,6 +112,15 @@ bool MainWindow::addUnavailableFieldItem(
     return true;
 }
 
+std::size_t MainWindow::storedFieldCount() const
+{
+    if (!m_dataset) {
+        return 0;
+    }
+    return std::min(
+        m_dataset->storedFieldCount(), m_dataset->metadata().fields.size());
+}
+
 std::vector<MainWindow::DerivedFieldRow> MainWindow::derivedFieldRows() const
 {
     std::vector<DerivedFieldRow> rows;
@@ -125,7 +134,7 @@ std::vector<MainWindow::DerivedFieldRow> MainWindow::derivedFieldRows() const
         return rows;
     }
     const auto& fields = m_dataset->metadata().fields;
-    const auto stored = std::min(m_dataset->storedFieldCount(), fields.size());
+    const auto stored = storedFieldCount();
     const auto& definitions = m_derivedFields->definitions();
     const auto skipped = m_dataset->skippedDerivedFields();
     rows.reserve(definitions.size());
@@ -209,7 +218,7 @@ void MainWindow::populateFieldSelector(const std::vector<DerivedFieldRow>& rows)
         return;
     }
     const auto& fields = m_dataset->metadata().fields;
-    const auto stored = std::min(m_dataset->storedFieldCount(), fields.size());
+    const auto stored = storedFieldCount();
     for (std::size_t field = 0; field < stored; ++field) {
         m_fieldSelector->addItem(QString::fromStdString(fields[field].name),
             static_cast<unsigned int>(field));

--- a/src/qt/SmokeHarnessDerived.cpp
+++ b/src/qt/SmokeHarnessDerived.cpp
@@ -818,16 +818,25 @@ void armDerivedChecks(amrvis::qt::MainWindow& window, QApplication& application)
                     finish(18);
                     return;
                 }
-                // A definition this dataset cannot satisfy is accepted and
-                // shown greyed out rather than refused: the list is shared
-                // with windows that may well be able to satisfy it.
+                // Written here, a definition is a claim that it works on the
+                // data in front of the user, so one this dataset cannot
+                // satisfy is refused rather than quietly greyed out later.
                 if (!appendDefinition(*dialog, QStringLiteral("elsewhere"),
                         QStringLiteral("nonesuch * 2"))
-                    || !clickApply(*dialog) || errorShown(*dialog)) {
-                    qCritical("a definition for another dataset was refused");
+                    || !clickApply(*dialog) || !errorShown(*dialog)) {
+                    qCritical("a hand-written definition this dataset cannot "
+                              "provide was accepted");
                     finish(14);
                     return;
                 }
+                // The same list arriving as something the user did not write
+                // -- another window's Apply, on the list every window shares
+                // -- is committed and shown greyed out instead. That is what
+                // keeps one list usable across plotfiles, and what phase 4
+                // checks. Taken from the draft rather than written out again,
+                // so it is the same list the editor holds and the dialog
+                // counts it as committed.
+                amrvis::qt::DerivedFieldStore::session().set(dialog->draft());
                 *phase = 4;
                 return;
             }
@@ -1545,17 +1554,26 @@ void armRemoteDerivedChecks(
                 return;
             }
             if (*phase == 1) {
+                // `elsewhere` reads a field this dataset has not got, and it
+                // is written here, so Apply refuses it -- over a remote
+                // session as over a local one, since the check is the same
+                // resolution the server would perform.
                 if (dialog == nullptr
                     || !writeDefinition(*dialog, QStringLiteral("product"),
                         QStringLiteral("density * temperature"))
                     || !appendDefinition(*dialog,
                         QStringLiteral("elsewhere"),
                         QStringLiteral("nonesuch * 2"))
-                    || !clickApply(*dialog) || errorShown(*dialog)) {
-                    qCritical("the editor refused the definitions");
+                    || !clickApply(*dialog) || !errorShown(*dialog)) {
+                    qCritical("the editor accepted a definition this remote "
+                              "dataset cannot provide");
                     finish(6);
                     return;
                 }
+                // Committed the way a peer window commits it, which is the
+                // route that leaves an unresolvable definition greyed out
+                // rather than refused.
+                amrvis::qt::DerivedFieldStore::session().set(dialog->draft());
                 *ticks = 0;
                 *phase = 2;
                 return;

--- a/tests/unit/test_derived_field_controller.cpp
+++ b/tests/unit/test_derived_field_controller.cpp
@@ -551,6 +551,35 @@ int main(int argc, char** argv)
         require(dialog->draft()[0].expression == "dens temperature ity",
             "a field written in mid-name merged with the tail");
 
+        // The confirmation survives the reload the Apply itself started: that
+        // load comes back through refreshAvailability, which is where a
+        // verdict about the outgoing dataset is taken down.
+        dialog->setDraft({{"fine", "density * 2"}});
+        applyButton->click();
+        auto* applied =
+            dialog->findChild<QLabel*>(QStringLiteral("expressionApplied"));
+        require(applied != nullptr && !applied->text().isEmpty(),
+            "Apply did not confirm what it applied");
+        controller.refreshAvailability();
+        require(!applied->text().isEmpty(),
+            "the reload the Apply started wiped its own confirmation");
+
+        // A definition that fails only because one written above it could not
+        // be provided is not the user's row to answer for: refusing it would
+        // name a field they can see defined one line up, while the row that
+        // actually broke it committed without comment.
+        dialog->setDraft({{"base", "nonesuch"}});
+        add->click();
+        name->setText(QStringLiteral("twice"));
+        source->setPlainText(QStringLiteral("base * 2"));
+        waitQuiet();
+        require(warning->text().isEmpty(),
+            "a definition was blamed for the failure of the one it reads");
+        applyButton->click();
+        require(error->text().isEmpty()
+                && controller.definitions().size() == 2,
+            "a definition was refused for the failure of the one it reads");
+
         // A row still being written is not complained about.
         dialog->setDraft({});
         add->click();

--- a/tests/unit/test_derived_field_controller.cpp
+++ b/tests/unit/test_derived_field_controller.cpp
@@ -12,6 +12,7 @@
 #include <QListWidget>
 #include <QPlainTextEdit>
 #include <QPushButton>
+#include <QTextCursor>
 #include <QTemporaryDir>
 #include <QTextDocument>
 
@@ -503,6 +504,52 @@ int main(int argc, char** argv)
                 == (QStringLiteral("density ") + written).toStdString(),
             "a field written in from the list did not land at the end, "
             "separated from what was there");
+
+        // A refusal that names a row other than the selected one still
+        // carries its offer: showError selects that row, and the selection
+        // handler clears the error box on its way past.
+        dialog->setCommitted({{"a", "density"}, {"b", "temperature"}});
+        list->setCurrentRow(0);
+        source->setPlainText(QStringLiteral("nonesuch * 2"));
+        list->setCurrentRow(1);
+        source->setPlainText(QStringLiteral("temperature * 3"));
+        applyButton->click();
+        require(!error->text().isEmpty() && anyway->isVisible(),
+            "a refusal on an unselected row arrived without its offer");
+
+        // Editing after a refusal takes it down, so the advisory never paints
+        // under it -- and the offer cannot commit rows nothing examined.
+        source->setPlainText(QStringLiteral("nonesuch * 3"));
+        require(error->text().isEmpty() && !anyway->isVisible(),
+            "a refusal outlived the draft it was about");
+
+        // Nor does it survive the dataset it named being replaced.
+        applyButton->click();
+        require(!error->text().isEmpty(), "the edit was not refused");
+        controller.refreshAvailability();
+        require(error->text().isEmpty() && !anyway->isVisible(),
+            "a refusal about the previous dataset was left standing");
+
+        // A fault Apply will refuse is not painted in the colour that
+        // promises nothing was stopped.
+        dialog->setDraft({{"t", "density"}});
+        source->setPlainText(QStringLiteral("sqrt("));
+        waitFor([&] { return !warning->text().isEmpty(); });
+        require(warning->styleSheet().contains(QStringLiteral("red")),
+            "a fault Apply will refuse was shown as advice");
+
+        // A field written into the middle of a name is separated from both
+        // sides, not just the one behind the cursor.
+        dialog->setDraft({{"t", "density"}});
+        list->setCurrentRow(0);
+        {
+            auto cursor = source->textCursor();
+            cursor.setPosition(4);
+            source->setTextCursor(cursor);
+        }
+        emit storedFields->itemDoubleClicked(storedFields->item(1));
+        require(dialog->draft()[0].expression == "dens temperature ity",
+            "a field written in mid-name merged with the tail");
 
         // A row still being written is not complained about.
         dialog->setDraft({});

--- a/tests/unit/test_derived_field_controller.cpp
+++ b/tests/unit/test_derived_field_controller.cpp
@@ -427,18 +427,64 @@ int main(int argc, char** argv)
         // Typing something and taking it back is not writing a definition, so
         // it must not hold every later Apply to a list carried from another
         // plotfile -- there is nothing inside the editor that could clear it.
-        dialog->setDraft({{"carried", "absent * 2"}});
         dialog->setCommitted({{"carried", "absent * 2"}});
-        source->setPlainText(QStringLiteral("absent * 2 "));
+        source->setPlainText(QStringLiteral("absent * 3"));
+        require(dialog->handEdited(0), "an edit did not count as one");
+        // Let the warning actually appear, so the revert has something to
+        // take back: without this the second edit merely restarts the timer
+        // and nothing was ever on screen.
+        waitFor([&] { return !warning->text().isEmpty(); });
+        require(!warning->text().isEmpty(), "the edit did not warn");
         source->setPlainText(QStringLiteral("absent * 2"));
         waitQuiet();
         require(!dialog->handEdited(0),
             "a definition typed into and put back was still counted as "
             "written here");
+        require(warning->text().isEmpty(),
+            "the warning outlived the edit it was about");
         applyButton->click();
         require(error->text().isEmpty(),
             "Apply was deadlocked by a definition the user only brushed "
             "against");
+
+        // The same, for a list that arrived by import rather than by commit:
+        // its rows are measured against what was imported, not against a
+        // committed list they were never part of.
+        dialog->setDraft({{"imported", "absent * 4"}});
+        source->setPlainText(QStringLiteral("absent * 5"));
+        source->setPlainText(QStringLiteral("absent * 4"));
+        require(!dialog->handEdited(0),
+            "an imported definition put back was counted as written here");
+        applyButton->click();
+        require(error->text().isEmpty(),
+            "Apply was deadlocked by an imported definition");
+
+        // And a row typed from scratch is held to the dataset even when it
+        // happens to match what used to sit at that index.
+        dialog->setCommitted({{"a", "density"}, {"ghost", "absent * 2"}});
+        list->setCurrentRow(1);
+        remove->click();
+        add->click();
+        name->setText(QStringLiteral("ghost"));
+        source->setPlainText(QStringLiteral("absent * 2"));
+        require(dialog->handEdited(1),
+            "a definition typed from scratch passed as one carried here");
+        applyButton->click();
+        require(!error->text().isEmpty(),
+            "a hand-written definition this dataset cannot provide slipped "
+            "through");
+
+        // Which the user may overrule: the refusal offers it, and taking the
+        // offer commits the same draft.
+        auto* anyway = dialog->findChild<QPushButton*>(
+            QStringLiteral("applyAnywayButton"));
+        require(anyway != nullptr && anyway->isVisible(),
+            "the refusal did not offer to commit anyway");
+        anyway->click();
+        require(error->text().isEmpty()
+                && controller.definitions().size() == 2
+                && controller.definitions()[1].name == "ghost",
+            "Apply anyway did not commit the definition");
 
         // A field written in from the list lands where the user is typing,
         // which for a row they just selected is the end of what is there.
@@ -454,8 +500,9 @@ int main(int argc, char** argv)
         const auto written = storedFields->item(1)->text();
         emit storedFields->itemDoubleClicked(storedFields->item(1));
         require(dialog->draft()[0].expression
-                == (QStringLiteral("density") + written).toStdString(),
-            "a field written in from the list did not land at the end");
+                == (QStringLiteral("density ") + written).toStdString(),
+            "a field written in from the list did not land at the end, "
+            "separated from what was there");
 
         // A row still being written is not complained about.
         dialog->setDraft({});

--- a/tests/unit/test_derived_field_controller.cpp
+++ b/tests/unit/test_derived_field_controller.cpp
@@ -444,9 +444,14 @@ int main(int argc, char** argv)
             list->setCurrentRow(1);
             source->setPlainText(wide + QStringLiteral(" + f0"));
             quiet();
+            require(!warning->text().isEmpty(),
+                "the fault of the list was never mentioned at all");
             require(!warning->text().contains(QStringLiteral("dataset")),
                 "a list fault in another row was reported as this dataset's "
                 "doing");
+            fixture.storedFields = QStringList{
+                QStringLiteral("density"), QStringLiteral("temperature")};
+            controller.refreshAvailability();
         }
 
         // Typing something and taking it back is not writing a definition, so
@@ -801,6 +806,20 @@ int main(int argc, char** argv)
             QStringLiteral("density"), QStringLiteral("temperature")};
         controller.refreshAvailability();
 
+        // A refusal that the data itself caused goes when the data does, even
+        // though there was never anything to overrule: nothing would say it
+        // again, and it names a state that has gone.
+        dialog->setDraft({{"twice", "density * 2"}});
+        fixture.datasetOpen = false;
+        controller.refreshAvailability();
+        applyButton->click();
+        require(!error->text().isEmpty() && !anyway->isVisible(),
+            "an editor with no dataset did not refuse");
+        fixture.datasetOpen = true;
+        controller.refreshAvailability();
+        require(error->text().isEmpty(),
+            "a refusal naming a state that has gone was left standing");
+
         // A row still being written is not complained about.
         dialog->setDraft({});
         add->click();
@@ -808,6 +827,45 @@ int main(int argc, char** argv)
         quiet();
         require(warning->text().isEmpty(),
             "a half-typed definition was complained about");
+        delete parent;
+    }
+
+    // The key the editor is opened with is the key it is refreshed against.
+    // Spelled two ways, the first session installed after the editor opened --
+    // any sequence frame, or the reload an Apply started -- read as a change of
+    // dataset and took down a verdict that was still true of it.
+    {
+        Fixture fixture;
+        DerivedFieldStore store;
+        DerivedFieldController controller(fixture.hooks(store), store);
+        auto* parent = new QWidget;
+        controller.showEditor(parent);
+        auto* dialog = parent->findChild<ExpressionEditorDialog*>();
+        require(dialog != nullptr, "the editor did not open");
+        auto* add = dialog->findChild<QPushButton*>(
+            QStringLiteral("newExpressionButton"));
+        auto* name =
+            dialog->findChild<QLineEdit*>(QStringLiteral("expressionName"));
+        auto* source = dialog->findChild<QPlainTextEdit*>(
+            QStringLiteral("expressionSource"));
+        auto* applyButton = dialog->findChild<QPushButton*>(
+            QStringLiteral("applyExpressionsButton"));
+        auto* error =
+            dialog->findChild<QLabel*>(QStringLiteral("expressionError"));
+        require(add != nullptr && name != nullptr && source != nullptr
+                && applyButton != nullptr && error != nullptr,
+            "the editor is missing a widget this block drives");
+
+        add->click();
+        name->setText(QStringLiteral("twice"));
+        source->setPlainText(QStringLiteral("nonesuch * 2"));
+        applyButton->click();
+        require(!error->text().isEmpty(),
+            "a definition this dataset cannot provide was not refused");
+        controller.refreshAvailability();
+        require(!error->text().isEmpty(),
+            "the first session installed after the editor opened was mistaken "
+            "for a change of dataset");
         delete parent;
     }
 

--- a/tests/unit/test_derived_field_controller.cpp
+++ b/tests/unit/test_derived_field_controller.cpp
@@ -423,6 +423,47 @@ int main(int argc, char** argv)
                 "a list fault in another row was reported as this dataset's "
                 "doing");
         }
+
+        // Typing something and taking it back is not writing a definition, so
+        // it must not hold every later Apply to a list carried from another
+        // plotfile -- there is nothing inside the editor that could clear it.
+        dialog->setDraft({{"carried", "absent * 2"}});
+        dialog->setCommitted({{"carried", "absent * 2"}});
+        source->setPlainText(QStringLiteral("absent * 2 "));
+        source->setPlainText(QStringLiteral("absent * 2"));
+        waitQuiet();
+        require(!dialog->handEdited(0),
+            "a definition typed into and put back was still counted as "
+            "written here");
+        applyButton->click();
+        require(error->text().isEmpty(),
+            "Apply was deadlocked by a definition the user only brushed "
+            "against");
+
+        // A field written in from the list lands where the user is typing,
+        // which for a row they just selected is the end of what is there.
+        fixture.storedFields = QStringList{
+            QStringLiteral("density"), QStringLiteral("temperature")};
+        controller.refreshAvailability();
+        dialog->setDraft({{"twice", "density"}});
+        list->setCurrentRow(0);
+        auto* storedFields =
+            dialog->findChild<QListWidget*>(QStringLiteral("storedFieldList"));
+        require(storedFields != nullptr && storedFields->count() > 1,
+            "the editor lists no stored fields to write in");
+        const auto written = storedFields->item(1)->text();
+        emit storedFields->itemDoubleClicked(storedFields->item(1));
+        require(dialog->draft()[0].expression
+                == (QStringLiteral("density") + written).toStdString(),
+            "a field written in from the list did not land at the end");
+
+        // A row still being written is not complained about.
+        dialog->setDraft({});
+        add->click();
+        name->setText(QStringLiteral("s"));
+        waitQuiet();
+        require(warning->text().isEmpty(),
+            "a half-typed definition was complained about");
         delete parent;
     }
 

--- a/tests/unit/test_derived_field_controller.cpp
+++ b/tests/unit/test_derived_field_controller.cpp
@@ -388,6 +388,41 @@ int main(int argc, char** argv)
         waitQuiet();
         require(warning->text().isEmpty(),
             "a diagnostic queued for a deleted row landed on its successor");
+
+        // Apply overtakes a diagnostic still in flight: clicking it inside the
+        // debounce must not have the advisory reappear beside the refusal a
+        // moment later. Deliberately without waiting -- waiting is what lets
+        // the timer fire first and hides this.
+        dialog->setDraft({{"twice", "density * 2"}});
+        source->setPlainText(QStringLiteral("nonesuch * 2"));
+        applyButton->click();
+        waitQuiet();
+        require(!error->text().isEmpty() && warning->text().isEmpty(),
+            "a diagnostic in flight when Apply was refused came back beside "
+            "the refusal");
+
+        // A fault that belongs to the list and names a *different* row says
+        // nothing about this one: reporting what the dataset then makes of it
+        // would blame the data for a consequence of that other fault.
+        {
+            QStringList many;
+            QStringList terms;
+            for (int field = 0; field <= 16; ++field) {
+                many.append(QStringLiteral("f%1").arg(field));
+                terms.append(QStringLiteral("f%1").arg(field));
+            }
+            fixture.storedFields = many;
+            controller.refreshAvailability();
+            const auto wide = terms.join(QStringLiteral(" + "));
+            dialog->setDraft({{"a", wide.toStdString()},
+                {"b", wide.toStdString()}});
+            list->setCurrentRow(1);
+            source->setPlainText(wide + QStringLiteral(" + f0"));
+            waitQuiet();
+            require(!warning->text().contains(QStringLiteral("dataset")),
+                "a list fault in another row was reported as this dataset's "
+                "doing");
+        }
         delete parent;
     }
 

--- a/tests/unit/test_derived_field_controller.cpp
+++ b/tests/unit/test_derived_field_controller.cpp
@@ -3,7 +3,9 @@
 #include "ExpressionEditorDialog.hpp"
 
 #include <QApplication>
+#include <QCoreApplication>
 #include <QDialog>
+#include <QElapsedTimer>
 #include <QFile>
 #include <QLabel>
 #include <QLineEdit>
@@ -50,6 +52,10 @@ struct Fixture {
     // What the next chooseFile answers, and what it was asked for.
     QString chosenPath;
     std::optional<bool> lastChooseForSaving;
+    // The fields the open dataset stores. Empty stands for no dataset open,
+    // which the editor shows no field list and no warning for.
+    QStringList storedFields{
+        QStringLiteral("density"), QStringLiteral("temperature")};
 
     [[nodiscard]] DerivedFieldController::Hooks hooks(
         const DerivedFieldStore& store)
@@ -73,6 +79,26 @@ struct Fixture {
                 [this](QWidget*, bool forSaving) {
                     lastChooseForSaving = forSaving;
                     return chosenPath;
+                },
+            .storedFieldNames = [this] { return storedFields; },
+            // The real resolution against a dataset of those fields, so the
+            // reasons the editor shows here are the ones a dataset gives.
+            .resolveAgainstOpenDataset =
+                [this](const std::vector<DerivedFieldDefinition>& definitions) {
+                    std::vector<DerivedFieldSkip> skipped;
+                    if (storedFields.isEmpty()) {
+                        return skipped;
+                    }
+                    amrvis::DatasetMetadata metadata;
+                    metadata.dimension = 2;
+                    for (const auto& name : storedFields) {
+                        amrvis::FieldMetadata field;
+                        field.name = name.toStdString();
+                        metadata.fields.push_back(std::move(field));
+                    }
+                    return amrvis::installDerivedFields(metadata, definitions,
+                        amrvis::DerivedFieldPolicy::Skip)
+                        .skipped;
                 },
         };
     }
@@ -151,6 +177,87 @@ int main(int argc, char** argv)
         require(controller.definitions().empty()
                 && fixture.reloads == before + 1,
             "clearing the list did not commit and reload");
+    }
+
+    // The editor lists the dataset's stored fields, and measures a definition
+    // against that dataset as it is *typed* -- and only then. A plotfile of
+    // another shape opening under a list written for the last one is not the
+    // user's error to correct, so nothing but an edit asks the question.
+    {
+        Fixture fixture;
+        DerivedFieldStore store;
+        DerivedFieldController controller(fixture.hooks(store), store);
+        require(!controller.apply({{"twice", "density * 2"}}).has_value(),
+            "a resolvable definition was refused");
+
+        auto* parent = new QWidget;
+        controller.showEditor(parent);
+        auto* dialog = parent->findChild<ExpressionEditorDialog*>();
+        require(dialog != nullptr, "the editor did not open");
+
+        auto* fields =
+            dialog->findChild<QListWidget*>(QStringLiteral("storedFieldList"));
+        require(fields != nullptr && fields->count() == 2
+                && fields->item(0)->text() == QStringLiteral("density")
+                && fields->item(1)->text() == QStringLiteral("temperature"),
+            "the editor does not list the dataset's stored fields");
+
+        auto* warning =
+            dialog->findChild<QLabel*>(QStringLiteral("expressionWarning"));
+        auto* source = dialog->findChild<QPlainTextEdit*>(
+            QStringLiteral("expressionSource"));
+        require(warning != nullptr && source != nullptr,
+            "the editor is missing its expression box or warning");
+        require(warning->text().isEmpty(),
+            "a definition this dataset can provide warned about itself");
+
+        // Past the diagnostics debounce, which is what makes this the verdict
+        // on what was typed rather than one per keystroke.
+        const auto settle = [] {
+            QElapsedTimer timer;
+            timer.start();
+            while (timer.elapsed() < 600) {
+                QCoreApplication::processEvents(QEventLoop::AllEvents, 10);
+            }
+        };
+
+        source->setPlainText(QStringLiteral("nonesuch * 2"));
+        settle();
+        require(!warning->text().isEmpty(),
+            "a hand-written expression naming no field of this dataset said "
+            "nothing");
+        // Named as the dataset's limitation rather than as a mistake, and
+        // still committable: the list is shared with windows and plotfiles
+        // that may have the field.
+        require(!controller.apply(dialog->draft()).has_value(),
+            "a definition this dataset cannot provide was refused");
+
+        source->setPlainText(QStringLiteral("density * 3"));
+        settle();
+        require(warning->text().isEmpty(),
+            "the warning outlived the expression it was about");
+
+        // What the user did not type is left alone. An import replaces every
+        // row at once and is tolerated whole; the field list greys out what
+        // this dataset cannot provide.
+        dialog->setDraft({{"stranger", "absent * 2"}});
+        settle();
+        require(warning->text().isEmpty(),
+            "an imported definition was complained about");
+
+        // And so is a dataset arriving that cannot provide what is already
+        // written: refreshAvailability drops the warning rather than raising
+        // one against a list the user has not touched.
+        fixture.storedFields = QStringList{QStringLiteral("other")};
+        controller.refreshAvailability();
+        settle();
+        require(warning->text().isEmpty(),
+            "opening another dataset raised a warning about an untouched "
+            "definition");
+        require(fields->count() == 1
+                && fields->item(0)->text() == QStringLiteral("other"),
+            "the field list did not follow the dataset");
+        delete parent;
     }
 
     // A reload that fails leaves the list committed here and installed

--- a/tests/unit/test_derived_field_controller.cpp
+++ b/tests/unit/test_derived_field_controller.cpp
@@ -290,6 +290,107 @@ int main(int argc, char** argv)
         delete parent;
     }
 
+    // The warning belongs to the row being written: not to the first thing
+    // wrong in the list, and not to whatever slides into that row's number
+    // afterwards. A refusal replaces it, and a deletion takes it away.
+    {
+        Fixture fixture;
+        DerivedFieldStore store;
+        DerivedFieldController controller(fixture.hooks(store), store);
+        auto* parent = new QWidget;
+        controller.showEditor(parent);
+        auto* dialog = parent->findChild<ExpressionEditorDialog*>();
+        require(dialog != nullptr, "the editor did not open");
+        auto* warning =
+            dialog->findChild<QLabel*>(QStringLiteral("expressionWarning"));
+        auto* error =
+            dialog->findChild<QLabel*>(QStringLiteral("expressionError"));
+        auto* source = dialog->findChild<QPlainTextEdit*>(
+            QStringLiteral("expressionSource"));
+        auto* name =
+            dialog->findChild<QLineEdit*>(QStringLiteral("expressionName"));
+        auto* add = dialog->findChild<QPushButton*>(
+            QStringLiteral("newExpressionButton"));
+        auto* remove = dialog->findChild<QPushButton*>(
+            QStringLiteral("deleteExpressionButton"));
+        auto* applyButton = dialog->findChild<QPushButton*>(
+            QStringLiteral("applyExpressionsButton"));
+        require(warning != nullptr && error != nullptr && source != nullptr
+                && name != nullptr && add != nullptr && remove != nullptr
+                && applyButton != nullptr,
+            "the editor is missing a widget this block drives");
+
+        // Runs the loop until the diagnostic has had its say, or long enough
+        // to be sure it never will.
+        const auto waitFor = [](auto predicate) {
+            QElapsedTimer timer;
+            timer.start();
+            while (timer.elapsed() < 2000 && !predicate()) {
+                QCoreApplication::processEvents(QEventLoop::AllEvents, 10);
+            }
+        };
+        const auto waitQuiet = [] {
+            QElapsedTimer timer;
+            timer.start();
+            while (timer.elapsed() < 700) {
+                QCoreApplication::processEvents(QEventLoop::AllEvents, 10);
+            }
+        };
+
+        // Row 0 is left unnamed, which is a fault of its own and the first in
+        // the list; row 1 is where the user is typing. The warning must be
+        // about row 1's syntax, not about the data.
+        add->click();
+        source->setPlainText(QStringLiteral("density"));
+        add->click();
+        name->setText(QStringLiteral("bad"));
+        source->setPlainText(QStringLiteral("sqrt("));
+        waitFor([&] { return !warning->text().isEmpty(); });
+        require(!warning->text().isEmpty()
+                && !warning->text().contains(QStringLiteral("dataset")),
+            "a syntax error in the row being written was blamed on the "
+            "dataset");
+
+        // A refusal supersedes the advisory rather than standing beside it.
+        dialog->setDraft({{"twice", "density * 2"}});
+        source->setPlainText(QStringLiteral("nonesuch * 2"));
+        waitFor([&] { return !warning->text().isEmpty(); });
+        require(!warning->text().isEmpty(), "the edited row did not warn");
+        applyButton->click();
+        require(!error->text().isEmpty() && warning->text().isEmpty(),
+            "a refusal left the same sentence showing twice");
+
+        // Deleting the only definition takes the warning with it: nothing is
+        // selected afterwards, so no row change would.
+        dialog->setDraft({{"twice", "nonesuch * 2"}});
+        source->setPlainText(QStringLiteral("nonesuch * 3"));
+        waitFor([&] { return !warning->text().isEmpty(); });
+        require(!warning->text().isEmpty(), "the edited row did not warn");
+        remove->click();
+        require(warning->text().isEmpty(),
+            "deleting the definition left its warning on screen");
+
+        // And a diagnostic queued for a row that is then deleted must not land
+        // on whatever takes its number -- here a row that was edited too, so
+        // every other guard passes.
+        dialog->setDraft({{"first", "density"}, {"second", "density"}});
+        auto* list =
+            dialog->findChild<QListWidget*>(QStringLiteral("expressionList"));
+        require(list != nullptr, "the editor has no definition list");
+        // The successor is edited *and* unresolvable, so a diagnostic that
+        // landed on it would have something to say -- which is what makes
+        // this a test rather than a coincidence.
+        list->setCurrentRow(1);
+        source->setPlainText(QStringLiteral("absent * 2"));
+        list->setCurrentRow(0);
+        source->setPlainText(QStringLiteral("nonesuch * 2"));
+        remove->click();
+        waitQuiet();
+        require(warning->text().isEmpty(),
+            "a diagnostic queued for a deleted row landed on its successor");
+        delete parent;
+    }
+
     // A reload that fails leaves the list committed here and installed
     // nowhere, and the store emits nothing for a list that has not moved -- so
     // the Apply pressed again is the only thing left that can ask for it.

--- a/tests/unit/test_derived_field_controller.cpp
+++ b/tests/unit/test_derived_field_controller.cpp
@@ -661,6 +661,32 @@ int main(int argc, char** argv)
         require(dialog->draft().empty() && !dialog->handEdited(0),
             "an empty draft still answered about a row");
 
+        // A fault of the list that names a row *above* this one is still said
+        // out loud: Apply will refuse it, and staying silent because it
+        // belongs to another row leaves the advisory quiet about the thing
+        // that is about to stop the user.
+        {
+            QStringList many;
+            QStringList terms;
+            for (int field = 0; field <= 16; ++field) {
+                many.append(QStringLiteral("f%1").arg(field));
+                terms.append(QStringLiteral("f%1").arg(field));
+            }
+            fixture.storedFields = many;
+            controller.refreshAvailability();
+            dialog->setDraft({{"wide", terms.join(QStringLiteral(" + ")).toStdString()},
+                {"narrow", "f0"}});
+            list->setCurrentRow(1);
+            source->setPlainText(QStringLiteral("f0 + 1"));
+            require(waitUntil([&] { return !warning->text().isEmpty(); }),
+                "a list fault in the row above was never mentioned");
+            require(!warning->text().contains(QStringLiteral("dataset")),
+                "a fault of the list was blamed on the data");
+            fixture.storedFields = QStringList{
+                QStringLiteral("density"), QStringLiteral("temperature")};
+            controller.refreshAvailability();
+        }
+
         // A row still being written is not complained about.
         dialog->setDraft({});
         add->click();

--- a/tests/unit/test_derived_field_controller.cpp
+++ b/tests/unit/test_derived_field_controller.cpp
@@ -580,6 +580,50 @@ int main(int argc, char** argv)
                 && controller.definitions().size() == 2,
             "a definition was refused for the failure of the one it reads");
 
+        // A row that fails for reasons of its own *as well* is still the
+        // user's to answer for: naming a lost definition alongside a field
+        // that was never there must not buy it a pass. Both orders, because
+        // the first symbol scanned should not decide it.
+        dialog->setDraft({{"base", "nonesuch"}});
+        add->click();
+        name->setText(QStringLiteral("mixed"));
+        source->setPlainText(QStringLiteral("also_absent + base"));
+        applyButton->click();
+        require(!error->text().isEmpty(),
+            "a row failing on a missing field slipped through behind a lost "
+            "definition it also read");
+
+        dialog->setDraft({{"base", "nonesuch"}});
+        add->click();
+        name->setText(QStringLiteral("mixed"));
+        source->setPlainText(QStringLiteral("base + also_absent"));
+        applyButton->click();
+        require(!error->text().isEmpty(),
+            "the order the symbols are written in decided whether the row "
+            "was checked");
+
+        // And a chain of them is still inherited all the way down.
+        dialog->setDraft({{"base", "nonesuch"}, {"mid", "base * 2"}});
+        add->click();
+        name->setText(QStringLiteral("leaf"));
+        source->setPlainText(QStringLiteral("mid + 1"));
+        applyButton->click();
+        require(error->text().isEmpty()
+                && controller.definitions().size() == 3,
+            "a definition two rows below the lost one was blamed for it");
+
+        // A symbol that names an earlier lost definition *and* a stored field
+        // resolved to the stored one, so the earlier row is not the reason
+        // and the user's row is still theirs to answer for.
+        dialog->setDraft({{"density", "nonesuch"}});
+        add->click();
+        name->setText(QStringLiteral("b"));
+        source->setPlainText(QStringLiteral("density * absent"));
+        applyButton->click();
+        require(!error->text().isEmpty(),
+            "a name collision with a stored field passed a genuine failure "
+            "off as inherited");
+
         // A row still being written is not complained about.
         dialog->setDraft({});
         add->click();

--- a/tests/unit/test_derived_field_controller.cpp
+++ b/tests/unit/test_derived_field_controller.cpp
@@ -245,6 +245,36 @@ int main(int argc, char** argv)
         require(warning->text().isEmpty(),
             "an imported definition was complained about");
 
+        // And Apply takes it: it was never a claim about this dataset, so it
+        // is committed and greyed out in the field list, as a list carried
+        // from another plotfile is.
+        auto* applyButton = dialog->findChild<QPushButton*>(
+            QStringLiteral("applyExpressionsButton"));
+        auto* error =
+            dialog->findChild<QLabel*>(QStringLiteral("expressionError"));
+        require(applyButton != nullptr && error != nullptr,
+            "the editor is missing its Apply button or error label");
+        applyButton->click();
+        require(controller.definitions().size() == 1
+                && controller.definitions()[0].name == "stranger"
+                && error->text().isEmpty(),
+            "an imported definition this dataset cannot provide was refused");
+
+        // Typed here, the same kind of definition is held to the data in
+        // front of the user, and Apply says so rather than committing it to
+        // be discovered greyed out later.
+        source->setPlainText(QStringLiteral("absent * 3"));
+        settle();
+        require(!warning->text().isEmpty(),
+            "the edited definition did not warn");
+        applyButton->click();
+        require(!error->text().isEmpty(),
+            "a hand-written definition this dataset cannot provide was "
+            "accepted");
+        require(controller.definitions().size() == 1
+                && controller.definitions()[0].expression == "absent * 2",
+            "the refused edit was committed anyway");
+
         // And so is a dataset arriving that cannot provide what is already
         // written: refreshAvailability drops the warning rather than raising
         // one against a list the user has not touched.

--- a/tests/unit/test_derived_field_controller.cpp
+++ b/tests/unit/test_derived_field_controller.cpp
@@ -97,9 +97,10 @@ struct Fixture {
     // which the editor shows no field list and no warning for.
     QStringList storedFields{
         QStringLiteral("density"), QStringLiteral("temperature")};
-    // The rest of the vocabulary: two datasets sharing every field name still
-    // differ here if one of them has no z to speak of.
-    QString geometry{QStringLiteral("2d+geo")};
+    // The rest of what decides resolution: two datasets sharing every field
+    // name still differ here if one has no z to speak of, or centres a field
+    // differently.
+    QString shape{QStringLiteral("2d+geo:00")};
 
     [[nodiscard]] DerivedFieldController::Hooks hooks(
         const DerivedFieldStore& store)
@@ -125,7 +126,7 @@ struct Fixture {
                     return chosenPath;
                 },
             .storedFieldNames = [this] { return storedFields; },
-            .datasetGeometry = [this] { return geometry; },
+            .datasetShape = [this] { return shape; },
             // The real resolution against a dataset of those fields, so the
             // reasons the editor shows here are the ones a dataset gives.
             .resolveAgainstOpenDataset =
@@ -748,11 +749,54 @@ int main(int argc, char** argv)
         source->setPlainText(QStringLiteral("absent * 2"));
         require(waitUntil([&] { return !warning->text().isEmpty(); }),
             "the edited row did not warn");
-        fixture.geometry = QStringLiteral("3d+geo");
+        fixture.shape = QStringLiteral("3d+geo:00");
         controller.refreshAvailability();
         require(waitUntil([&] { return warning->text().isEmpty(); }, 400),
-            "a dimensionality change was mistaken for the same dataset");
-        fixture.geometry = QStringLiteral("2d+geo");
+            "a change of shape was mistaken for the same dataset");
+        fixture.shape = QStringLiteral("2d+geo:00");
+        fixture.storedFields = QStringList{
+            QStringLiteral("density"), QStringLiteral("temperature")};
+        controller.refreshAvailability();
+
+        // A shape that moved with every name unchanged still counts: a field
+        // centred differently makes an expression that mixes centerings stop
+        // resolving, so a verdict about the old one has to go.
+        dialog->setDraft({{"twice", "density * 2"}});
+        source->setPlainText(QStringLiteral("absent * 2"));
+        require(waitUntil([&] { return !warning->text().isEmpty(); }),
+            "the edited row did not warn");
+        fixture.shape = QStringLiteral("2d+geo:01");
+        controller.refreshAvailability();
+        require(waitUntil([&] { return !warning->text().isEmpty(); }),
+            "a centering change was mistaken for the same dataset");
+        fixture.shape = QStringLiteral("2d+geo:00");
+        controller.refreshAvailability();
+
+        // Losing the dataset counts too, though every unavailable state has
+        // the same empty shape: without the reason in the key, a refusal
+        // naming one of them survives the arrival of another.
+        dialog->setDraft({{"twice", "nonesuch * 2"}});
+        source->setPlainText(QStringLiteral("nonesuch * 3"));
+        applyButton->click();
+        require(!error->text().isEmpty(), "the edit was not refused");
+        fixture.datasetOpen = false;
+        controller.refreshAvailability();
+        require(error->text().isEmpty(),
+            "a verdict about the data survived the data going away");
+        fixture.datasetOpen = true;
+        controller.refreshAvailability();
+
+        // But a fault in the definition itself is true whatever is open, and
+        // nothing here would say it again -- so it stays put.
+        dialog->setDraft({{"", "density"}});
+        applyButton->click();
+        require(!error->text().isEmpty() && !anyway->isVisible(),
+            "an unnamed definition was not refused");
+        fixture.storedFields = QStringList{QStringLiteral("elsewhere")};
+        controller.refreshAvailability();
+        require(!error->text().isEmpty(),
+            "a fault of the definition was wiped by a dataset arriving, "
+            "leaving an editor whose Apply still refuses");
         fixture.storedFields = QStringList{
             QStringLiteral("density"), QStringLiteral("temperature")};
         controller.refreshAvailability();

--- a/tests/unit/test_derived_field_controller.cpp
+++ b/tests/unit/test_derived_field_controller.cpp
@@ -3,6 +3,7 @@
 #include "ExpressionEditorDialog.hpp"
 
 #include <QApplication>
+#include <QEventLoop>
 #include <QCoreApplication>
 #include <QDialog>
 #include <QElapsedTimer>
@@ -14,6 +15,7 @@
 #include <QPushButton>
 #include <QTextCursor>
 #include <QTemporaryDir>
+#include <QTimer>
 #include <QTextDocument>
 
 #include <cstdlib>
@@ -30,6 +32,44 @@ using amrvis::DerivedFieldSkip;
 using amrvis::qt::DerivedFieldController;
 using amrvis::qt::DerivedFieldStore;
 using amrvis::qt::ExpressionEditorDialog;
+
+// The debounce the controller arms its diagnostics on. The tests wait against
+// this rather than against numbers of their own, so raising it cannot quietly
+// turn an assertion that nothing fired into one that fired late.
+constexpr int kDiagnosticsDebounceMs = 250;
+
+// Runs the event loop for a fixed span without spinning: a single-shot timer
+// quits it, so the process idles instead of burning a core on processEvents.
+void pump(int milliseconds)
+{
+    QEventLoop loop;
+    QTimer::singleShot(milliseconds, &loop, &QEventLoop::quit);
+    loop.exec();
+}
+
+// Long enough for a diagnostic to have fired and been seen not to. Used for the
+// assertions that something must *not* appear, which is why it is a fixed span
+// rather than a poll: there is no event to wait for.
+void quiet()
+{
+    pump(kDiagnosticsDebounceMs * 3);
+}
+
+// Runs until `predicate` holds, or gives up. Returns as soon as it holds, so a
+// passing test costs the debounce rather than the ceiling.
+template <typename Predicate>
+bool waitUntil(Predicate predicate, int ceilingMs = 2000)
+{
+    QElapsedTimer elapsed;
+    elapsed.start();
+    while (!predicate()) {
+        if (elapsed.elapsed() >= ceilingMs) {
+            return false;
+        }
+        pump(10);
+    }
+    return true;
+}
 
 void require(bool condition, const char* message)
 {
@@ -212,18 +252,8 @@ int main(int argc, char** argv)
         require(warning->text().isEmpty(),
             "a definition this dataset can provide warned about itself");
 
-        // Past the diagnostics debounce, which is what makes this the verdict
-        // on what was typed rather than one per keystroke.
-        const auto settle = [] {
-            QElapsedTimer timer;
-            timer.start();
-            while (timer.elapsed() < 600) {
-                QCoreApplication::processEvents(QEventLoop::AllEvents, 10);
-            }
-        };
-
         source->setPlainText(QStringLiteral("nonesuch * 2"));
-        settle();
+        quiet();
         require(!warning->text().isEmpty(),
             "a hand-written expression naming no field of this dataset said "
             "nothing");
@@ -234,7 +264,7 @@ int main(int argc, char** argv)
             "a definition this dataset cannot provide was refused");
 
         source->setPlainText(QStringLiteral("density * 3"));
-        settle();
+        quiet();
         require(warning->text().isEmpty(),
             "the warning outlived the expression it was about");
 
@@ -242,7 +272,7 @@ int main(int argc, char** argv)
         // row at once and is tolerated whole; the field list greys out what
         // this dataset cannot provide.
         dialog->setDraft({{"stranger", "absent * 2"}});
-        settle();
+        quiet();
         require(warning->text().isEmpty(),
             "an imported definition was complained about");
 
@@ -265,7 +295,7 @@ int main(int argc, char** argv)
         // front of the user, and Apply says so rather than committing it to
         // be discovered greyed out later.
         source->setPlainText(QStringLiteral("absent * 3"));
-        settle();
+        quiet();
         require(!warning->text().isEmpty(),
             "the edited definition did not warn");
         applyButton->click();
@@ -281,7 +311,7 @@ int main(int argc, char** argv)
         // one against a list the user has not touched.
         fixture.storedFields = QStringList{QStringLiteral("other")};
         controller.refreshAvailability();
-        settle();
+        quiet();
         require(warning->text().isEmpty(),
             "opening another dataset raised a warning about an untouched "
             "definition");
@@ -321,23 +351,6 @@ int main(int argc, char** argv)
                 && applyButton != nullptr,
             "the editor is missing a widget this block drives");
 
-        // Runs the loop until the diagnostic has had its say, or long enough
-        // to be sure it never will.
-        const auto waitFor = [](auto predicate) {
-            QElapsedTimer timer;
-            timer.start();
-            while (timer.elapsed() < 2000 && !predicate()) {
-                QCoreApplication::processEvents(QEventLoop::AllEvents, 10);
-            }
-        };
-        const auto waitQuiet = [] {
-            QElapsedTimer timer;
-            timer.start();
-            while (timer.elapsed() < 700) {
-                QCoreApplication::processEvents(QEventLoop::AllEvents, 10);
-            }
-        };
-
         // Row 0 is left unnamed, which is a fault of its own and the first in
         // the list; row 1 is where the user is typing. The warning must be
         // about row 1's syntax, not about the data.
@@ -346,7 +359,7 @@ int main(int argc, char** argv)
         add->click();
         name->setText(QStringLiteral("bad"));
         source->setPlainText(QStringLiteral("sqrt("));
-        waitFor([&] { return !warning->text().isEmpty(); });
+        waitUntil([&] { return !warning->text().isEmpty(); });
         require(!warning->text().isEmpty()
                 && !warning->text().contains(QStringLiteral("dataset")),
             "a syntax error in the row being written was blamed on the "
@@ -355,7 +368,7 @@ int main(int argc, char** argv)
         // A refusal supersedes the advisory rather than standing beside it.
         dialog->setDraft({{"twice", "density * 2"}});
         source->setPlainText(QStringLiteral("nonesuch * 2"));
-        waitFor([&] { return !warning->text().isEmpty(); });
+        waitUntil([&] { return !warning->text().isEmpty(); });
         require(!warning->text().isEmpty(), "the edited row did not warn");
         applyButton->click();
         require(!error->text().isEmpty() && warning->text().isEmpty(),
@@ -365,7 +378,7 @@ int main(int argc, char** argv)
         // selected afterwards, so no row change would.
         dialog->setDraft({{"twice", "nonesuch * 2"}});
         source->setPlainText(QStringLiteral("nonesuch * 3"));
-        waitFor([&] { return !warning->text().isEmpty(); });
+        waitUntil([&] { return !warning->text().isEmpty(); });
         require(!warning->text().isEmpty(), "the edited row did not warn");
         remove->click();
         require(warning->text().isEmpty(),
@@ -386,7 +399,7 @@ int main(int argc, char** argv)
         list->setCurrentRow(0);
         source->setPlainText(QStringLiteral("nonesuch * 2"));
         remove->click();
-        waitQuiet();
+        quiet();
         require(warning->text().isEmpty(),
             "a diagnostic queued for a deleted row landed on its successor");
 
@@ -397,7 +410,7 @@ int main(int argc, char** argv)
         dialog->setDraft({{"twice", "density * 2"}});
         source->setPlainText(QStringLiteral("nonesuch * 2"));
         applyButton->click();
-        waitQuiet();
+        quiet();
         require(!error->text().isEmpty() && warning->text().isEmpty(),
             "a diagnostic in flight when Apply was refused came back beside "
             "the refusal");
@@ -419,7 +432,7 @@ int main(int argc, char** argv)
                 {"b", wide.toStdString()}});
             list->setCurrentRow(1);
             source->setPlainText(wide + QStringLiteral(" + f0"));
-            waitQuiet();
+            quiet();
             require(!warning->text().contains(QStringLiteral("dataset")),
                 "a list fault in another row was reported as this dataset's "
                 "doing");
@@ -434,10 +447,10 @@ int main(int argc, char** argv)
         // Let the warning actually appear, so the revert has something to
         // take back: without this the second edit merely restarts the timer
         // and nothing was ever on screen.
-        waitFor([&] { return !warning->text().isEmpty(); });
+        waitUntil([&] { return !warning->text().isEmpty(); });
         require(!warning->text().isEmpty(), "the edit did not warn");
         source->setPlainText(QStringLiteral("absent * 2"));
-        waitQuiet();
+        quiet();
         require(!dialog->handEdited(0),
             "a definition typed into and put back was still counted as "
             "written here");
@@ -534,7 +547,7 @@ int main(int argc, char** argv)
         // promises nothing was stopped.
         dialog->setDraft({{"t", "density"}});
         source->setPlainText(QStringLiteral("sqrt("));
-        waitFor([&] { return !warning->text().isEmpty(); });
+        waitUntil([&] { return !warning->text().isEmpty(); });
         require(warning->styleSheet().contains(QStringLiteral("red")),
             "a fault Apply will refuse was shown as advice");
 
@@ -572,7 +585,7 @@ int main(int argc, char** argv)
         add->click();
         name->setText(QStringLiteral("twice"));
         source->setPlainText(QStringLiteral("base * 2"));
-        waitQuiet();
+        quiet();
         require(warning->text().isEmpty(),
             "a definition was blamed for the failure of the one it reads");
         applyButton->click();
@@ -628,7 +641,7 @@ int main(int argc, char** argv)
         dialog->setDraft({});
         add->click();
         name->setText(QStringLiteral("s"));
-        waitQuiet();
+        quiet();
         require(warning->text().isEmpty(),
             "a half-typed definition was complained about");
         delete parent;

--- a/tests/unit/test_derived_field_controller.cpp
+++ b/tests/unit/test_derived_field_controller.cpp
@@ -637,6 +637,30 @@ int main(int argc, char** argv)
             "a name collision with a stored field passed a genuine failure "
             "off as inherited");
 
+        // The baseline tracks the draft through deletions at either end, so
+        // "did the user write this row" keeps answering about the row it is
+        // asked about and not about whatever used to sit at that number.
+        dialog->setCommitted({{"a", "density"}, {"b", "temperature"},
+            {"c", "density + 1"}});
+        require(!dialog->handEdited(0) && !dialog->handEdited(1)
+                && !dialog->handEdited(2),
+            "a freshly committed list counted as written here");
+        list->setCurrentRow(0);
+        remove->click();
+        require(dialog->draft().size() == 2 && !dialog->handEdited(0)
+                && !dialog->handEdited(1),
+            "deleting the first row made a survivor look written here");
+        list->setCurrentRow(1);
+        remove->click();
+        require(dialog->draft().size() == 1 && !dialog->handEdited(0),
+            "deleting the last row made the survivor look written here");
+        source->setPlainText(QStringLiteral("temperature * 4"));
+        require(dialog->handEdited(0),
+            "an edit after deletions did not count as written here");
+        remove->click();
+        require(dialog->draft().empty() && !dialog->handEdited(0),
+            "an empty draft still answered about a row");
+
         // A row still being written is not complained about.
         dialog->setDraft({});
         add->click();

--- a/tests/unit/test_derived_field_controller.cpp
+++ b/tests/unit/test_derived_field_controller.cpp
@@ -97,6 +97,9 @@ struct Fixture {
     // which the editor shows no field list and no warning for.
     QStringList storedFields{
         QStringLiteral("density"), QStringLiteral("temperature")};
+    // The rest of the vocabulary: two datasets sharing every field name still
+    // differ here if one of them has no z to speak of.
+    QString geometry{QStringLiteral("2d+geo")};
 
     [[nodiscard]] DerivedFieldController::Hooks hooks(
         const DerivedFieldStore& store)
@@ -122,6 +125,7 @@ struct Fixture {
                     return chosenPath;
                 },
             .storedFieldNames = [this] { return storedFields; },
+            .datasetGeometry = [this] { return geometry; },
             // The real resolution against a dataset of those fields, so the
             // reasons the editor shows here are the ones a dataset gives.
             .resolveAgainstOpenDataset =
@@ -306,9 +310,15 @@ int main(int argc, char** argv)
                 && controller.definitions()[0].expression == "absent * 2",
             "the refused edit was committed anyway");
 
-        // And so is a dataset arriving that cannot provide what is already
-        // written: refreshAvailability drops the warning rather than raising
-        // one against a list the user has not touched.
+        // And a dataset arriving raises nothing about a definition the user
+        // has *not* touched -- carried here from another plotfile, which this
+        // one may well be unable to provide through nobody's fault. (A row
+        // they did write is a different matter and is answered again; that is
+        // covered below.) setDraft is what makes this list carried rather
+        // than written: it takes the baseline with it.
+        dialog->setDraft({{"stranger", "absent * 2"}});
+        require(!dialog->handEdited(0),
+            "a freshly imported definition counted as written here");
         fixture.storedFields = QStringList{QStringLiteral("other")};
         controller.refreshAvailability();
         quiet();
@@ -536,12 +546,23 @@ int main(int argc, char** argv)
         require(error->text().isEmpty() && !anyway->isVisible(),
             "a refusal outlived the draft it was about");
 
-        // Nor does it survive the dataset it named being replaced.
+        // Nor does it survive the dataset it named being replaced -- its
+        // "Apply anyway" would otherwise offer to overrule a verdict computed
+        // against data that is no longer open. A session installed *without*
+        // the vocabulary moving leaves it alone, because the verdict still
+        // describes what is open.
         applyButton->click();
         require(!error->text().isEmpty(), "the edit was not refused");
         controller.refreshAvailability();
+        require(!error->text().isEmpty() && anyway->isVisible(),
+            "an unchanged dataset took down a verdict still true of it");
+        fixture.storedFields = QStringList{QStringLiteral("elsewhere")};
+        controller.refreshAvailability();
         require(error->text().isEmpty() && !anyway->isVisible(),
             "a refusal about the previous dataset was left standing");
+        fixture.storedFields = QStringList{
+            QStringLiteral("density"), QStringLiteral("temperature")};
+        controller.refreshAvailability();
 
         // A fault Apply will refuse is not painted in the colour that
         // promises nothing was stopped.
@@ -686,6 +707,55 @@ int main(int argc, char** argv)
                 QStringLiteral("density"), QStringLiteral("temperature")};
             controller.refreshAvailability();
         }
+
+        // A session installed without the vocabulary moving -- a sequence
+        // frame, or the reload an Apply started -- leaves standing what the
+        // editor has already said, and does not rebuild the field list under
+        // the user's cursor.
+        dialog->setDraft({{"twice", "density * 2"}});
+        source->setPlainText(QStringLiteral("nonesuch * 2"));
+        require(waitUntil([&] { return !warning->text().isEmpty(); }),
+            "the edited row did not warn");
+        {
+            auto* storedList = dialog->findChild<QListWidget*>(
+                QStringLiteral("storedFieldList"));
+            require(storedList != nullptr && storedList->count() == 2,
+                "the stored fields are not listed");
+            storedList->setCurrentRow(1);
+            controller.refreshAvailability();
+            require(!warning->text().isEmpty(),
+                "an unchanged dataset took down what the editor had said");
+            require(storedList->currentRow() == 1,
+                "an unchanged dataset rebuilt the field list under the user");
+        }
+
+        // A vocabulary that did move takes the verdict down -- and asks
+        // again, so the row the user wrote is answered against the data now
+        // open rather than left silent until their next keystroke. The new
+        // dataset cannot provide it either, so the answer coming back is what
+        // distinguishes a re-ask from a cancellation: without it the label
+        // simply stays empty.
+        require(dialog->handEdited(0),
+            "the row under test is not one the user wrote");
+        fixture.storedFields = QStringList{QStringLiteral("other"),
+            QStringLiteral("another")};
+        controller.refreshAvailability();
+        require(waitUntil([&] { return !warning->text().isEmpty(); }),
+            "the question was not asked again against the dataset now open");
+
+        // Geometry alone counts as a move, even with every name unchanged.
+        dialog->setDraft({{"twice", "density * 2"}});
+        source->setPlainText(QStringLiteral("absent * 2"));
+        require(waitUntil([&] { return !warning->text().isEmpty(); }),
+            "the edited row did not warn");
+        fixture.geometry = QStringLiteral("3d+geo");
+        controller.refreshAvailability();
+        require(waitUntil([&] { return warning->text().isEmpty(); }, 400),
+            "a dimensionality change was mistaken for the same dataset");
+        fixture.geometry = QStringLiteral("2d+geo");
+        fixture.storedFields = QStringList{
+            QStringLiteral("density"), QStringLiteral("temperature")};
+        controller.refreshAvailability();
 
         // A row still being written is not complained about.
         dialog->setDraft({});


### PR DESCRIPTION
An expression the open dataset cannot resolve was only ever shown as a greyed row in the field list, which a user writing one has no reason to be looking at. The editor now resolves the draft as the definition is typed and says why this dataset cannot provide it, in the field list's own wording.

Only while typing: a row switch, an import and a dataset opening all clear the warning instead of recomputing it. A list is shared by windows showing different data, and a session may open a plotfile of another shape entirely, so a definition that means nothing here is not a mistake to correct -- it is committed and greyed out as before.

The dialog also lists the dataset's stored fields beside the expression, which double-clicking writes in, so they need not be hunted for in the Variable menu.