### PR TITLE
draw the Dataset window's values in their color-bar colors

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -271,6 +271,14 @@ Choose **View > Dataset...** or press **Ctrl+D** to inspect raw values for
 the visible physical region. Values are grouped by AMR level. Clicking a
 value highlights the corresponding sample in the main view.
 
+Each value is drawn in the color the color bar gives it, so a number and the
+pixel it stands for share one color; values past either end of the range take
+that end's color, and a value the range cannot map -- a NaN, or a non-positive
+value with **Log** ticked -- is drawn in magenta, as it is in the image. The
+colors follow the palette and range as you change them, while the values
+themselves stay as read until **Refresh**. Samples no grid covers at a level
+are left blank on a darker background.
+
 The Dataset and line-plot windows close with their **Close** button or with
 Ctrl+W (Cmd+W on macOS), the same key that closes the main and volume windows.
 

--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -8,6 +8,7 @@ add_executable(amrexplorer_qt
     ColorBarWidget.cpp
     ColorBarWidget.hpp
     CurrentRowBulletDelegate.hpp
+    DatasetColoring.hpp
     DatasetExtract.hpp
     DatasetWindow.cpp
     DatasetWindow.hpp

--- a/src/qt/DatasetColoring.hpp
+++ b/src/qt/DatasetColoring.hpp
@@ -1,0 +1,68 @@
+#pragma once
+
+// The colors the Dataset window draws its numbers in: the palette slot the
+// scalar renderer gives the same value under the same display range, so a
+// number in the table, the pixel it stands for in the image, and the color bar
+// beside them all carry one color.
+
+#include "Theme.hpp"
+
+#include <amrexplorer/core/ValueMapping.hpp>
+#include <amrexplorer/render2d/Palette.hpp>
+#include <amrexplorer/render2d/ScalarRenderer.hpp>
+
+#include <QColor>
+
+#include <optional>
+
+namespace amrvis::qt {
+
+// The palette is held by value rather than by pointer as the color bar holds
+// it: the Dataset window is a top-level WA_DeleteOnClose widget whose deferred
+// delete can outlive the MainWindow that owns the PaletteController, and a
+// palette is 1 KB of trivially copyable bytes.
+struct DatasetColoring {
+    Palette palette;
+    // nullopt for a range nothing can be mapped through (see
+    // resolveValueRange); the window then falls back to a plain foreground
+    // rather than drawing every number in the first slot's color.
+    std::optional<ResolvedValueRange> range;
+};
+
+[[nodiscard]] inline DatasetColoring makeDatasetColoring(
+    const Palette& palette, double minimum, double maximum, bool logarithmic)
+{
+    return DatasetColoring{
+        palette, resolveValueRange(minimum, maximum, logarithmic)};
+}
+
+// What a value is drawn in. Mapped through ValueMapping, exactly as
+// renderScalarPlane maps the same value, so the two cannot drift apart at the
+// truncation ties valueSlot documents. Values outside the range take the end
+// colors, as they do in the image; a value the range cannot map at all -- a
+// NaN, or a non-positive one under a logarithmic range -- takes the renderer's
+// own nan color.
+[[nodiscard]] inline QColor datasetValueColor(
+    const DatasetColoring& coloring, double value)
+{
+    if (!coloring.range) {
+        return viewportForeground();
+    }
+    if (!mappableValue(value, *coloring.range)) {
+        return QColor::fromRgb(
+            static_cast<QRgb>(ScalarRenderSettings{}.nanColor));
+    }
+    const auto slot = valueSlot(value, *coloring.range, Palette::colorSlots);
+    return QColor::fromRgb(static_cast<QRgb>(
+        coloring.palette.slotArgb(Palette::paletteStart + slot)));
+}
+
+// Behind a sample no grid covers at that level, matching the color the
+// renderer fills a pixel with when no level provides one.
+[[nodiscard]] inline QColor datasetUncoveredBackground()
+{
+    return QColor::fromRgb(
+        static_cast<QRgb>(ScalarRenderSettings{}.invalidColor));
+}
+
+} // namespace amrvis::qt

--- a/src/qt/DatasetWindow.cpp
+++ b/src/qt/DatasetWindow.cpp
@@ -4,6 +4,7 @@
 #include "CloseWindowAction.hpp"
 #include "NumberFormat.hpp"
 #include "QtErrorText.hpp"
+#include "Theme.hpp"
 
 #include <amrexplorer/io/PlotfileBlockReader.hpp>
 #include <amrexplorer/io/PlotfileDataset.hpp>
@@ -15,6 +16,7 @@
 #include <QHBoxLayout>
 #include <QLabel>
 #include <QModelIndex>
+#include <QPalette>
 #include <QPushButton>
 #include <QTabWidget>
 #include <QTableView>
@@ -66,10 +68,11 @@ int datasetPageMaximumExtent(const DatasetSession& dataset)
 // (destroying every model) before or while the backing m_levels changes.
 class LevelTableModel final : public QAbstractTableModel {
 public:
-    LevelTableModel(const DatasetLevelExtract& extract, QString format,
-        QObject* parent)
+    LevelTableModel(const DatasetLevelExtract& extract,
+        const DatasetColoring& coloring, QString format, QObject* parent)
         : QAbstractTableModel(parent)
         , m_extract(extract)
+        , m_coloring(coloring)
         , m_format(std::move(format))
     {
     }
@@ -102,9 +105,20 @@ public:
             return covered
                 ? QVariant(static_cast<int>(Qt::AlignRight | Qt::AlignVCenter))
                 : QVariant();
+        case Qt::ForegroundRole:
+            // The color the color bar gives this value, which is the color the
+            // image draws the sample in.
+            return covered
+                ? QVariant(datasetValueColor(m_coloring,
+                      static_cast<double>(m_extract.values[offset])))
+                : QVariant();
         case Qt::BackgroundRole:
-            // Cells no grid covers at this level are shaded, as before.
-            return covered ? QVariant() : QVariant(QColor(Qt::darkGray));
+            // Cells no grid covers at this level are shaded, as before -- in
+            // the renderer's own no-data color now that the covered cells sit
+            // on the viewport background, which the old dark gray matched
+            // almost exactly.
+            return covered
+                ? QVariant() : QVariant(datasetUncoveredBackground());
         default:
             return {};
         }
@@ -134,6 +148,9 @@ private:
     }
 
     const DatasetLevelExtract& m_extract;
+    // Held by reference like the extract above, and on the same terms: it is a
+    // member of the owning DatasetWindow, which outlives every model it builds.
+    const DatasetColoring& m_coloring;
     QString m_format;
 };
 
@@ -197,6 +214,23 @@ void DatasetWindow::setNumberFormat(QString format)
     // compared to re-reading the dataset.
     if (!m_levels.empty()) {
         populateTabs();
+    }
+}
+
+void DatasetWindow::setColoring(DatasetColoring coloring)
+{
+    m_coloring = std::move(coloring);
+    // Not populateTabs: the models read the coloring by reference and it has
+    // just moved under them, so all that is owed is a repaint. Rebuilding the
+    // tabs would throw away the current tab and every scroll position, and the
+    // palette can change under an open window at any time.
+    //
+    // A repaint is enough because the views hold nothing: QTableView asks the
+    // model for each visible cell as it paints it.
+    for (int page = 0; page < m_tabs->count(); ++page) {
+        if (auto* table = m_tabs->widget(page)->findChild<QTableView*>()) {
+            table->viewport()->update();
+        }
     }
 }
 
@@ -312,7 +346,16 @@ void DatasetWindow::populateTabs()
         // visible cells, so a full-domain table no longer freezes the GUI.
         auto* table = new QTableView(page);
         table->setEditTriggers(QAbstractItemView::NoEditTriggers);
-        auto* model = new LevelTableModel(extract, m_numberFormat, table);
+        // The values are drawn in their color-bar colors, so the cells they sit
+        // on are the viewport's background rather than the theme's -- which is
+        // white under a light theme, where the bright end of viridis, plasma or
+        // blackbody would be all but invisible. Through the view's palette so
+        // the empty area past the last row and column matches the cells.
+        auto viewPalette = table->palette();
+        viewPalette.setColor(QPalette::Base, viewportBackground());
+        table->setPalette(viewPalette);
+        auto* model
+            = new LevelTableModel(extract, m_coloring, m_numberFormat, table);
         table->setModel(model);
         auto* pageLayout = new QVBoxLayout(page);
         pageLayout->addWidget(info);

--- a/src/qt/DatasetWindow.hpp
+++ b/src/qt/DatasetWindow.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "DatasetColoring.hpp"
 #include "DatasetExtract.hpp"
 
 #include <amrexplorer/core/Geometry.hpp>
@@ -37,9 +38,10 @@ struct DatasetRequest {
 // (the legacy Dataset window): one tab per AMR level (for standalone
 // MultiFabs and FABs, which have no AMR hierarchy, the single tab is named
 // after the format instead) with the i/j sample indices as headers and the
-// level min/max above the table; clicking a value
-// highlights the corresponding sample in the image. Reads run off the GUI
-// thread and are cancelled on close or refresh.
+// level min/max above the table; each value is drawn in its color-bar color
+// (see DatasetColoring) and clicking one highlights the corresponding sample
+// in the image. Reads run off the GUI thread and are cancelled on close or
+// refresh.
 class DatasetWindow final : public QWidget {
     Q_OBJECT
 
@@ -53,6 +55,12 @@ public:
     // Applies the printf-style readout format, re-rendering the already
     // loaded values (no re-read) when the tabs are populated.
     void setNumberFormat(QString format);
+    // The palette and display range the values are drawn in -- the active
+    // view's, so the table agrees with the image and the color bar. Repaints
+    // the loaded values in place; the values themselves are untouched, so a
+    // palette or range change recolors the window without a re-read and
+    // without disturbing the current tab or scroll position.
+    void setColoring(DatasetColoring coloring);
 
 signals:
     // Physical bounds of the clicked sample at its level's resolution (2-D
@@ -81,6 +89,7 @@ private:
 
     DatasetRequest m_request;
     QString m_numberFormat;
+    DatasetColoring m_coloring;
     QLabel* m_status = nullptr;
     QTabWidget* m_tabs = nullptr;
     std::vector<LevelData> m_levels;

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -1033,6 +1033,7 @@ void MainWindow::syncActiveViewColorControls(const PlaneViewState& state)
     if (m_range->mode() != RangeMode::User) {
         m_range->showDisplayRange(state.displayMinimum, state.displayMaximum);
     }
+    syncDatasetWindowColors();
 }
 
 std::array<int, 2> MainWindow::displayAxes(int normal) const
@@ -1776,6 +1777,7 @@ void MainWindow::refreshMetadataDisplay()
 void MainWindow::refreshPaletteDisplay()
 {
     m_colorBar->setPalette(&m_paletteController->palette());
+    syncDatasetWindowColors();
     scheduleSliceRequest();
     updateGridBoxes();
     updateOverlays();

--- a/src/qt/MainWindow.hpp
+++ b/src/qt/MainWindow.hpp
@@ -724,6 +724,10 @@ private:
     void showDatasetWindow();
     void closeDatasetWindow();
     void refreshDatasetWindow();
+    // Pushes the active view's palette and display range -- the pair the color
+    // bar is drawn from -- to an open Dataset window, so its numbers keep the
+    // colors the bar is showing. Called from every place that moves either.
+    void syncDatasetWindowColors();
     void datasetCellActivated(const RealBox& physicalCell);
     [[nodiscard]] std::optional<DatasetRequest> buildDatasetRequest() const;
     void showUserGuide();

--- a/src/qt/MainWindowDataset.cpp
+++ b/src/qt/MainWindowDataset.cpp
@@ -589,6 +589,7 @@ void MainWindow::showDatasetWindow()
     auto* window = new DatasetWindow(*request);
     window->setNumberFormat(m_numberFormat);
     m_datasetWindow = window;
+    syncDatasetWindowColors();
     connect(window, &QObject::destroyed, this, [this, window] {
         if (m_datasetWindow == window) {
             m_datasetWindow = nullptr;
@@ -617,6 +618,20 @@ void MainWindow::closeDatasetWindow()
     if (window != nullptr) {
         window->close();
     }
+}
+
+void MainWindow::syncDatasetWindowColors()
+{
+    if (m_datasetWindow == nullptr || m_activeView == nullptr) {
+        return;
+    }
+    // The active view's display range, which is what the color bar is set from
+    // (syncActiveViewColorControls) -- read from the same place rather than
+    // passed in, so the two cannot be given different numbers.
+    m_datasetWindow->setColoring(
+        makeDatasetColoring(m_paletteController->palette(),
+            m_activeView->displayMinimum, m_activeView->displayMaximum,
+            m_activeView->displayLogarithmic));
 }
 
 void MainWindow::refreshDatasetWindow()

--- a/src/qt/MainWindowSlice.cpp
+++ b/src/qt/MainWindowSlice.cpp
@@ -1545,6 +1545,10 @@ void MainWindow::syncVisibleRanges()
                         m_activeView->displayLogarithmic);
                     m_colorBar->setFieldRange(label, globalMin, globalMax);
                     m_range->showDisplayRange(globalMin, globalMax);
+                    // The panel loop above wrote this range into every applied
+                    // panel's state, the active one included, so the Dataset
+                    // window reads the same numbers the bar just took.
+                    syncDatasetWindowColors();
                 }
                 // The deferred full-domain range store (see the slice-arrival
                 // completion): the union is only known here. This block runs

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -625,6 +625,20 @@ if(TARGET amrexplorer_qt)
         COMMAND "${CMAKE_COMMAND}" -E env QT_QPA_PLATFORM=offscreen
             "$<TARGET_FILE:test_derived_field_controller>")
 
+    add_executable(test_dataset_colors unit/test_dataset_colors.cpp)
+    target_include_directories(test_dataset_colors
+        PRIVATE "${PROJECT_SOURCE_DIR}/src/qt")
+    target_link_libraries(test_dataset_colors
+        PRIVATE
+            amrexplorer::render2d
+            amrexplorer::warnings
+            Qt6::Core
+            Qt6::Gui
+    )
+    # Only QColor and the renderer, no widgets, so this one needs no QPA
+    # platform.
+    add_test(NAME dataset_colors COMMAND test_dataset_colors)
+
     add_executable(test_palette_controller
         unit/test_palette_controller.cpp
         "${PROJECT_SOURCE_DIR}/src/qt/PaletteController.cpp"

--- a/tests/unit/test_dataset_colors.cpp
+++ b/tests/unit/test_dataset_colors.cpp
@@ -1,0 +1,170 @@
+// Coverage for DatasetColoring, the value-to-color mapping the Dataset window
+// draws its numbers with. The load-bearing case is the cross-check against
+// renderScalarPlane: the whole point of the header is that a number in the
+// table and the pixel it stands for in the image carry one color, so the
+// expectation comes from the renderer itself rather than from a second copy of
+// the formula here.
+
+#include "DatasetColoring.hpp"
+#include "Theme.hpp"
+
+#include <amrexplorer/core/Result.hpp>
+#include <amrexplorer/render2d/Palette.hpp>
+#include <amrexplorer/render2d/ScalarRenderer.hpp>
+
+#include <QColor>
+
+#include <cmath>
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
+#include <limits>
+#include <string>
+#include <vector>
+
+namespace {
+
+void require(bool condition, const std::string& message)
+{
+    if (!condition) {
+        std::cerr << "FAILED: " << message << '\n';
+        std::exit(1);
+    }
+}
+
+std::uint32_t argbOf(const QColor& color)
+{
+    return static_cast<std::uint32_t>(color.rgb());
+}
+
+// Every value drawn the way the renderer draws that same value: same palette,
+// same range, same log flag. Values are floats because that is what both the
+// image plane and the dataset extract hold.
+void requireAgreesWithRenderer(const std::string& what,
+    const std::vector<float>& values, const amrvis::Palette& palette,
+    double minimum, double maximum, bool logarithmic)
+{
+    amrvis::ScalarPlane plane;
+    plane.width = static_cast<int>(values.size());
+    plane.height = 1;
+    plane.values = values;
+    plane.valid.assign(values.size(), 1);
+    plane.sourceLevel.assign(values.size(), 0);
+    const auto image = amrvis::renderScalarPlane(plane,
+        amrvis::ScalarRenderSettings{
+            .minimum = minimum,
+            .maximum = maximum,
+            .logarithmic = logarithmic,
+            .palette = &palette
+        });
+    require(image.valid(), what + ": the renderer produced no image");
+
+    const auto coloring = amrvis::qt::makeDatasetColoring(
+        palette, minimum, maximum, logarithmic);
+    require(coloring.range.has_value(), what + ": the range did not resolve");
+    std::size_t distinct = 0;
+    for (std::size_t pixel = 0; pixel < values.size(); ++pixel) {
+        const auto drawn = argbOf(amrvis::qt::datasetValueColor(
+            coloring, static_cast<double>(values[pixel])));
+        require(drawn == image.rgba[pixel],
+            what + ": value " + std::to_string(values[pixel])
+                + " is drawn in " + std::to_string(drawn)
+                + " but rendered as " + std::to_string(image.rgba[pixel]));
+        distinct += pixel > 0 && image.rgba[pixel] != image.rgba[pixel - 1];
+    }
+    // Otherwise the agreement above is the agreement of one flat color.
+    require(distinct >= 3, what + ": the values barely differ in color");
+}
+
+} // namespace
+
+int main()
+{
+    const auto& rainbow = amrvis::builtinPalette(amrvis::BuiltinPalette::Rainbow);
+    const auto reversedViridis
+        = amrvis::builtinPalette(amrvis::BuiltinPalette::Viridis).reversed();
+
+    // A span whose top and whose exact interior ties are the cases
+    // ValueMapping documents as sensitive to how the normalization is spelled,
+    // plus values under and over the range.
+    requireAgreesWithRenderer("linear rainbow",
+        {-3.0F, 0.0F, 1.0F, 12.25F, 24.5F, 36.75F, 48.0F, 49.0F, 60.0F},
+        rainbow, 0.0, 49.0, false);
+    requireAgreesWithRenderer("linear reversed viridis",
+        {-3.0F, 0.0F, 1.0F, 12.25F, 24.5F, 36.75F, 48.0F, 49.0F, 60.0F},
+        reversedViridis, 0.0, 49.0, false);
+    requireAgreesWithRenderer("logarithmic rainbow",
+        {1e-4F, 1e-3F, 1e-2F, 0.1F, 1.0F, 10.0F, 100.0F, 1e3F},
+        rainbow, 1e-3, 100.0, true);
+    requireAgreesWithRenderer("negative span",
+        {-20.0F, -10.0F, -7.5F, -5.0F, -2.5F, 0.0F, 5.0F},
+        rainbow, -10.0, 0.0, false);
+
+    // The ends, named outright: the color bar's bottom and top are the
+    // palette's first and last data slots, and the reversal swaps them.
+    const auto linear = amrvis::qt::makeDatasetColoring(rainbow, 2.0, 8.0, false);
+    require(argbOf(amrvis::qt::datasetValueColor(linear, 2.0))
+            == rainbow.slotArgb(amrvis::Palette::paletteStart),
+        "the minimum is not the palette's first data slot");
+    require(argbOf(amrvis::qt::datasetValueColor(linear, -100.0))
+            == rainbow.slotArgb(amrvis::Palette::paletteStart),
+        "a value under the range does not clamp to the first data slot");
+    require(argbOf(amrvis::qt::datasetValueColor(linear, 8.0))
+            == rainbow.slotArgb(amrvis::Palette::paletteEnd),
+        "the maximum is not the palette's last data slot");
+    require(argbOf(amrvis::qt::datasetValueColor(linear, 100.0))
+            == rainbow.slotArgb(amrvis::Palette::paletteEnd),
+        "a value over the range does not clamp to the last data slot");
+    const auto reversed = amrvis::qt::makeDatasetColoring(
+        rainbow.reversed(), 2.0, 8.0, false);
+    require(argbOf(amrvis::qt::datasetValueColor(reversed, 2.0))
+            == rainbow.slotArgb(amrvis::Palette::paletteEnd),
+        "reversal did not swap the low end");
+    require(argbOf(amrvis::qt::datasetValueColor(reversed, 8.0))
+            == rainbow.slotArgb(amrvis::Palette::paletteStart),
+        "reversal did not swap the high end");
+
+    // Values no range can map take the renderer's nan color, so an unplottable
+    // number is as conspicuous in the table as its pixel is in the image.
+    const auto nanColor = amrvis::ScalarRenderSettings{}.nanColor;
+    require(argbOf(amrvis::qt::datasetValueColor(
+                linear, std::numeric_limits<double>::quiet_NaN())) == nanColor,
+        "NaN is not drawn in the renderer's nan color");
+    require(argbOf(amrvis::qt::datasetValueColor(
+                linear, std::numeric_limits<double>::infinity())) == nanColor,
+        "an infinity is not drawn in the renderer's nan color");
+    const auto logarithmic
+        = amrvis::qt::makeDatasetColoring(rainbow, 1e-3, 100.0, true);
+    require(argbOf(amrvis::qt::datasetValueColor(logarithmic, 0.0)) == nanColor,
+        "zero under a log range is not drawn in the renderer's nan color");
+    require(argbOf(amrvis::qt::datasetValueColor(logarithmic, -1.0)) == nanColor,
+        "a negative under a log range is not drawn in the nan color");
+
+    // A range nothing can be mapped through: no color is meaningful, so the
+    // numbers stay legible in the plain viewport foreground instead of all
+    // taking the first slot's color.
+    for (const auto& unusable : {
+             amrvis::qt::makeDatasetColoring(rainbow, 5.0, 5.0, false),
+             amrvis::qt::makeDatasetColoring(rainbow, 8.0, 2.0, false),
+             amrvis::qt::makeDatasetColoring(rainbow, -1.0, 10.0, true),
+             amrvis::qt::makeDatasetColoring(rainbow,
+                 std::numeric_limits<double>::quiet_NaN(), 1.0, false)}) {
+        require(!unusable.range.has_value(),
+            "an unusable range resolved anyway");
+        require(amrvis::qt::datasetValueColor(unusable, 5.0)
+                == amrvis::qt::viewportForeground(),
+            "an unusable range does not fall back to the viewport foreground");
+    }
+
+    // Samples no grid covers at a level are shaded in the color the renderer
+    // fills a pixel with when no level provides one.
+    require(argbOf(amrvis::qt::datasetUncoveredBackground())
+            == amrvis::ScalarRenderSettings{}.invalidColor,
+        "the uncovered shade is not the renderer's invalid color");
+    require(amrvis::qt::datasetUncoveredBackground()
+            != amrvis::qt::viewportBackground(),
+        "uncovered cells are indistinguishable from covered ones");
+
+    std::cout << "dataset colors OK\n";
+    return 0;
+}


### PR DESCRIPTION
Each number takes the palette slot the scalar renderer gives that value under the active view's display range, so a number, its pixel and the color bar agree. The cells sit on the viewport background, and samples no grid covers take the renderer's no-data shade instead of the dark gray that now matches it.

The colors follow the palette and the range live; the values stay as read until Refresh.