### PR TITLE
draw contour and vector overlays where the data is

### DIFF
--- a/include/amrexplorer/render2d/Contours.hpp
+++ b/include/amrexplorer/render2d/Contours.hpp
@@ -66,8 +66,12 @@ struct ContourPolyline {
 // plane, with the output mapped from contour-plane pixel space into
 // display-plane pixel space. The plane is at contour resolution (its samples
 // are the marching-squares grid; #56 removed supersampling), so sample center j
-// maps to display pixel ((j + 0.5) * display / plane) - 0.5 (cell-center to
-// cell-center; display-plane sample i sits at scene coordinate i).
+// maps to display pixel ((j + 0.5) * display / plane) - 0.5, cell-center to
+// cell-center. Output is in pixel-INDEX convention: display-plane sample i is
+// coordinate i, not the continuous coordinate of its center. A consumer drawing
+// into a continuous pixel space -- Qt scene units, where sample i spans
+// [i, i + 1] -- must add 0.5 per axis; see MainWindow::updateOverlay. The -0.5
+// above and that +0.5 cancel by design, so do not delete either one alone.
 [[nodiscard]] std::vector<ContourPolyline> contourPolylinesForDisplay(
     const ScalarPlane& plane,
     const std::vector<double>& values, int displayWidth, int displayHeight);

--- a/src/qt/MainWindowInteraction.cpp
+++ b/src/qt/MainWindowInteraction.cpp
@@ -155,8 +155,11 @@ QLineF MainWindow::planeSegmentToScene(const PlaneViewState& state,
 {
     // Plane row 0 is the bottom row; the displayed image is mirrored
     // vertically, so scene y runs opposite to plane y (see showSlice).
-    const auto top = static_cast<double>(state.plane->height) - 1.0;
-    return QLineF(QPointF(x0, top - y0), QPointF(x1, top - y1));
+    // Glyph coordinates are continuous raster pixels -- a pixel center is at
+    // i + 0.5 (see generateVectorGlyphs) -- and so are scene coordinates, so
+    // the vertical flip is height - y and x passes through unchanged.
+    const auto height = static_cast<double>(state.plane->height);
+    return QLineF(QPointF(x0, height - y0), QPointF(x1, height - y1));
 }
 
 QColor MainWindow::overlayColor() const
@@ -229,21 +232,28 @@ void MainWindow::updateOverlay(PlaneViewState& state)
     try {
         // The polylines were extracted from the refined data-resolution
         // contour plane on the slice worker and are already in display-plane
-        // pixel space (see appendContours); this thread only converts them
-        // to painter paths. Plane row 0 is the bottom row; the displayed
-        // image is mirrored vertically, so scene y runs opposite to plane y
-        // (see showSlice).
+        // pixel-index space -- pixel k's center is coordinate k (see
+        // contourPolylinesForDisplay); this thread only converts them to
+        // painter paths. Scene coordinates are continuous raster pixels
+        // (pixel k's center at k + 0.5), hence the +0.5 on both axes; the
+        // spherical mapping's sceneFromPlanePixel is likewise edge-based.
+        // Without the shift every contour draws half a display pixel up and
+        // left, poking out of the image at the left/top boundary and
+        // stopping half a pixel short at the right/bottom. Plane row 0 is
+        // the bottom row; the displayed image is mirrored vertically, so
+        // scene y runs opposite to plane y (see showSlice).
         const auto contourColor = overlayColor();
         const bool spherical = displayIsSpherical();
         const auto mapping = planeMapping(state);
-        const auto top = static_cast<double>(state.plane->height) - 1.0;
+        const auto height = static_cast<double>(state.plane->height);
         // Cartesian: plane pixel maps 1:1 to the scene (only the vertical flip).
         // Spherical: re-project each (r, theta) plane pixel through the warp.
         const auto toScene = [&](const auto& point) -> QPointF {
             if (spherical) {
-                return mapping.sceneFromPlanePixel(point[0], point[1]);
+                return mapping.sceneFromPlanePixel(
+                    point[0] + 0.5, point[1] + 0.5);
             }
-            return QPointF(point[0], top - point[1]);
+            return QPointF(point[0] + 0.5, height - (point[1] + 0.5));
         };
         std::map<double, QPainterPath> pathsByValue;
         for (const auto& polyline : state.contourPolylines) {

--- a/src/qt/MainWindowInteraction.cpp
+++ b/src/qt/MainWindowInteraction.cpp
@@ -237,16 +237,19 @@ void MainWindow::updateOverlay(PlaneViewState& state)
         // painter paths. Scene coordinates are continuous raster pixels
         // (pixel k's center at k + 0.5), hence the +0.5 on both axes; the
         // spherical mapping's sceneFromPlanePixel is likewise edge-based.
-        // Without the shift every contour draws half a display pixel up and
-        // left, poking out of the image at the left/top boundary and
-        // stopping half a pixel short at the right/bottom. Plane row 0 is
-        // the bottom row; the displayed image is mirrored vertically, so
-        // scene y runs opposite to plane y (see showSlice).
+        // Without the shift every contour lands half a display pixel off the
+        // cell centers, overflowing one boundary and stopping half a pixel
+        // short of the opposite one. The two paths miss in opposite vertical
+        // directions: Cartesian up and left, spherical down and left, because
+        // its row goes through sceneFromDisplay, where dropping the half-row
+        // *raises* scene y instead of lowering it. Plane row 0 is the bottom
+        // row; the displayed image is mirrored vertically, so scene y runs
+        // opposite to plane y (see showSlice).
         const auto contourColor = overlayColor();
         const bool spherical = displayIsSpherical();
         const auto mapping = planeMapping(state);
         const auto height = static_cast<double>(state.plane->height);
-        // Cartesian: plane pixel maps 1:1 to the scene (only the vertical flip).
+        // Cartesian: shift to the pixel center, then flip (scene y is top-down).
         // Spherical: re-project each (r, theta) plane pixel through the warp.
         const auto toScene = [&](const auto& point) -> QPointF {
             if (spherical) {


### PR DESCRIPTION
Contour polylines arrive in pixel-index coordinates -- pixel k's center is coordinate k, the convention contourPolylinesForDisplay maps into -- while scene coordinates are continuous raster pixels whose centers sit at k + 0.5. The conversion never bridged the two, so every contour drew half a display pixel up and to the left: a line crossing the boundary poked out of the image at the left and top and stopped half a pixel short at the right and bottom. Both paths shift by a half now, the spherical one included, since sceneFromPlanePixel is edge-based too.

Vector glyphs were skewed the other way. They are emitted at pixel centers already (i + 0.5), so the flip owed them height - y rather than the index form (height - 1) - y, which drew every arrow a whole raster pixel high.

Nothing here needs to know how the data is centered: the sampler places a nodal sample at i*dx and a cell-centered one at (i+0.5)*dx while resampling both onto the same output raster, so raw MultiFabs and FABs come out right by construction.