### PR TITLE
highlight a selected block of Dataset values in the image

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -269,7 +269,11 @@ for plotfiles and integer indices for standalone FABs and MultiFabs.
 
 Choose **View > Dataset...** or press **Ctrl+D** to inspect raw values for
 the visible physical region. Values are grouped by AMR level. Clicking a
-value highlights the corresponding sample in the main view.
+value highlights the corresponding sample in the main view, and dragging
+across a block of values highlights the region they cover. Only values a grid
+covers at that level count, so selecting a whole level's table marks just the
+part of the view that level provides. One level's tab holds the selection at a
+time; selecting on another clears it.
 
 Each value is drawn in the color the color bar gives it, so a number and the
 pixel it stands for share one color; values past either end of the range take

--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -10,6 +10,7 @@ add_executable(amrexplorer_qt
     CurrentRowBulletDelegate.hpp
     DatasetColoring.hpp
     DatasetExtract.hpp
+    DatasetSelection.hpp
     DatasetWindow.cpp
     DatasetWindow.hpp
     DerivedFieldController.cpp

--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -11,6 +11,7 @@ add_executable(amrexplorer_qt
     DatasetColoring.hpp
     DatasetExtract.hpp
     DatasetSelection.hpp
+    DatasetValueDelegate.hpp
     DatasetWindow.cpp
     DatasetWindow.hpp
     DerivedFieldController.cpp

--- a/src/qt/DatasetSelection.hpp
+++ b/src/qt/DatasetSelection.hpp
@@ -5,6 +5,7 @@
 // types) so the index arithmetic -- which flips rows against j and has to skip
 // the samples no grid covers -- can be tested on a synthetic page.
 
+#include <amrexplorer/core/Geometry.hpp>
 #include <amrexplorer/data/DatasetPage.hpp>
 
 #include <algorithm>
@@ -79,6 +80,27 @@ struct SelectedSampleBox {
     return SelectedSampleBox{page.lower[0] + minColumn,
         page.lower[0] + maxColumn, page.upper[1] - maxRow,
         page.upper[1] - minRow};
+}
+
+// Whether the plane cutting `normal` at `position` still passes through a
+// marked cell -- the 3-D question the in-plane projection cannot answer. The
+// cell carries its own slice's physical bounds (cellsSelected collapses the
+// normal axis to the sample it was taken from, and sampleBounds gives that one
+// index a full cell's extent), so moving the plane off it has to take the
+// marker with it rather than redraw it, unchanged, over a sample that is no
+// longer on screen.
+//
+// Inclusive at both faces: a plane sitting exactly on a boundary cuts the
+// cells either side of it, and keeping the marker up there is the reading that
+// matches what the user sees.
+[[nodiscard]] inline bool datasetCellOnDisplayedSlice(
+    const RealBox& cell, int normal, double position) noexcept
+{
+    if (normal < 0 || normal > 2) {
+        return false;
+    }
+    const auto axis = static_cast<std::size_t>(normal);
+    return position >= cell.lower[axis] && position <= cell.upper[axis];
 }
 
 } // namespace amrvis::qt

--- a/src/qt/DatasetSelection.hpp
+++ b/src/qt/DatasetSelection.hpp
@@ -90,9 +90,11 @@ struct SelectedSampleBox {
 // marker with it rather than redraw it, unchanged, over a sample that is no
 // longer on screen.
 //
-// Inclusive at both faces: a plane sitting exactly on a boundary cuts the
-// cells either side of it, and keeping the marker up there is the reading that
-// matches what the user sees.
+// Half-open, [lower, upper), because that is the ownership the raster under
+// the marker was built with: sampleIndex floors, so a plane landing exactly on
+// a cell's upper face renders the *next* sample, and a marker left on this one
+// would sit over a cell that is no longer displayed. The lower face does
+// belong here, so only that end is inclusive.
 [[nodiscard]] inline bool datasetCellOnDisplayedSlice(
     const RealBox& cell, int normal, double position) noexcept
 {
@@ -100,7 +102,7 @@ struct SelectedSampleBox {
         return false;
     }
     const auto axis = static_cast<std::size_t>(normal);
-    return position >= cell.lower[axis] && position <= cell.upper[axis];
+    return position >= cell.lower[axis] && position < cell.upper[axis];
 }
 
 } // namespace amrvis::qt

--- a/src/qt/DatasetSelection.hpp
+++ b/src/qt/DatasetSelection.hpp
@@ -1,0 +1,84 @@
+#pragma once
+
+// Turning a block of selected Dataset-window table cells into the sample
+// indices it stands for. Kept out of the window (and out of Qt's selection
+// types) so the index arithmetic -- which flips rows against j and has to skip
+// the samples no grid covers -- can be tested on a synthetic page.
+
+#include <amrexplorer/data/DatasetPage.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <optional>
+#include <span>
+
+namespace amrvis::qt {
+
+// A contiguous block of table cells in the window's own row/column terms:
+// column 0 is the page's lowest i, and row 0 is its *highest* j (see
+// LevelTableModel::headerData).
+struct CellRange {
+    int topRow = 0;
+    int leftColumn = 0;
+    int bottomRow = 0;
+    int rightColumn = 0;
+};
+
+// Sample indices along the two in-plane axes, inclusive.
+struct SelectedSampleBox {
+    int iLow = 0;
+    int iHigh = 0;
+    int jLow = 0;
+    int jHigh = 0;
+    friend bool operator==(const SelectedSampleBox&, const SelectedSampleBox&)
+        = default;
+};
+
+// The sample bounds of the covered cells the ranges cover, or nullopt when
+// they cover none. Only covered cells count: a selection dragged out past the
+// grids at this level marks the data the user actually caught, not the empty
+// cells they swept over -- the same rule as clicking one, which does nothing
+// on an uncovered cell. The result is a bounding box, so uncovered samples
+// inside it are included; a rectangle is what the image can highlight.
+[[nodiscard]] inline std::optional<SelectedSampleBox> coveredSelectionBounds(
+    const DatasetPage& page, std::span<const CellRange> ranges)
+{
+    if (page.nx <= 0 || page.ny <= 0) {
+        return std::nullopt;
+    }
+    int minRow = page.ny;
+    int maxRow = -1;
+    int minColumn = page.nx;
+    int maxColumn = -1;
+    for (const auto& range : ranges) {
+        const auto top = std::max(range.topRow, 0);
+        const auto bottom = std::min(range.bottomRow, page.ny - 1);
+        const auto left = std::max(range.leftColumn, 0);
+        const auto right = std::min(range.rightColumn, page.nx - 1);
+        for (int row = top; row <= bottom; ++row) {
+            // Row 0 is the highest j; the values run j ascending with the
+            // first in-plane axis fastest (LevelTableModel::cellOffset).
+            const auto valueRow = static_cast<std::size_t>(page.ny - 1 - row);
+            for (int column = left; column <= right; ++column) {
+                const auto offset = static_cast<std::size_t>(column)
+                    + static_cast<std::size_t>(page.nx) * valueRow;
+                if (page.covered[offset] == 0) {
+                    continue;
+                }
+                minRow = std::min(minRow, row);
+                maxRow = std::max(maxRow, row);
+                minColumn = std::min(minColumn, column);
+                maxColumn = std::max(maxColumn, column);
+            }
+        }
+    }
+    if (maxRow < 0) {
+        return std::nullopt;
+    }
+    // Rows run opposite to j, so the bottom row carries the lowest j.
+    return SelectedSampleBox{page.lower[0] + minColumn,
+        page.lower[0] + maxColumn, page.upper[1] - maxRow,
+        page.upper[1] - minRow};
+}
+
+} // namespace amrvis::qt

--- a/src/qt/DatasetValueDelegate.hpp
+++ b/src/qt/DatasetValueDelegate.hpp
@@ -1,0 +1,73 @@
+#pragma once
+
+// The Dataset window's item delegate. It exists for one reason: a selected
+// cell has to keep the colors the model gives it.
+//
+// The default QStyledItemDelegate paints a selected item with the theme's
+// Highlight brush and its text in HighlightedText, which overrides both the
+// per-value color the table draws its numbers in and the no-data shade behind
+// the samples no grid covers. Selecting is the window's ordinary interaction
+// -- a click marks a sample in the image, a drag marks a region -- and a
+// selection is meant to stay up while the user looks at the image, so under
+// the stock delegate the block you are looking at is exactly the block whose
+// colors have gone.
+
+#include <QColor>
+#include <QModelIndex>
+#include <QPalette>
+#include <QStyle>
+#include <QStyleOptionViewItem>
+#include <QStyledItemDelegate>
+
+namespace amrvis::qt {
+
+// The fill for a selected cell: its own background mixed a third of the way
+// towards the theme's selection color. Enough of a shift to read as selected,
+// while an uncovered cell stays recognisably dark and every value keeps its
+// own color. A background rather than a wash over the top, so the text is
+// drawn on it at full strength; the one thing that still tints a value is a
+// style's focus rect over the *current* cell, which Fusion draws as a
+// translucent wash -- but it does that to an unselected current cell too, so
+// it is the style's doing and not this delegate's.
+[[nodiscard]] inline QColor datasetSelectionBackground(
+    const QColor& ground, const QColor& highlight)
+{
+    constexpr float weight = 0.35F;
+    const auto mix = [](float from, float to) {
+        return from * (1.0F - weight) + to * weight;
+    };
+    return QColor::fromRgbF(mix(ground.redF(), highlight.redF()),
+        mix(ground.greenF(), highlight.greenF()),
+        mix(ground.blueF(), highlight.blueF()));
+}
+
+class DatasetValueDelegate final : public QStyledItemDelegate {
+public:
+    using QStyledItemDelegate::QStyledItemDelegate;
+
+protected:
+    void initStyleOption(
+        QStyleOptionViewItem* option, const QModelIndex& index) const override
+    {
+        // The base fills in the model's roles: ForegroundRole becomes
+        // QPalette::Text and BackgroundRole becomes backgroundBrush.
+        QStyledItemDelegate::initStyleOption(option, index);
+        if (!(option->state & QStyle::State_Selected)) {
+            return;
+        }
+        const auto ground = option->backgroundBrush.style() != Qt::NoBrush
+            ? option->backgroundBrush.color()
+            : option->palette.color(QPalette::Base);
+        // Painted as an unselected cell carrying a different background: with
+        // the flag cleared the style fills with backgroundBrush and draws the
+        // text in QPalette::Text, so both of the model's colors survive. The
+        // alternative -- leaving the flag and pointing HighlightedText at the
+        // value's color -- keeps the theme's saturated fill, on which a value
+        // near the palette's own blue end would be unreadable.
+        option->state &= ~QStyle::State_Selected;
+        option->backgroundBrush = datasetSelectionBackground(
+            ground, option->palette.color(QPalette::Highlight));
+    }
+};
+
+} // namespace amrvis::qt

--- a/src/qt/DatasetWindow.cpp
+++ b/src/qt/DatasetWindow.cpp
@@ -2,6 +2,7 @@
 
 #include <amrexplorer/pipeline/SlicePipeline.hpp>
 #include "CloseWindowAction.hpp"
+#include "DatasetValueDelegate.hpp"
 #include "NumberFormat.hpp"
 #include "QtErrorText.hpp"
 #include "Theme.hpp"
@@ -357,6 +358,11 @@ void DatasetWindow::populateTabs()
         auto viewPalette = table->palette();
         viewPalette.setColor(QPalette::Base, viewportBackground());
         table->setPalette(viewPalette);
+        // Keeps a selected cell's value color and no-data shade, which the
+        // default delegate would paint over with the theme's selection colors
+        // (see DatasetValueDelegate) -- and a selection here is meant to stay
+        // up while the user reads the image it marks.
+        table->setItemDelegate(new DatasetValueDelegate(table));
         auto* model
             = new LevelTableModel(extract, m_coloring, m_numberFormat, table);
         table->setModel(model);

--- a/src/qt/DatasetWindow.cpp
+++ b/src/qt/DatasetWindow.cpp
@@ -14,6 +14,8 @@
 #include <QColor>
 #include <QFutureWatcher>
 #include <QHBoxLayout>
+#include <QItemSelection>
+#include <QItemSelectionModel>
 #include <QLabel>
 #include <QModelIndex>
 #include <QPalette>
@@ -29,6 +31,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <exception>
+#include <span>
 #include <stdexcept>
 #include <utility>
 #include <vector>
@@ -371,28 +374,61 @@ void DatasetWindow::populateTabs()
             label += tr(" (truncated)");
         }
         m_tabs->addTab(page, label);
-        connect(table, &QTableView::clicked, this,
-            [this, entry](const QModelIndex& index) {
-                cellClicked(entry, index.row(), index.column());
-            });
+        // Driven off the selection rather than QTableView::clicked, which
+        // fires only when the press and the release land on the same cell and
+        // so says nothing about a drag. One handler then covers the click, the
+        // drag and the keyboard (shift-arrow) alike, because each of them is
+        // just a selection.
+        connect(table->selectionModel(),
+            &QItemSelectionModel::selectionChanged, this,
+            [this, entry, table] { selectionChanged(entry, *table); });
     }
 }
 
-void DatasetWindow::cellClicked(std::size_t levelEntry, int row, int column)
+void DatasetWindow::selectionChanged(
+    std::size_t levelEntry, const QTableView& table)
+{
+    const auto* selection = table.selectionModel();
+    if (selection == nullptr || !selection->hasSelection()) {
+        // Nothing selected here, so there is nothing to mark -- and this is
+        // also what the tables cleared below report, which is what keeps
+        // clearOtherSelections from coming back round through their handlers.
+        // A cleared selection leaves the last highlight up, as a click on an
+        // uncovered cell always has.
+        return;
+    }
+    clearOtherSelections(table);
+    const auto selected = selection->selection();
+    std::vector<CellRange> ranges;
+    ranges.reserve(static_cast<std::size_t>(selected.size()));
+    for (const auto& range : selected) {
+        ranges.push_back(CellRange{range.top(), range.left(), range.bottom(),
+            range.right()});
+    }
+    cellsSelected(levelEntry, ranges);
+}
+
+void DatasetWindow::clearOtherSelections(const QTableView& keep)
+{
+    for (int page = 0; page < m_tabs->count(); ++page) {
+        auto* table = m_tabs->widget(page)->findChild<QTableView*>();
+        if (table == nullptr || table == &keep
+            || table->selectionModel() == nullptr) {
+            continue;
+        }
+        table->clearSelection();
+    }
+}
+
+void DatasetWindow::cellsSelected(
+    std::size_t levelEntry, std::span<const CellRange> ranges)
 {
     if (levelEntry >= m_levels.size() || !m_request.dataset) {
         return;
     }
     const auto& levelData = m_levels[levelEntry];
-    const auto& extract = levelData.extract;
-    if (column < 0 || column >= extract.nx || row < 0 || row >= extract.ny) {
-        return;
-    }
-    const auto j = extract.upper[1] - row;
-    const auto offset = static_cast<std::size_t>(column)
-        + static_cast<std::size_t>(extract.nx) * static_cast<std::size_t>(
-            static_cast<std::int64_t>(j) - extract.lower[1]);
-    if (extract.covered[offset] == 0) {
+    const auto bounds = coveredSelectionBounds(levelData.extract, ranges);
+    if (!bounds) {
         return;
     }
 
@@ -400,21 +436,22 @@ void DatasetWindow::cellClicked(std::size_t levelEntry, int row, int column)
     const auto& level = metadata.levels[static_cast<std::size_t>(levelData.level)];
     const auto axes = slicePlaneAxes(
         metadata.dimension, m_request.normalAxis);
-    // The sample's physical bin at this level's resolution. On nodal axes
-    // this is centered on the node rather than shifted to the next cell.
-    const std::array<int, 2> sample{extract.lower[0] + column, j};
-    auto pointBox = level.domain;
+    // The samples' physical bins at this level's resolution. On nodal axes
+    // these are centered on the nodes rather than shifted to the next cell.
+    const std::array<int, 2> low{bounds->iLow, bounds->jLow};
+    const std::array<int, 2> high{bounds->iHigh, bounds->jHigh};
+    auto sampleBox = level.domain;
     for (std::size_t entry = 0; entry < 2; ++entry) {
         const auto axis = static_cast<std::size_t>(axes[entry]);
-        pointBox.lower[axis] = sample[entry];
-        pointBox.upper[axis] = sample[entry];
+        sampleBox.lower[axis] = low[entry];
+        sampleBox.upper[axis] = high[entry];
     }
     if (metadata.dimension == 3) {
         const auto normal = static_cast<std::size_t>(m_request.normalAxis);
-        pointBox.lower[normal] = extract.sliceIndex;
-        pointBox.upper[normal] = extract.sliceIndex;
+        sampleBox.lower[normal] = levelData.extract.sliceIndex;
+        sampleBox.upper[normal] = levelData.extract.sliceIndex;
     }
-    emit cellActivated(sampleBounds(level, pointBox, metadata.dimension));
+    emit cellActivated(sampleBounds(level, sampleBox, metadata.dimension));
 }
 
 } // namespace amrvis::qt

--- a/src/qt/DatasetWindow.hpp
+++ b/src/qt/DatasetWindow.hpp
@@ -2,6 +2,7 @@
 
 #include "DatasetColoring.hpp"
 #include "DatasetExtract.hpp"
+#include "DatasetSelection.hpp"
 
 #include <amrexplorer/core/Geometry.hpp>
 #include <amrexplorer/core/Request.hpp>
@@ -14,10 +15,12 @@
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <span>
 #include <vector>
 
 class QCloseEvent;
 class QLabel;
+class QTableView;
 class QTabWidget;
 
 namespace amrvis::qt {
@@ -39,9 +42,9 @@ struct DatasetRequest {
 // MultiFabs and FABs, which have no AMR hierarchy, the single tab is named
 // after the format instead) with the i/j sample indices as headers and the
 // level min/max above the table; each value is drawn in its color-bar color
-// (see DatasetColoring) and clicking one highlights the corresponding sample
-// in the image. Reads run off the GUI thread and are cancelled on close or
-// refresh.
+// (see DatasetColoring), and selecting values -- one click, or a drag across
+// a block -- highlights the samples they stand for in the image. Reads run
+// off the GUI thread and are cancelled on close or refresh.
 class DatasetWindow final : public QWidget {
     Q_OBJECT
 
@@ -63,8 +66,9 @@ public:
     void setColoring(DatasetColoring coloring);
 
 signals:
-    // Physical bounds of the clicked sample at its level's resolution (2-D
-    // leaves axis 2 zeroed).
+    // Physical bounds of the selected samples at their level's resolution (one
+    // cell for a click, the bounding box of a dragged block; 2-D leaves axis 2
+    // zeroed).
     void cellActivated(const amrvis::RealBox& physicalCell);
     // The Refresh button; the owner rebuilds the request from app state.
     void refreshRequested();
@@ -85,7 +89,13 @@ private:
         const DatasetRequest& request, StopToken cancellation);
     void startLoad();
     void populateTabs();
-    void cellClicked(std::size_t levelEntry, int row, int column);
+    // A table's selection became non-empty: the other levels' tables give up
+    // theirs (one selection at a time, so the highlight always names the level
+    // whose tab it was made on) and the image marks what this one holds.
+    void selectionChanged(std::size_t levelEntry, const QTableView& table);
+    void clearOtherSelections(const QTableView& keep);
+    void cellsSelected(
+        std::size_t levelEntry, std::span<const CellRange> ranges);
 
     DatasetRequest m_request;
     QString m_numberFormat;

--- a/src/qt/MainWindow.hpp
+++ b/src/qt/MainWindow.hpp
@@ -730,6 +730,11 @@ private:
     void ensureVectorFieldDefaults();
     void showDatasetWindow();
     void closeDatasetWindow();
+    // Drops every view's marked cell and the outline drawn from it. Over
+    // allViewStates(), not currentViews(): the latter is empty mid-teardown,
+    // because openDatasetImpl zeroes m_viewDimension before it closes the
+    // window, and a cell left behind there is redrawn over the next dataset.
+    void clearDatasetCellHighlights();
     void refreshDatasetWindow();
     // Pushes the active view's palette and display range -- the pair the color
     // bar is drawn from -- to an open Dataset window, so its numbers keep the

--- a/src/qt/MainWindow.hpp
+++ b/src/qt/MainWindow.hpp
@@ -525,6 +525,13 @@ private:
         bool displayLogarithmic = false;
         std::vector<VectorSegment> vectorSegments;
         std::vector<SliceGridBox> gridBoxes;
+        // The Dataset window cell this view is marking, held so showSlice can
+        // put the red outline back after setImage clears the scene -- the same
+        // reason it rebuilds the grid boxes, overlays and crosshairs. Asking
+        // the Dataset table for it again is not an option: the selection that
+        // produced it is still up, and Qt emits no selectionChanged for a cell
+        // that is already selected, so nothing would report it.
+        std::optional<RealBox> datasetCell;
         // Cache key of the slice that produced the planes above: a UI change
         // that leaves every key field untouched (palette/log/range/contour
         // count) is satisfied from the cached planes instead of querying
@@ -729,6 +736,10 @@ private:
     // colors the bar is showing. Called from every place that moves either.
     void syncDatasetWindowColors();
     void datasetCellActivated(const RealBox& physicalCell);
+    // Draws state.datasetCell as the view's cell highlight, or clears it when
+    // the cell falls outside the raster. Called both when the selection moves
+    // and after a redraw replaces the image.
+    void applyDatasetCellHighlight(PlaneViewState& state);
     [[nodiscard]] std::optional<DatasetRequest> buildDatasetRequest() const;
     void showUserGuide();
     void showKeyboardMouseReference();

--- a/src/qt/MainWindowDataset.cpp
+++ b/src/qt/MainWindowDataset.cpp
@@ -677,6 +677,19 @@ void MainWindow::applyDatasetCellHighlight(PlaneViewState& state)
     if (plane.width <= 0 || plane.height <= 0) {
         return;
     }
+    // In 3-D the marked cell sits on one slice, and the projection below reads
+    // only the two displayed axes: without this the outline would come back
+    // unchanged after the plane moved off the cell it marks. Measured against
+    // the displayed raster's own position, not m_slicePosition3d, which has
+    // already moved ahead whenever a slice is in flight (see updateOverlay).
+    if (m_dataset && m_dataset->metadata().dimension == 3
+        && state.hasCachedRequest
+        && !datasetCellOnDisplayedSlice(physicalCell,
+            state.cachedRequest.normalDirection,
+            state.cachedRequest.physicalPosition)) {
+        state.view->setCellHighlight(std::nullopt);
+        return;
+    }
     const auto axes = displayAxes(state.normal);
     const auto xAxis = static_cast<std::size_t>(axes[0]);
     const auto yAxis = static_cast<std::size_t>(axes[1]);

--- a/src/qt/MainWindowDataset.cpp
+++ b/src/qt/MainWindowDataset.cpp
@@ -594,10 +594,7 @@ void MainWindow::showDatasetWindow()
         if (m_datasetWindow == window) {
             m_datasetWindow = nullptr;
         }
-        for (auto* state : currentViews()) {
-            state->datasetCell.reset();
-            state->view->setCellHighlight(std::nullopt);
-        }
+        clearDatasetCellHighlights();
     });
     connect(window, &DatasetWindow::extractionFailed, this,
         &MainWindow::reportBackgroundError);
@@ -614,10 +611,23 @@ void MainWindow::showDatasetWindow()
 
 void MainWindow::closeDatasetWindow()
 {
+    // Now, not when the window's deferred destroyed arrives: a dataset
+    // replacement gets back to the event loop -- where that deletion runs --
+    // with m_viewDimension already zeroed, and the marked cell has to be gone
+    // before the incoming dataset's first showSlice can draw it.
+    clearDatasetCellHighlights();
     auto* window = m_datasetWindow;
     m_datasetWindow = nullptr;
     if (window != nullptr) {
         window->close();
+    }
+}
+
+void MainWindow::clearDatasetCellHighlights()
+{
+    for (auto* state : allViewStates()) {
+        state->datasetCell.reset();
+        state->view->setCellHighlight(std::nullopt);
     }
 }
 

--- a/src/qt/MainWindowDataset.cpp
+++ b/src/qt/MainWindowDataset.cpp
@@ -595,6 +595,7 @@ void MainWindow::showDatasetWindow()
             m_datasetWindow = nullptr;
         }
         for (auto* state : currentViews()) {
+            state->datasetCell.reset();
             state->view->setCellHighlight(std::nullopt);
         }
     });
@@ -652,11 +653,21 @@ void MainWindow::datasetCellActivated(const RealBox& physicalCell)
     if (m_activeView == nullptr) {
         return;
     }
-    const auto& plane = *m_activeView->plane;
+    m_activeView->datasetCell = physicalCell;
+    applyDatasetCellHighlight(*m_activeView);
+}
+
+void MainWindow::applyDatasetCellHighlight(PlaneViewState& state)
+{
+    if (!state.datasetCell) {
+        return;
+    }
+    const auto& physicalCell = *state.datasetCell;
+    const auto& plane = *state.plane;
     if (plane.width <= 0 || plane.height <= 0) {
         return;
     }
-    const auto axes = displayAxes(m_activeView->normal);
+    const auto axes = displayAxes(state.normal);
     const auto xAxis = static_cast<std::size_t>(axes[0]);
     const auto yAxis = static_cast<std::size_t>(axes[1]);
     if (displayIsSpherical()) {
@@ -665,16 +676,16 @@ void MainWindow::datasetCellActivated(const RealBox& physicalCell)
         const double r1 = physicalCell.upper[xAxis];
         const double t0 = physicalCell.lower[yAxis];
         const double t1 = physicalCell.upper[yAxis];
-        const auto mapping = planeMapping(*m_activeView);
+        const auto mapping = planeMapping(state);
         const bool valid = r1 > r0 && t1 > t0;
         // Branch on the view state's mode, matching the mapping (see
         // updateGridBoxes).
-        if (m_activeView->sphericalDisplay == SphericalDisplay::RZ) {
+        if (state.sphericalDisplay == SphericalDisplay::RZ) {
             std::optional<QPainterPath> highlight;
             if (valid) {
                 highlight = sphericalSectorPath(mapping, r0, r1, t0, t1);
             }
-            m_activeView->view->setCellHighlightPath(highlight);
+            state.view->setCellHighlightPath(highlight);
         } else {
             std::optional<QRectF> highlight;
             if (valid) {
@@ -685,7 +696,7 @@ void MainWindow::datasetCellActivated(const RealBox& physicalCell)
                     highlight = rect;
                 }
             }
-            m_activeView->view->setCellHighlight(highlight);
+            state.view->setCellHighlight(highlight);
         }
         return;
     }
@@ -711,7 +722,7 @@ void MainWindow::datasetCellActivated(const RealBox& physicalCell)
     if (!rectangle.isEmpty()) {
         highlight = rectangle;
     }
-    m_activeView->view->setCellHighlight(highlight);
+    state.view->setCellHighlight(highlight);
 }
 
 void MainWindow::openDataset(

--- a/src/qt/MainWindowSlice.cpp
+++ b/src/qt/MainWindowSlice.cpp
@@ -1286,6 +1286,10 @@ void MainWindow::showSlice(PlaneViewState& state, SliceDisplayResult display,
     updateParticleOverlay(state);
     // This view's region may have changed; refresh every view's guides.
     updateCrosshairs();
+    // The Dataset window's marked cell, on the same footing as the overlays
+    // above: setImage cleared it, and no selection signal is coming to ask for
+    // it again (see applyDatasetCellHighlight).
+    applyDatasetCellHighlight(state);
 
     // setImage demotes Custom to Fit when the coordinator returns Refit -- a
     // spherical r-theta to R-Z switch does it -- so the raster funnel has to

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -650,6 +650,22 @@ if(TARGET amrexplorer_qt)
     # Plain index arithmetic over a DatasetPage: no Qt, no QPA platform.
     add_test(NAME dataset_selection COMMAND test_dataset_selection)
 
+    add_executable(test_dataset_selected_cell
+        unit/test_dataset_selected_cell.cpp)
+    target_include_directories(test_dataset_selected_cell
+        PRIVATE "${PROJECT_SOURCE_DIR}/src/qt")
+    target_link_libraries(test_dataset_selected_cell
+        PRIVATE
+            amrexplorer::warnings
+            Qt6::Core
+            Qt6::Gui
+            Qt6::Widgets
+    )
+    # Paints through the real style, so it needs a QPA platform.
+    add_test(NAME dataset_selected_cell
+        COMMAND "${CMAKE_COMMAND}" -E env QT_QPA_PLATFORM=offscreen
+            "$<TARGET_FILE:test_dataset_selected_cell>")
+
     add_executable(test_palette_controller
         unit/test_palette_controller.cpp
         "${PROJECT_SOURCE_DIR}/src/qt/PaletteController.cpp"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -639,6 +639,17 @@ if(TARGET amrexplorer_qt)
     # platform.
     add_test(NAME dataset_colors COMMAND test_dataset_colors)
 
+    add_executable(test_dataset_selection unit/test_dataset_selection.cpp)
+    target_include_directories(test_dataset_selection
+        PRIVATE "${PROJECT_SOURCE_DIR}/src/qt")
+    target_link_libraries(test_dataset_selection
+        PRIVATE
+            amrexplorer::core
+            amrexplorer::warnings
+    )
+    # Plain index arithmetic over a DatasetPage: no Qt, no QPA platform.
+    add_test(NAME dataset_selection COMMAND test_dataset_selection)
+
     add_executable(test_palette_controller
         unit/test_palette_controller.cpp
         "${PROJECT_SOURCE_DIR}/src/qt/PaletteController.cpp"

--- a/tests/unit/test_dataset_selected_cell.cpp
+++ b/tests/unit/test_dataset_selected_cell.cpp
@@ -278,20 +278,15 @@ int main(int argc, char** argv)
         "a selected uncovered cell (" + hex(blankSelected.background)
             + ") is no darker than a selected covered one ("
             + hex(selected.background) + ")");
-    // ... where the stock delegate gives both the identical selection fill.
-    require(render(stock, uncovered, Selected::Yes).background
-            == render(stock, covered, Selected::Yes).background,
-        "the stock delegate no longer flattens the no-data shade under a "
-        "selection");
 
-    // The margin the exact-color counts leave, so a future host whose fonts
-    // render thinner glyphs shows up as a shrinking number rather than as a
-    // sudden failure.
     // The mix itself, where a per-channel slip is visible in a way the
     // rendered cells above cannot show.
     requireBlendsEveryChannel(cellBase, selectionColor, "covered");
     requireBlendsEveryChannel(noDataColor, selectionColor, "uncovered");
 
+    // The margin the exact-color counts leave, so a future host whose fonts
+    // render thinner glyphs shows up as a shrinking number rather than as a
+    // sudden failure.
     std::cout << "dataset selected cell OK (" << plain.valuePixels
               << " value pixels)\n";
     return 0;

--- a/tests/unit/test_dataset_selected_cell.cpp
+++ b/tests/unit/test_dataset_selected_cell.cpp
@@ -1,0 +1,298 @@
+// Coverage for DatasetValueDelegate: a selected cell must keep the colors the
+// model gives it. The default QStyledItemDelegate paints selected text in
+// HighlightedText over a Highlight fill, which wipes out both the value's
+// color-bar color and the no-data shade behind an uncovered sample -- and
+// selecting is this window's ordinary interaction.
+//
+// Rendered rather than reasoned about: each case paints a real cell through
+// the real delegate and counts pixels, which is the only way to see what the
+// style actually did. The stock delegate is rendered beside it so the test
+// states the regression it is guarding, not just the fix.
+
+#include "DatasetValueDelegate.hpp"
+
+#include <QApplication>
+#include <QColor>
+#include <QFont>
+#include <QFontMetrics>
+#include <QImage>
+#include <QPainter>
+#include <QStandardItemModel>
+#include <QStyleOptionViewItem>
+#include <QStyledItemDelegate>
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
+#include <string>
+
+namespace {
+
+void require(bool condition, const std::string& message)
+{
+    if (!condition) {
+        std::cerr << "FAILED: " << message << '\n';
+        std::exit(1);
+    }
+}
+
+const QColor valueColor(0xE0, 0x20, 0x20);
+const QColor noDataColor(0x30, 0x30, 0x30);
+const QColor cellBase(0x88, 0x88, 0x88);
+const QColor selectionColor(0x30, 0x60, 0xD0);
+const QColor selectedTextColor(0xFF, 0xFF, 0xFF);
+
+// Largest per-channel difference: a coarse "are these two colors visibly
+// apart" measure, which is all the assertions below need.
+int channelDistance(QRgb left, QRgb right)
+{
+    return std::max({std::abs(qRed(left) - qRed(right)),
+        std::abs(qGreen(left) - qGreen(right)),
+        std::abs(qBlue(left) - qBlue(right))});
+}
+
+// How far a pixel may sit from the value's color and still count as that
+// value's: a style may draw a translucent focus rect over the current cell,
+// which shifts the digits without repainting them. Fusion's wash moves the
+// nearest pixel exactly 24 away, and a delegate that had lost the color
+// instead lands at 127 (Windows) or 172 (Fusion), so this sits in the middle
+// of [24, 127] rather than on either edge. The 24 is a property of the wash's
+// alpha over an unantialiased glyph, not of the font: it is the same across
+// every family, which only changes how many pixels are that close.
+constexpr int focusWashTolerance = 40;
+
+struct Render {
+    // Pixels drawn in exactly the value's color: the digits.
+    int valuePixels = 0;
+    // Pixels near enough to it to still be reading as that value.
+    int nearValuePixels = 0;
+    // Pixels drawn in exactly the theme's selected-text color, and pixels
+    // near enough to it to be that text under a focus wash.
+    int selectedTextPixels = 0;
+    int nearSelectedTextPixels = 0;
+    // A corner, which no glyph reaches: the cell's background.
+    QRgb background = 0;
+};
+
+enum class Selected : std::uint8_t { No, Yes };
+// The clicked cell is also the view's current cell, so State_HasFocus rides
+// along with State_Selected on every click -- the combination that actually
+// occurs, and the one a style's focus rect reacts to.
+enum class Current : std::uint8_t { No, Yes };
+
+Render render(const QStyledItemDelegate& delegate, const QModelIndex& index,
+    Selected selected, Current current = Current::No)
+{
+    QImage image(80, 24, QImage::Format_ARGB32_Premultiplied);
+    // The view paints its viewport in Base and the delegate paints the item
+    // on top, leaving that showing where it fills nothing; start from Base so
+    // the corner below reads what the cell would really sit on.
+    image.fill(cellBase);
+    QStyleOptionViewItem option;
+    option.rect = QRect(0, 0, 80, 24);
+    option.displayAlignment = Qt::AlignRight | Qt::AlignVCenter;
+    option.features = QStyleOptionViewItem::HasDisplay;
+    option.state = QStyle::State_Enabled;
+    option.palette.setColor(QPalette::Base, cellBase);
+    option.palette.setColor(QPalette::Highlight, selectionColor);
+    option.palette.setColor(QPalette::HighlightedText, selectedTextColor);
+    option.palette.setColor(QPalette::Text, Qt::black);
+    // Pinned, because the counts below are of pixels in *exactly* the value's
+    // color and an antialiased 9pt sans can leave as few as none of them: the
+    // same cell renders 3 such pixels under this host's default sans and 0
+    // under Liberation Sans, so a runner's fontconfig would decide whether
+    // this test measured anything. A larger unantialiased face puts the count
+    // in the tens on every family.
+    QFont probeFont;
+    probeFont.setPixelSize(14);
+    probeFont.setStyleStrategy(QFont::NoAntialias);
+    option.font = probeFont;
+    option.fontMetrics = QFontMetrics(probeFont);
+    if (selected == Selected::Yes) {
+        option.state |= QStyle::State_Selected;
+    }
+    if (current == Current::Yes) {
+        option.state |= QStyle::State_HasFocus;
+    }
+    {
+        QPainter painter(&image);
+        delegate.paint(&painter, option, index);
+    }
+    Render result;
+    result.background = image.pixel(2, 2);
+    for (int y = 0; y < image.height(); ++y) {
+        for (int x = 0; x < image.width(); ++x) {
+            const auto pixel = image.pixel(x, y);
+            result.valuePixels += pixel == valueColor.rgb();
+            result.nearValuePixels
+                += channelDistance(pixel, valueColor.rgb())
+                <= focusWashTolerance;
+            result.selectedTextPixels += pixel == selectedTextColor.rgb();
+            result.nearSelectedTextPixels
+                += channelDistance(pixel, selectedTextColor.rgb())
+                <= focusWashTolerance;
+        }
+    }
+    return result;
+}
+
+// Rec. 601 luma, only ever compared between two of these.
+double luminance(QRgb pixel)
+{
+    return 0.299 * qRed(pixel) + 0.587 * qGreen(pixel) + 0.114 * qBlue(pixel);
+}
+
+std::string hex(QRgb pixel)
+{
+    return QColor(pixel).name().toStdString();
+}
+
+// Both halves of what a selected cell's background has to be: visibly moved
+// from where it was, and still nearer to that than to the theme's fill. The
+// second is what keeps the blend from collapsing into the flat highlight the
+// delegate exists to avoid -- a weight of 0.99 satisfies the first alone.
+void requireReadsAsSelected(
+    QRgb plain, QRgb selected, const std::string& what)
+{
+    constexpr int visible = 16;
+    const auto moved = channelDistance(selected, plain);
+    require(moved >= visible,
+        what + ": a selected cell (" + hex(selected) + ") is not visibly apart"
+            " from an unselected one (" + hex(plain) + "): "
+            + std::to_string(moved) + " < " + std::to_string(visible));
+    const auto towardsHighlight
+        = channelDistance(selected, selectionColor.rgb());
+    require(moved < towardsHighlight,
+        what + ": a selected cell (" + hex(selected) + ") is nearer the"
+            " theme's fill (" + std::to_string(towardsHighlight) + ") than its"
+            " own background (" + std::to_string(moved) + "), so it has lost"
+            " what was under it");
+}
+
+// Every channel of the blend lies between the two it mixes -- strictly, where
+// those two differ. A property rather than a recomputed weight, and enough to
+// catch a mix that drops a channel or repeats another one in its place, which
+// the rendered assertions cannot see: both still produce a visibly shifted,
+// ground-nearer color.
+void requireBlendsEveryChannel(const QColor& ground, const QColor& highlight,
+    const std::string& what)
+{
+    const auto blended = amrvis::qt::datasetSelectionBackground(
+        ground, highlight);
+    const auto between = [](int from, int to, int mixed) {
+        return from == to ? mixed == from
+                          : mixed > std::min(from, to) && mixed < std::max(from, to);
+    };
+    require(between(ground.red(), highlight.red(), blended.red())
+            && between(ground.green(), highlight.green(), blended.green())
+            && between(ground.blue(), highlight.blue(), blended.blue()),
+        what + ": " + blended.name().toStdString() + " does not mix every"
+            " channel of " + ground.name().toStdString() + " towards "
+            + highlight.name().toStdString());
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    QApplication app(argc, argv);
+
+    QStandardItemModel model(2, 1);
+    // A covered sample: a number in its color-bar color.
+    model.setData(model.index(0, 0), QStringLiteral("1.5"), Qt::DisplayRole);
+    model.setData(model.index(0, 0), valueColor, Qt::ForegroundRole);
+    // An uncovered one: blank, on the renderer's no-data shade.
+    model.setData(model.index(1, 0), noDataColor, Qt::BackgroundRole);
+
+    const QStyledItemDelegate stock;
+    const amrvis::qt::DatasetValueDelegate delegate;
+    const auto covered = model.index(0, 0);
+    const auto uncovered = model.index(1, 0);
+
+    // What the review found, pinned so the fix cannot quietly regress to it:
+    // under the stock delegate a selected value loses its color outright and
+    // comes back in the theme's selected-text color.
+    const auto stockPlain = render(stock, covered, Selected::No);
+    const auto stockSelected = render(stock, covered, Selected::Yes);
+    require(stockPlain.valuePixels > 0,
+        "the stock delegate drew no value-colored pixels at all, so this test "
+        "is measuring nothing");
+    require(stockSelected.valuePixels == 0,
+        "the stock delegate no longer drops the value color -- if Qt changed "
+        "this, the delegate may no longer be needed");
+    require(stockSelected.selectedTextPixels > 0,
+        "the stock delegate did not repaint the value in HighlightedText");
+
+    // The fix: the same digits, in the same color, selected or not.
+    const auto plain = render(delegate, covered, Selected::No);
+    const auto selected = render(delegate, covered, Selected::Yes);
+    require(plain.valuePixels == stockPlain.valuePixels,
+        "the delegate changed how an unselected value is drawn");
+    require(selected.valuePixels == plain.valuePixels,
+        "a selected value lost its color: " + std::to_string(plain.valuePixels)
+            + " colored pixels became " + std::to_string(selected.valuePixels));
+    require(selected.selectedTextPixels == 0,
+        "a selected value was painted in the theme's selected-text color");
+
+    // It still has to read as selected, and the cell's own background is what
+    // says so -- not the theme's fill, which would hide the shading below.
+    require(plain.background == cellBase.rgb(),
+        "an unselected covered cell no longer sits on the view's base color: "
+            + hex(plain.background));
+    requireReadsAsSelected(plain.background, selected.background, "covered");
+
+    // The state every click actually produces: selected *and* current. A
+    // style may wash the focus rect over the cell, which shifts the value's
+    // color a little -- it does that to an unselected current cell too -- but
+    // the value must still be its own color and not the selected-text one.
+    const auto focused = render(delegate, covered, Selected::Yes, Current::Yes);
+    const auto stockFocused = render(stock, covered, Selected::Yes, Current::Yes);
+    require(focused.nearValuePixels > 0,
+        "a clicked (selected and current) value is not recognisably its own "
+        "color any more");
+    // Near-white rather than exactly white: the same wash that shifts our
+    // value color shifts the stock delegate's white text off pure white, so
+    // an exact count is zero for both delegates here and discriminates
+    // nothing on the style this test actually runs under.
+    require(focused.nearSelectedTextPixels == 0,
+        "a clicked value was painted in the theme's selected-text color");
+    require(stockFocused.nearValuePixels == 0,
+        "the stock delegate no longer loses the value color on a clicked cell "
+        "-- if Qt changed this, the delegate may no longer be needed");
+    require(stockFocused.nearSelectedTextPixels > 0,
+        "the stock delegate did not repaint a clicked value in the theme's "
+        "selected-text color, so the check above is watching for nothing");
+
+    // The no-data shade survives selection too, and stays darker than a
+    // selected covered cell, so a selection dragged past the grids still shows
+    // where the data stops.
+    const auto blankPlain = render(delegate, uncovered, Selected::No);
+    const auto blankSelected = render(delegate, uncovered, Selected::Yes);
+    require(blankPlain.background == noDataColor.rgb(),
+        "an unselected uncovered cell lost its no-data shade: "
+            + hex(blankPlain.background));
+    requireReadsAsSelected(
+        blankPlain.background, blankSelected.background, "uncovered");
+    require(luminance(blankSelected.background) < luminance(selected.background),
+        "a selected uncovered cell (" + hex(blankSelected.background)
+            + ") is no darker than a selected covered one ("
+            + hex(selected.background) + ")");
+    // ... where the stock delegate gives both the identical selection fill.
+    require(render(stock, uncovered, Selected::Yes).background
+            == render(stock, covered, Selected::Yes).background,
+        "the stock delegate no longer flattens the no-data shade under a "
+        "selection");
+
+    // The margin the exact-color counts leave, so a future host whose fonts
+    // render thinner glyphs shows up as a shrinking number rather than as a
+    // sudden failure.
+    // The mix itself, where a per-channel slip is visible in a way the
+    // rendered cells above cannot show.
+    requireBlendsEveryChannel(cellBase, selectionColor, "covered");
+    requireBlendsEveryChannel(noDataColor, selectionColor, "uncovered");
+
+    std::cout << "dataset selected cell OK (" << plain.valuePixels
+              << " value pixels)\n";
+    return 0;
+}

--- a/tests/unit/test_dataset_selection.cpp
+++ b/tests/unit/test_dataset_selection.cpp
@@ -1,0 +1,113 @@
+// Coverage for coveredSelectionBounds, which turns a block of selected
+// Dataset-window cells into the sample indices the image highlights. The
+// arithmetic it has to get right is the row/j flip (row 0 is the highest j)
+// and the coverage skip, so the page below is deliberately offset from the
+// origin and holes are punched in it.
+
+#include "DatasetSelection.hpp"
+
+#include <cstdlib>
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace {
+
+void require(bool condition, const std::string& message)
+{
+    if (!condition) {
+        std::cerr << "FAILED: " << message << '\n';
+        std::exit(1);
+    }
+}
+
+// A 4x3 page (i in 10..13, j in 20..22) with every cell covered; values run
+// j ascending with i fastest, matching a real DatasetPage.
+amrvis::DatasetPage makePage()
+{
+    amrvis::DatasetPage page;
+    page.lower = {10, 20};
+    page.upper = {13, 22};
+    page.nx = 4;
+    page.ny = 3;
+    page.values.assign(12, 0.0F);
+    page.covered.assign(12, 1);
+    return page;
+}
+
+// The cell at (i, j) in the page's own storage order.
+std::size_t offsetOf(const amrvis::DatasetPage& page, int i, int j)
+{
+    return static_cast<std::size_t>(i - page.lower[0])
+        + static_cast<std::size_t>(page.nx)
+            * static_cast<std::size_t>(j - page.lower[1]);
+}
+
+std::string describe(const amrvis::qt::SelectedSampleBox& box)
+{
+    return "i " + std::to_string(box.iLow) + ".." + std::to_string(box.iHigh)
+        + ", j " + std::to_string(box.jLow) + ".." + std::to_string(box.jHigh);
+}
+
+void requireBounds(const amrvis::DatasetPage& page,
+    const std::vector<amrvis::qt::CellRange>& ranges,
+    const amrvis::qt::SelectedSampleBox& expected, const std::string& what)
+{
+    const auto bounds = amrvis::qt::coveredSelectionBounds(page, ranges);
+    require(bounds.has_value(), what + ": no bounds at all");
+    require(*bounds == expected,
+        what + ": got " + describe(*bounds) + ", wanted " + describe(expected));
+}
+
+} // namespace
+
+int main()
+{
+    const auto page = makePage();
+
+    // One cell. Row 0 is the highest j, so the top-left cell is (i=10, j=22)
+    // -- the flip this whole function exists for.
+    requireBounds(page, {{0, 0, 0, 0}}, {10, 10, 22, 22}, "top-left cell");
+    requireBounds(page, {{2, 3, 2, 3}}, {13, 13, 20, 20}, "bottom-right cell");
+
+    // A dragged block, and the whole table.
+    requireBounds(page, {{0, 1, 1, 2}}, {11, 12, 21, 22}, "a 2x2 block");
+    requireBounds(page, {{0, 0, 2, 3}}, {10, 13, 20, 22}, "the whole page");
+
+    // Two disjoint ranges (ctrl-drag) give one bounding box over both.
+    requireBounds(page, {{0, 0, 0, 0}, {2, 3, 2, 3}}, {10, 13, 20, 22},
+        "two opposite corners");
+
+    // Uncovered cells do not count towards the bounds: the selection below
+    // sweeps the whole page but only the middle row is covered.
+    auto holed = makePage();
+    for (int i = 10; i <= 13; ++i) {
+        holed.covered[offsetOf(holed, i, 20)] = 0;
+        holed.covered[offsetOf(holed, i, 22)] = 0;
+    }
+    holed.covered[offsetOf(holed, 10, 21)] = 0;
+    requireBounds(holed, {{0, 0, 2, 3}}, {11, 13, 21, 21},
+        "a selection over mostly uncovered cells");
+
+    // ... and a selection that catches none of them marks nothing, the same
+    // as clicking a single uncovered cell.
+    require(!amrvis::qt::coveredSelectionBounds(holed, std::vector<
+                amrvis::qt::CellRange>{{0, 0, 0, 3}}).has_value(),
+        "an all-uncovered selection produced bounds");
+    require(!amrvis::qt::coveredSelectionBounds(
+                page, std::vector<amrvis::qt::CellRange>{}).has_value(),
+        "an empty selection produced bounds");
+
+    // A range past the page's edge is clamped rather than read out of bounds
+    // (a stale selection can outlive the page it was made on).
+    requireBounds(page, {{-5, -5, 99, 99}}, {10, 13, 20, 22},
+        "a range past the edges");
+
+    // An empty page has nothing to select.
+    require(!amrvis::qt::coveredSelectionBounds(amrvis::DatasetPage{},
+                std::vector<amrvis::qt::CellRange>{{0, 0, 0, 0}}).has_value(),
+        "an empty page produced bounds");
+
+    std::cout << "dataset selection OK\n";
+    return 0;
+}

--- a/tests/unit/test_dataset_selection.cpp
+++ b/tests/unit/test_dataset_selection.cpp
@@ -122,12 +122,14 @@ int main()
         "a plane moved one cell up kept the marker");
     require(!amrvis::qt::datasetCellOnDisplayedSlice(cell, normalZ, 1.75),
         "a plane moved one cell down kept the marker");
-    // Both faces count: a plane sitting exactly on a boundary cuts the cells
-    // either side of it.
+    // The faces are half-open, matching the ownership sampleIndex floors into:
+    // the lower one is this cell's, the upper one already belongs to the
+    // sample the raster draws there instead.
     require(amrvis::qt::datasetCellOnDisplayedSlice(cell, normalZ, 2.0),
         "a plane on the cell's lower face lost its marker");
-    require(amrvis::qt::datasetCellOnDisplayedSlice(cell, normalZ, 2.5),
-        "a plane on the cell's upper face lost its marker");
+    require(!amrvis::qt::datasetCellOnDisplayedSlice(cell, normalZ, 2.5),
+        "a plane on the cell's upper face kept the marker, though the raster "
+        "there shows the next sample");
     // The other axes read their own bounds, not z's.
     require(amrvis::qt::datasetCellOnDisplayedSlice(cell, 0, 0.5),
         "an x-normal plane inside the cell lost its marker");

--- a/tests/unit/test_dataset_selection.cpp
+++ b/tests/unit/test_dataset_selection.cpp
@@ -3,6 +3,10 @@
 // arithmetic it has to get right is the row/j flip (row 0 is the highest j)
 // and the coverage skip, so the page below is deliberately offset from the
 // origin and holes are punched in it.
+//
+// Also datasetCellOnDisplayedSlice, which decides whether a marked cell is
+// still on the plane being shown. Without it a 3-D slice move redraws the old
+// outline at the same in-plane position on a plane the cell is not on.
 
 #include "DatasetSelection.hpp"
 
@@ -107,6 +111,32 @@ int main()
     require(!amrvis::qt::coveredSelectionBounds(amrvis::DatasetPage{},
                 std::vector<amrvis::qt::CellRange>{{0, 0, 0, 0}}).has_value(),
         "an empty page produced bounds");
+
+    // A marked cell spanning z in [2.0, 2.5): the one sample the plane it was
+    // taken from cuts. Only a plane inside that span may keep the marker.
+    const amrvis::RealBox cell{{0.0, 0.0, 2.0}, {1.0, 1.0, 2.5}};
+    constexpr int normalZ = 2;
+    require(amrvis::qt::datasetCellOnDisplayedSlice(cell, normalZ, 2.25),
+        "the plane that cuts the cell lost its marker");
+    require(!amrvis::qt::datasetCellOnDisplayedSlice(cell, normalZ, 2.75),
+        "a plane moved one cell up kept the marker");
+    require(!amrvis::qt::datasetCellOnDisplayedSlice(cell, normalZ, 1.75),
+        "a plane moved one cell down kept the marker");
+    // Both faces count: a plane sitting exactly on a boundary cuts the cells
+    // either side of it.
+    require(amrvis::qt::datasetCellOnDisplayedSlice(cell, normalZ, 2.0),
+        "a plane on the cell's lower face lost its marker");
+    require(amrvis::qt::datasetCellOnDisplayedSlice(cell, normalZ, 2.5),
+        "a plane on the cell's upper face lost its marker");
+    // The other axes read their own bounds, not z's.
+    require(amrvis::qt::datasetCellOnDisplayedSlice(cell, 0, 0.5),
+        "an x-normal plane inside the cell lost its marker");
+    require(!amrvis::qt::datasetCellOnDisplayedSlice(cell, 0, 2.25),
+        "an x-normal plane read the cell's z bounds");
+    // A normal outside 0..2 is nobody's axis; marking nothing is the safe
+    // reading, since the alternative indexes past the box.
+    require(!amrvis::qt::datasetCellOnDisplayedSlice(cell, 3, 2.25),
+        "an out-of-range normal was accepted");
 
     std::cout << "dataset selection OK\n";
     return 0;


### PR DESCRIPTION
Dragging across the table did nothing: QTableView::clicked fires only when the press and the release land on the same cell. Drive off the selection model instead, so a click, a drag and shift-arrow are one path, and send the bounding box of the selected samples through cellActivated, which already took an arbitrary box.

Only covered samples count, so selecting a whole level's table marks just the part of the view that level provides, and one tab holds the selection at a time.