### PR TITLE
fix slice grid box validation across floating-point rounding

### DIFF
--- a/src/core/Metadata.cpp
+++ b/src/core/Metadata.cpp
@@ -64,10 +64,13 @@ RealBox sampleBounds(
     for (int axis = 0; axis < dimension; ++axis) {
         const auto i = static_cast<std::size_t>(axis);
         const auto nodalHalf = isNodal(box, axis) ? 0.5 : 0.0;
-        // This geometry crosses the remote boundary. Spell out the fused
-        // evaluation so a client and server built by different compilers do
-        // not disagree according to whether either compiler contracted a
-        // multiply followed by an add.
+        // This geometry crosses the remote boundary, so the compiler must
+        // not be the one that picks it: contraction is on by default and
+        // happens wherever the target has an fma instruction, which makes the
+        // value a property of the build rather than of the catalog. Pin the
+        // fused form as the canonical evaluation. Peers built before this pin
+        // still derive the separately-rounded value, which is why
+        // SessionValidation accepts that one as well.
         result.lower[i] = std::fma(
             static_cast<double>(box.lower[i]) - nodalHalf,
             level.cellSize[i], level.indexOrigin[i]);

--- a/src/core/Metadata.cpp
+++ b/src/core/Metadata.cpp
@@ -64,12 +64,16 @@ RealBox sampleBounds(
     for (int axis = 0; axis < dimension; ++axis) {
         const auto i = static_cast<std::size_t>(axis);
         const auto nodalHalf = isNodal(box, axis) ? 0.5 : 0.0;
-        result.lower[i] = level.indexOrigin[i]
-            + (static_cast<double>(box.lower[i]) - nodalHalf)
-                * level.cellSize[i];
-        result.upper[i] = level.indexOrigin[i]
-            + (static_cast<double>(box.upper[i]) + 1.0 - nodalHalf)
-                * level.cellSize[i];
+        // This geometry crosses the remote boundary. Spell out the fused
+        // evaluation so a client and server built by different compilers do
+        // not disagree according to whether either compiler contracted a
+        // multiply followed by an add.
+        result.lower[i] = std::fma(
+            static_cast<double>(box.lower[i]) - nodalHalf,
+            level.cellSize[i], level.indexOrigin[i]);
+        result.upper[i] = std::fma(
+            static_cast<double>(box.upper[i]) + 1.0 - nodalHalf,
+            level.cellSize[i], level.indexOrigin[i]);
     }
     return result;
 }

--- a/src/data/SessionValidation.cpp
+++ b/src/data/SessionValidation.cpp
@@ -455,6 +455,9 @@ void validateSessionViewResult(const DatasetMetadata& metadata,
         // plane axes. Every edge retains the exact fused and separately-rounded
         // values a peer can derive; the search band locates either value, while
         // matchesCoordinates prevents the band itself from admitting a third.
+        // The clip is also what keeps an accepted box inside the window, so no
+        // separate window test is needed below: every alternative a box can
+        // match is already confined to it.
         struct ExpectedLevel {
             int level = 0;
             std::vector<ExpectedBox> boxes;
@@ -547,17 +550,6 @@ void validateSessionViewResult(const DatasetMetadata& metadata,
             }
             requirePlaneRegion(box.physicalRegion, metadata.dimension,
                 query.normalDirection, "slice result grid box");
-            for (const auto axis : planeAxes(
-                     metadata.dimension, query.normalDirection)) {
-                const auto entry = static_cast<std::size_t>(axis);
-                if (box.physicalRegion.lower[entry]
-                        < query.visibleRegion.lower[entry]
-                    || box.physicalRegion.upper[entry]
-                        > query.visibleRegion.upper[entry]) {
-                    throw std::invalid_argument(
-                        "slice result grid box escapes the visible region");
-                }
-            }
             if (metadata.dimension == 3) {
                 const auto normal
                     = static_cast<std::size_t>(query.normalDirection);

--- a/src/data/SessionValidation.cpp
+++ b/src/data/SessionValidation.cpp
@@ -76,51 +76,87 @@ void requireSourceLevels(const std::vector<std::int16_t>& levels,
     }
 }
 
-bool withinTolerance(double left, double right, double tolerance) noexcept
+bool withinSearchBand(double left, double right, double width) noexcept
 {
-    return left == right || std::fabs(left - right) <= tolerance;
+    return left == right || std::fabs(left - right) <= width;
 }
 
-// The expected boxes are sorted as lower[0..2], upper[0..2]. Recursively
-// narrow that lexicographic range one coordinate at a time instead of scanning
-// every box with the same x edge. A tolerance below half a cell leaves at most
-// one grid coordinate on either side of the answer; clipping can add the
-// viewport edge as one more exact value, so the search stays narrowly branched.
 double boxCoordinate(const RealBox& box, std::size_t coordinate) noexcept
 {
     return coordinate < 3 ? box.lower[coordinate]
                           : box.upper[coordinate - 3];
 }
 
-using BoxIterator = std::vector<RealBox>::const_iterator;
+// Older peers evaluated sampleBounds as an expression one compiler could
+// contract and another could execute as a rounded multiply followed by an add.
+// Current peers use explicit fma, so these are the canonical and legacy values
+// a compatible peer can derive from the catalog. Keep them as exact
+// alternatives instead of widening the comparison into a numeric interval:
+// the latter either becomes smaller than one ulp at extreme offsets or large
+// enough to admit geometry no query produced.
+double unfusedMultiplyAdd(double left, double right, double addend) noexcept
+{
+    volatile double product = left * right;
+    return addend + product;
+}
+
+struct ExpectedBox {
+    RealBox key;
+    std::array<std::array<double, 2>, 6> coordinates{};
+};
+
+double boxCoordinate(const ExpectedBox& box, std::size_t coordinate) noexcept
+{
+    return boxCoordinate(box.key, coordinate);
+}
+
+bool matchesCoordinates(const ExpectedBox& expected,
+    const RealBox& answer) noexcept
+{
+    for (std::size_t coordinate = 0; coordinate < 6; ++coordinate) {
+        const auto value = boxCoordinate(answer, coordinate);
+        if (value != expected.coordinates[coordinate][0]
+            && value != expected.coordinates[coordinate][1]) {
+            return false;
+        }
+    }
+    return true;
+}
+
+using BoxIterator = std::vector<ExpectedBox>::const_iterator;
 
 bool matchesExpectedBox(BoxIterator first, BoxIterator last,
-    const RealBox& answer, const std::array<double, 3>& tolerance,
+    const RealBox& answer, const std::array<double, 6>& searchBand,
     std::size_t coordinate = 0)
 {
     const auto target = boxCoordinate(answer, coordinate);
-    const auto allowed = tolerance[coordinate % 3];
+    const auto allowed = searchBand[coordinate];
     // Within this range all preceding coordinates are equal, so this
-    // coordinate is ordered. Skip values strictly below its tolerance band
+    // coordinate is ordered. Skip values strictly below its search band
     // without forming target-allowed, which could overflow at a finite edge.
     auto candidate = std::lower_bound(first, last, target,
-        [coordinate, allowed](const RealBox& box, double value) {
+        [coordinate, allowed](const ExpectedBox& box, double value) {
             const auto entry = boxCoordinate(box, coordinate);
             return entry < value
-                && !withinTolerance(entry, value, allowed);
+                && !withinSearchBand(entry, value, allowed);
         });
     while (candidate != last) {
         const auto value = boxCoordinate(*candidate, coordinate);
-        if (!withinTolerance(value, target, allowed)) {
+        if (!withinSearchBand(value, target, allowed)) {
             break;
         }
         const auto groupEnd = std::upper_bound(candidate, last, value,
-            [coordinate](double entry, const RealBox& box) {
+            [coordinate](double entry, const ExpectedBox& box) {
                 return entry < boxCoordinate(box, coordinate);
             });
-        if (coordinate == 5
-            || matchesExpectedBox(candidate, groupEnd, answer, tolerance,
-                coordinate + 1)) {
+        if (coordinate == 5) {
+            if (std::any_of(candidate, groupEnd, [&](const auto& expected) {
+                    return matchesCoordinates(expected, answer);
+                })) {
+                return true;
+            }
+        } else if (matchesExpectedBox(candidate, groupEnd, answer, searchBand,
+                       coordinate + 1)) {
             return true;
         }
         candidate = groupEnd;
@@ -416,16 +452,13 @@ void validateSessionViewResult(const DatasetMetadata& metadata,
         }
         // Expected boxes per level, built once and reused: each catalog box of
         // that level, in physical space, clipped to the visible region on the
-        // plane axes -- the geometry the query derives, up to the last-ulp
-        // rounding the match below tolerates rather than trusts. The
-        // slice-intersection and non-degeneracy filters it also applies are
-        // deliberately *not* mirrored, so this stays a superset: it can only
-        // reject a box that corresponds to no catalog box at all, never one the
-        // query legitimately chose to keep or drop.
+        // plane axes. Every edge retains the exact fused and separately-rounded
+        // values a peer can derive; the search band locates either value, while
+        // matchesCoordinates prevents the band itself from admitting a third.
         struct ExpectedLevel {
             int level = 0;
-            std::vector<RealBox> boxes;
-            std::array<double, 3> axisTolerance{};
+            std::vector<ExpectedBox> boxes;
+            std::array<double, 6> searchBand{};
         };
         std::vector<ExpectedLevel> expectedByLevel;
         const auto expectedFor = [&](int level) -> const ExpectedLevel& {
@@ -441,43 +474,64 @@ void validateSessionViewResult(const DatasetMetadata& metadata,
                 = metadata.levels[static_cast<std::size_t>(level)];
             built.boxes.reserve(source.boxes.size());
             for (const auto& indexBox : source.boxes) {
-                auto physical
-                    = sampleBounds(source, indexBox, metadata.dimension);
+                ExpectedBox expected;
+                for (int axis = 0; axis < metadata.dimension; ++axis) {
+                    const auto entry = static_cast<std::size_t>(axis);
+                    const auto nodalHalf
+                        = isNodal(indexBox, axis) ? 0.5 : 0.0;
+                    const std::array<double, 2> factors{
+                        static_cast<double>(indexBox.lower[entry]) - nodalHalf,
+                        static_cast<double>(indexBox.upper[entry]) + 1.0
+                            - nodalHalf};
+                    for (std::size_t side = 0; side < 2; ++side) {
+                        const auto coordinate = entry + side * 3;
+                        expected.coordinates[coordinate] = {
+                            unfusedMultiplyAdd(factors[side],
+                                source.cellSize[entry],
+                                source.indexOrigin[entry]),
+                            std::fma(factors[side], source.cellSize[entry],
+                                source.indexOrigin[entry])};
+                    }
+                }
                 for (const auto axis : planeAxes(
                          metadata.dimension, query.normalDirection)) {
                     const auto entry = static_cast<std::size_t>(axis);
-                    physical.lower[entry] = std::max(physical.lower[entry],
-                        query.visibleRegion.lower[entry]);
-                    physical.upper[entry] = std::min(physical.upper[entry],
-                        query.visibleRegion.upper[entry]);
+                    for (auto& value : expected.coordinates[entry]) {
+                        value = std::max(
+                            value, query.visibleRegion.lower[entry]);
+                    }
+                    for (auto& value : expected.coordinates[entry + 3]) {
+                        value = std::min(
+                            value, query.visibleRegion.upper[entry]);
+                    }
                 }
-                built.boxes.push_back(physical);
+                for (std::size_t coordinate = 0; coordinate < 6;
+                    ++coordinate) {
+                    const auto& values = expected.coordinates[coordinate];
+                    // Only a finite alternative can survive result validation;
+                    // use it as the searchable key if the unfused product
+                    // overflowed but the fused operation did not.
+                    const auto key = std::isfinite(values[0])
+                        ? values[0] : values[1];
+                    if (coordinate < 3) {
+                        expected.key.lower[coordinate] = key;
+                    } else {
+                        expected.key.upper[coordinate - 3] = key;
+                    }
+                    const auto width = std::fabs(values[0] - values[1]);
+                    if (std::isfinite(width)) {
+                        built.searchBand[coordinate]
+                            = std::max(built.searchBand[coordinate], width);
+                    }
+                }
+                built.boxes.push_back(std::move(expected));
             }
             std::sort(built.boxes.begin(), built.boxes.end(),
-                [](const RealBox& left, const RealBox& right) {
-                    return left.lower.values < right.lower.values
-                        || (left.lower.values == right.lower.values
-                            && left.upper.values < right.upper.values);
+                [](const ExpectedBox& left, const ExpectedBox& right) {
+                    return left.key.lower.values < right.key.lower.values
+                        || (left.key.lower.values == right.key.lower.values
+                            && left.key.upper.values < right.key.upper.values);
                 });
-            const auto bounds
-                = sampleBounds(source, source.domain, metadata.dimension);
-            for (int axis = 0; axis < metadata.dimension; ++axis) {
-                const auto entry = static_cast<std::size_t>(axis);
-                const auto scale = std::max(
-                    {std::fabs(bounds.lower[entry]),
-                        std::fabs(bounds.upper[entry]),
-                        std::fabs(source.indexOrigin[entry])});
-                // The server and client can evaluate
-                // origin + index*cellSize with different contraction and
-                // last-ulp rounding. Scale the allowance to those arithmetic
-                // terms, but never let it approach a distinct cell boundary:
-                // past that point a physical coordinate cannot prove which
-                // catalog box the peer named.
-                const auto rounding = 16.0
-                    * std::numeric_limits<double>::epsilon() * scale;
-                built.axisTolerance[entry] = std::min(
-                    rounding, 0.25 * source.cellSize[entry]);
-            }
             expectedByLevel.push_back(std::move(built));
             return expectedByLevel.back();
         };
@@ -493,10 +547,32 @@ void validateSessionViewResult(const DatasetMetadata& metadata,
             }
             requirePlaneRegion(box.physicalRegion, metadata.dimension,
                 query.normalDirection, "slice result grid box");
+            for (const auto axis : planeAxes(
+                     metadata.dimension, query.normalDirection)) {
+                const auto entry = static_cast<std::size_t>(axis);
+                if (box.physicalRegion.lower[entry]
+                        < query.visibleRegion.lower[entry]
+                    || box.physicalRegion.upper[entry]
+                        > query.visibleRegion.upper[entry]) {
+                    throw std::invalid_argument(
+                        "slice result grid box escapes the visible region");
+                }
+            }
+            if (metadata.dimension == 3) {
+                const auto normal
+                    = static_cast<std::size_t>(query.normalDirection);
+                if (!(query.physicalPosition
+                            >= box.physicalRegion.lower[normal]
+                        && query.physicalPosition
+                            < box.physicalRegion.upper[normal])) {
+                    throw std::invalid_argument(
+                        "slice result grid box misses the requested slice");
+                }
+            }
             const auto& expected = expectedFor(box.level);
             if (!matchesExpectedBox(expected.boxes.begin(),
                     expected.boxes.end(), box.physicalRegion,
-                    expected.axisTolerance)) {
+                    expected.searchBand)) {
                 throw std::invalid_argument(
                     "slice result grid box matches no box in the catalog");
             }

--- a/src/data/SessionValidation.cpp
+++ b/src/data/SessionValidation.cpp
@@ -76,6 +76,58 @@ void requireSourceLevels(const std::vector<std::int16_t>& levels,
     }
 }
 
+bool withinTolerance(double left, double right, double tolerance) noexcept
+{
+    return left == right || std::fabs(left - right) <= tolerance;
+}
+
+// The expected boxes are sorted as lower[0..2], upper[0..2]. Recursively
+// narrow that lexicographic range one coordinate at a time instead of scanning
+// every box with the same x edge. A tolerance below half a cell leaves at most
+// one grid coordinate on either side of the answer; clipping can add the
+// viewport edge as one more exact value, so the search stays narrowly branched.
+double boxCoordinate(const RealBox& box, std::size_t coordinate) noexcept
+{
+    return coordinate < 3 ? box.lower[coordinate]
+                          : box.upper[coordinate - 3];
+}
+
+using BoxIterator = std::vector<RealBox>::const_iterator;
+
+bool matchesExpectedBox(BoxIterator first, BoxIterator last,
+    const RealBox& answer, const std::array<double, 3>& tolerance,
+    std::size_t coordinate = 0)
+{
+    const auto target = boxCoordinate(answer, coordinate);
+    const auto allowed = tolerance[coordinate % 3];
+    // Within this range all preceding coordinates are equal, so this
+    // coordinate is ordered. Skip values strictly below its tolerance band
+    // without forming target-allowed, which could overflow at a finite edge.
+    auto candidate = std::lower_bound(first, last, target,
+        [coordinate, allowed](const RealBox& box, double value) {
+            const auto entry = boxCoordinate(box, coordinate);
+            return entry < value
+                && !withinTolerance(entry, value, allowed);
+        });
+    while (candidate != last) {
+        const auto value = boxCoordinate(*candidate, coordinate);
+        if (!withinTolerance(value, target, allowed)) {
+            break;
+        }
+        const auto groupEnd = std::upper_bound(candidate, last, value,
+            [coordinate](double entry, const RealBox& box) {
+                return entry < boxCoordinate(box, coordinate);
+            });
+        if (coordinate == 5
+            || matchesExpectedBox(candidate, groupEnd, answer, tolerance,
+                coordinate + 1)) {
+            return true;
+        }
+        candidate = groupEnd;
+    }
+    return false;
+}
+
 } // namespace
 
 void validateSessionViewRequest(const DatasetMetadata& metadata,
@@ -364,23 +416,30 @@ void validateSessionViewResult(const DatasetMetadata& metadata,
         }
         // Expected boxes per level, built once and reused: each catalog box of
         // that level, in physical space, clipped to the visible region on the
-        // plane axes -- exactly the geometry the query derives. The
+        // plane axes -- the geometry the query derives, up to the last-ulp
+        // rounding the match below tolerates rather than trusts. The
         // slice-intersection and non-degeneracy filters it also applies are
         // deliberately *not* mirrored, so this stays a superset: it can only
         // reject a box that corresponds to no catalog box at all, never one the
         // query legitimately chose to keep or drop.
-        std::vector<std::pair<int, std::vector<RealBox>>> expectedByLevel;
-        const auto expectedFor = [&](int level) -> const std::vector<RealBox>& {
+        struct ExpectedLevel {
+            int level = 0;
+            std::vector<RealBox> boxes;
+            std::array<double, 3> axisTolerance{};
+        };
+        std::vector<ExpectedLevel> expectedByLevel;
+        const auto expectedFor = [&](int level) -> const ExpectedLevel& {
             const auto known = std::find_if(expectedByLevel.begin(),
                 expectedByLevel.end(),
-                [level](const auto& entry) { return entry.first == level; });
+                [level](const auto& entry) { return entry.level == level; });
             if (known != expectedByLevel.end()) {
-                return known->second;
+                return *known;
             }
-            std::vector<RealBox> boxes;
+            ExpectedLevel built;
+            built.level = level;
             const auto& source
                 = metadata.levels[static_cast<std::size_t>(level)];
-            boxes.reserve(source.boxes.size());
+            built.boxes.reserve(source.boxes.size());
             for (const auto& indexBox : source.boxes) {
                 auto physical
                     = sampleBounds(source, indexBox, metadata.dimension);
@@ -392,16 +451,35 @@ void validateSessionViewResult(const DatasetMetadata& metadata,
                     physical.upper[entry] = std::min(physical.upper[entry],
                         query.visibleRegion.upper[entry]);
                 }
-                boxes.push_back(physical);
+                built.boxes.push_back(physical);
             }
-            std::sort(boxes.begin(), boxes.end(),
+            std::sort(built.boxes.begin(), built.boxes.end(),
                 [](const RealBox& left, const RealBox& right) {
                     return left.lower.values < right.lower.values
                         || (left.lower.values == right.lower.values
                             && left.upper.values < right.upper.values);
                 });
-            expectedByLevel.emplace_back(level, std::move(boxes));
-            return expectedByLevel.back().second;
+            const auto bounds
+                = sampleBounds(source, source.domain, metadata.dimension);
+            for (int axis = 0; axis < metadata.dimension; ++axis) {
+                const auto entry = static_cast<std::size_t>(axis);
+                const auto scale = std::max(
+                    {std::fabs(bounds.lower[entry]),
+                        std::fabs(bounds.upper[entry]),
+                        std::fabs(source.indexOrigin[entry])});
+                // The server and client can evaluate
+                // origin + index*cellSize with different contraction and
+                // last-ulp rounding. Scale the allowance to those arithmetic
+                // terms, but never let it approach a distinct cell boundary:
+                // past that point a physical coordinate cannot prove which
+                // catalog box the peer named.
+                const auto rounding = 16.0
+                    * std::numeric_limits<double>::epsilon() * scale;
+                built.axisTolerance[entry] = std::min(
+                    rounding, 0.25 * source.cellSize[entry]);
+            }
+            expectedByLevel.push_back(std::move(built));
+            return expectedByLevel.back();
         };
         for (const auto& box : slice->gridBoxes) {
             // A grid box, unlike a sample, always comes from a real level:
@@ -416,15 +494,9 @@ void validateSessionViewResult(const DatasetMetadata& metadata,
             requirePlaneRegion(box.physicalRegion, metadata.dimension,
                 query.normalDirection, "slice result grid box");
             const auto& expected = expectedFor(box.level);
-            const auto found = std::lower_bound(expected.begin(),
-                expected.end(), box.physicalRegion,
-                [](const RealBox& left, const RealBox& right) {
-                    return left.lower.values < right.lower.values
-                        || (left.lower.values == right.lower.values
-                            && left.upper.values < right.upper.values);
-                });
-            if (found == expected.end()
-                || !(*found == box.physicalRegion)) {
+            if (!matchesExpectedBox(expected.boxes.begin(),
+                    expected.boxes.end(), box.physicalRegion,
+                    expected.axisTolerance)) {
                 throw std::invalid_argument(
                     "slice result grid box matches no box in the catalog");
             }

--- a/tests/unit/test_session_validation.cpp
+++ b/tests/unit/test_session_validation.cpp
@@ -131,6 +131,34 @@ amrvis::LineQueryResult lineResult(int axis)
     return result;
 }
 
+double unfusedMultiplyAdd(double left, double right, double addend)
+{
+    volatile double product = left * right;
+    return addend + product;
+}
+
+amrvis::RealBox evaluatedBounds(const amrvis::LevelMetadata& level,
+    const amrvis::IntBox& box, int dimension, bool fused)
+{
+    amrvis::RealBox result;
+    for (int axis = 0; axis < dimension; ++axis) {
+        const auto entry = static_cast<std::size_t>(axis);
+        const auto nodalHalf = amrvis::isNodal(box, axis) ? 0.5 : 0.0;
+        const auto evaluate = [&](double factor) {
+            return fused
+                ? std::fma(factor, level.cellSize[entry],
+                    level.indexOrigin[entry])
+                : unfusedMultiplyAdd(factor, level.cellSize[entry],
+                    level.indexOrigin[entry]);
+        };
+        result.lower[entry]
+            = evaluate(static_cast<double>(box.lower[entry]) - nodalHalf);
+        result.upper[entry] = evaluate(
+            static_cast<double>(box.upper[entry]) + 1.0 - nodalHalf);
+    }
+    return result;
+}
+
 amrvis::DatasetPageRequest pageRequest(int dimension)
 {
     amrvis::DatasetPageRequest request;
@@ -399,12 +427,9 @@ int main()
             validateSessionViewResult(metadata, view, overlay);
         }, "a grid box over the catalog box was rejected");
 
-        // The bounds are recomputed on this side of the wire, and the two
-        // evaluations may round differently -- a fused multiply-add on the
-        // producer moves a bound by its last ulp (#223). Agreement is a
-        // tolerance, not a bitwise match. Only the dimension's own axes are
-        // perturbed: the axes past it are zero filler on both sides, not
-        // arithmetic, and cannot disagree.
+        // This geometry has no fused/unfused disagreement: its origin, indices
+        // and cell size are all exact. An arbitrary ulp nudge is therefore not
+        // an alternate evaluation of the catalog box and must not be admitted.
         auto perturbed = sliceResult(region);
         auto nudged = catalogBox;
         for (auto* const corner : {&nudged.lower, &nudged.upper}) {
@@ -419,9 +444,9 @@ int main()
             }
         }
         perturbed.gridBoxes.push_back({1, nudged});
-        requireAccepted([&] {
+        requireRejected([&] {
             validateSessionViewResult(metadata, view, perturbed);
-        }, "a grid box off by ulps from the catalog box was rejected");
+        }, "an underived ulp-nudged grid box was accepted");
 
         if (dimension == 3) {
             // All three axes are compared, so the normal extent has to be the
@@ -434,6 +459,16 @@ int main()
             requireRejected([&] {
                 validateSessionViewResult(metadata, view, stretched);
             }, "a grid box with an invented normal extent was accepted");
+
+            auto offSliceRequest = request;
+            offSliceRequest.physicalPosition = 99.0;
+            const ViewDataRequest offSliceView = offSliceRequest;
+            auto offSlice = sliceResult(region);
+            offSlice.gridBoxes.push_back({1, catalogBox});
+            requireRejectedWith([&] {
+                validateSessionViewResult(metadata, offSliceView, offSlice);
+            }, "misses the requested slice",
+                "a catalog box away from the requested slice was accepted");
         }
 
         // A line answer to a slice request is not an answer at all.
@@ -442,9 +477,9 @@ int main()
         }, "a line result answered a slice request");
     }
 
-    // The reported failure used coordinates around 1e22. Exercise the scale
-    // that makes independently contracted multiply-adds disagree, rather than
-    // proving the tolerance only around the fixture's small integers.
+    // The reported failure used coordinates around 1e22. Exercise actual fused
+    // and separately-rounded evaluations, including independent edge choices,
+    // rather than standing in for them with an arbitrary ulp translation.
     {
         auto metadata = dataset(2);
         constexpr double origin = -4.57724532306911e22;
@@ -460,22 +495,36 @@ int main()
             metadata.levels.front(), metadata.levels.front().domain, 2);
         auto request = sliceRequest(2);
         request.visibleRegion = metadata.physicalDomain;
-        const ViewDataRequest view = request;
-        auto answer = sliceResult(request.visibleRegion);
-        auto box = sampleBounds(
-            metadata.levels.back(), metadata.levels.back().boxes.front(), 2);
-        for (auto* const corner : {&box.lower, &box.upper}) {
-            for (std::size_t axis = 0; axis < 2; ++axis) {
-                for (int step = 0; step < 2; ++step) {
-                    (*corner)[axis] = std::nextafter((*corner)[axis],
-                        std::numeric_limits<double>::infinity());
-                }
-            }
+        for (std::size_t axis = 0; axis < 2; ++axis) {
+            request.visibleRegion.lower[axis] -= cellSize;
+            request.visibleRegion.upper[axis] += cellSize;
         }
-        answer.gridBoxes.push_back({1, box});
-        requireAccepted([&] {
-            validateSessionViewResult(metadata, view, answer);
-        }, "large-coordinate last-ulp box rounding was rejected");
+        const ViewDataRequest view = request;
+        const auto& level = metadata.levels.back();
+        const auto& indexBox = level.boxes.front();
+        const auto unfused = evaluatedBounds(level, indexBox, 2, false);
+        const auto fused = evaluatedBounds(level, indexBox, 2, true);
+        require(unfused != fused,
+            "the large-coordinate fused/unfused fixture is vacuous");
+        require(sampleBounds(level, indexBox, 2) == fused,
+            "sampleBounds did not use the canonical fused evaluation");
+        auto mixed = unfused;
+        mixed.lower[0] = fused.lower[0];
+        mixed.upper[1] = fused.upper[1];
+        auto inward = unfused;
+        for (std::size_t axis = 0; axis < 2; ++axis) {
+            inward.lower[axis]
+                = std::max(unfused.lower[axis], fused.lower[axis]);
+            inward.upper[axis]
+                = std::min(unfused.upper[axis], fused.upper[axis]);
+        }
+        for (const auto& box : {unfused, fused, mixed, inward}) {
+            auto answer = sliceResult(request.visibleRegion);
+            answer.gridBoxes.push_back({1, box});
+            requireAccepted([&] {
+                validateSessionViewResult(metadata, view, answer);
+            }, "a legitimate fused/unfused grid-box edge was rejected");
+        }
     }
 
     // Coordinate magnitude must not turn the rounding allowance into whole
@@ -493,6 +542,10 @@ int main()
             metadata.levels.front(), metadata.levels.front().domain, 2);
         auto request = sliceRequest(2);
         request.visibleRegion = metadata.physicalDomain;
+        for (std::size_t axis = 0; axis < 2; ++axis) {
+            request.visibleRegion.lower[axis] -= cellSize;
+            request.visibleRegion.upper[axis] += cellSize;
+        }
         const ViewDataRequest view = request;
         auto answer = sliceResult(request.visibleRegion);
         auto shifted = metadata.physicalDomain;
@@ -507,38 +560,190 @@ int main()
             "a whole-cell-shifted box at large coordinates was accepted");
     }
 
-    // A slab decomposition gives many boxes the same first coordinate. The
-    // full-key search must still reach every later y group without falling
-    // back to a linear scan from the first shared x edge for each answer.
+    // A catalog box merely touching the viewport is clipped to zero width and
+    // SliceQuery drops it. It cannot authorize a positive sliver whose edges
+    // happen to lie inside a broad coordinate-scale tolerance.
     {
         auto metadata = dataset(2);
+        constexpr double origin = 1.0e13;
         for (auto& level : metadata.levels) {
-            level.domain = IntBox{Int3{{0, 0, 0}},
-                Int3{{0, 63, 0}}, Int3{{0, 0, 0}}};
+            level.domain = IntBox{Int3{{0, 0, 0}}, Int3{{1, 1, 0}},
+                Int3{{0, 0, 0}}};
+            level.boxes = {IntBox{Int3{{0, 0, 0}}, Int3{{0, 0, 0}},
+                Int3{{0, 0, 0}}}};
+            level.indexOrigin = Real3{{origin, origin, 0.0}};
+            level.cellSize = Real3{{1.0, 1.0, 1.0}};
+        }
+        metadata.physicalDomain = sampleBounds(
+            metadata.levels.front(), metadata.levels.front().domain, 2);
+        auto request = sliceRequest(2);
+        request.visibleRegion = RealBox{Real3{{origin + 1.0, origin, 0.0}},
+            Real3{{origin + 2.0, origin + 1.0, 0.0}}};
+        const ViewDataRequest view = request;
+        auto answer = sliceResult(request.visibleRegion);
+        auto sliver = RealBox{Real3{{origin + 1.0, origin, 0.0}},
+            Real3{{std::nextafter(origin + 1.0,
+                       std::numeric_limits<double>::infinity()),
+                origin + 1.0, 0.0}}};
+        answer.gridBoxes.push_back({1, sliver});
+        requireRejectedWith([&] {
+            validateSessionViewResult(metadata, view, answer);
+        }, "matches no box",
+            "a positive sliver derived from a zero-width clip was accepted");
+    }
+
+    // Above the old quarter-cell cap threshold, a legal int-index edge can
+    // differ by one coordinate ulp between fused and separately-rounded
+    // evaluation. Both exact outcomes remain legitimate even when that ulp is
+    // wider than one quarter of a cell.
+    {
+        auto metadata = dataset(2);
+        metadata.finestLevel = 0;
+        metadata.levels.resize(1);
+        auto& level = metadata.levels.front();
+        constexpr double origin = 1.0e8;
+        constexpr double cellSize = 2.9224442392587661e-8;
+        constexpr int gridIndex = 1671731333;
+        level.level = 0;
+        level.domain = IntBox{Int3{{0, 0, 0}},
+            Int3{{2000000000, 2000000000, 0}}, Int3{{0, 0, 0}}};
+        level.boxes = {IntBox{Int3{{gridIndex, gridIndex, 0}},
+            Int3{{gridIndex, gridIndex, 0}}, Int3{{0, 0, 0}}}};
+        level.indexOrigin = Real3{{origin, origin, 0.0}};
+        level.cellSize = Real3{{cellSize, cellSize, 1.0}};
+        metadata.physicalDomain = sampleBounds(level, level.domain, 2);
+        const auto unfused = evaluatedBounds(level, level.boxes.front(), 2,
+            false);
+        const auto fused = evaluatedBounds(level, level.boxes.front(), 2, true);
+        require(unfused.lower[0] != fused.lower[0]
+                && std::fabs(unfused.lower[0] - fused.lower[0])
+                    > 0.25 * cellSize,
+            "the capped-regime fused/unfused fixture is vacuous");
+        auto request = sliceRequest(2);
+        request.maximumLevel = 0;
+        request.visibleRegion = metadata.physicalDomain;
+        const ViewDataRequest view = request;
+        for (const auto& box : {unfused, fused}) {
+            auto answer = sliceResult(request.visibleRegion);
+            answer.plane.sourceLevel = {0, 0, -1, 0};
+            answer.gridBoxes.push_back({0, box});
+            requireAccepted([&] {
+                validateSessionViewResult(metadata, view, answer);
+            }, "a capped-regime fused/unfused grid box was rejected");
+        }
+    }
+
+    // Per-level identity is part of the result. A fine box one eighth of a
+    // coarse cell inside the coarse box is valid under its own tag, but the old
+    // quarter-cell aperture also accepted it when falsely tagged coarse.
+    {
+        auto metadata = dataset(2);
+        constexpr double origin = 1.0e14;
+        auto& coarse = metadata.levels[0];
+        coarse.domain = IntBox{Int3{{0, 0, 0}}, Int3{{15, 15, 0}},
+            Int3{{0, 0, 0}}};
+        coarse.boxes = {IntBox{Int3{{0, 0, 0}}, Int3{{7, 7, 0}},
+            Int3{{0, 0, 0}}}};
+        coarse.indexOrigin = Real3{{origin, origin, 0.0}};
+        coarse.cellSize = Real3{{1.0, 1.0, 1.0}};
+        auto& fine = metadata.levels[1];
+        fine.domain = IntBox{Int3{{0, 0, 0}}, Int3{{127, 127, 0}},
+            Int3{{0, 0, 0}}};
+        fine.boxes = {IntBox{Int3{{1, 1, 0}}, Int3{{63, 63, 0}},
+            Int3{{0, 0, 0}}}};
+        fine.indexOrigin = Real3{{origin, origin, 0.0}};
+        fine.cellSize = Real3{{0.125, 0.125, 1.0}};
+        metadata.physicalDomain = sampleBounds(coarse, coarse.domain, 2);
+        auto request = sliceRequest(2);
+        request.visibleRegion = metadata.physicalDomain;
+        const ViewDataRequest view = request;
+        const auto fineBox = sampleBounds(fine, fine.boxes.front(), 2);
+        auto correct = sliceResult(request.visibleRegion);
+        correct.gridBoxes.push_back({1, fineBox});
+        requireAccepted([&] {
+            validateSessionViewResult(metadata, view, correct);
+        }, "a fine grid box with its correct level was rejected");
+        auto mistagged = sliceResult(request.visibleRegion);
+        mistagged.gridBoxes.push_back({0, fineBox});
+        requireRejectedWith([&] {
+            validateSessionViewResult(metadata, view, mistagged);
+        }, "matches no box", "fine geometry falsely tagged coarse was accepted");
+    }
+
+    // A far level-domain edge must not grant slack to a catalog box near zero.
+    {
+        auto metadata = dataset(2);
+        metadata.finestLevel = 0;
+        metadata.levels.resize(1);
+        auto& level = metadata.levels.front();
+        level.level = 0;
+        level.domain = IntBox{Int3{{0, 0, 0}},
+            Int3{{1000000000, 1000000000, 0}}, Int3{{0, 0, 0}}};
+        level.boxes = {IntBox{Int3{{0, 0, 0}}, Int3{{0, 0, 0}},
+            Int3{{0, 0, 0}}}};
+        metadata.physicalDomain = sampleBounds(level, level.domain, 2);
+        auto request = sliceRequest(2);
+        request.maximumLevel = 0;
+        request.visibleRegion
+            = RealBox{Real3{{0.0, 0.0, 0.0}}, Real3{{2.0, 2.0, 0.0}}};
+        const ViewDataRequest view = request;
+        auto shifted = sampleBounds(level, level.boxes.front(), 2);
+        for (std::size_t axis = 0; axis < 2; ++axis) {
+            shifted.lower[axis] += 1.0e-6;
+            shifted.upper[axis] += 1.0e-6;
+        }
+        auto answer = sliceResult(request.visibleRegion);
+        answer.plane.sourceLevel = {0, 0, -1, 0};
+        answer.gridBoxes.push_back({0, shifted});
+        requireRejectedWith([&] {
+            validateSessionViewResult(metadata, view, answer);
+        }, "matches no box",
+            "a near-origin box used the far domain edge as tolerance");
+    }
+
+    // A slab decomposition gives many boxes the same first coordinate. The
+    // full-key search must still reach every later y group, including mixed
+    // fused/unfused edges, without falling back to a linear scan from the first
+    // shared x edge for each answer.
+    {
+        auto metadata = dataset(2);
+        constexpr double origin = -4.57724532306911e22;
+        constexpr double cellSize = 7.132980051857025e18;
+        for (auto& level : metadata.levels) {
+            level.domain = IntBox{Int3{{5000, 5000, 0}},
+                Int3{{5000, 5063, 0}}, Int3{{0, 0, 0}}};
             level.boxes.clear();
             for (int y = 0; y < 64; ++y) {
-                level.boxes.push_back(IntBox{Int3{{0, y, 0}},
-                    Int3{{0, y, 0}}, Int3{{0, 0, 0}}});
+                level.boxes.push_back(IntBox{Int3{{5000, 5000 + y, 0}},
+                    Int3{{5000, 5000 + y, 0}}, Int3{{0, 0, 0}}});
             }
+            level.indexOrigin = Real3{{origin, origin, 0.0}};
+            level.cellSize = Real3{{cellSize, cellSize, 1.0}};
         }
         metadata.physicalDomain = sampleBounds(
             metadata.levels.front(), metadata.levels.front().domain, 2);
         auto request = sliceRequest(2);
         request.visibleRegion = metadata.physicalDomain;
+        for (std::size_t axis = 0; axis < 2; ++axis) {
+            request.visibleRegion.lower[axis] -= cellSize;
+            request.visibleRegion.upper[axis] += cellSize;
+        }
         const ViewDataRequest view = request;
         auto answer = sliceResult(request.visibleRegion);
+        auto sawDisagreement = false;
         for (const auto& indexBox : metadata.levels.back().boxes) {
-            auto box = sampleBounds(metadata.levels.back(), indexBox, 2);
-            for (auto* const corner : {&box.lower, &box.upper}) {
-                for (std::size_t axis = 0; axis < 2; ++axis) {
-                    for (int step = 0; step < 2; ++step) {
-                        (*corner)[axis] = std::nextafter((*corner)[axis],
-                            std::numeric_limits<double>::infinity());
-                    }
-                }
-            }
+            const auto unfused = evaluatedBounds(
+                metadata.levels.back(), indexBox, 2, false);
+            const auto fused = evaluatedBounds(
+                metadata.levels.back(), indexBox, 2, true);
+            sawDisagreement = sawDisagreement || unfused != fused;
+            auto box = unfused;
+            box.lower[0] = fused.lower[0];
+            box.upper[1] = fused.upper[1];
             answer.gridBoxes.push_back({1, box});
         }
+        require(sawDisagreement,
+            "the slab fused/unfused fixture is vacuous");
         requireAccepted([&] {
             validateSessionViewResult(metadata, view, answer);
         }, "a later grid box sharing the first coordinate was rejected");

--- a/tests/unit/test_session_validation.cpp
+++ b/tests/unit/test_session_validation.cpp
@@ -430,23 +430,25 @@ int main()
         // This geometry has no fused/unfused disagreement: its origin, indices
         // and cell size are all exact. An arbitrary ulp nudge is therefore not
         // an alternate evaluation of the catalog box and must not be admitted.
+        // Nudge inward so the box stays within the window and across the slice:
+        // the catalog match is then the only check left to reject it, which is
+        // what the named reason confirms.
         auto perturbed = sliceResult(region);
         auto nudged = catalogBox;
-        for (auto* const corner : {&nudged.lower, &nudged.upper}) {
-            for (std::size_t axis = 0;
-                axis < static_cast<std::size_t>(metadata.dimension);
-                ++axis) {
-                auto& component = (*corner)[axis];
-                for (int step = 0; step < 2; ++step) {
-                    component = std::nextafter(component,
-                        std::numeric_limits<double>::infinity());
-                }
+        for (std::size_t axis = 0;
+            axis < static_cast<std::size_t>(metadata.dimension); ++axis) {
+            for (int step = 0; step < 2; ++step) {
+                nudged.lower[axis] = std::nextafter(nudged.lower[axis],
+                    std::numeric_limits<double>::infinity());
+                nudged.upper[axis] = std::nextafter(nudged.upper[axis],
+                    -std::numeric_limits<double>::infinity());
             }
         }
         perturbed.gridBoxes.push_back({1, nudged});
-        requireRejected([&] {
+        requireRejectedWith([&] {
             validateSessionViewResult(metadata, view, perturbed);
-        }, "an underived ulp-nudged grid box was accepted");
+        }, "matches no box",
+            "an underived ulp-nudged grid box was accepted");
 
         if (dimension == 3) {
             // All three axes are compared, so the normal extent has to be the
@@ -527,9 +529,10 @@ int main()
         }
     }
 
-    // Coordinate magnitude must not turn the rounding allowance into whole
-    // cells. At 1e16 the spacing between doubles is 2, so the uncapped
-    // 16*epsilon*scale tolerance accepted this one-cell translation.
+    // Coordinate magnitude must not buy an answer any slack. At 1e16 the
+    // spacing between doubles is 2, a whole cell here, so this one-cell
+    // translation is exactly what an allowance scaled to the coordinate would
+    // have admitted.
     {
         auto metadata = dataset(2);
         constexpr double origin = 1.0e16;
@@ -561,8 +564,8 @@ int main()
     }
 
     // A catalog box merely touching the viewport is clipped to zero width and
-    // SliceQuery drops it. It cannot authorize a positive sliver whose edges
-    // happen to lie inside a broad coordinate-scale tolerance.
+    // SliceQuery drops it. It cannot authorize a positive sliver one ulp wide
+    // at the same edge.
     {
         auto metadata = dataset(2);
         constexpr double origin = 1.0e13;
@@ -592,10 +595,11 @@ int main()
             "a positive sliver derived from a zero-width clip was accepted");
     }
 
-    // Above the old quarter-cell cap threshold, a legal int-index edge can
-    // differ by one coordinate ulp between fused and separately-rounded
-    // evaluation. Both exact outcomes remain legitimate even when that ulp is
-    // wider than one quarter of a cell.
+    // A cell small beside its coordinate puts the fused and separately-rounded
+    // evaluations of a legal int-index edge more than a quarter of a cell
+    // apart. Both are still exact evaluations of the same catalog box, so both
+    // have to be accepted -- which is why the accepted set is the two
+    // alternatives and not an interval scaled to the cell.
     {
         auto metadata = dataset(2);
         metadata.finestLevel = 0;
@@ -618,7 +622,7 @@ int main()
         require(unfused.lower[0] != fused.lower[0]
                 && std::fabs(unfused.lower[0] - fused.lower[0])
                     > 0.25 * cellSize,
-            "the capped-regime fused/unfused fixture is vacuous");
+            "the wide-ulp fused/unfused fixture is vacuous");
         auto request = sliceRequest(2);
         request.maximumLevel = 0;
         request.visibleRegion = metadata.physicalDomain;
@@ -629,13 +633,14 @@ int main()
             answer.gridBoxes.push_back({0, box});
             requireAccepted([&] {
                 validateSessionViewResult(metadata, view, answer);
-            }, "a capped-regime fused/unfused grid box was rejected");
+            }, "a wide-ulp fused/unfused grid box was rejected");
         }
     }
 
     // Per-level identity is part of the result. A fine box one eighth of a
-    // coarse cell inside the coarse box is valid under its own tag, but the old
-    // quarter-cell aperture also accepted it when falsely tagged coarse.
+    // coarse cell inside the coarse box is valid under its own tag and matches
+    // nothing under the coarse one, so the level an answer names is the level
+    // it has to be matched against.
     {
         auto metadata = dataset(2);
         constexpr double origin = 1.0e14;
@@ -670,7 +675,9 @@ int main()
         }, "matches no box", "fine geometry falsely tagged coarse was accepted");
     }
 
-    // A far level-domain edge must not grant slack to a catalog box near zero.
+    // The search band comes from the catalog boxes' own fused/unfused width and
+    // from nothing else, so a level whose domain runs out to index 1e9 grants
+    // no slack at all to a box sitting at the origin.
     {
         auto metadata = dataset(2);
         metadata.finestLevel = 0;
@@ -698,13 +705,13 @@ int main()
         requireRejectedWith([&] {
             validateSessionViewResult(metadata, view, answer);
         }, "matches no box",
-            "a near-origin box used the far domain edge as tolerance");
+            "a near-origin box used the far domain edge as slack");
     }
 
     // A slab decomposition gives many boxes the same first coordinate. The
-    // full-key search must still reach every later y group, including mixed
-    // fused/unfused edges, without falling back to a linear scan from the first
-    // shared x edge for each answer.
+    // search descends coordinate by coordinate, so every later y group has to
+    // stay reachable behind that shared x edge, including boxes whose edges mix
+    // fused and separately-rounded evaluation.
     {
         auto metadata = dataset(2);
         constexpr double origin = -4.57724532306911e22;

--- a/tests/unit/test_session_validation.cpp
+++ b/tests/unit/test_session_validation.cpp
@@ -378,6 +378,51 @@ int main()
             validateSessionViewResult(metadata, view, invented);
         }, "a grid box matching no catalog box was accepted");
 
+        // The overlay a good peer sends: each catalog box of the level, in
+        // physical space and clipped to the window -- here the level's one
+        // box covers the window exactly. sampleBounds leaves the axis past
+        // the dimension at zero, the way the peer's own arithmetic does.
+        const auto& source = metadata.levels.back();
+        auto catalogBox = sampleBounds(
+            source, source.boxes.front(), metadata.dimension);
+        for (const auto axis :
+            planeAxes(metadata.dimension, request.normalDirection)) {
+            const auto entry = static_cast<std::size_t>(axis);
+            catalogBox.lower[entry] = std::max(catalogBox.lower[entry],
+                request.visibleRegion.lower[entry]);
+            catalogBox.upper[entry] = std::min(catalogBox.upper[entry],
+                request.visibleRegion.upper[entry]);
+        }
+        auto overlay = sliceResult(region);
+        overlay.gridBoxes.push_back({1, catalogBox});
+        requireAccepted([&] {
+            validateSessionViewResult(metadata, view, overlay);
+        }, "a grid box over the catalog box was rejected");
+
+        // The bounds are recomputed on this side of the wire, and the two
+        // evaluations may round differently -- a fused multiply-add on the
+        // producer moves a bound by its last ulp (#223). Agreement is a
+        // tolerance, not a bitwise match. Only the dimension's own axes are
+        // perturbed: the axes past it are zero filler on both sides, not
+        // arithmetic, and cannot disagree.
+        auto perturbed = sliceResult(region);
+        auto nudged = catalogBox;
+        for (auto* const corner : {&nudged.lower, &nudged.upper}) {
+            for (std::size_t axis = 0;
+                axis < static_cast<std::size_t>(metadata.dimension);
+                ++axis) {
+                auto& component = (*corner)[axis];
+                for (int step = 0; step < 2; ++step) {
+                    component = std::nextafter(component,
+                        std::numeric_limits<double>::infinity());
+                }
+            }
+        }
+        perturbed.gridBoxes.push_back({1, nudged});
+        requireAccepted([&] {
+            validateSessionViewResult(metadata, view, perturbed);
+        }, "a grid box off by ulps from the catalog box was rejected");
+
         if (dimension == 3) {
             // All three axes are compared, so the normal extent has to be the
             // catalog box's own rather than anything plausible.
@@ -395,6 +440,108 @@ int main()
         requireRejected([&] {
             validateSessionViewResult(metadata, view, lineResult(0));
         }, "a line result answered a slice request");
+    }
+
+    // The reported failure used coordinates around 1e22. Exercise the scale
+    // that makes independently contracted multiply-adds disagree, rather than
+    // proving the tolerance only around the fixture's small integers.
+    {
+        auto metadata = dataset(2);
+        constexpr double origin = -4.57724532306911e22;
+        constexpr double cellSize = 7.132980051857025e18;
+        for (auto& level : metadata.levels) {
+            level.domain = IntBox{Int3{{5000, 5000, 0}},
+                Int3{{6000, 6000, 0}}, Int3{{0, 0, 0}}};
+            level.boxes = {level.domain};
+            level.indexOrigin = Real3{{origin, origin, 0.0}};
+            level.cellSize = Real3{{cellSize, cellSize, 1.0}};
+        }
+        metadata.physicalDomain = sampleBounds(
+            metadata.levels.front(), metadata.levels.front().domain, 2);
+        auto request = sliceRequest(2);
+        request.visibleRegion = metadata.physicalDomain;
+        const ViewDataRequest view = request;
+        auto answer = sliceResult(request.visibleRegion);
+        auto box = sampleBounds(
+            metadata.levels.back(), metadata.levels.back().boxes.front(), 2);
+        for (auto* const corner : {&box.lower, &box.upper}) {
+            for (std::size_t axis = 0; axis < 2; ++axis) {
+                for (int step = 0; step < 2; ++step) {
+                    (*corner)[axis] = std::nextafter((*corner)[axis],
+                        std::numeric_limits<double>::infinity());
+                }
+            }
+        }
+        answer.gridBoxes.push_back({1, box});
+        requireAccepted([&] {
+            validateSessionViewResult(metadata, view, answer);
+        }, "large-coordinate last-ulp box rounding was rejected");
+    }
+
+    // Coordinate magnitude must not turn the rounding allowance into whole
+    // cells. At 1e16 the spacing between doubles is 2, so the uncapped
+    // 16*epsilon*scale tolerance accepted this one-cell translation.
+    {
+        auto metadata = dataset(2);
+        constexpr double origin = 1.0e16;
+        constexpr double cellSize = 2.0;
+        for (auto& level : metadata.levels) {
+            level.indexOrigin = Real3{{origin, origin, 0.0}};
+            level.cellSize = Real3{{cellSize, cellSize, 1.0}};
+        }
+        metadata.physicalDomain = sampleBounds(
+            metadata.levels.front(), metadata.levels.front().domain, 2);
+        auto request = sliceRequest(2);
+        request.visibleRegion = metadata.physicalDomain;
+        const ViewDataRequest view = request;
+        auto answer = sliceResult(request.visibleRegion);
+        auto shifted = metadata.physicalDomain;
+        for (std::size_t axis = 0; axis < 2; ++axis) {
+            shifted.lower[axis] += cellSize;
+            shifted.upper[axis] += cellSize;
+        }
+        answer.gridBoxes.push_back({1, shifted});
+        requireRejectedWith([&] {
+            validateSessionViewResult(metadata, view, answer);
+        }, "matches no box",
+            "a whole-cell-shifted box at large coordinates was accepted");
+    }
+
+    // A slab decomposition gives many boxes the same first coordinate. The
+    // full-key search must still reach every later y group without falling
+    // back to a linear scan from the first shared x edge for each answer.
+    {
+        auto metadata = dataset(2);
+        for (auto& level : metadata.levels) {
+            level.domain = IntBox{Int3{{0, 0, 0}},
+                Int3{{0, 63, 0}}, Int3{{0, 0, 0}}};
+            level.boxes.clear();
+            for (int y = 0; y < 64; ++y) {
+                level.boxes.push_back(IntBox{Int3{{0, y, 0}},
+                    Int3{{0, y, 0}}, Int3{{0, 0, 0}}});
+            }
+        }
+        metadata.physicalDomain = sampleBounds(
+            metadata.levels.front(), metadata.levels.front().domain, 2);
+        auto request = sliceRequest(2);
+        request.visibleRegion = metadata.physicalDomain;
+        const ViewDataRequest view = request;
+        auto answer = sliceResult(request.visibleRegion);
+        for (const auto& indexBox : metadata.levels.back().boxes) {
+            auto box = sampleBounds(metadata.levels.back(), indexBox, 2);
+            for (auto* const corner : {&box.lower, &box.upper}) {
+                for (std::size_t axis = 0; axis < 2; ++axis) {
+                    for (int step = 0; step < 2; ++step) {
+                        (*corner)[axis] = std::nextafter((*corner)[axis],
+                            std::numeric_limits<double>::infinity());
+                    }
+                }
+            }
+            answer.gridBoxes.push_back({1, box});
+        }
+        requireAccepted([&] {
+            validateSessionViewResult(metadata, view, answer);
+        }, "a later grid box sharing the first coordinate was rejected");
     }
 
     // Line results.


### PR DESCRIPTION
Allow slice grid boxes to match catalog geometry within a bounded, scale-aware tolerance so client/server differences in contraction and last-ULP rounding do not reject valid responses.

Cap the tolerance below the cell spacing to keep distinct boxes separable, and search the full sorted box key hierarchically to avoid quadratic scans when boxes share an axis coordinate.

Add regressions for small- and large-coordinate rounding, whole-cell shifts, and aligned slab decompositions.

Fixes #223