### PR TITLE
draw only the particles in the cells the slice crosses

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -62,7 +62,7 @@ the window, wired to it in one of two ways:
 | `SequenceController` | the plotfile sequence: frame list, prefetch, frame switches and their generations | `test_sequence_controller` |
 | `AnimationExporter` | the animation-export state machine (frames → images/MP4) | via the export smoke tests |
 | `PaletteController` | palette choice, reversal, custom `.pal` files, the Palette menu and selector, persistence | `test_palette_controller` |
-| `ParticleController` | particle species/fraction/seed/colours, the sample load, the Particles dialog, action and progress bar | `test_particle_controller` |
+| `ParticleController` | particle species/fraction/seed/colours, the slice-cell filter, the sample load, the Particles dialog, action and progress bar | `test_particle_controller` |
 | `DiagnosticsModel` | the Diagnostics dock: request/stale counters, read and cache metrics, probe and error histories | `test_diagnostics_model` |
 | `FabNavigator` | standalone FAB / MultiFab navigation: the selector dock, drill-down and return, the async header reads | `test_fab_navigator` |
 | `RemoteSessionController` | the ssh-launched server session and its connection, the Open Remote dialog (`RemoteOpenDialog`), the remote browser (`RemoteFileDialog`), per-destination settings | `test_remote_session_controller`, `test_remote_open_dialog`, `test_remote_file_dialog` |

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -561,24 +561,34 @@ each:
 - **Color** picks the point color. Each species starts with a distinct default.
 - **Alpha** sets opacity from 0 to 100 percent.
 
-Below the species list are three settings that apply to all of them:
+Below the species list are the settings that apply to all of them:
 
 - **Visible subset** is the percentage of particles drawn, from 0.01 to 100.
 - **Sampling seed** chooses *which* particles the subset contains. Change it to
   look at a different sample of the same size.
 - **Point size** is the drawn diameter in pixels, from 1 to 12.
+- **Only particles in cells the slice crosses** narrows each panel to the
+  particles lying inside the cells that panel is showing. 3-D data only.
 
 The same particles stay selected as you step through the frames of a sequence,
 and for a given seed a lower percentage thins the same set of particles rather
 than replacing it.
 
 For 3-D data, particles are projected onto each of the three orthogonal slice
-panels. The projection is through the whole volume: a panel shows every selected
-particle, not only those near that slice plane.
+panels. By default the projection is through the whole volume: a panel shows
+every selected particle, not only those near that slice plane. That reads well
+on a sparse dataset and turns into a wash of points on a dense one, which is
+what the **Only particles in cells the slice crosses** box is for. Ticked, a
+particle is drawn only where it falls inside the cell the plane cuts, so each
+panel shows one cell's thickness of particles and follows the plane as you move
+it. The thickness is the cell actually drawn at that point, so a region shown at
+a coarse level keeps its thicker cell rather than losing particles to a finer
+level's spacing; where a panel shows no data it shows no particles either.
 
 Particle settings are not saved between sessions. Species selection, colors,
-subset percentage, seed, and point size all reset when a new dataset or sequence
-is opened; they carry across the frames of an open sequence.
+subset percentage, seed, point size, and the slice-cell filter all reset when a
+new dataset or sequence is opened; they carry across the frames of an open
+sequence.
 
 ## 2-D spherical coordinates
 

--- a/include/amrexplorer/pipeline/ParticleProjection.hpp
+++ b/include/amrexplorer/pipeline/ParticleProjection.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <amrexplorer/core/Metadata.hpp>
 #include <amrexplorer/core/Result.hpp>
 #include <amrexplorer/io/ParticleReader.hpp>
 
@@ -13,14 +14,35 @@ struct ParticlePixel {
     double y = 0.0;
 };
 
+// The half-open physical span the slice plane's cell occupies on the plane
+// normal, at one AMR level. lower == upper means the plane cuts no cell at
+// that level, so nothing drawn from it can hold a particle.
+struct SliceCellSlab {
+    double lower = 0.0;
+    double upper = 0.0;
+};
+
+// The cell the plane cuts at every level, indexed the way a plane's
+// sourceLevel is: positionally into metadata.levels. Empty for anything but a
+// 3-D dataset, which is the only case where a slice has a normal to filter on.
+[[nodiscard]] std::vector<SliceCellSlab> sliceCellSlabs(
+    const DatasetMetadata& metadata, int normalAxis, double slicePosition);
+
 // Projects physical particle positions into a slice plane's raster scene
 // coordinates. The in-plane physical bounds map inclusively to the raster
 // edges: x increases from 0 to width, while y is flipped from height to 0 to
-// match the Qt image scene. The normal coordinate is deliberately ignored;
-// particles are projected through the full volume rather than filtered to a
-// slice thickness.
+// match the Qt image scene.
+//
+// With no levelSlabs the normal coordinate is ignored and particles are
+// projected through the full volume -- the default. Given one slab per level,
+// a particle is kept only when its normal coordinate lies in the slab of the
+// level that supplied the pixel it projects onto (plane.sourceLevel), so the
+// thickness always matches the cell actually drawn there; a particle over an
+// uncovered pixel is dropped, there being no cell for it to be in.
 [[nodiscard]] std::vector<ParticlePixel>
 projectParticlePoints(std::span<const ParticlePoint> particles,
-                      const ScalarPlane& plane, int dimension, int normalDirection);
+                      const ScalarPlane& plane, int dimension,
+                      int normalDirection,
+                      std::span<const SliceCellSlab> levelSlabs = {});
 
 } // namespace amrvis

--- a/src/pipeline/ParticleProjection.cpp
+++ b/src/pipeline/ParticleProjection.cpp
@@ -109,14 +109,21 @@ projectParticlePoints(std::span<const ParticlePoint> particles,
             // sourceLevel is written -- increasing physical y -- not the way
             // the emitted scene y is flipped. The inclusive clip above lands
             // the upper edge exactly on width/height, hence the clamp.
-            const auto column = std::clamp(
-                static_cast<int>(std::floor(
-                    (x - region.lower[xAxis]) * plane.width / xExtent)),
-                0, plane.width - 1);
-            const auto row = std::clamp(
-                static_cast<int>(std::floor(
-                    (y - region.lower[yAxis]) * plane.height / yExtent)),
-                0, plane.height - 1);
+            // Clamped as a double, before the cast. Multiplying first
+            // is what keeps the binning exact, but it also overflows to
+            // infinity for a region whose extent approaches the double
+            // range -- and casting that to int is undefined, where clamping
+            // it lands on the last column the way any coordinate at the
+            // upper edge should. Non-negative throughout (x >= lower), so
+            // truncation is the floor.
+            const auto scaled
+                = (x - region.lower[xAxis]) * plane.width / xExtent;
+            const auto column = static_cast<int>(std::clamp(
+                scaled, 0.0, static_cast<double>(plane.width - 1)));
+            const auto scaledRow
+                = (y - region.lower[yAxis]) * plane.height / yExtent;
+            const auto row = static_cast<int>(std::clamp(
+                scaledRow, 0.0, static_cast<double>(plane.height - 1)));
             const auto level = plane.sourceLevel[static_cast<std::size_t>(column)
                 + static_cast<std::size_t>(plane.width)
                     * static_cast<std::size_t>(row)];

--- a/src/pipeline/ParticleProjection.cpp
+++ b/src/pipeline/ParticleProjection.cpp
@@ -19,22 +19,29 @@ std::vector<SliceCellSlab> sliceCellSlabs(
     const auto axis = static_cast<std::size_t>(normalAxis);
     slabs.reserve(metadata.levels.size());
     for (const auto& level : metadata.levels) {
-        // An empty slab (lower == upper) for a level whose index range does
-        // not reach this position: sampleIndex throws rather than return a
-        // meaningless index, and nothing drawn from such a level can hold a
-        // particle anyway.
+        // An empty slab (lower == upper) says the plane cuts no cell at this
+        // level. Two ways to get one, and neither is sampleIndex returning a
+        // sentinel: it throws only for a non-finite or int-range-exceeding
+        // coordinate, and for a position off the end of a level it returns an
+        // extrapolated index that sampleBounds would turn into a cell that is
+        // not there. So the index is range-checked against the level's own
+        // domain as well.
         SliceCellSlab slab;
         try {
             const auto index = sampleIndex(level, normalAxis, slicePosition);
-            // The level's own domain box collapsed to that one index on the
-            // normal, so it carries the level's centering and sampleBounds
-            // places nodal and cell-centered levels alike.
-            auto cell = level.domain;
-            cell.lower[axis] = index;
-            cell.upper[axis] = index;
-            const auto bounds = sampleBounds(level, cell, metadata.dimension);
-            slab.lower = bounds.lower[axis];
-            slab.upper = bounds.upper[axis];
+            if (index >= level.domain.lower[axis]
+                && index <= level.domain.upper[axis]) {
+                // The level's own domain box collapsed to that one index on
+                // the normal, so it carries the level's centering and
+                // sampleBounds places nodal and cell-centered levels alike.
+                auto cell = level.domain;
+                cell.lower[axis] = index;
+                cell.upper[axis] = index;
+                const auto bounds
+                    = sampleBounds(level, cell, metadata.dimension);
+                slab.lower = bounds.lower[axis];
+                slab.upper = bounds.upper[axis];
+            }
         } catch (const std::out_of_range&) {
             // The default empty slab stands: sampleIndex is the only call
             // above that throws, and it throws before slab is touched.

--- a/src/pipeline/ParticleProjection.cpp
+++ b/src/pipeline/ParticleProjection.cpp
@@ -101,17 +101,21 @@ projectParticlePoints(std::span<const ParticlePoint> particles,
             continue;
         }
         if (filtering) {
-            // The pixel this point falls in. The row counts the way
+            // The pixel this point falls in, and the inverse of the
+            // sampleCentre the query binned that pixel with: the extent is
+            // divided last there and has to be here too, or a coordinate a
+            // ULP from a pixel edge lands on the other side of it -- across
+            // a level jump, that is the wrong slab. The row counts the way
             // sourceLevel is written -- increasing physical y -- not the way
             // the emitted scene y is flipped. The inclusive clip above lands
             // the upper edge exactly on width/height, hence the clamp.
             const auto column = std::clamp(
-                static_cast<int>(
-                    std::floor((x - region.lower[xAxis]) / xExtent * plane.width)),
+                static_cast<int>(std::floor(
+                    (x - region.lower[xAxis]) * plane.width / xExtent)),
                 0, plane.width - 1);
             const auto row = std::clamp(
-                static_cast<int>(
-                    std::floor((y - region.lower[yAxis]) / yExtent * plane.height)),
+                static_cast<int>(std::floor(
+                    (y - region.lower[yAxis]) * plane.height / yExtent)),
                 0, plane.height - 1);
             const auto level = plane.sourceLevel[static_cast<std::size_t>(column)
                 + static_cast<std::size_t>(plane.width)

--- a/src/pipeline/ParticleProjection.cpp
+++ b/src/pipeline/ParticleProjection.cpp
@@ -2,13 +2,53 @@
 
 #include <amrexplorer/pipeline/SlicePipeline.hpp>
 
+#include <algorithm>
 #include <cmath>
+#include <stdexcept>
 
 namespace amrvis {
 
+std::vector<SliceCellSlab> sliceCellSlabs(
+    const DatasetMetadata& metadata, int normalAxis, double slicePosition)
+{
+    std::vector<SliceCellSlab> slabs;
+    if (metadata.dimension != 3 || normalAxis < 0
+        || normalAxis >= metadata.dimension) {
+        return slabs;
+    }
+    const auto axis = static_cast<std::size_t>(normalAxis);
+    slabs.reserve(metadata.levels.size());
+    for (const auto& level : metadata.levels) {
+        // An empty slab (lower == upper) for a level whose index range does
+        // not reach this position: sampleIndex throws rather than return a
+        // meaningless index, and nothing drawn from such a level can hold a
+        // particle anyway.
+        SliceCellSlab slab;
+        try {
+            const auto index = sampleIndex(level, normalAxis, slicePosition);
+            // The level's own domain box collapsed to that one index on the
+            // normal, so it carries the level's centering and sampleBounds
+            // places nodal and cell-centered levels alike.
+            auto cell = level.domain;
+            cell.lower[axis] = index;
+            cell.upper[axis] = index;
+            const auto bounds = sampleBounds(level, cell, metadata.dimension);
+            slab.lower = bounds.lower[axis];
+            slab.upper = bounds.upper[axis];
+        } catch (const std::out_of_range&) {
+            // The default empty slab stands: sampleIndex is the only call
+            // above that throws, and it throws before slab is touched.
+        }
+        slabs.push_back(slab);
+    }
+    return slabs;
+}
+
 std::vector<ParticlePixel>
 projectParticlePoints(std::span<const ParticlePoint> particles,
-                      const ScalarPlane& plane, int dimension, int normalDirection)
+                      const ScalarPlane& plane, int dimension,
+                      int normalDirection,
+                      std::span<const SliceCellSlab> levelSlabs)
 {
     if ((dimension != 2 && dimension != 3)
         || (dimension == 3 && (normalDirection < 0 || normalDirection >= dimension))
@@ -27,6 +67,22 @@ projectParticlePoints(std::span<const ParticlePoint> particles,
         return {};
     }
 
+    // Filtering to the cells the plane cuts needs the per-pixel level, and a
+    // query sizes values/valid/sourceLevel together -- so a plane whose
+    // sourceLevel does not match its raster carries no answer to give. Only
+    // 3-D has a normal to filter on: in 2-D the slice is the domain, and
+    // normalDirection is not even constrained to be an axis.
+    const bool filtering = !levelSlabs.empty() && dimension == 3;
+    const auto pixelCount = static_cast<std::size_t>(plane.width)
+        * static_cast<std::size_t>(plane.height);
+    if (filtering && plane.sourceLevel.size() != pixelCount) {
+        return {};
+    }
+    // Only read when filtering, which implies a 3-D normal in range; below
+    // three dimensions normalDirection is not constrained to be an axis.
+    const auto normalAxis
+        = static_cast<std::size_t>(filtering ? normalDirection : 0);
+
     std::vector<ParticlePixel> projected;
     projected.reserve(particles.size());
     for (const auto& particle : particles) {
@@ -36,6 +92,35 @@ projectParticlePoints(std::span<const ParticlePoint> particles,
             || x > region.upper[xAxis] || y < region.lower[yAxis]
             || y > region.upper[yAxis]) {
             continue;
+        }
+        if (filtering) {
+            // The pixel this point falls in. The row counts the way
+            // sourceLevel is written -- increasing physical y -- not the way
+            // the emitted scene y is flipped. The inclusive clip above lands
+            // the upper edge exactly on width/height, hence the clamp.
+            const auto column = std::clamp(
+                static_cast<int>(
+                    std::floor((x - region.lower[xAxis]) / xExtent * plane.width)),
+                0, plane.width - 1);
+            const auto row = std::clamp(
+                static_cast<int>(
+                    std::floor((y - region.lower[yAxis]) / yExtent * plane.height)),
+                0, plane.height - 1);
+            const auto level = plane.sourceLevel[static_cast<std::size_t>(column)
+                + static_cast<std::size_t>(plane.width)
+                    * static_cast<std::size_t>(row)];
+            if (level < 0
+                || static_cast<std::size_t>(level) >= levelSlabs.size()) {
+                continue;
+            }
+            const auto& slab = levelSlabs[static_cast<std::size_t>(level)];
+            const auto normal = particle.position[normalAxis];
+            // Half-open, the rule the slice itself uses to pick its cell and
+            // its grid boxes: a position on the upper face belongs to the
+            // next cell up.
+            if (!(normal >= slab.lower) || !(normal < slab.upper)) {
+                continue;
+            }
         }
         projected.push_back(
             {.x = (x - region.lower[xAxis]) / xExtent * plane.width,

--- a/src/qt/ImageView.cpp
+++ b/src/qt/ImageView.cpp
@@ -130,6 +130,7 @@ void ImageView::setImage(
     m_pathItems.clear();
     m_pointItems.clear();
     m_pointOverlayColors.clear();
+    m_pointOverlayPointCount = 0;
     m_crosshairVerticalItem = nullptr;
     m_crosshairHorizontalItem = nullptr;
     m_cellHighlightItem = nullptr;
@@ -303,6 +304,7 @@ void ImageView::setPointOverlays(const std::vector<PointOverlay>& overlays)
     }
     m_pointItems.clear();
     m_pointOverlayColors.clear();
+    m_pointOverlayPointCount = 0;
     if (!hasImage()) {
         return;
     }
@@ -318,12 +320,18 @@ void ImageView::setPointOverlays(const std::vector<PointOverlay>& overlays)
         item->setZValue(3.0);
         m_pointItems.push_back(item);
         m_pointOverlayColors.push_back(overlay.color);
+        m_pointOverlayPointCount += overlay.points.size();
     }
 }
 
 std::size_t ImageView::pointOverlayCount() const noexcept
 {
     return m_pointItems.size();
+}
+
+std::size_t ImageView::pointOverlayPointCount() const noexcept
+{
+    return m_pointOverlayPointCount;
 }
 
 const std::vector<QColor>& ImageView::pointOverlayColors() const noexcept

--- a/src/qt/ImageView.cpp
+++ b/src/qt/ImageView.cpp
@@ -519,6 +519,7 @@ void ImageView::setPlaceholder(const QString& text)
     m_overlayItems.clear();
     m_pathItems.clear();
     m_pointItems.clear();
+    m_pointOverlayPointCount = 0;
     m_crosshairVertical.reset();
     m_crosshairHorizontal.reset();
     m_crosshairVerticalItem = nullptr;

--- a/src/qt/ImageView.hpp
+++ b/src/qt/ImageView.hpp
@@ -164,6 +164,9 @@ public:
         return m_gridItems.size();
     }
     [[nodiscard]] std::size_t pointOverlayCount() const noexcept;
+    // The points across those batches: a filter that thins a batch without
+    // emptying it leaves pointOverlayCount unchanged.
+    [[nodiscard]] std::size_t pointOverlayPointCount() const noexcept;
     [[nodiscard]] const std::vector<QColor>& pointOverlayColors() const noexcept;
     // Renders the scene (base image plus grid boxes and any other overlays)
     // to a fresh QImage for export. scaleFactor multiplies the raster's native
@@ -273,6 +276,7 @@ private:
     std::vector<QGraphicsPathItem*> m_pathItems;
     std::vector<QGraphicsItem*> m_pointItems;
     std::vector<QColor> m_pointOverlayColors;
+    std::size_t m_pointOverlayPointCount = 0;
     std::optional<QLineF> m_crosshairVertical;
     std::optional<QLineF> m_crosshairHorizontal;
     QColor m_crosshairVerticalColor;

--- a/src/qt/MainWindow.hpp
+++ b/src/qt/MainWindow.hpp
@@ -436,6 +436,8 @@ public:
     [[nodiscard]] double particleFractionForTest() const noexcept;
     void setParticlePointSizeForTest(int pointSize);
     [[nodiscard]] int particlePointSizeForTest() const noexcept;
+    void setParticleSliceCellsOnlyForTest(bool sliceCellsOnly);
+    [[nodiscard]] bool particleSliceCellsOnlyForTest() const noexcept;
     // Invalid when the species has no stored color, which is what a reset
     // leaves behind until the next dataset re-seeds the defaults.
     [[nodiscard]] QColor particleColorForTest(const std::string& species) const;
@@ -444,7 +446,10 @@ public:
     [[nodiscard]] bool particleOverlaysUseColorForTest(
         const QColor& color);
     [[nodiscard]] std::size_t particleSampleCountForTest() const;
+    // Point batches (one per drawn species) and the points in them: the
+    // slice-cell filter thins the batches without emptying them.
     [[nodiscard]] std::size_t particleOverlayCountForTest();
+    [[nodiscard]] std::size_t particleOverlayPointCountForTest();
     [[nodiscard]] bool particleLoadingForTest() const noexcept;
     [[nodiscard]] bool particleLoadingUiActiveForTest() const;
     [[nodiscard]] bool particleLoadingUiSettledForTest() const;

--- a/src/qt/MainWindowInteraction.cpp
+++ b/src/qt/MainWindowInteraction.cpp
@@ -308,9 +308,16 @@ void MainWindow::updateParticleOverlay(PlaneViewState& state)
     // request that produced the plane on show, not m_slicePosition3d, which
     // has already moved ahead whenever a slice is in flight: the overlay
     // belongs to the raster under it. Empty means project through the volume.
+    //
+    // That request has to name the installed dataset, too. A frame switch
+    // assigns m_dataset before it shows the frame's planes, so a frame that
+    // then fails leaves the raster and its levels owned by different
+    // datasets -- and this reads sourceLevel from the one and cellSize from
+    // the other. Same test the raster path uses (see ownerChanged).
     std::vector<SliceCellSlab> levelSlabs;
     if (m_particleController->settings().sliceCellsOnly
-        && state.hasCachedRequest) {
+        && state.hasCachedRequest
+        && state.cachedRequest.dataset == m_dataset->id()) {
         levelSlabs = sliceCellSlabs(m_dataset->metadata(), state.normal,
             state.cachedRequest.physicalPosition);
     }

--- a/src/qt/MainWindowInteraction.cpp
+++ b/src/qt/MainWindowInteraction.cpp
@@ -316,10 +316,22 @@ void MainWindow::updateParticleOverlay(PlaneViewState& state)
     // the other. Same test the raster path uses (see ownerChanged).
     std::vector<SliceCellSlab> levelSlabs;
     if (m_particleController->settings().sliceCellsOnly
-        && state.hasCachedRequest
-        && state.cachedRequest.dataset == m_dataset->id()) {
-        levelSlabs = sliceCellSlabs(m_dataset->metadata(), state.normal,
-            state.cachedRequest.physicalPosition);
+        && m_dataset->metadata().dimension == 3) {
+        if (state.hasCachedRequest
+            && state.cachedRequest.dataset == m_dataset->id()) {
+            levelSlabs = sliceCellSlabs(m_dataset->metadata(), state.normal,
+                state.cachedRequest.physicalPosition);
+        }
+        if (levelSlabs.empty()) {
+            // Filter on, nothing trustworthy to filter with. An empty vector
+            // reads as "no filtering" to the projector, so falling through
+            // here would draw the whole volume -- the one picture the ticked
+            // box exists to avoid. Draw nothing instead, which is what the
+            // projector itself does when a plane's sourceLevel does not
+            // match its raster.
+            state.view->setPointOverlays(overlays);
+            return;
+        }
     }
     const auto& samples = m_particleController->samples();
     overlays.reserve(samples.size());

--- a/src/qt/MainWindowInteraction.cpp
+++ b/src/qt/MainWindowInteraction.cpp
@@ -304,6 +304,16 @@ void MainWindow::updateParticleOverlay(PlaneViewState& state)
     const bool spherical = displayIsSpherical();
     const auto mapping = planeMapping(state);
     const auto planeHeight = static_cast<double>(state.plane->height);
+    // The cells this plane cuts, when the filter is on. Taken from the
+    // request that produced the plane on show, not m_slicePosition3d, which
+    // has already moved ahead whenever a slice is in flight: the overlay
+    // belongs to the raster under it. Empty means project through the volume.
+    std::vector<SliceCellSlab> levelSlabs;
+    if (m_particleController->settings().sliceCellsOnly
+        && state.hasCachedRequest) {
+        levelSlabs = sliceCellSlabs(m_dataset->metadata(), state.normal,
+            state.cachedRequest.physicalPosition);
+    }
     const auto& samples = m_particleController->samples();
     overlays.reserve(samples.size());
     for (const auto& sample : samples) {
@@ -313,7 +323,7 @@ void MainWindow::updateParticleOverlay(PlaneViewState& state)
             = static_cast<float>(m_particleController->settings().pointSize);
         const auto projected = projectParticlePoints(
             sample.points, *state.plane,
-            m_dataset->metadata().dimension, state.normal);
+            m_dataset->metadata().dimension, state.normal, levelSlabs);
         overlay.points.reserve(projected.size());
         for (const auto& point : projected) {
             if (spherical) {

--- a/src/qt/MainWindowTestAccess.cpp
+++ b/src/qt/MainWindowTestAccess.cpp
@@ -826,8 +826,9 @@ std::uint64_t MainWindow::cacheResidentBytesForTest() const
 void MainWindow::setParticleSelectionForTest(
     std::vector<std::string> species, double fraction, std::uint64_t seed)
 {
+    const auto settings = m_particleController->settings();
     m_particleController->applySelection(std::move(species), fraction,
-        m_particleController->settings().pointSize, seed);
+        settings.pointSize, seed, settings.sliceCellsOnly);
 }
 
 std::uint64_t MainWindow::particleSeedForTest() const noexcept
@@ -847,13 +848,28 @@ void MainWindow::setParticlePointSizeForTest(int pointSize)
     // today -- but not if that parameter ever became a const reference,
     // which would alias the very vector the move overwrites.
     const auto settings = m_particleController->settings();
-    m_particleController->applySelection(
-        settings.species, settings.fraction, pointSize, settings.seed);
+    m_particleController->applySelection(settings.species, settings.fraction,
+        pointSize, settings.seed, settings.sliceCellsOnly);
 }
 
 int MainWindow::particlePointSizeForTest() const noexcept
 {
     return m_particleController->settings().pointSize;
+}
+
+void MainWindow::setParticleSliceCellsOnlyForTest(bool sliceCellsOnly)
+{
+    // The same copy-first hardening as the point size above: the by-value
+    // species parameter is copied before the body moves into
+    // m_settings.species.
+    const auto settings = m_particleController->settings();
+    m_particleController->applySelection(settings.species, settings.fraction,
+        settings.pointSize, settings.seed, sliceCellsOnly);
+}
+
+bool MainWindow::particleSliceCellsOnlyForTest() const noexcept
+{
+    return m_particleController->settings().sliceCellsOnly;
 }
 
 QColor MainWindow::particleColorForTest(const std::string& species) const
@@ -897,6 +913,15 @@ std::size_t MainWindow::particleOverlayCountForTest()
     std::size_t count = 0;
     for (const auto* state : currentViews()) {
         count += state->view->pointOverlayCount();
+    }
+    return count;
+}
+
+std::size_t MainWindow::particleOverlayPointCountForTest()
+{
+    std::size_t count = 0;
+    for (const auto* state : currentViews()) {
+        count += state->view->pointOverlayPointCount();
     }
     return count;
 }

--- a/src/qt/ParticleController.cpp
+++ b/src/qt/ParticleController.cpp
@@ -91,7 +91,7 @@ QColor ParticleController::colorFor(const std::string& species) const
 }
 
 void ParticleController::applySelection(std::vector<std::string> species,
-    double fraction, int pointSize, std::uint64_t seed)
+    double fraction, int pointSize, std::uint64_t seed, bool sliceCellsOnly)
 {
     const bool sampleChanged = !m_settings.selectionInitialized
         || species != m_settings.species || fraction != m_settings.fraction
@@ -100,11 +100,12 @@ void ParticleController::applySelection(std::vector<std::string> species,
     m_settings.fraction = fraction;
     m_settings.seed = seed;
     m_settings.pointSize = pointSize;
+    m_settings.sliceCellsOnly = sliceCellsOnly;
     m_settings.selectionInitialized = true;
     if (!sampleChanged) {
-        // Colour, alpha and point size only affect the installed point
-        // batches; do not reread particle files when the sampled identities
-        // are unchanged.
+        // Colour, alpha, point size and the slice-cell filter only affect the
+        // installed point batches; do not reread particle files when the
+        // sampled identities are unchanged.
         emit overlaysChanged();
         return;
     }
@@ -425,7 +426,22 @@ void ParticleController::showDialog(QWidget* parent)
     sizeRow->addStretch(1);
     layout->addLayout(sizeRow);
 
+    // 3-D only: in 2-D the slice is the whole domain, so every particle is
+    // already in a cell the plane crosses and the filter would do nothing.
+    QCheckBox* sliceCellsOnly = nullptr;
     if (dataset->metadata().dimension == 3) {
+        sliceCellsOnly = new QCheckBox(
+            tr("Only particles in cells the slice crosses"), dialog);
+        // Named, unlike the species rows: those are found by type and order,
+        // and an unnamed extra check box would join that list.
+        sliceCellsOnly->setObjectName(
+            QStringLiteral("particlesSliceCellsOnly"));
+        sliceCellsOnly->setChecked(m_settings.sliceCellsOnly);
+        sliceCellsOnly->setToolTip(
+            tr("Draw a particle only where it lies inside the cell the slice "
+               "plane cuts. Unticked, every particle is projected onto the "
+               "plane through the whole volume."));
+        layout->addWidget(sliceCellsOnly);
         layout->addWidget(new QLabel(
             tr("In 3-D, points are projected onto each orthogonal view."),
             dialog));
@@ -437,8 +453,8 @@ void ParticleController::showDialog(QWidget* parent)
     // Context is this controller: the connection cannot outlive the object
     // the lambda acts on, and it goes with the dialog's buttons anyway.
     connect(buttons, &QDialogButtonBox::clicked, this,
-        [this, dialog, buttons, speciesControls, fraction, seed, pointSize](
-            QAbstractButton* button) {
+        [this, dialog, buttons, speciesControls, fraction, seed, pointSize,
+            sliceCellsOnly](QAbstractButton* button) {
             const auto role = buttons->buttonRole(button);
             if (role == QDialogButtonBox::RejectRole) {
                 dialog->reject();
@@ -468,8 +484,12 @@ void ParticleController::showDialog(QWidget* parent)
                     static_cast<float>(controls.alpha->value()) / 100.0F);
                 m_settings.colors[controls.name] = applied;
             }
+            // No check box below three dimensions; keep what is stored so
+            // the filter is not silently cleared by a 2-D dataset's dialog.
             applySelection(std::move(selectedSpecies),
-                fraction->value() / 100.0, pointSize->value(), seedValue);
+                fraction->value() / 100.0, pointSize->value(), seedValue,
+                sliceCellsOnly != nullptr ? sliceCellsOnly->isChecked()
+                                          : m_settings.sliceCellsOnly);
             if (role == QDialogButtonBox::AcceptRole) {
                 dialog->accept();
             }

--- a/src/qt/ParticleController.cpp
+++ b/src/qt/ParticleController.cpp
@@ -432,8 +432,12 @@ void ParticleController::showDialog(QWidget* parent)
     if (dataset->metadata().dimension == 3) {
         sliceCellsOnly = new QCheckBox(
             tr("Only particles in cells the slice crosses"), dialog);
-        // Named, unlike the species rows: those are found by type and order,
-        // and an unnamed extra check box would join that list.
+        // Named so a test can ask for this box by name. The name does not
+        // keep it out of a bare findChildren<QCheckBox*>(), which matches
+        // every object name; what keeps the species rows findable by type
+        // and order is that this box exists in 3-D alone and is added after
+        // their grid. A 3-D test that indexes that list has to account for
+        // it.
         sliceCellsOnly->setObjectName(
             QStringLiteral("particlesSliceCellsOnly"));
         sliceCellsOnly->setChecked(m_settings.sliceCellsOnly);

--- a/src/qt/ParticleController.hpp
+++ b/src/qt/ParticleController.hpp
@@ -48,6 +48,10 @@ public:
         double fraction = 1.0;
         std::uint64_t seed = 0;
         int pointSize = defaultPointSize;
+        // Draw only the particles lying inside the cell each slice plane
+        // cuts, instead of projecting the whole volume onto it. 3-D only:
+        // in 2-D the slice is the domain, so it would filter nothing.
+        bool sliceCellsOnly = false;
         std::unordered_map<std::string, QColor> colors;
     };
 
@@ -81,12 +85,13 @@ public:
     // The dialog's and the tests' entry point: installs the selection. A
     // change to the sampled identities (species, fraction, seed) emits
     // sampleSelectionChanged for the host to act on; a cosmetic change (point
-    // size) only emits overlaysChanged.
+    // size, the slice-cell filter) only emits overlaysChanged.
     void applySelection(std::vector<std::string> species, double fraction,
-        int pointSize, std::uint64_t seed);
+        int pointSize, std::uint64_t seed, bool sliceCellsOnly);
     void setColor(const std::string& species, const QColor& color);
     // Reinstalls what a restored frame spec carries (species, fraction, seed,
-    // initialised), leaving colours and point size alone.
+    // initialised), leaving the display settings -- colours, point size, the
+    // slice-cell filter -- alone.
     void restoreSelection(std::vector<std::string> species, double fraction,
         std::uint64_t seed, bool selectionInitialized);
     // Drops every setting back to its default: the shared reset for the two

--- a/src/qt/SmokeHarnessRange.cpp
+++ b/src/qt/SmokeHarnessRange.cpp
@@ -691,10 +691,12 @@ Outcome dispatchRange(Context& context)
         const auto choose = [&window, chosenColor] {
             window.setParticleSelectionForTest({"Tracer"}, 0.0005, 37);
             window.setParticlePointSizeForTest(9);
+            window.setParticleSliceCellsOnlyForTest(true);
             window.setParticleColorForTest("Tracer", chosenColor);
             return window.particleSeedForTest() == 37
                 && window.particleFractionForTest() == 0.0005
                 && window.particlePointSizeForTest() == 9
+                && window.particleSliceCellsOnlyForTest()
                 && window.particleColorForTest("Tracer") == chosenColor;
         };
         const auto wasReset = [&window, chosenColor, defaultPointSize](
@@ -702,15 +704,17 @@ Outcome dispatchRange(Context& context)
             if (window.particleSeedForTest() == 0
                 && window.particleFractionForTest() == 1.0
                 && window.particlePointSizeForTest() == *defaultPointSize
+                && !window.particleSliceCellsOnlyForTest()
                 && window.particleColorForTest("Tracer") != chosenColor) {
                 return true;
             }
             qCritical("%s inherited particle settings: seed %llu, subset %g, "
-                      "point size %d, colour %s",
+                      "point size %d, slice cells only %d, colour %s",
                 what,
                 static_cast<unsigned long long>(window.particleSeedForTest()),
                 window.particleFractionForTest(),
                 window.particlePointSizeForTest(),
+                static_cast<int>(window.particleSliceCellsOnlyForTest()),
                 qUtf8Printable(
                     window.particleColorForTest("Tracer").name(QColor::HexArgb)));
             return false;
@@ -770,6 +774,71 @@ Outcome dispatchRange(Context& context)
             [&application] { application.exit(3); });
         QTimer::singleShot(0, &window, [&window, first] {
             window.openDataset(first);
+        });
+    } else if (argc == 3
+        && std::string_view(argv[1])
+            == "--particle-slice-cells-smoke-test") {
+        // The end-to-end probe for the slice-cell filter. The unit tests pin
+        // the geometry and the signal routing separately; only this says the
+        // window really builds the slabs for the plane on show and hands them
+        // to the projection. Turning it on must thin the drawn points and
+        // leave the loaded samples alone -- it filters the drawing, it does
+        // not resample -- and unticking it must restore the projection.
+        const std::filesystem::path path(argv[2]);
+        auto* poll = new QTimer(&window);
+        poll->setInterval(10);
+        auto attempts = std::make_shared<int>(0);
+        QObject::connect(&window, &amrvis::qt::MainWindow::initialSliceFinished,
+            &application, [&window, &application, poll](bool success) {
+                if (!success) {
+                    application.exit(1);
+                    return;
+                }
+                window.setParticleSelectionForTest({"Tracer"}, 1.0, 37);
+                poll->start();
+            });
+        QObject::connect(poll, &QTimer::timeout, &application,
+            [&window, &application, poll, attempts] {
+                if (++*attempts > 500) {
+                    application.exit(1);
+                    return;
+                }
+                if (window.particleLoadingForTest()
+                    || window.particleSampleCountForTest() == 0
+                    || window.particleOverlayPointCountForTest() == 0) {
+                    return;
+                }
+                poll->stop();
+                const auto samples = window.particleSampleCountForTest();
+                const auto projected = window.particleOverlayPointCountForTest();
+                window.setParticleSliceCellsOnlyForTest(true);
+                const auto filtered = window.particleOverlayPointCountForTest();
+                if (filtered == 0 || filtered >= projected) {
+                    qCritical("the slice-cell filter drew %llu of %llu points",
+                        static_cast<unsigned long long>(filtered),
+                        static_cast<unsigned long long>(projected));
+                    application.exit(1);
+                    return;
+                }
+                if (window.particleSampleCountForTest() != samples) {
+                    qCritical("the slice-cell filter reloaded the samples");
+                    application.exit(1);
+                    return;
+                }
+                window.setParticleSliceCellsOnlyForTest(false);
+                if (window.particleOverlayPointCountForTest() != projected) {
+                    qCritical("unticking the filter did not restore the "
+                              "projection through the volume");
+                    application.exit(1);
+                    return;
+                }
+                window.close();
+                application.exit(0);
+            });
+        QTimer::singleShot(20000, &application,
+            [&application] { application.exit(4); });
+        QTimer::singleShot(0, &window, [&window, path] {
+            window.openDataset(path);
         });
     } else if (argc == 4
         && std::string_view(argv[1]) == "--range-cache-smoke-test") {

--- a/src/qt/SmokeHarnessRange.cpp
+++ b/src/qt/SmokeHarnessRange.cpp
@@ -813,15 +813,22 @@ Outcome dispatchRange(Context& context)
                 const auto projected = window.particleOverlayPointCountForTest();
                 window.setParticleSliceCellsOnlyForTest(true);
                 const auto filtered = window.particleOverlayPointCountForTest();
+                // Before the count: a reload clears the samples and redraws
+                // synchronously, so it would reach the branch below as a
+                // plain "drew nothing" and report the wrong cause.
+                if (window.particleSampleCountForTest() != samples) {
+                    qCritical("the slice-cell filter reloaded the samples: "
+                              "%llu, was %llu",
+                        static_cast<unsigned long long>(
+                            window.particleSampleCountForTest()),
+                        static_cast<unsigned long long>(samples));
+                    application.exit(1);
+                    return;
+                }
                 if (filtered == 0 || filtered >= projected) {
                     qCritical("the slice-cell filter drew %llu of %llu points",
                         static_cast<unsigned long long>(filtered),
                         static_cast<unsigned long long>(projected));
-                    application.exit(1);
-                    return;
-                }
-                if (window.particleSampleCountForTest() != samples) {
-                    qCritical("the slice-cell filter reloaded the samples");
                     application.exit(1);
                     return;
                 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1416,6 +1416,20 @@ if(TARGET amrexplorer_qt)
     )
     set_tests_properties(
         qt_particle_visible_range_smoke_3d PROPERTIES TIMEOUT 30)
+    # Turning the slice-cell filter on thins the drawn points without
+    # reloading the samples, and unticking it restores the projection.
+    add_test(
+        NAME qt_particle_slice_cells_smoke_3d
+        COMMAND "${CMAKE_COMMAND}"
+            "-DMATERIALIZER=$<TARGET_FILE:fixture_materializer>"
+            "-DAMREXPLORER_QT=$<TARGET_FILE:amrexplorer_qt>"
+            "-DSOURCE=${CMAKE_CURRENT_SOURCE_DIR}/data/plotfile_3d"
+            "-DWORK=${CMAKE_CURRENT_BINARY_DIR}/fixtures_particle_slice_cells"
+            -DMODE=particle-slice-cells
+            -P "${CMAKE_CURRENT_SOURCE_DIR}/qt_smoke_driver.cmake"
+    )
+    set_tests_properties(
+        qt_particle_slice_cells_smoke_3d PROPERTIES TIMEOUT 30)
     # The particles dialog is modeless: it must not block the main window, one
     # instance is reused, and Apply draws without closing it.
     add_test(

--- a/tests/qt_smoke_driver.cmake
+++ b/tests/qt_smoke_driver.cmake
@@ -14,7 +14,7 @@
 #                 export-quit |
 #                 contour-sync | raster-zoom | rubber-zoom-sync |
 #                 particle-visible-range | particle-dialog |
-#                 particle-settings-reset |
+#                 particle-settings-reset | particle-slice-cells |
 #                 rubber-zoom-local | rubber-overzoom | pan-zoom |
 #                 range-cache | fab-zoom | cache-budget |
 #                 fixed-scale-1 | fixed-scale-4 | sequence-transform-preserve |
@@ -277,6 +277,10 @@ elseif(MODE STREQUAL "particle-dialog")
     run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt00010" "2.5")
     run_or_die("${AMREXPLORER_QT}" --particle-dialog-smoke-test
         "${WORK}/plt00000" "${WORK}/plt00010")
+elseif(MODE STREQUAL "particle-slice-cells")
+    run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt")
+    run_or_die("${AMREXPLORER_QT}" --particle-slice-cells-smoke-test
+        "${WORK}/plt")
 elseif(MODE STREQUAL "particle-settings-reset")
     run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt00000")
     run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt00010" "2.5")

--- a/tests/unit/test_image_view_pan.cpp
+++ b/tests/unit/test_image_view_pan.cpp
@@ -244,6 +244,40 @@ void arrowKeysRequestPanOnlyWhenFocusedWithAnImage()
         "Ctrl with the keypad flag must not be claimed as a pan");
 }
 
+// Every teardown that drops the point items has to drop their tally with
+// them. setImage and setPointOverlays do; setPlaceholder is the third one,
+// and a stale tally there outlives the scene it counted -- the particle
+// overlay accessors then answer for a view that is showing "Loading...".
+void tearingDownTheSceneForgetsThePointOverlays()
+{
+    amrvis::qt::ImageView view;
+    view.setImage(solidImage(16, 16));
+    amrvis::qt::PointOverlay overlay;
+    overlay.points = {{1.0, 1.0}, {2.0, 2.0}, {3.0, 3.0}};
+    overlay.color = Qt::red;
+    overlay.size = 2.0F;
+    view.setPointOverlays({overlay});
+    require(view.pointOverlayCount() == 1 && view.pointOverlayPointCount() == 3,
+        "the point overlay was not installed");
+
+    view.setPlaceholder(QStringLiteral("Loading dataset..."));
+    require(view.pointOverlayCount() == 0,
+        "the placeholder left the point items behind");
+    require(view.pointOverlayPointCount() == 0,
+        "the placeholder left the point tally behind");
+
+    // The other two teardowns, so the three cannot drift apart.
+    view.setImage(solidImage(16, 16));
+    view.setPointOverlays({overlay});
+    view.setImage(solidImage(16, 16));
+    require(view.pointOverlayPointCount() == 0,
+        "a new image left the point tally behind");
+    view.setPointOverlays({overlay});
+    view.setPointOverlays({});
+    require(view.pointOverlayPointCount() == 0,
+        "replacing the overlays left the point tally behind");
+}
+
 } // namespace
 
 int main(int argc, char* argv[])
@@ -252,5 +286,6 @@ int main(int argc, char* argv[])
     scrollBarPanFollowsContentDelta();
     fullyVisibleSceneIgnoresPan();
     arrowKeysRequestPanOnlyWhenFocusedWithAnImage();
+    tearingDownTheSceneForgetsThePointOverlays();
     return 0;
 }

--- a/tests/unit/test_image_view_pan.cpp
+++ b/tests/unit/test_image_view_pan.cpp
@@ -248,7 +248,9 @@ void arrowKeysRequestPanOnlyWhenFocusedWithAnImage()
 // them. setImage and setPointOverlays do; setPlaceholder is the third one,
 // and a stale tally there outlives the scene it counted -- the particle
 // overlay accessors then answer for a view that is showing "Loading...".
-void tearingDownTheSceneForgetsThePointOverlays()
+// The tally only: m_pointOverlayColors has the same gap in setPlaceholder,
+// which predates this and is not fixed here.
+void tearingDownTheSceneForgetsThePointTally()
 {
     amrvis::qt::ImageView view;
     view.setImage(solidImage(16, 16));
@@ -286,6 +288,6 @@ int main(int argc, char* argv[])
     scrollBarPanFollowsContentDelta();
     fullyVisibleSceneIgnoresPan();
     arrowKeysRequestPanOnlyWhenFocusedWithAnImage();
-    tearingDownTheSceneForgetsThePointOverlays();
+    tearingDownTheSceneForgetsThePointTally();
     return 0;
 }

--- a/tests/unit/test_particle_controller.cpp
+++ b/tests/unit/test_particle_controller.cpp
@@ -37,7 +37,9 @@ void require(bool condition, const char* message)
 // after an optional delay so a load can be cancelled or superseded in flight.
 class FakeSession final : public amrvis::DatasetSession {
 public:
-    FakeSession()
+    // The particles dialog offers the slice-cell filter only in 3-D, where a
+    // slice has a normal to filter on; both dimensions need covering.
+    explicit FakeSession(int dimension = 2)
     {
         amrvis::ParticleSpeciesMetadata electrons;
         electrons.name = "electrons";
@@ -46,7 +48,7 @@ public:
         ions.name = "ions";
         ions.particleCount = 20;
         m_species = {electrons, ions};
-        m_metadata.dimension = 2;
+        m_metadata.dimension = dimension;
     }
 
     std::size_t pointsPerSpecies = 3;
@@ -296,24 +298,25 @@ int main(int argc, char** argv)
     }
 
     // applySelection: identity changes (species, fraction, seed, first
-    // application) ask the host to reload; a point-size change alone only
-    // redraws. setColor redraws. clearSelection/resetSettings/restoreSelection
-    // shape the settings as the dataset transitions need.
+    // application) ask the host to reload; a point-size or slice-cell-filter
+    // change alone only redraws. setColor redraws.
+    // clearSelection/resetSettings/restoreSelection shape the settings as the
+    // dataset transitions need.
     {
         Observed observed;
         ParticleController controller(hooks());
         observe(controller, observed);
         // The very first application reloads even when it changes nothing
         // else: the defaults, applied, are still a selection to sample.
-        controller.applySelection({}, 1.0, 3, 0);
+        controller.applySelection({}, 1.0, 3, 0, false);
         require(observed.selection == 1 && observed.overlays == 0,
             "the first application of the defaults did not ask for a reload");
-        controller.applySelection({}, 1.0, 3, 0);
+        controller.applySelection({}, 1.0, 3, 0, false);
         require(observed.selection == 1 && observed.overlays == 1,
             "re-applying the defaults reloaded");
         controller.clearSelection();
         observed = Observed{};
-        controller.applySelection({"ions"}, 0.5, 4, 7);
+        controller.applySelection({"ions"}, 0.5, 4, 7, true);
         require(observed.selection == 1 && observed.overlays == 0,
             "the first selection did not ask for a reload");
         require(controller.settings().selectionInitialized
@@ -321,19 +324,31 @@ int main(int argc, char** argv)
                     == std::vector<std::string>{"ions"}
                 && controller.settings().fraction == 0.5
                 && controller.settings().seed == 7
-                && controller.settings().pointSize == 4,
+                && controller.settings().pointSize == 4
+                && controller.settings().sliceCellsOnly,
             "applySelection did not install the selection");
-        controller.applySelection({"ions"}, 0.5, 9, 7);
+        // Point size and the filter change together, to distinct values, so
+        // a swap of the two trailing arguments cannot pass: 9 is not a bool
+        // and false is not 9.
+        controller.applySelection({"ions"}, 0.5, 9, 7, false);
         require(observed.selection == 1 && observed.overlays == 1,
             "a point-size change reloaded instead of redrawing");
-        controller.applySelection({"ions"}, 0.25, 9, 7);
+        require(controller.settings().pointSize == 9
+                && !controller.settings().sliceCellsOnly,
+            "the cosmetic arguments did not land where they belong");
+        controller.applySelection({"ions"}, 0.5, 9, 7, true);
+        require(observed.selection == 1 && observed.overlays == 2,
+            "a slice-cell-filter change reloaded instead of redrawing");
+        require(controller.settings().sliceCellsOnly,
+            "the slice-cell filter did not install");
+        controller.applySelection({"ions"}, 0.25, 9, 7, true);
         require(observed.selection == 2, "a fraction change did not reload");
-        controller.applySelection({"ions"}, 0.25, 9, 8);
+        controller.applySelection({"ions"}, 0.25, 9, 8, true);
         require(observed.selection == 3, "a seed change did not reload");
-        controller.applySelection({"ions", "electrons"}, 0.25, 9, 8);
+        controller.applySelection({"ions", "electrons"}, 0.25, 9, 8, true);
         require(observed.selection == 4, "a species change did not reload");
         controller.setColor("ions", QColor(Qt::blue));
-        require(observed.overlays == 2 && observed.selection == 4,
+        require(observed.overlays == 3 && observed.selection == 4,
             "setColor did not redraw, or reloaded");
         controller.clearSelection();
         require(!controller.settings().selectionInitialized
@@ -347,11 +362,13 @@ int main(int argc, char** argv)
                     == std::vector<std::string>{"electrons"}
                 && controller.settings().fraction == 0.75
                 && controller.settings().seed == 3
-                && controller.settings().pointSize == 9,
+                && controller.settings().pointSize == 9
+                && controller.settings().sliceCellsOnly,
             "restoreSelection did not reinstall the spec's fields only");
         controller.resetSettings();
         require(controller.settings().colors.empty()
                 && controller.settings().pointSize == 3
+                && !controller.settings().sliceCellsOnly
                 && controller.settings().fraction == 1.0,
             "resetSettings left something behind");
     }
@@ -594,6 +611,12 @@ int main(int argc, char** argv)
         require(checks.size() == 2 && !checks[0]->isChecked()
                 && checks[1]->isChecked(),
             "the species rows do not reflect the selection");
+        // 2-D: the slice is the domain, so the filter would do nothing and
+        // the check box is not offered -- which is also what keeps the
+        // species rows above findable by type and order.
+        require(dialog->findChild<QCheckBox*>(
+                    QStringLiteral("particlesSliceCellsOnly")) == nullptr,
+            "the slice-cell check box was offered for 2-D data");
         controller.showDialog(&host);
         require(host.findChildren<QDialog*>(QStringLiteral("particlesDialog"))
                     .size() == 1,
@@ -627,6 +650,51 @@ int main(int argc, char** argv)
         require(host.findChild<QDialog*>(QStringLiteral("particlesDialog"))
                     == nullptr,
             "closeDialog did not close the dialog");
+    }
+
+    // The 3-D dialog offers the slice-cell filter, shows what is stored, and
+    // Apply routes it through applySelection as a redraw rather than a
+    // reload: the samples it filters are already loaded.
+    {
+        auto volume = std::make_shared<FakeSession>(3);
+        current = volume;
+        Observed observed;
+        ParticleController controller(hooks());
+        controller.configureForDataset(false);
+        controller.restoreSelection({"ions"}, 0.5, 3, true);
+        observe(controller, observed);
+        QWidget host;
+        controller.showDialog(&host);
+        auto* dialog = host.findChild<QDialog*>(QStringLiteral("particlesDialog"));
+        require(dialog != nullptr, "the dialog was not shown");
+        auto* filter = dialog->findChild<QCheckBox*>(
+            QStringLiteral("particlesSliceCellsOnly"));
+        require(filter != nullptr,
+            "the slice-cell check box was not offered for 3-D data");
+        require(!filter->isChecked(),
+            "the check box did not start from the stored setting");
+        filter->setChecked(true);
+        auto* buttons = dialog->findChild<QDialogButtonBox*>(
+            QStringLiteral("particlesDialogButtons"));
+        require(buttons != nullptr, "no button box");
+        buttons->button(QDialogButtonBox::Apply)->click();
+        require(controller.settings().sliceCellsOnly,
+            "Apply did not route the slice-cell filter");
+        require(observed.overlays == 1 && observed.selection == 0,
+            "the slice-cell filter reloaded instead of redrawing");
+        // Reopened, the box shows what was applied.
+        controller.closeDialog();
+        QCoreApplication::processEvents();
+        QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
+        controller.showDialog(&host);
+        dialog = host.findChild<QDialog*>(QStringLiteral("particlesDialog"));
+        require(dialog != nullptr, "the dialog did not reopen");
+        filter = dialog->findChild<QCheckBox*>(
+            QStringLiteral("particlesSliceCellsOnly"));
+        require(filter != nullptr && filter->isChecked(),
+            "the reopened check box did not show the applied setting");
+        controller.closeDialog();
+        current = session;
     }
 
     std::cout << "particle controller tests passed\n";

--- a/tests/unit/test_particle_projection.cpp
+++ b/tests/unit/test_particle_projection.cpp
@@ -77,6 +77,31 @@ amrvis::ScalarPlane splitLevelPlane(int width, int height)
     return result;
 }
 
+// sourceLevel varying by row *and* column, on a non-square raster: the
+// quadrants pin the row mapping, the column mapping, and their pairing at
+// once. Rows count the way a slice query writes them -- increasing physical y
+// -- while the emitted scene y is flipped, so a lookup that reused the
+// flipped value would read the wrong half.
+//
+//   y high |  uncovered  |  level 0   |
+//   y low  |  level 0    |  level 1   |
+//            x low          x high
+amrvis::ScalarPlane quadrantLevelPlane(int width, int height)
+{
+    auto result = plane(width, height, {{0.0, 0.0, 0.0}}, {{10.0, 10.0, 8.0}});
+    result.sourceLevel.reserve(
+        static_cast<std::size_t>(width) * static_cast<std::size_t>(height));
+    for (int row = 0; row < height; ++row) {
+        for (int column = 0; column < width; ++column) {
+            const bool lowY = row < height / 2;
+            const bool lowX = column < width / 2;
+            result.sourceLevel.push_back(
+                lowY ? (lowX ? 0 : 1) : (lowX ? -1 : 0));
+        }
+    }
+    return result;
+}
+
 } // namespace
 
 int main()
@@ -239,6 +264,86 @@ int main()
         require(amrvis::projectParticlePoints(coarse, mismatched, 3, 2, slabs)
                     .empty(),
                 "a plane with no usable source levels was filtered anyway");
+    }
+
+    // The row mapping, and its pairing with the column mapping. Four
+    // particles the same distance from the plane, one per quadrant: only the
+    // two over a level-0 pixel survive, and which two says the rows were read
+    // in the direction a slice query writes them.
+    {
+        const auto metadata = twoLevelMetadata();
+        const auto slabs = amrvis::sliceCellSlabs(metadata, 2, 4.25);
+        const auto display = quadrantLevelPlane(8, 4);
+        // Inside the coarse cell [4, 5), outside the fine cell [4, 4.5).
+        const auto atLowYLowX = point(1.25, 1.25, 4.75);    // level 0
+        const auto atLowYHighX = point(8.75, 1.25, 4.75);   // level 1
+        const auto atHighYLowX = point(1.25, 8.75, 4.75);   // uncovered
+        const auto atHighYHighX = point(8.75, 8.75, 4.75);  // level 0
+        const auto kept = amrvis::projectParticlePoints(
+            std::vector{atLowYLowX, atLowYHighX, atHighYLowX, atHighYHighX},
+            display, 3, 2, slabs);
+        require(kept.size() == 2,
+                "the quadrant pattern did not keep exactly the level-0 pair");
+        // Scene y is flipped, so low physical y is the *larger* scene y.
+        require(nearlyEqual(kept[0].x, 1.0) && nearlyEqual(kept[0].y, 3.5),
+                "the low-y level-0 particle was not the one kept");
+        require(nearlyEqual(kept[1].x, 7.0) && nearlyEqual(kept[1].y, 0.5),
+                "the high-y level-0 particle was not the one kept");
+        // Each rejected quadrant on its own, so a failure names the pixel
+        // that misread rather than only the pair count.
+        require(amrvis::projectParticlePoints(
+                    std::vector{atLowYHighX}, display, 3, 2, slabs)
+                    .empty(),
+                "the low-y fine quadrant kept a particle outside its cell");
+        require(amrvis::projectParticlePoints(
+                    std::vector{atHighYLowX}, display, 3, 2, slabs)
+                    .empty(),
+                "the high-y uncovered quadrant drew a particle");
+    }
+
+    // A particle exactly on the face between two cells belongs to the upper
+    // one, at every level -- so it is drawn from exactly one cell per level,
+    // never from both and never from none. The plane standing at the
+    // particle's own coordinate is always one that draws it, which is what
+    // makes "never from none" hold whatever the refinement.
+    {
+        const auto metadata = twoLevelMetadata();
+        const auto display = splitLevelPlane(10, 4);
+        const std::vector onFace{point(2.5, 5.0, 4.5)};      // level-0 pixel
+        const std::vector onFineFace{point(7.5, 5.0, 4.5)};  // level-1 pixel
+
+        // Level 0, dx = 1: 4.5 is interior to cell 4, so the cell below is 3
+        // and only cell 4 holds the particle.
+        require(amrvis::projectParticlePoints(onFace, display, 3, 2,
+                    amrvis::sliceCellSlabs(metadata, 2, 3.5))
+                    .empty(),
+                "the coarse cell below the particle drew it");
+        require(amrvis::projectParticlePoints(onFace, display, 3, 2,
+                    amrvis::sliceCellSlabs(metadata, 2, 4.25))
+                    .size() == 1,
+                "the coarse cell containing the particle did not draw it");
+
+        // Level 1, dx = 1/2: 4.5 is exactly the face between cells 8 and 9.
+        // The upper cell takes it; the lower one does not.
+        require(amrvis::projectParticlePoints(onFineFace, display, 3, 2,
+                    amrvis::sliceCellSlabs(metadata, 2, 4.25))
+                    .empty(),
+                "the fine cell below the face drew the particle");
+        require(amrvis::projectParticlePoints(onFineFace, display, 3, 2,
+                    amrvis::sliceCellSlabs(metadata, 2, 4.75))
+                    .size() == 1,
+                "the fine cell above the face did not draw the particle");
+
+        // The general form: a plane at the particle's own coordinate draws it
+        // whichever level supplies the pixel, because sampleIndex puts the
+        // plane and the particle in the same cell by construction.
+        for (const auto& probe : {onFace, onFineFace}) {
+            const auto own = amrvis::sliceCellSlabs(
+                metadata, 2, probe.front().position[2]);
+            require(amrvis::projectParticlePoints(probe, display, 3, 2, own)
+                        .size() == 1,
+                    "a particle was invisible from its own coordinate");
+        }
     }
 
     return 0;

--- a/tests/unit/test_particle_projection.cpp
+++ b/tests/unit/test_particle_projection.cpp
@@ -211,6 +211,27 @@ int main()
                 "a 2-D dataset produced slabs");
         require(amrvis::sliceCellSlabs(metadata, 3, 4.25).empty(),
                 "an out-of-range normal produced slabs");
+
+        // A position off the end of every level: sampleIndex extrapolates an
+        // index rather than throwing, so the slabs are only empty because the
+        // index is checked against the level's own domain. The levels span
+        // z in [0, 8).
+        for (const auto& off : amrvis::sliceCellSlabs(metadata, 2, 12.5)) {
+            require(!(off.lower < off.upper),
+                    "a position past the domain produced a cell to keep "
+                    "particles in");
+        }
+        for (const auto& below : amrvis::sliceCellSlabs(metadata, 2, -1.5)) {
+            require(!(below.lower < below.upper),
+                    "a position below the domain produced a cell to keep "
+                    "particles in");
+        }
+        // The last cell is still a cell: the check is a domain test, not an
+        // off-by-one that eats the top of the range.
+        const auto top = amrvis::sliceCellSlabs(metadata, 2, 7.5);
+        require(top.size() == 2 && nearlyEqual(top[0].lower, 7.0)
+                    && nearlyEqual(top[0].upper, 8.0),
+                "the level's last cell was rejected as out of domain");
     }
 
     // The decisive case: two particles the same distance from the plane, one

--- a/tests/unit/test_particle_projection.cpp
+++ b/tests/unit/test_particle_projection.cpp
@@ -41,6 +41,42 @@ amrvis::ScalarPlane plane(int width, int height, amrvis::Real3 lower,
     return result;
 }
 
+amrvis::LevelMetadata level(int index, double cellSize, int upperIndex)
+{
+    amrvis::LevelMetadata result;
+    result.level = index;
+    result.domain.lower = {{0, 0, 0}};
+    result.domain.upper = {{upperIndex, upperIndex, upperIndex}};
+    result.cellSize = {{cellSize, cellSize, cellSize}};
+    return result;
+}
+
+// A unit-origin 3-D hierarchy over [0, 8) with dx = 1 on level 0 and dx = 1/2
+// on level 1, so a plane cuts a cell twice as thick in the coarse regions.
+amrvis::DatasetMetadata twoLevelMetadata()
+{
+    amrvis::DatasetMetadata metadata;
+    metadata.dimension = 3;
+    metadata.finestLevel = 1;
+    metadata.levels = {level(0, 1.0, 7), level(1, 0.5, 15)};
+    return metadata;
+}
+
+// An XY raster over x, y in [0, 10) whose left half was supplied by level 0
+// and right half by level 1 -- the composition the filter has to respect.
+amrvis::ScalarPlane splitLevelPlane(int width, int height)
+{
+    auto result = plane(width, height, {{0.0, 0.0, 0.0}}, {{10.0, 10.0, 8.0}});
+    result.sourceLevel.reserve(
+        static_cast<std::size_t>(width) * static_cast<std::size_t>(height));
+    for (int row = 0; row < height; ++row) {
+        for (int column = 0; column < width; ++column) {
+            result.sourceLevel.push_back(column < width / 2 ? 0 : 1);
+        }
+    }
+    return result;
+}
+
 } // namespace
 
 int main()
@@ -126,6 +162,83 @@ int main()
             amrvis::projectParticlePoints(std::vector{point(0.5, 0.5)}, valid, 3, 3)
                 .empty(),
             "invalid 3-D normal accepted a particle projection");
+    }
+
+    // sliceCellSlabs: the cell each level puts around the slice position.
+    {
+        const auto metadata = twoLevelMetadata();
+        const auto slabs = amrvis::sliceCellSlabs(metadata, 2, 4.25);
+        require(slabs.size() == 2, "a slab per level was not produced");
+        require(nearlyEqual(slabs[0].lower, 4.0)
+                    && nearlyEqual(slabs[0].upper, 5.0),
+                "the coarse slab is not the cell containing the position");
+        require(nearlyEqual(slabs[1].lower, 4.0)
+                    && nearlyEqual(slabs[1].upper, 4.5),
+                "the fine slab is not the cell containing the position");
+        require(nearlyEqual(slabs[1].upper - slabs[1].lower,
+                            0.5 * (slabs[0].upper - slabs[0].lower)),
+                "refining the level did not halve the slab");
+
+        // A 2-D dataset has no normal to filter on.
+        auto flat = metadata;
+        flat.dimension = 2;
+        require(amrvis::sliceCellSlabs(flat, 2, 4.25).empty(),
+                "a 2-D dataset produced slabs");
+        require(amrvis::sliceCellSlabs(metadata, 3, 4.25).empty(),
+                "an out-of-range normal produced slabs");
+    }
+
+    // The decisive case: two particles the same distance from the plane, one
+    // over a coarse pixel and one over a fine one. The coarse cell still holds
+    // its particle; the fine cell does not reach that far. A filter that used
+    // one thickness for the whole raster would keep or drop both.
+    {
+        const auto metadata = twoLevelMetadata();
+        const auto slabs = amrvis::sliceCellSlabs(metadata, 2, 4.25);
+        const auto display = splitLevelPlane(10, 4);
+        const std::vector coarse{point(2.5, 5.0, 4.75)};
+        const std::vector fine{point(7.5, 5.0, 4.75)};
+        require(amrvis::projectParticlePoints(coarse, display, 3, 2, slabs)
+                    .size() == 1,
+                "a particle inside the coarse cell the plane cuts was dropped");
+        require(amrvis::projectParticlePoints(fine, display, 3, 2, slabs)
+                    .empty(),
+                "a particle outside the fine cell the plane cuts was drawn");
+        // Both are still drawn when nothing is filtered, and land where the
+        // unfiltered projection puts them.
+        const auto unfiltered =
+            amrvis::projectParticlePoints(fine, display, 3, 2);
+        require(unfiltered.size() == 1 && nearlyEqual(unfiltered[0].x, 7.5)
+                    && nearlyEqual(unfiltered[0].y, 2.0),
+                "the default no longer projects through the volume");
+        const auto kept =
+            amrvis::projectParticlePoints(coarse, display, 3, 2, slabs);
+        require(nearlyEqual(kept[0].x, 2.5) && nearlyEqual(kept[0].y, 2.0),
+                "filtering moved the point it kept");
+
+        // Half-open on the normal, the rule the slice uses for its own cell.
+        require(amrvis::projectParticlePoints(
+                    std::vector{point(2.5, 5.0, 4.0)}, display, 3, 2, slabs)
+                    .size() == 1,
+                "the cell's lower face was excluded");
+        require(amrvis::projectParticlePoints(
+                    std::vector{point(2.5, 5.0, 5.0)}, display, 3, 2, slabs)
+                    .empty(),
+                "the cell's upper face was included");
+
+        // No data drawn at a pixel means no cell there to be in.
+        auto uncovered = display;
+        uncovered.sourceLevel.assign(uncovered.sourceLevel.size(), -1);
+        require(amrvis::projectParticlePoints(coarse, uncovered, 3, 2, slabs)
+                    .empty(),
+                "a particle over an uncovered pixel was drawn");
+
+        // A plane whose sourceLevel does not match its raster cannot answer.
+        auto mismatched = display;
+        mismatched.sourceLevel.pop_back();
+        require(amrvis::projectParticlePoints(coarse, mismatched, 3, 2, slabs)
+                    .empty(),
+                "a plane with no usable source levels was filtered anyway");
     }
 
     return 0;

--- a/tests/unit/test_particle_projection.cpp
+++ b/tests/unit/test_particle_projection.cpp
@@ -234,6 +234,55 @@ int main()
                 "the level's last cell was rejected as out of domain");
     }
 
+    // 2-D has no normal to filter on -- slicePlaneAxes returns {0, 1}
+    // whatever normalDirection is, so honouring slabs here would test an
+    // in-plane coordinate against them. The particle's y sits outside the
+    // coarse slab, so a projector that filtered in 2-D would drop it.
+    {
+        const auto metadata = twoLevelMetadata();
+        const auto slabs = amrvis::sliceCellSlabs(metadata, 2, 4.25);
+        const auto display = splitLevelPlane(10, 4);
+        require(!slabs.empty(), "the fixture produced no slabs to hand in");
+        const auto projected = amrvis::projectParticlePoints(
+            std::vector{point(2.5, 5.0)}, display, 2, 1, slabs);
+        require(projected.size() == 1,
+                "a 2-D projection filtered against slabs it has no normal for");
+    }
+
+    // The pixel index is the inverse of the sampleCentre the query binned
+    // that pixel with, and sampleCentre divides the extent last on purpose.
+    // Pre-dividing rounds the step down, and for this region, width and
+    // coordinate it lands one column short -- 23 rather than 24. Column 24 is
+    // the first supplied by the finer level here, so the two spellings
+    // disagree about which cell thickness the particle is tested against, and
+    // therefore about whether it is drawn at all. Hex literals so the doubles
+    // are exact rather than reparsed from decimal.
+    {
+        const auto metadata = twoLevelMetadata();
+        const auto slabs = amrvis::sliceCellSlabs(metadata, 2, 4.25);
+        constexpr double lower = -0x1.11a39d91d4d80p+2;
+        constexpr double upper = 0x1.57e4070faa688p+9;
+        constexpr double edge = 0x1.8aae266666954p+3;
+        constexpr int width = 1000;
+        constexpr int height = 4;
+        auto display = plane(width, height, {{lower, 0.0, 0.0}},
+            {{upper, 10.0, 8.0}});
+        display.sourceLevel.reserve(
+            static_cast<std::size_t>(width) * static_cast<std::size_t>(height));
+        for (int row = 0; row < height; ++row) {
+            for (int column = 0; column < width; ++column) {
+                display.sourceLevel.push_back(column < 24 ? 0 : 1);
+            }
+        }
+        // Inside the coarse cell [4, 5), outside the fine cell [4, 4.5): kept
+        // if the lookup lands on column 23, dropped if it lands on 24.
+        require(amrvis::projectParticlePoints(
+                    std::vector{point(edge, 5.0, 4.75)}, display, 3, 2, slabs)
+                    .empty(),
+                "the pixel lookup pre-divided the extent and read the "
+                "neighbouring column's level");
+    }
+
     // The decisive case: two particles the same distance from the plane, one
     // over a coarse pixel and one over a fine one. The coarse cell still holds
     // its particle; the fine cell does not reach that far. A filter that used

--- a/tests/unit/test_particle_projection.cpp
+++ b/tests/unit/test_particle_projection.cpp
@@ -283,6 +283,37 @@ int main()
                 "neighbouring column's level");
     }
 
+    // A region whose extent approaches the double range: (x - lower) *
+    // width overflows to infinity, and casting that to int is undefined.
+    // Clamping before the cast puts the particle at the upper edge on the
+    // last column, which is where the raster drew it.
+    {
+        const auto metadata = twoLevelMetadata();
+        const auto slabs = amrvis::sliceCellSlabs(metadata, 2, 4.25);
+        constexpr int width = 1000;
+        constexpr int height = 4;
+        constexpr double extent = 1.0e308;
+        auto display = plane(width, height, {{0.0, 0.0, 0.0}},
+            {{extent, 10.0, 8.0}});
+        // Only the last column comes from the finer level, so binning there
+        // rather than anywhere else decides the answer.
+        display.sourceLevel.assign(
+            static_cast<std::size_t>(width) * static_cast<std::size_t>(height),
+            0);
+        for (int row = 0; row < height; ++row) {
+            display.sourceLevel[static_cast<std::size_t>(width - 1)
+                + static_cast<std::size_t>(width)
+                    * static_cast<std::size_t>(row)]
+                = 1;
+        }
+        // Inside the coarse cell [4, 5), outside the fine cell [4, 4.5).
+        require(amrvis::projectParticlePoints(
+                    std::vector{point(extent, 5.0, 4.75)}, display, 3, 2, slabs)
+                    .empty(),
+                "a region near the double range did not bin the upper edge "
+                "onto the last column");
+    }
+
     // The decisive case: two particles the same distance from the plane, one
     // over a coarse pixel and one over a fine one. The coarse cell still holds
     // its particle; the fine cell does not reach that far. A filter that used


### PR DESCRIPTION
A new Particles dialog check box, off by default: projection through the whole volume stays what an untouched dialog does. Ticked, a particle is drawn only where it falls inside the cell the plane cuts.

The thickness comes from the plane's per-pixel sourceLevel, so a region shown at a coarse level keeps its thicker cell instead of losing particles to a finer level's spacing. Client-side only; nothing new crosses the wire.