### PR TITLE
Add length scale reference to slice views

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -561,7 +561,9 @@ length unit, so AMReXplorer leaves it unset by default and displays native
 coordinate values in scientific notation. Choose **View > Length Units...** to
 identify the unit used by the plotfile; AMReXplorer can then label the bar in a
 natural physical unit. This setting changes only the annotation, not dataset
-coordinates or geometry.
+coordinates or geometry. The selection resets to unset whenever you open a new
+dataset or sequence, and is not saved between app sessions. Stepping through
+frames within a sequence keeps the selection.
 
 Choose **View > Contours...** to select one of three display modes:
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -189,9 +189,12 @@ The main controls are:
    3-D panels.
 4. **Range, Log, and Palette** control the mapping from values to colors.
 5. **Slice panels** display the XY, XZ, and YZ planes for a 3-D dataset.
-   A lower-right scale bar treats plotfile coordinates as centimetres and
-   automatically labels the current view in cm, AU, pc, or kpc. It is omitted
-   when the horizontal coordinate is an angle (the spherical theta-r view).
+   A lower-right scale bar uses native plotfile coordinates by default and
+   labels them as code units in scientific notation. Use **View > Length
+   Units...** to identify the plotfile coordinate unit, or **View > Scale Bar**
+   to show or hide the annotation. It is omitted when the horizontal coordinate
+   is an angle (the spherical theta-r view), and the option is disabled when
+   cell sizes are anisotropic.
 6. **Isometric view** shows the domain, grid boxes, and current slice planes;
    **View > Volume Rendering...** opens the same view with the field
    ray-cast into it.
@@ -551,6 +554,14 @@ between palettes.
 ## Grid boxes, contours, and vectors
 
 Press **B** or choose **View > Boxes** to show AMR grid boundaries.
+
+Choose **View > Scale Bar** to show or hide the length annotation. The option
+is unavailable when cell sizes are anisotropic. Plotfiles do not declare their
+length unit, so AMReXplorer leaves it unset by default and displays native
+coordinate values in scientific notation. Choose **View > Length Units...** to
+identify the unit used by the plotfile; AMReXplorer can then label the bar in a
+natural physical unit. This setting changes only the annotation, not dataset
+coordinates or geometry.
 
 Choose **View > Contours...** to select one of three display modes:
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -189,6 +189,9 @@ The main controls are:
    3-D panels.
 4. **Range, Log, and Palette** control the mapping from values to colors.
 5. **Slice panels** display the XY, XZ, and YZ planes for a 3-D dataset.
+   A lower-right scale bar treats plotfile coordinates as centimetres and
+   automatically labels the current view in cm, AU, pc, or kpc. It is omitted
+   when the horizontal coordinate is an angle (the spherical theta-r view).
 6. **Isometric view** shows the domain, grid boxes, and current slice planes;
    **View > Volume Rendering...** opens the same view with the field
    ray-cast into it.

--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -56,6 +56,7 @@ add_executable(amrexplorer_qt
     RemoteOpenDialog.hpp
     RemoteSessionController.cpp
     RemoteSessionController.hpp
+    ScaleBar.hpp
     ScientificDoubleSpinBox.cpp
     ScientificDoubleSpinBox.hpp
     SshConnectArguments.hpp

--- a/src/qt/ImageView.cpp
+++ b/src/qt/ImageView.cpp
@@ -91,6 +91,68 @@ private:
     qreal m_size = 3.0;
 };
 
+void paintScaleBar(QPainter* painter, const QRectF& imageBounds,
+    double cmPerImagePixel, double pixelsPerImagePixel)
+{
+    if (!(cmPerImagePixel > 0.0) || imageBounds.width() < 40.0
+        || imageBounds.height() < 36.0 || !(pixelsPerImagePixel > 0.0)
+        || !std::isfinite(pixelsPerImagePixel)) {
+        return;
+    }
+
+    const double cmPerOutputPixel = cmPerImagePixel / pixelsPerImagePixel;
+    const double maximumPixels = imageBounds.width() * 0.25;
+    const auto bar = chooseScaleBar(imageBounds.width() * cmPerOutputPixel,
+        maximumPixels * cmPerOutputPixel, maximumPixels);
+    if (!bar) {
+        return;
+    }
+
+    constexpr double inset = 12.0;
+    constexpr double tickHalfHeight = 4.0;
+    const double right = imageBounds.right() - inset;
+    const double left = right - bar->lengthPixels;
+    const double y = imageBounds.bottom() - inset;
+    const QLineF horizontal(left, y, right, y);
+    const QLineF leftTick(
+        left, y - tickHalfHeight, left, y + tickHalfHeight);
+    const QLineF rightTick(
+        right, y - tickHalfHeight, right, y + tickHalfHeight);
+    const QColor foreground(255, 255, 255, 230);
+    const QColor outline(0, 0, 0, 190);
+
+    painter->save();
+    painter->resetTransform();
+    painter->setRenderHint(QPainter::Antialiasing);
+    QPen halo(outline);
+    halo.setWidth(5);
+    halo.setCapStyle(Qt::FlatCap);
+    painter->setPen(halo);
+    painter->drawLines({horizontal, leftTick, rightTick});
+    QPen line(foreground);
+    line.setWidth(2);
+    line.setCapStyle(Qt::FlatCap);
+    painter->setPen(line);
+    painter->drawLines({horizontal, leftTick, rightTick});
+
+    QFont font = painter->font();
+    font.setPointSize(10);
+    font.setBold(true);
+    painter->setFont(font);
+    const QString label = QString::fromStdString(bar->label);
+    const auto fm = painter->fontMetrics();
+    const QRectF textRect(left - 20.0,
+        y - tickHalfHeight - fm.height() - 2.0,
+        bar->lengthPixels + 40.0, fm.height());
+    painter->setPen(outline);
+    painter->drawText(textRect.translated(1.0, 1.0),
+        Qt::AlignHCenter | Qt::AlignVCenter, label);
+    painter->setPen(foreground);
+    painter->drawText(textRect,
+        Qt::AlignHCenter | Qt::AlignVCenter, label);
+    painter->restore();
+}
+
 } // namespace
 
 ImageView::ImageView(QWidget* parent)
@@ -458,7 +520,6 @@ void ImageView::drawForeground(QPainter* painter, const QRectF& /*rect*/)
     }
     constexpr int margin = 8;
     const QColor foreground(255, 255, 255, 230);
-    const QColor outline(0, 0, 0, 190);
     painter->setRenderHint(QPainter::Antialiasing);
 
     if (!m_indicatorH.isEmpty() || !m_indicatorV.isEmpty()) {
@@ -519,55 +580,8 @@ void ImageView::drawForeground(QPainter* painter, const QRectF& /*rect*/)
         const auto p0 = itemToViewport.map(QPointF(0.0, 0.0));
         const auto p1 = itemToViewport.map(QPointF(1.0, 0.0));
         const double pixelsPerImagePixel = QLineF(p0, p1).length();
-        if (imageBounds.width() >= 40.0 && imageBounds.height() >= 36.0
-            && pixelsPerImagePixel > 0.0
-            && std::isfinite(pixelsPerImagePixel)) {
-            const double cmPerViewportPixel
-                = m_scaleBarCmPerImagePixel / pixelsPerImagePixel;
-            const double maximumPixels = imageBounds.width() * 0.25;
-            const auto bar = chooseScaleBar(
-                imageBounds.width() * cmPerViewportPixel,
-                maximumPixels * cmPerViewportPixel, maximumPixels);
-            if (bar) {
-                constexpr double inset = 12.0;
-                constexpr double tickHalfHeight = 4.0;
-                const double right = imageBounds.right() - inset;
-                const double left = right - bar->lengthPixels;
-                const double y = imageBounds.bottom() - inset;
-                const QLineF horizontal(left, y, right, y);
-                const QLineF leftTick(left, y - tickHalfHeight,
-                    left, y + tickHalfHeight);
-                const QLineF rightTick(right, y - tickHalfHeight,
-                    right, y + tickHalfHeight);
-
-                QPen halo(outline);
-                halo.setWidth(5);
-                halo.setCapStyle(Qt::FlatCap);
-                painter->setPen(halo);
-                painter->drawLines({horizontal, leftTick, rightTick});
-                QPen line(foreground);
-                line.setWidth(2);
-                line.setCapStyle(Qt::FlatCap);
-                painter->setPen(line);
-                painter->drawLines({horizontal, leftTick, rightTick});
-
-                QFont font = painter->font();
-                font.setPointSize(10);
-                font.setBold(true);
-                painter->setFont(font);
-                const QString label = QString::fromStdString(bar->label);
-                const auto fm = painter->fontMetrics();
-                const QRectF textRect(left - 20.0,
-                    y - tickHalfHeight - fm.height() - 2.0,
-                    bar->lengthPixels + 40.0, fm.height());
-                painter->setPen(outline);
-                painter->drawText(textRect.translated(1.0, 1.0),
-                    Qt::AlignHCenter | Qt::AlignVCenter, label);
-                painter->setPen(foreground);
-                painter->drawText(textRect,
-                    Qt::AlignHCenter | Qt::AlignVCenter, label);
-            }
-        }
+        paintScaleBar(painter, imageBounds, m_scaleBarCmPerImagePixel,
+            pixelsPerImagePixel);
     }
 
     painter->restore();
@@ -665,6 +679,9 @@ QImage ImageView::composedImage(qreal scaleFactor) const
     // the item sits at its cell offset, and the export must follow it.
     m_scene->render(&painter, QRectF(0.0, 0.0, outWidth, outHeight),
         m_item->sceneBoundingRect());
+    paintScaleBar(&painter, QRectF(0.0, 0.0, outWidth, outHeight),
+        m_scaleBarCmPerImagePixel,
+        static_cast<double>(outWidth) / static_cast<double>(baseWidth));
     if (m_lineGuide != nullptr) {
         m_lineGuide->setVisible(guideVisible);
     }

--- a/src/qt/ImageView.cpp
+++ b/src/qt/ImageView.cpp
@@ -92,18 +92,21 @@ private:
 };
 
 void paintScaleBar(QPainter* painter, const QRectF& imageBounds,
-    double cmPerImagePixel, double pixelsPerImagePixel)
+    double codeUnitsPerImagePixel, double pixelsPerImagePixel,
+    std::optional<LengthUnit> lengthUnit)
 {
-    if (!(cmPerImagePixel > 0.0) || imageBounds.width() < 40.0
+    if (!(codeUnitsPerImagePixel > 0.0) || imageBounds.width() < 40.0
         || imageBounds.height() < 36.0 || !(pixelsPerImagePixel > 0.0)
         || !std::isfinite(pixelsPerImagePixel)) {
         return;
     }
 
-    const double cmPerOutputPixel = cmPerImagePixel / pixelsPerImagePixel;
+    const double codeUnitsPerOutputPixel
+        = codeUnitsPerImagePixel / pixelsPerImagePixel;
     const double maximumPixels = imageBounds.width() * 0.25;
-    const auto bar = chooseScaleBar(imageBounds.width() * cmPerOutputPixel,
-        maximumPixels * cmPerOutputPixel, maximumPixels);
+    const auto bar = chooseScaleBar(
+        imageBounds.width() * codeUnitsPerOutputPixel,
+        maximumPixels * codeUnitsPerOutputPixel, maximumPixels, lengthUnit);
     if (!bar) {
         return;
     }
@@ -493,12 +496,14 @@ void ImageView::setAxisIndicator(const QString& horizontal,
     }
 }
 
-void ImageView::setScaleBarPhysicalWidth(double widthCm)
+void ImageView::setScaleBarWidth(double widthCodeUnits,
+    std::optional<LengthUnit> lengthUnit)
 {
-    m_scaleBarCmPerImagePixel = hasImage() && widthCm > 0.0
-            && std::isfinite(widthCm) && m_image.width() > 0
-        ? widthCm / static_cast<double>(m_image.width())
+    m_scaleBarCodeUnitsPerImagePixel = hasImage() && widthCodeUnits > 0.0
+            && std::isfinite(widthCodeUnits) && m_image.width() > 0
+        ? widthCodeUnits / static_cast<double>(m_image.width())
         : 0.0;
+    m_scaleBarLengthUnit = lengthUnit;
     if (viewport() != nullptr) {
         viewport()->update();
     }
@@ -573,15 +578,16 @@ void ImageView::drawForeground(QPainter* painter, const QRectF& /*rect*/)
         }
     }
 
-    if (m_scaleBarCmPerImagePixel > 0.0 && m_item != nullptr) {
+    if (m_scaleBarCodeUnitsPerImagePixel > 0.0 && m_item != nullptr) {
         const auto itemToViewport = m_item->deviceTransform(viewportTransform());
         const auto imageBounds = itemToViewport.mapRect(m_item->boundingRect())
                                      .intersected(QRectF(vp->rect()));
         const auto p0 = itemToViewport.map(QPointF(0.0, 0.0));
         const auto p1 = itemToViewport.map(QPointF(1.0, 0.0));
         const double pixelsPerImagePixel = QLineF(p0, p1).length();
-        paintScaleBar(painter, imageBounds, m_scaleBarCmPerImagePixel,
-            pixelsPerImagePixel);
+        paintScaleBar(painter, imageBounds,
+            m_scaleBarCodeUnitsPerImagePixel, pixelsPerImagePixel,
+            m_scaleBarLengthUnit);
     }
 
     painter->restore();
@@ -616,7 +622,8 @@ void ImageView::setPlaceholder(const QString& text)
     m_image = {};
     m_logicalSize = {};
     m_placement.reset();
-    m_scaleBarCmPerImagePixel = 0.0;
+    m_scaleBarCodeUnitsPerImagePixel = 0.0;
+    m_scaleBarLengthUnit.reset();
     m_placeholderText = text;
     setBackgroundBrush(palette().window());
     auto* label = m_scene->addText(text);
@@ -680,8 +687,9 @@ QImage ImageView::composedImage(qreal scaleFactor) const
     m_scene->render(&painter, QRectF(0.0, 0.0, outWidth, outHeight),
         m_item->sceneBoundingRect());
     paintScaleBar(&painter, QRectF(0.0, 0.0, outWidth, outHeight),
-        m_scaleBarCmPerImagePixel,
-        static_cast<double>(outWidth) / static_cast<double>(baseWidth));
+        m_scaleBarCodeUnitsPerImagePixel,
+        static_cast<double>(outWidth) / static_cast<double>(baseWidth),
+        m_scaleBarLengthUnit);
     if (m_lineGuide != nullptr) {
         m_lineGuide->setVisible(guideVisible);
     }

--- a/src/qt/ImageView.cpp
+++ b/src/qt/ImageView.cpp
@@ -1,4 +1,5 @@
 #include "ImageView.hpp"
+#include "ScaleBar.hpp"
 
 #include "Theme.hpp"
 
@@ -430,73 +431,143 @@ void ImageView::setAxisIndicator(const QString& horizontal,
     }
 }
 
+void ImageView::setScaleBarPhysicalWidth(double widthCm)
+{
+    m_scaleBarCmPerImagePixel = hasImage() && widthCm > 0.0
+            && std::isfinite(widthCm) && m_image.width() > 0
+        ? widthCm / static_cast<double>(m_image.width())
+        : 0.0;
+    if (viewport() != nullptr) {
+        viewport()->update();
+    }
+}
+
 void ImageView::drawForeground(QPainter* painter, const QRectF& /*rect*/)
 {
-    if (!hasImage() || (m_indicatorH.isEmpty() && m_indicatorV.isEmpty())) {
+    if (!hasImage()) {
         return;
     }
 
     painter->save();
     painter->resetTransform();
 
-    constexpr int armLen = 26;
-    constexpr int headLen = 6;
-    constexpr int headHalf = 3;
-    constexpr int margin = 8;
-    const QColor fg(255, 255, 255, 200);
-
     const auto* vp = viewport();
     if (vp == nullptr) {
         painter->restore();
         return;
     }
-    const int vh = vp->height();
-
-    const QPoint origin(margin, vh - margin);
-    const QPoint vTip(origin.x(), origin.y() - armLen);
-    const QPoint hTip(origin.x() + armLen, origin.y());
-
-    QPen pen(fg);
-    pen.setWidth(2);
-    pen.setCapStyle(Qt::RoundCap);
-    pen.setJoinStyle(Qt::RoundJoin);
-    painter->setPen(pen);
-    painter->setBrush(fg);
+    constexpr int margin = 8;
+    const QColor foreground(255, 255, 255, 230);
+    const QColor outline(0, 0, 0, 190);
     painter->setRenderHint(QPainter::Antialiasing);
 
-    painter->drawLine(origin, vTip);
-    QPolygon vHead;
-    vHead << QPoint(vTip.x(), vTip.y())
-          << QPoint(vTip.x() - headHalf, vTip.y() + headLen)
-          << QPoint(vTip.x() + headHalf, vTip.y() + headLen);
-    painter->drawPolygon(vHead);
+    if (!m_indicatorH.isEmpty() || !m_indicatorV.isEmpty()) {
+        constexpr int armLen = 26;
+        constexpr int headLen = 6;
+        constexpr int headHalf = 3;
+        const QPoint origin(margin, vp->height() - margin);
+        const QPoint vTip(origin.x(), origin.y() - armLen);
+        const QPoint hTip(origin.x() + armLen, origin.y());
 
-    painter->drawLine(origin, hTip);
-    QPolygon hHead;
-    hHead << QPoint(hTip.x(), hTip.y())
-          << QPoint(hTip.x() - headLen, hTip.y() - headHalf)
-          << QPoint(hTip.x() - headLen, hTip.y() + headHalf);
-    painter->drawPolygon(hHead);
+        QPen pen(foreground);
+        pen.setWidth(2);
+        pen.setCapStyle(Qt::RoundCap);
+        pen.setJoinStyle(Qt::RoundJoin);
+        painter->setPen(pen);
+        painter->setBrush(foreground);
 
-    QFont font;
-    font.setPointSize(11);
-    font.setBold(true);
-    painter->setFont(font);
-    painter->setPen(fg);
+        painter->drawLine(origin, vTip);
+        QPolygon vHead;
+        vHead << QPoint(vTip.x(), vTip.y())
+              << QPoint(vTip.x() - headHalf, vTip.y() + headLen)
+              << QPoint(vTip.x() + headHalf, vTip.y() + headLen);
+        painter->drawPolygon(vHead);
 
-    if (!m_indicatorH.isEmpty()) {
-        const auto fm = painter->fontMetrics();
-        const QRectF rect(hTip.x() + 4,
-            hTip.y() - fm.height() / 2.0, 40, fm.height());
-        painter->drawText(rect, Qt::AlignLeft | Qt::AlignVCenter,
-            m_indicatorH);
+        painter->drawLine(origin, hTip);
+        QPolygon hHead;
+        hHead << QPoint(hTip.x(), hTip.y())
+              << QPoint(hTip.x() - headLen, hTip.y() - headHalf)
+              << QPoint(hTip.x() - headLen, hTip.y() + headHalf);
+        painter->drawPolygon(hHead);
+
+        QFont font;
+        font.setPointSize(11);
+        font.setBold(true);
+        painter->setFont(font);
+        painter->setPen(foreground);
+
+        if (!m_indicatorH.isEmpty()) {
+            const auto fm = painter->fontMetrics();
+            const QRectF rect(hTip.x() + 4,
+                hTip.y() - fm.height() / 2.0, 40, fm.height());
+            painter->drawText(rect, Qt::AlignLeft | Qt::AlignVCenter,
+                m_indicatorH);
+        }
+        if (!m_indicatorV.isEmpty()) {
+            const auto fm = painter->fontMetrics();
+            const QRectF rect(vTip.x() - 20,
+                vTip.y() - headLen - fm.height() - 2, 40, fm.height());
+            painter->drawText(rect, Qt::AlignHCenter | Qt::AlignVCenter,
+                m_indicatorV);
+        }
     }
-    if (!m_indicatorV.isEmpty()) {
-        const auto fm = painter->fontMetrics();
-        const QRectF rect(vTip.x() - 20,
-            vTip.y() - headLen - fm.height() - 2, 40, fm.height());
-        painter->drawText(rect, Qt::AlignHCenter | Qt::AlignVCenter,
-            m_indicatorV);
+
+    if (m_scaleBarCmPerImagePixel > 0.0 && m_item != nullptr) {
+        const auto itemToViewport = m_item->deviceTransform(viewportTransform());
+        const auto imageBounds = itemToViewport.mapRect(m_item->boundingRect())
+                                     .intersected(QRectF(vp->rect()));
+        const auto p0 = itemToViewport.map(QPointF(0.0, 0.0));
+        const auto p1 = itemToViewport.map(QPointF(1.0, 0.0));
+        const double pixelsPerImagePixel = QLineF(p0, p1).length();
+        if (imageBounds.width() >= 40.0 && imageBounds.height() >= 36.0
+            && pixelsPerImagePixel > 0.0
+            && std::isfinite(pixelsPerImagePixel)) {
+            const double cmPerViewportPixel
+                = m_scaleBarCmPerImagePixel / pixelsPerImagePixel;
+            const double maximumPixels = imageBounds.width() * 0.25;
+            const auto bar = chooseScaleBar(
+                imageBounds.width() * cmPerViewportPixel,
+                maximumPixels * cmPerViewportPixel, maximumPixels);
+            if (bar) {
+                constexpr double inset = 12.0;
+                constexpr double tickHalfHeight = 4.0;
+                const double right = imageBounds.right() - inset;
+                const double left = right - bar->lengthPixels;
+                const double y = imageBounds.bottom() - inset;
+                const QLineF horizontal(left, y, right, y);
+                const QLineF leftTick(left, y - tickHalfHeight,
+                    left, y + tickHalfHeight);
+                const QLineF rightTick(right, y - tickHalfHeight,
+                    right, y + tickHalfHeight);
+
+                QPen halo(outline);
+                halo.setWidth(5);
+                halo.setCapStyle(Qt::FlatCap);
+                painter->setPen(halo);
+                painter->drawLines({horizontal, leftTick, rightTick});
+                QPen line(foreground);
+                line.setWidth(2);
+                line.setCapStyle(Qt::FlatCap);
+                painter->setPen(line);
+                painter->drawLines({horizontal, leftTick, rightTick});
+
+                QFont font = painter->font();
+                font.setPointSize(10);
+                font.setBold(true);
+                painter->setFont(font);
+                const QString label = QString::fromStdString(bar->label);
+                const auto fm = painter->fontMetrics();
+                const QRectF textRect(left - 20.0,
+                    y - tickHalfHeight - fm.height() - 2.0,
+                    bar->lengthPixels + 40.0, fm.height());
+                painter->setPen(outline);
+                painter->drawText(textRect.translated(1.0, 1.0),
+                    Qt::AlignHCenter | Qt::AlignVCenter, label);
+                painter->setPen(foreground);
+                painter->drawText(textRect,
+                    Qt::AlignHCenter | Qt::AlignVCenter, label);
+            }
+        }
     }
 
     painter->restore();
@@ -531,6 +602,7 @@ void ImageView::setPlaceholder(const QString& text)
     m_image = {};
     m_logicalSize = {};
     m_placement.reset();
+    m_scaleBarCmPerImagePixel = 0.0;
     m_placeholderText = text;
     setBackgroundBrush(palette().window());
     auto* label = m_scene->addText(text);

--- a/src/qt/ImageView.hpp
+++ b/src/qt/ImageView.hpp
@@ -130,6 +130,10 @@ public:
     // raster. Plotfile coordinates are interpreted as centimetres. A
     // non-positive or non-finite width clears the bar.
     void setScaleBarPhysicalWidth(double widthCm);
+    [[nodiscard]] bool hasScaleBar() const noexcept
+    {
+        return m_scaleBarCmPerImagePixel > 0.0;
+    }
     // Cosmetic red rectangle marking the cell picked in the dataset window;
     // std::nullopt clears it, and setImage/setPlaceholder drop it too. It
     // layers at z 4, above the overlay segments.

--- a/src/qt/ImageView.hpp
+++ b/src/qt/ImageView.hpp
@@ -126,6 +126,10 @@ public:
     // Small L-shaped axis indicator painted in the lower-left corner of the
     // viewport (not the scene), so it stays fixed regardless of zoom or pan.
     void setAxisIndicator(const QString& horizontal, const QString& vertical);
+    // Add a yt-style physical scale bar in the lower-right of the displayed
+    // raster. Plotfile coordinates are interpreted as centimetres. A
+    // non-positive or non-finite width clears the bar.
+    void setScaleBarPhysicalWidth(double widthCm);
     // Cosmetic red rectangle marking the cell picked in the dataset window;
     // std::nullopt clears it, and setImage/setPlaceholder drop it too. It
     // layers at z 4, above the overlay segments.
@@ -286,6 +290,7 @@ private:
     QGraphicsItem* m_cellHighlightItem = nullptr;
     QString m_indicatorH;
     QString m_indicatorV;
+    double m_scaleBarCmPerImagePixel = 0.0;
     QPoint m_pressPosition;
     QPoint m_lastPanPosition;
     QPointF m_panAccumulated;

--- a/src/qt/ImageView.hpp
+++ b/src/qt/ImageView.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "ScaleBar.hpp"
+
 #include <amrexplorer/pipeline/ImageTransformPolicy.hpp>
 
 #include <QGraphicsView>
@@ -126,13 +128,15 @@ public:
     // Small L-shaped axis indicator painted in the lower-left corner of the
     // viewport (not the scene), so it stays fixed regardless of zoom or pan.
     void setAxisIndicator(const QString& horizontal, const QString& vertical);
-    // Add a yt-style physical scale bar in the lower-right of the displayed
-    // raster. Plotfile coordinates are interpreted as centimetres. A
-    // non-positive or non-finite width clears the bar.
-    void setScaleBarPhysicalWidth(double widthCm);
+    // Add a scale bar in the lower-right of the displayed raster. The width is
+    // in native plotfile coordinates; an absent unit labels that native value
+    // as code units, while an explicit unit permits physical-unit conversion.
+    // A non-positive or non-finite width clears the bar.
+    void setScaleBarWidth(double widthCodeUnits,
+        std::optional<LengthUnit> lengthUnit = std::nullopt);
     [[nodiscard]] bool hasScaleBar() const noexcept
     {
-        return m_scaleBarCmPerImagePixel > 0.0;
+        return m_scaleBarCodeUnitsPerImagePixel > 0.0;
     }
     // Cosmetic red rectangle marking the cell picked in the dataset window;
     // std::nullopt clears it, and setImage/setPlaceholder drop it too. It
@@ -294,7 +298,8 @@ private:
     QGraphicsItem* m_cellHighlightItem = nullptr;
     QString m_indicatorH;
     QString m_indicatorV;
-    double m_scaleBarCmPerImagePixel = 0.0;
+    double m_scaleBarCodeUnitsPerImagePixel = 0.0;
+    std::optional<LengthUnit> m_scaleBarLengthUnit;
     QPoint m_pressPosition;
     QPoint m_lastPanPosition;
     QPointF m_panAccumulated;

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -1364,6 +1364,19 @@ void MainWindow::createMenus()
         }
         saveSettings();  // overlay/boxes
     });
+    m_scaleBarAction = new QAction(tr("Scale Bar"), this);
+    m_scaleBarAction->setCheckable(true);
+    m_scaleBarAction->setChecked(m_scaleBarVisible);
+    m_scaleBarAction->setEnabled(false);
+    connect(m_scaleBarAction, &QAction::toggled, this, [this](bool visible) {
+        m_scaleBarVisible = visible;
+        updateScaleBars();
+        saveSettings();  // overlay/scaleBar
+    });
+    auto* lengthUnitsAction = new QAction(tr("Length &Units..."), this);
+    lengthUnitsAction->setObjectName(QStringLiteral("lengthUnitsAction"));
+    connect(lengthUnitsAction, &QAction::triggered,
+        this, [this] { showLengthUnitsDialog(); });
     m_slicePlanesAction = new QAction(tr("Sl&ice Planes"), this);
     m_slicePlanesAction->setCheckable(true);
     m_slicePlanesAction->setEnabled(false);
@@ -1399,6 +1412,8 @@ void MainWindow::createMenus()
     viewMenu->addMenu(scaleMenu);
     viewMenu->addMenu(m_levelMenu);
     viewMenu->addAction(m_boxesAction);
+    viewMenu->addAction(m_scaleBarAction);
+    viewMenu->addAction(lengthUnitsAction);
     viewMenu->addAction(m_slicePlanesAction);
     viewMenu->addAction(m_volumeController->createAction(this));
     viewMenu->addMenu(paletteMenu);

--- a/src/qt/MainWindow.hpp
+++ b/src/qt/MainWindow.hpp
@@ -419,6 +419,7 @@ public:
     [[nodiscard]] std::array<int, 2> activeViewImageSizeForTest() const;
     [[nodiscard]] std::array<int, 2> activeViewViewportSizeForTest() const;
     [[nodiscard]] QImage activeViewViewportImageForTest() const;
+    [[nodiscard]] bool activeViewHasScaleBarForTest() const;
     [[nodiscard]] bool activeViewFitsWindowForTest() const;
 
     // Test-only: shrink the open dataset's cache budget to force cache-pressure

--- a/src/qt/MainWindow.hpp
+++ b/src/qt/MainWindow.hpp
@@ -1160,7 +1160,7 @@ private:
     // The saved preference is separate from the action's checked state:
     // anisotropic datasets force the action off without erasing what the user
     // selected for datasets on which a physical scale bar is meaningful.
-    bool m_scaleBarVisible = true;
+    bool m_scaleBarVisible = false;
     // Empty means the plotfile coordinate unit is unknown. Otherwise this is
     // one of ScaleBar.hpp's stable length-unit ids (cm, AU, pc, ...).
     QString m_lengthUnitId;

--- a/src/qt/MainWindow.hpp
+++ b/src/qt/MainWindow.hpp
@@ -889,6 +889,7 @@ private:
     void updateGridBoxes();
     void updateScaleBar(PlaneViewState& state);
     void updateScaleBars();
+    void resetLengthUnit();
     void updateCrosshairs(PlaneViewState& state);
     void updateCrosshairs();
     [[nodiscard]] QLineF planeSegmentToScene(const PlaneViewState& state,

--- a/src/qt/MainWindow.hpp
+++ b/src/qt/MainWindow.hpp
@@ -419,6 +419,8 @@ public:
     [[nodiscard]] std::array<int, 2> activeViewImageSizeForTest() const;
     [[nodiscard]] std::array<int, 2> activeViewViewportSizeForTest() const;
     [[nodiscard]] QImage activeViewViewportImageForTest() const;
+    void setScaleBarVisibleForTest(bool visible);
+    [[nodiscard]] bool scaleBarActionEnabledForTest() const;
     [[nodiscard]] bool activeViewHasScaleBarForTest() const;
     [[nodiscard]] bool activeViewFitsWindowForTest() const;
 
@@ -727,6 +729,8 @@ private:
         int wField, int contourColor);
     void showNumberFormatDialog();
     void applyNumberFormat(const QString& format);
+    void showLengthUnitsDialog();
+    void applyLengthUnit(const QString& unitId);
     void validateVectorMode();
     void ensureVectorFieldDefaults();
     void showDatasetWindow();
@@ -883,6 +887,8 @@ private:
     void updateOverlays();
     void updateGridBoxes(PlaneViewState& state);
     void updateGridBoxes();
+    void updateScaleBar(PlaneViewState& state);
+    void updateScaleBars();
     void updateCrosshairs(PlaneViewState& state);
     void updateCrosshairs();
     [[nodiscard]] QLineF planeSegmentToScene(const PlaneViewState& state,
@@ -1034,6 +1040,7 @@ private:
     DatasetWindow* m_datasetWindow = nullptr;
     SetContoursDialog* m_contoursDialog = nullptr;
     QDialog* m_numberFormatDialog = nullptr;
+    QDialog* m_lengthUnitsDialog = nullptr;
     UserGuideDialog* m_userGuideDialog = nullptr;
     QComboBox* m_fieldSelector = nullptr;
     QComboBox* m_levelSelector = nullptr;
@@ -1149,6 +1156,14 @@ private:
     // Window-owned so rebuildVariableMenu's clear() does not delete it.
     QAction* m_expressionEditorAction = nullptr;
     QAction* m_boxesAction = nullptr;
+    QAction* m_scaleBarAction = nullptr;
+    // The saved preference is separate from the action's checked state:
+    // anisotropic datasets force the action off without erasing what the user
+    // selected for datasets on which a physical scale bar is meaningful.
+    bool m_scaleBarVisible = true;
+    // Empty means the plotfile coordinate unit is unknown. Otherwise this is
+    // one of ScaleBar.hpp's stable length-unit ids (cm, AU, pc, ...).
+    QString m_lengthUnitId;
     QAction* m_slicePlanesAction = nullptr;
     QAction* m_resetZoomAction = nullptr;
     QAction* m_syncRubberBandZoomAction = nullptr;

--- a/src/qt/MainWindowDataset.cpp
+++ b/src/qt/MainWindowDataset.cpp
@@ -145,12 +145,6 @@ void MainWindow::restoreSettings()
             QStringLiteral("overlay/scaleBar"), false).toBool();
         m_scaleBarAction->setChecked(m_scaleBarVisible);
     }
-    {
-        const auto stored = settings.value(
-            QStringLiteral("scaleBar/lengthUnit")).toString();
-        m_lengthUnitId = lengthUnitFromId(stored.toStdString())
-            ? stored : QString{};
-    }
     if (m_sphericalSupersampleGroup != nullptr) {
         const auto stored = settings.value(
             QStringLiteral("spherical/supersample"), m_sphericalSupersample).toInt();
@@ -204,7 +198,7 @@ void MainWindow::saveSettings()
         m_boxesAction->isChecked());
     settings.setValue(QStringLiteral("overlay/scaleBar"),
         m_scaleBarVisible);
-    settings.setValue(QStringLiteral("scaleBar/lengthUnit"), m_lengthUnitId);
+    settings.remove(QStringLiteral("scaleBar/lengthUnit"));
     settings.setValue(QStringLiteral("spherical/supersample"),
         m_sphericalSupersample);
     settings.setValue(QStringLiteral("spherical/display"),
@@ -811,6 +805,7 @@ void MainWindow::openDatasetImpl(const std::filesystem::path& path,
     setPlaybackMode(PlaybackMode::None);
     closeSequence();
     resetRangeState();
+    resetLengthUnit();
     // The new dataset arrives fitted -- setPlaceholder below puts every view
     // back to Fit -- so the scale report has to come back with it. Without
     // this the toolbar kept claiming the previous dataset's "4x" over a fitted
@@ -888,10 +883,8 @@ void MainWindow::openDatasetImpl(const std::filesystem::path& path,
     // The particles dialog lists this dataset's species; the next one has its
     // own. (A sequence frame switch keeps it open -- the species are the same.)
     m_particleController->closeDialog();
-    // The Number Format and Length Units dialogs are deliberately *not* closed
-    // here. Unlike the contours dialog above, their settings are dataset-
-    // independent and persisted, so closing them on every open would only
-    // discard a selection the user had not yet applied.
+    // Number Format is dataset-independent and persisted, so its dialog stays
+    // open without discarding a selection the user had not yet applied.
     m_datasetPath = path;
     m_diagnosticsModel->resetDatasetMetrics();
     m_fieldSelector->setEnabled(false);

--- a/src/qt/MainWindowDataset.cpp
+++ b/src/qt/MainWindowDataset.cpp
@@ -139,6 +139,18 @@ void MainWindow::restoreSettings()
         m_boxesAction->setChecked(
             settings.value(QStringLiteral("overlay/boxes"), false).toBool());
     }
+    if (m_scaleBarAction != nullptr) {
+        const QSignalBlocker scaleBarBlocker(m_scaleBarAction);
+        m_scaleBarVisible = settings.value(
+            QStringLiteral("overlay/scaleBar"), true).toBool();
+        m_scaleBarAction->setChecked(m_scaleBarVisible);
+    }
+    {
+        const auto stored = settings.value(
+            QStringLiteral("scaleBar/lengthUnit")).toString();
+        m_lengthUnitId = lengthUnitFromId(stored.toStdString())
+            ? stored : QString{};
+    }
     if (m_sphericalSupersampleGroup != nullptr) {
         const auto stored = settings.value(
             QStringLiteral("spherical/supersample"), m_sphericalSupersample).toInt();
@@ -190,6 +202,9 @@ void MainWindow::saveSettings()
     // it looked persisted and was not.
     settings.setValue(QStringLiteral("overlay/boxes"),
         m_boxesAction->isChecked());
+    settings.setValue(QStringLiteral("overlay/scaleBar"),
+        m_scaleBarVisible);
+    settings.setValue(QStringLiteral("scaleBar/lengthUnit"), m_lengthUnitId);
     settings.setValue(QStringLiteral("spherical/supersample"),
         m_sphericalSupersample);
     settings.setValue(QStringLiteral("spherical/display"),
@@ -873,16 +888,17 @@ void MainWindow::openDatasetImpl(const std::filesystem::path& path,
     // The particles dialog lists this dataset's species; the next one has its
     // own. (A sequence frame switch keeps it open -- the species are the same.)
     m_particleController->closeDialog();
-    // The Number Format dialog is deliberately *not* closed here. Unlike the
-    // contours dialog above, its setting is dataset-independent and persisted,
-    // so closing it on every open only discarded whatever the user had typed
-    // but not yet applied.
+    // The Number Format and Length Units dialogs are deliberately *not* closed
+    // here. Unlike the contours dialog above, their settings are dataset-
+    // independent and persisted, so closing them on every open would only
+    // discard a selection the user had not yet applied.
     m_datasetPath = path;
     m_diagnosticsModel->resetDatasetMetrics();
     m_fieldSelector->setEnabled(false);
     m_levelSelector->setEnabled(false);
     m_range->setControlsReady(false);
     m_boxesAction->setEnabled(false);
+    m_scaleBarAction->setEnabled(false);
     m_slicePlanesAction->setEnabled(false);
     setSlicePositionControlsVisible(false);
     m_animationPanel->setSweepVisible(false);

--- a/src/qt/MainWindowDataset.cpp
+++ b/src/qt/MainWindowDataset.cpp
@@ -142,7 +142,7 @@ void MainWindow::restoreSettings()
     if (m_scaleBarAction != nullptr) {
         const QSignalBlocker scaleBarBlocker(m_scaleBarAction);
         m_scaleBarVisible = settings.value(
-            QStringLiteral("overlay/scaleBar"), true).toBool();
+            QStringLiteral("overlay/scaleBar"), false).toBool();
         m_scaleBarAction->setChecked(m_scaleBarVisible);
     }
     {

--- a/src/qt/MainWindowInteraction.cpp
+++ b/src/qt/MainWindowInteraction.cpp
@@ -182,7 +182,16 @@ void MainWindow::applyLengthUnit(const QString& unitId)
     }
     m_lengthUnitId = normalized;
     updateScaleBars();
-    saveSettings();
+}
+
+void MainWindow::resetLengthUnit()
+{
+    // Coordinate units belong to this dataset, including any unapplied choice.
+    if (m_lengthUnitsDialog != nullptr) {
+        m_lengthUnitsDialog->reject();
+    }
+    m_lengthUnitId.clear();
+    updateScaleBars();
 }
 
 void MainWindow::validateVectorMode()

--- a/src/qt/MainWindowInteraction.cpp
+++ b/src/qt/MainWindowInteraction.cpp
@@ -109,6 +109,82 @@ void MainWindow::applyNumberFormat(const QString& format)
     saveSettings();
 }
 
+void MainWindow::showLengthUnitsDialog()
+{
+    if (m_lengthUnitsDialog != nullptr) {
+        m_lengthUnitsDialog->raise();
+        m_lengthUnitsDialog->activateWindow();
+        return;
+    }
+    auto* dialog = new QDialog(this);
+    dialog->setAttribute(Qt::WA_DeleteOnClose);
+    dialog->setWindowTitle(tr("Length Units"));
+    dialog->setWindowFlags(Qt::Window);
+
+    auto* explanation = new QLabel(tr(
+        "Select the unit used by plotfile coordinates. Leave it unset to "
+        "display native code-unit lengths."), dialog);
+    explanation->setWordWrap(true);
+    auto* units = new QComboBox(dialog);
+    units->setObjectName(QStringLiteral("lengthUnitsCombo"));
+    units->addItem(tr("Native code units (unset)"), QString{});
+    for (const auto& candidate : lengthUnits) {
+        QString label;
+        switch (candidate.unit) {
+        case LengthUnit::Centimetre: label = tr("Centimetres (cm)"); break;
+        case LengthUnit::Metre: label = tr("Metres (m)"); break;
+        case LengthUnit::Kilometre: label = tr("Kilometres (km)"); break;
+        case LengthUnit::AstronomicalUnit:
+            label = tr("Astronomical units (AU)");
+            break;
+        case LengthUnit::Parsec: label = tr("Parsecs (pc)"); break;
+        case LengthUnit::Kiloparsec: label = tr("Kiloparsecs (kpc)"); break;
+        case LengthUnit::Megaparsec: label = tr("Megaparsecs (Mpc)"); break;
+        }
+        units->addItem(label, QString::fromStdString(std::string(candidate.id)));
+    }
+    const auto selected = units->findData(m_lengthUnitId);
+    units->setCurrentIndex(selected >= 0 ? selected : 0);
+
+    auto* buttons = new QDialogButtonBox(QDialogButtonBox::Ok
+        | QDialogButtonBox::Apply | QDialogButtonBox::Cancel, dialog);
+    auto* layout = new QVBoxLayout(dialog);
+    layout->addWidget(explanation);
+    layout->addWidget(units);
+    layout->addWidget(buttons);
+
+    connect(buttons, &QDialogButtonBox::clicked, dialog,
+        [this, dialog, units, buttons](QAbstractButton* button) {
+            const auto role = buttons->buttonRole(button);
+            if (role == QDialogButtonBox::AcceptRole
+                || role == QDialogButtonBox::ApplyRole) {
+                applyLengthUnit(units->currentData().toString());
+                if (role == QDialogButtonBox::AcceptRole) {
+                    dialog->accept();
+                }
+            } else if (role == QDialogButtonBox::RejectRole) {
+                dialog->reject();
+            }
+        });
+    connect(dialog, &QDialog::finished, this, [this] {
+        m_lengthUnitsDialog = nullptr;
+    });
+    m_lengthUnitsDialog = dialog;
+    dialog->show();
+}
+
+void MainWindow::applyLengthUnit(const QString& unitId)
+{
+    const auto normalized = lengthUnitFromId(unitId.toStdString())
+        ? unitId : QString{};
+    if (m_lengthUnitId == normalized) {
+        return;
+    }
+    m_lengthUnitId = normalized;
+    updateScaleBars();
+    saveSettings();
+}
+
 void MainWindow::validateVectorMode()
 {
     if (m_displayMode != DisplayMode::VelocityVectors) {
@@ -1589,6 +1665,11 @@ void MainWindow::closeEvent(QCloseEvent* event)
     if (m_numberFormatDialog != nullptr) {
         auto* dialog = m_numberFormatDialog;
         m_numberFormatDialog = nullptr;
+        dialog->close();
+    }
+    if (m_lengthUnitsDialog != nullptr) {
+        auto* dialog = m_lengthUnitsDialog;
+        m_lengthUnitsDialog = nullptr;
         dialog->close();
     }
     if (m_userGuideDialog != nullptr) {

--- a/src/qt/MainWindowSlice.cpp
+++ b/src/qt/MainWindowSlice.cpp
@@ -27,6 +27,19 @@ void populateLevelCombo(QComboBox* combo, int finestLevel)
     }
 }
 
+bool hasIsotropicCellSizes(const DatasetMetadata& metadata)
+{
+    for (const auto& level : metadata.levels) {
+        for (int axis = 1; axis < metadata.dimension; ++axis) {
+            if (level.cellSize[static_cast<std::size_t>(axis)]
+                != level.cellSize[0]) {
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
 } // namespace
 
 void MainWindow::enableDatasetControls(const DatasetMetadata& metadata)
@@ -36,6 +49,13 @@ void MainWindow::enableDatasetControls(const DatasetMetadata& metadata)
     m_levelSelector->setEnabled(true);
     m_range->setControlsReady(true);
     m_boxesAction->setEnabled(true);
+    const bool scaleBarAvailable = metadata.hasPhysicalGeometry
+        && hasIsotropicCellSizes(metadata);
+    {
+        const QSignalBlocker blocker(m_scaleBarAction);
+        m_scaleBarAction->setChecked(scaleBarAvailable && m_scaleBarVisible);
+    }
+    m_scaleBarAction->setEnabled(scaleBarAvailable);
     m_slicePlanesAction->setEnabled(metadata.dimension == 3);
     rebuildLevelMenu();
     m_levelMenu->setEnabled(true);
@@ -917,6 +937,31 @@ void MainWindow::updateGridBoxes()
     }
 }
 
+void MainWindow::updateScaleBar(PlaneViewState& state)
+{
+    double horizontalWidthCodeUnits = 0.0;
+    if (m_scaleBarAction->isEnabled() && m_scaleBarAction->isChecked()
+        && m_dataset && state.view->hasImage()
+        && m_dataset->metadata().hasPhysicalGeometry
+        && !(displayIsSpherical()
+            && state.sphericalDisplay == SphericalDisplay::ThetaR)) {
+        const auto horizontalAxis = displayIsSpherical()
+            ? std::size_t{0}
+            : static_cast<std::size_t>(displayAxes(state.normal)[0]);
+        horizontalWidthCodeUnits = state.displayRegion.upper[horizontalAxis]
+            - state.displayRegion.lower[horizontalAxis];
+    }
+    state.view->setScaleBarWidth(horizontalWidthCodeUnits,
+        lengthUnitFromId(m_lengthUnitId.toStdString()));
+}
+
+void MainWindow::updateScaleBars()
+{
+    for (auto* state : currentViews()) {
+        updateScaleBar(*state);
+    }
+}
+
 void MainWindow::updateCrosshairs(PlaneViewState& state)
 {
     std::optional<QLineF> vertical;
@@ -1241,21 +1286,11 @@ void MainWindow::showSlice(PlaneViewState& state, SliceDisplayResult display,
     state.coordinateSystem = display.coordinateSystem;
     state.sphericalDisplay = display.sphericalDisplay;
     state.displayRegion = display.displayRegion;
-    // AMReX plotfile coordinates are conventionally centimetres in the
-    // astrophysical datasets this annotation targets. Theta-r puts an angle
-    // on the horizontal axis, so a horizontal physical-length bar would be a
-    // lie in that one spherical layout; omit it there.
-    double horizontalWidthCm = 0.0;
-    if (m_dataset->metadata().hasPhysicalGeometry
-        && !(displayIsSpherical()
-            && state.sphericalDisplay == SphericalDisplay::ThetaR)) {
-        const auto horizontalAxis = displayIsSpherical()
-            ? std::size_t{0}
-            : static_cast<std::size_t>(displayAxes(state.normal)[0]);
-        horizontalWidthCm = state.displayRegion.upper[horizontalAxis]
-            - state.displayRegion.lower[horizontalAxis];
-    }
-    state.view->setScaleBarPhysicalWidth(horizontalWidthCm);
+    // The plotfile does not declare a length unit. The selected interpretation
+    // is applied only while formatting the annotation; this width stays in
+    // native coordinates. Theta-r puts an angle on the horizontal axis, so a
+    // horizontal length bar would be a lie in that spherical layout.
+    updateScaleBar(state);
     state.contourPlane
         = std::make_shared<const ScalarPlane>(std::move(display.contourPlane));
     state.contourPolylines = std::move(display.contourPolylines);

--- a/src/qt/MainWindowSlice.cpp
+++ b/src/qt/MainWindowSlice.cpp
@@ -1241,6 +1241,20 @@ void MainWindow::showSlice(PlaneViewState& state, SliceDisplayResult display,
     state.coordinateSystem = display.coordinateSystem;
     state.sphericalDisplay = display.sphericalDisplay;
     state.displayRegion = display.displayRegion;
+    // AMReX plotfile coordinates are conventionally centimetres in the
+    // astrophysical datasets this annotation targets. Theta-r puts an angle
+    // on the horizontal axis, so a horizontal physical-length bar would be a
+    // lie in that one spherical layout; omit it there.
+    double horizontalWidthCm = 0.0;
+    if (!(displayIsSpherical()
+            && state.sphericalDisplay == SphericalDisplay::ThetaR)) {
+        const auto horizontalAxis = displayIsSpherical()
+            ? std::size_t{0}
+            : static_cast<std::size_t>(displayAxes(state.normal)[0]);
+        horizontalWidthCm = state.displayRegion.upper[horizontalAxis]
+            - state.displayRegion.lower[horizontalAxis];
+    }
+    state.view->setScaleBarPhysicalWidth(horizontalWidthCm);
     state.contourPlane
         = std::make_shared<const ScalarPlane>(std::move(display.contourPlane));
     state.contourPolylines = std::move(display.contourPolylines);

--- a/src/qt/MainWindowSlice.cpp
+++ b/src/qt/MainWindowSlice.cpp
@@ -1246,7 +1246,8 @@ void MainWindow::showSlice(PlaneViewState& state, SliceDisplayResult display,
     // on the horizontal axis, so a horizontal physical-length bar would be a
     // lie in that one spherical layout; omit it there.
     double horizontalWidthCm = 0.0;
-    if (!(displayIsSpherical()
+    if (m_dataset->metadata().hasPhysicalGeometry
+        && !(displayIsSpherical()
             && state.sphericalDisplay == SphericalDisplay::ThetaR)) {
         const auto horizontalAxis = displayIsSpherical()
             ? std::size_t{0}

--- a/src/qt/MainWindowSlice.cpp
+++ b/src/qt/MainWindowSlice.cpp
@@ -1766,6 +1766,7 @@ void MainWindow::prepareSequence(std::size_t frameCount)
     setPlaybackMode(PlaybackMode::None);
     closeSequence();
     resetRangeState();
+    resetLengthUnit();
     m_fabNavigator->reset();
     m_particleController->cancel();
     m_particleController->clearSamples();

--- a/src/qt/MainWindowTestAccess.cpp
+++ b/src/qt/MainWindowTestAccess.cpp
@@ -364,6 +364,16 @@ void MainWindow::setGridBoxesVisibleForTest(bool visible)
     m_boxesAction->setChecked(visible);
 }
 
+void MainWindow::setScaleBarVisibleForTest(bool visible)
+{
+    m_scaleBarAction->setChecked(visible);
+}
+
+bool MainWindow::scaleBarActionEnabledForTest() const
+{
+    return m_scaleBarAction->isEnabled();
+}
+
 std::size_t MainWindow::activeViewGridBoxCountForTest() const
 {
     return m_activeView == nullptr

--- a/src/qt/MainWindowTestAccess.cpp
+++ b/src/qt/MainWindowTestAccess.cpp
@@ -803,6 +803,11 @@ QImage MainWindow::activeViewViewportImageForTest() const
     return m_activeView->view->viewport()->grab().toImage();
 }
 
+bool MainWindow::activeViewHasScaleBarForTest() const
+{
+    return m_activeView != nullptr && m_activeView->view->hasScaleBar();
+}
+
 bool MainWindow::activeViewFitsWindowForTest() const
 {
     return m_activeView != nullptr && m_activeView->view->hasImage()

--- a/src/qt/ScaleBar.hpp
+++ b/src/qt/ScaleBar.hpp
@@ -1,0 +1,78 @@
+#pragma once
+
+#include <array>
+#include <cmath>
+#include <iomanip>
+#include <limits>
+#include <locale>
+#include <optional>
+#include <sstream>
+#include <string>
+#include <utility>
+
+namespace amrvis::qt {
+
+struct ScaleBarSpec {
+    double lengthCm = 0.0;
+    double lengthPixels = 0.0;
+    std::string label;
+};
+
+// Choose a 1/2/5 x 10^n length no longer than the available screen width.
+// The unit follows the whole visible physical scale, rather than the shorter
+// bar itself: a parsec-wide view should say "0.2 pc", not "40000 AU".
+[[nodiscard]] inline std::optional<ScaleBarSpec>
+chooseScaleBar(double visibleWidthCm, double maximumLengthCm, double maximumPixels) {
+    if (!(visibleWidthCm > 0.0) || !std::isfinite(visibleWidthCm) || !(maximumLengthCm > 0.0) ||
+        !std::isfinite(maximumLengthCm) || !(maximumPixels > 0.0) ||
+        !std::isfinite(maximumPixels)) {
+        return std::nullopt;
+    }
+
+    constexpr double astronomicalUnitCm = 1.495978707e13;
+    constexpr double parsecCm = 3.0856775814913673e18;
+    constexpr std::array units{
+        std::pair{1.0, "cm"},
+        std::pair{astronomicalUnitCm, "AU"},
+        std::pair{parsecCm, "pc"},
+        std::pair{1000.0 * parsecCm, "kpc"},
+    };
+
+    const auto* unit = &units.front();
+    for (const auto& candidate : units) {
+        if (visibleWidthCm >= candidate.first) {
+            unit = &candidate;
+        }
+    }
+
+    const double maximumInUnit = maximumLengthCm / unit->first;
+    if (!(maximumInUnit > 0.0) || !std::isfinite(maximumInUnit)) {
+        return std::nullopt;
+    }
+    const double decade = std::pow(10.0, std::floor(std::log10(maximumInUnit)));
+    if (!(decade > 0.0) || !std::isfinite(decade)) {
+        return std::nullopt;
+    }
+    double nice = decade;
+    for (const double multiplier : {1.0, 2.0, 5.0}) {
+        const double candidate = multiplier * decade;
+        if (candidate <= maximumInUnit ||
+            std::abs(candidate - maximumInUnit) <=
+                std::numeric_limits<double>::epsilon() * maximumInUnit) {
+            nice = candidate;
+        }
+    }
+
+    const double lengthCm = nice * unit->first;
+    const double lengthPixels = maximumPixels * lengthCm / maximumLengthCm;
+    if (!(lengthPixels > 0.0) || !std::isfinite(lengthPixels)) {
+        return std::nullopt;
+    }
+
+    std::ostringstream label;
+    label.imbue(std::locale::classic());
+    label << std::setprecision(3) << std::defaultfloat << nice << ' ' << unit->second;
+    return ScaleBarSpec{lengthCm, lengthPixels, label.str()};
+}
+
+} // namespace amrvis::qt

--- a/src/qt/ScaleBar.hpp
+++ b/src/qt/ScaleBar.hpp
@@ -8,44 +8,105 @@
 #include <optional>
 #include <sstream>
 #include <string>
-#include <utility>
+#include <string_view>
 
 namespace amrvis::qt {
 
+enum class LengthUnit {
+    Centimetre,
+    Metre,
+    Kilometre,
+    AstronomicalUnit,
+    Parsec,
+    Kiloparsec,
+    Megaparsec,
+};
+
+struct LengthUnitSpec {
+    LengthUnit unit;
+    double centimetresPerUnit;
+    std::string_view id;
+};
+
+inline constexpr double astronomicalUnitCm = 1.495978707e13;
+inline constexpr double parsecCm = 3.0856775814913673e18;
+inline constexpr std::array lengthUnits{
+    LengthUnitSpec{LengthUnit::Centimetre, 1.0, "cm"},
+    LengthUnitSpec{LengthUnit::Metre, 100.0, "m"},
+    LengthUnitSpec{LengthUnit::Kilometre, 1.0e5, "km"},
+    LengthUnitSpec{LengthUnit::AstronomicalUnit, astronomicalUnitCm, "AU"},
+    LengthUnitSpec{LengthUnit::Parsec, parsecCm, "pc"},
+    LengthUnitSpec{LengthUnit::Kiloparsec, 1.0e3 * parsecCm, "kpc"},
+    LengthUnitSpec{LengthUnit::Megaparsec, 1.0e6 * parsecCm, "Mpc"},
+};
+
+[[nodiscard]] inline std::optional<LengthUnit> lengthUnitFromId(
+    std::string_view id)
+{
+    for (const auto& candidate : lengthUnits) {
+        if (candidate.id == id) {
+            return candidate.unit;
+        }
+    }
+    return std::nullopt;
+}
+
+[[nodiscard]] inline const LengthUnitSpec& lengthUnitSpec(LengthUnit unit)
+{
+    for (const auto& candidate : lengthUnits) {
+        if (candidate.unit == unit) {
+            return candidate;
+        }
+    }
+    return lengthUnits.front();
+}
+
 struct ScaleBarSpec {
-    double lengthCm = 0.0;
+    double lengthCodeUnits = 0.0;
     double lengthPixels = 0.0;
     std::string label;
 };
 
 // Choose a 1/2/5 x 10^n length no longer than the available screen width.
-// The unit follows the whole visible physical scale, rather than the shorter
-// bar itself: a parsec-wide view should say "0.2 pc", not "40000 AU".
+// Without an explicitly selected plotfile unit, preserve native coordinate
+// values and say so in scientific notation. With one, the displayed unit
+// follows the whole visible physical scale rather than the shorter bar itself:
+// a parsec-wide view should say "0.2 pc", not "40000 AU".
 [[nodiscard]] inline std::optional<ScaleBarSpec>
-chooseScaleBar(double visibleWidthCm, double maximumLengthCm, double maximumPixels) {
-    if (!(visibleWidthCm > 0.0) || !std::isfinite(visibleWidthCm) || !(maximumLengthCm > 0.0) ||
-        !std::isfinite(maximumLengthCm) || !(maximumPixels > 0.0) ||
+chooseScaleBar(double visibleWidthCodeUnits, double maximumLengthCodeUnits,
+    double maximumPixels, std::optional<LengthUnit> codeUnit = std::nullopt) {
+    if (!(visibleWidthCodeUnits > 0.0)
+        || !std::isfinite(visibleWidthCodeUnits)
+        || !(maximumLengthCodeUnits > 0.0)
+        || !std::isfinite(maximumLengthCodeUnits) || !(maximumPixels > 0.0) ||
         !std::isfinite(maximumPixels)) {
         return std::nullopt;
     }
 
-    constexpr double astronomicalUnitCm = 1.495978707e13;
-    constexpr double parsecCm = 3.0856775814913673e18;
-    constexpr std::array units{
-        std::pair{1.0, "cm"},
-        std::pair{astronomicalUnitCm, "AU"},
-        std::pair{parsecCm, "pc"},
-        std::pair{1000.0 * parsecCm, "kpc"},
-    };
-
-    const auto* unit = &units.front();
-    for (const auto& candidate : units) {
-        if (visibleWidthCm >= candidate.first) {
-            unit = &candidate;
+    double maximumInUnit = maximumLengthCodeUnits;
+    double displayedUnitsPerCodeUnit = 1.0;
+    std::string_view displayedUnit;
+    if (codeUnit) {
+        const double centimetresPerCodeUnit
+            = lengthUnitSpec(*codeUnit).centimetresPerUnit;
+        const double visibleWidthCm
+            = visibleWidthCodeUnits * centimetresPerCodeUnit;
+        if (!(visibleWidthCm > 0.0) || !std::isfinite(visibleWidthCm)) {
+            return std::nullopt;
         }
+        const auto* unit = &lengthUnits.front();
+        for (const auto& candidate : lengthUnits) {
+            if (visibleWidthCm >= candidate.centimetresPerUnit) {
+                unit = &candidate;
+            }
+        }
+        displayedUnitsPerCodeUnit
+            = centimetresPerCodeUnit / unit->centimetresPerUnit;
+        maximumInUnit
+            = maximumLengthCodeUnits * displayedUnitsPerCodeUnit;
+        displayedUnit = unit->id;
     }
 
-    const double maximumInUnit = maximumLengthCm / unit->first;
     if (!(maximumInUnit > 0.0) || !std::isfinite(maximumInUnit)) {
         return std::nullopt;
     }
@@ -63,16 +124,23 @@ chooseScaleBar(double visibleWidthCm, double maximumLengthCm, double maximumPixe
         }
     }
 
-    const double lengthCm = nice * unit->first;
-    const double lengthPixels = maximumPixels * lengthCm / maximumLengthCm;
+    const double lengthCodeUnits = nice / displayedUnitsPerCodeUnit;
+    const double lengthPixels
+        = maximumPixels * lengthCodeUnits / maximumLengthCodeUnits;
     if (!(lengthPixels > 0.0) || !std::isfinite(lengthPixels)) {
         return std::nullopt;
     }
 
     std::ostringstream label;
     label.imbue(std::locale::classic());
-    label << std::setprecision(3) << std::defaultfloat << nice << ' ' << unit->second;
-    return ScaleBarSpec{lengthCm, lengthPixels, label.str()};
+    if (codeUnit) {
+        label << std::setprecision(3) << std::defaultfloat << nice << ' '
+              << displayedUnit;
+    } else {
+        label << std::scientific << std::setprecision(3) << nice
+              << " code units";
+    }
+    return ScaleBarSpec{lengthCodeUnits, lengthPixels, label.str()};
 }
 
 } // namespace amrvis::qt

--- a/src/qt/SmokeHarnessFab.cpp
+++ b/src/qt/SmokeHarnessFab.cpp
@@ -236,7 +236,8 @@ Outcome dispatchFab(Context& context)
                     && fabSelectorIsAscending(*selector)
                     && fabSelectorColumnsMatch(*selector, false)
                     && fabSelectorPointFilterMatches(*selector, *phase == 0)
-                    && fabRangeSelectorMatches(window);
+                    && fabRangeSelectorMatches(window)
+                    && !window.activeViewHasScaleBarForTest();
                 if (!valid) {
                     application.exit(1);
                 } else if ((*phase)++ == 0) {
@@ -262,7 +263,8 @@ Outcome dispatchFab(Context& context)
                     || !fabSelectorIsAscending(*selector)
                     || !fabSelectorColumnsMatch(*selector, true)
                     || !fabSelectorPointFilterMatches(
-                        *selector, *phase == 0)) {
+                        *selector, *phase == 0)
+                    || window.activeViewHasScaleBarForTest()) {
                     application.exit(1);
                     return;
                 }

--- a/src/qt/SmokeHarnessRange.cpp
+++ b/src/qt/SmokeHarnessRange.cpp
@@ -151,8 +151,32 @@ Outcome dispatchRange(Context& context)
         const std::filesystem::path path(argv[2]);
         QObject::connect(&window, &amrvis::qt::MainWindow::initialSliceFinished,
             &application, [&window, &application](bool success) {
-                const auto valid = success
-                    && rangeSelectorMatches(window, true);
+                const auto initiallyVisible =
+                    window.activeViewHasScaleBarForTest();
+                const auto actionEnabled =
+                    window.scaleBarActionEnabledForTest();
+                auto* lengthUnitsAction = window.findChild<QAction*>(
+                    QStringLiteral("lengthUnitsAction"));
+                if (lengthUnitsAction != nullptr) {
+                    lengthUnitsAction->trigger();
+                    QApplication::processEvents();
+                }
+                auto* lengthUnits = window.findChild<QComboBox*>(
+                    QStringLiteral("lengthUnitsCombo"));
+                const auto unitsUnsetByDefault = lengthUnits != nullptr
+                    && lengthUnits->currentData().toString().isEmpty();
+                if (auto* dialog = qobject_cast<QDialog*>(
+                        lengthUnits == nullptr ? nullptr
+                                               : lengthUnits->window())) {
+                    dialog->reject();
+                }
+                window.setScaleBarVisibleForTest(false);
+                const auto hidden = !window.activeViewHasScaleBarForTest();
+                window.setScaleBarVisibleForTest(true);
+                const auto restored = window.activeViewHasScaleBarForTest();
+                const auto valid = success && rangeSelectorMatches(window, true)
+                    && actionEnabled && unitsUnsetByDefault && initiallyVisible
+                    && hidden && restored;
                 application.exit(valid ? 0 : 1);
         });
         QTimer::singleShot(0, &window, [&window, path] { window.openDataset(path); });

--- a/src/qt/SmokeHarnessRange.cpp
+++ b/src/qt/SmokeHarnessRange.cpp
@@ -161,13 +161,13 @@ Outcome dispatchRange(Context& context)
                     lengthUnitsAction->trigger();
                     QApplication::processEvents();
                 }
-                auto* lengthUnits = window.findChild<QComboBox*>(
+                auto* lengthUnitsCombo = window.findChild<QComboBox*>(
                     QStringLiteral("lengthUnitsCombo"));
-                const auto unitsUnsetByDefault = lengthUnits != nullptr
-                    && lengthUnits->currentData().toString().isEmpty();
+                const auto unitsUnsetByDefault = lengthUnitsCombo != nullptr
+                    && lengthUnitsCombo->currentData().toString().isEmpty();
                 if (auto* dialog = qobject_cast<QDialog*>(
-                        lengthUnits == nullptr ? nullptr
-                                               : lengthUnits->window())) {
+                        lengthUnitsCombo == nullptr ? nullptr
+                                                    : lengthUnitsCombo->window())) {
                     dialog->reject();
                 }
                 window.setScaleBarVisibleForTest(false);

--- a/src/qt/SmokeHarnessRange.cpp
+++ b/src/qt/SmokeHarnessRange.cpp
@@ -1,5 +1,6 @@
 #include "SmokeHarnessInternal.hpp"
 
+#include "AppSettings.hpp"
 #include "MainWindow.hpp"
 
 #include <amrexplorer/render2d/Contours.hpp>
@@ -149,10 +150,12 @@ Outcome dispatchRange(Context& context)
         });
     } else if (argc == 3 && std::string_view(argv[1]) == "--slice-smoke-test") {
         const std::filesystem::path path(argv[2]);
+        const auto expectedScaleBarVisible = makeSettings().value(
+            QStringLiteral("overlay/scaleBar"), false).toBool();
         QObject::connect(&window, &amrvis::qt::MainWindow::initialSliceFinished,
-            &application, [&window, &application](bool success) {
-                const auto initiallyVisible =
-                    window.activeViewHasScaleBarForTest();
+            &application, [&window, &application, expectedScaleBarVisible](bool success) {
+                const auto initialVisibilityMatches =
+                    window.activeViewHasScaleBarForTest() == expectedScaleBarVisible;
                 const auto actionEnabled =
                     window.scaleBarActionEnabledForTest();
                 auto* lengthUnitsAction = window.findChild<QAction*>(
@@ -170,13 +173,14 @@ Outcome dispatchRange(Context& context)
                                                     : lengthUnitsCombo->window())) {
                     dialog->reject();
                 }
+                window.setScaleBarVisibleForTest(true);
+                const auto shown = window.activeViewHasScaleBarForTest();
                 window.setScaleBarVisibleForTest(false);
                 const auto hidden = !window.activeViewHasScaleBarForTest();
-                window.setScaleBarVisibleForTest(true);
-                const auto restored = window.activeViewHasScaleBarForTest();
+                window.setScaleBarVisibleForTest(expectedScaleBarVisible);
                 const auto valid = success && rangeSelectorMatches(window, true)
-                    && actionEnabled && unitsUnsetByDefault && initiallyVisible
-                    && hidden && restored;
+                    && actionEnabled && unitsUnsetByDefault && initialVisibilityMatches
+                    && shown && hidden;
                 application.exit(valid ? 0 : 1);
         });
         QTimer::singleShot(0, &window, [&window, path] { window.openDataset(path); });

--- a/src/qt/SmokeHarnessRange.cpp
+++ b/src/qt/SmokeHarnessRange.cpp
@@ -153,7 +153,8 @@ Outcome dispatchRange(Context& context)
         const auto expectedScaleBarVisible = makeSettings().value(
             QStringLiteral("overlay/scaleBar"), false).toBool();
         QObject::connect(&window, &amrvis::qt::MainWindow::initialSliceFinished,
-            &application, [&window, &application, expectedScaleBarVisible](bool success) {
+            &application, [&window, &application, expectedScaleBarVisible,
+                              path, reopened = false](bool success) mutable {
                 const auto initialVisibilityMatches =
                     window.activeViewHasScaleBarForTest() == expectedScaleBarVisible;
                 const auto actionEnabled =
@@ -168,6 +169,21 @@ Outcome dispatchRange(Context& context)
                     QStringLiteral("lengthUnitsCombo"));
                 const auto unitsUnsetByDefault = lengthUnitsCombo != nullptr
                     && lengthUnitsCombo->currentData().toString().isEmpty();
+                if (success && unitsUnsetByDefault && !reopened) {
+                    auto* dialog = qobject_cast<QDialog*>(lengthUnitsCombo->window());
+                    auto* buttons = dialog->findChild<QDialogButtonBox*>();
+                    lengthUnitsCombo->setCurrentIndex(
+                        lengthUnitsCombo->findData(QStringLiteral("pc")));
+                    buttons->button(QDialogButtonBox::Apply)->click();
+                    // Keep an unapplied choice in the open dialog as well.
+                    lengthUnitsCombo->setCurrentIndex(
+                        lengthUnitsCombo->findData(QStringLiteral("kpc")));
+                    reopened = true;
+                    QTimer::singleShot(0, &window, [&window, path] {
+                        window.openDataset(path);
+                    });
+                    return;
+                }
                 if (auto* dialog = qobject_cast<QDialog*>(
                         lengthUnitsCombo == nullptr ? nullptr
                                                     : lengthUnitsCombo->window())) {

--- a/src/qt/SmokeHarnessRemote.cpp
+++ b/src/qt/SmokeHarnessRemote.cpp
@@ -453,6 +453,12 @@ Outcome dispatchRemote(Context& context)
                     application.exit(1);
                     return;
                 }
+                if (window.scaleBarActionEnabledForTest()
+                    || window.activeViewHasScaleBarForTest()) {
+                    qCritical("the scale bar was available for anisotropic cells");
+                    application.exit(1);
+                    return;
+                }
                 QObject::connect(&window,
                     &amrvis::qt::MainWindow::interactiveSlicesSettled,
                     &application, [&window, &application, phase] {

--- a/tests/unit/test_image_view_pan.cpp
+++ b/tests/unit/test_image_view_pan.cpp
@@ -84,6 +84,28 @@ void scaleBarIsPaintedOverTheSlice()
         "setting a physical width did not paint a visible scale bar");
 }
 
+void scaleBarIsPaintedIntoExportedComposition()
+{
+    amrvis::qt::ImageView view;
+    view.setImage(solidImage(400, 300));
+    const QImage withoutBar = view.composedImage();
+
+    constexpr double pc = 3.0856775814913673e18;
+    view.setScaleBarPhysicalWidth(4.0 * pc);
+    const QImage withBar = view.composedImage();
+
+    require(withBar.size() == withoutBar.size(),
+        "painting the scale bar changed the export size");
+    int changed = 0;
+    for (int y = 0; y < withBar.height(); ++y) {
+        for (int x = withBar.width() / 2; x < withBar.width(); ++x) {
+            changed += withBar.pixel(x, y) != withoutBar.pixel(x, y) ? 1 : 0;
+        }
+    }
+    require(changed > 50,
+        "the exported composition omitted the visible scale bar");
+}
+
 // A scene larger than the viewport pans by its scroll bars, and the delta says
 // how far the *content* moves: content travelling +x backs the bar off by the
 // same amount. MainWindow's arrow-key step and its drag handler both hand
@@ -342,6 +364,7 @@ int main(int argc, char* argv[])
     QApplication application(argc, argv);
     scaleBarUsesNaturalAstrophysicalUnits();
     scaleBarIsPaintedOverTheSlice();
+    scaleBarIsPaintedIntoExportedComposition();
     scrollBarPanFollowsContentDelta();
     fullyVisibleSceneIgnoresPan();
     arrowKeysRequestPanOnlyWhenFocusedWithAnImage();

--- a/tests/unit/test_image_view_pan.cpp
+++ b/tests/unit/test_image_view_pan.cpp
@@ -30,27 +30,32 @@ QImage solidImage(int width, int height)
     return image;
 }
 
-void scaleBarUsesNaturalAstrophysicalUnits()
+void scaleBarUsesNativeOrExplicitUnits()
 {
     constexpr double au = 1.495978707e13;
     constexpr double pc = 3.0856775814913673e18;
 
-    const auto centimetres = amrvis::qt::chooseScaleBar(8.0e12, 2.4e12, 120.0);
-    require(centimetres && centimetres->label == "2e+12 cm",
-        "a sub-AU view did not use centimetres");
+    const auto native = amrvis::qt::chooseScaleBar(8.0, 2.4, 120.0);
+    require(native && native->label == "2.000e+00 code units",
+        "an unset unit did not preserve the native scale in scientific notation");
+
+    const auto centimetres = amrvis::qt::chooseScaleBar(8.0e12, 2.4e12,
+        120.0, amrvis::qt::LengthUnit::Centimetre);
+    require(centimetres && centimetres->label == "2e+07 km",
+        "an explicit centimetre scale did not convert to a natural unit");
 
     const auto astronomical = amrvis::qt::chooseScaleBar(8.0 * au,
-        2.4 * au, 120.0);
+        2.4 * au, 120.0, amrvis::qt::LengthUnit::Centimetre);
     require(astronomical && astronomical->label == "2 AU",
         "an AU-scale view did not use AU");
 
     const auto parsecs = amrvis::qt::chooseScaleBar(1.0 * pc,
-        0.26 * pc, 130.0);
+        0.26 * pc, 130.0, amrvis::qt::LengthUnit::Centimetre);
     require(parsecs && parsecs->label == "0.2 pc",
         "a parsec-scale view did not use pc");
 
     const auto kiloparsecs = amrvis::qt::chooseScaleBar(4.0e3 * pc,
-        1.2e3 * pc, 120.0);
+        1.2e3 * pc, 120.0, amrvis::qt::LengthUnit::Centimetre);
     require(kiloparsecs && kiloparsecs->label == "1 kpc",
         "a kiloparsec-scale view did not use kpc");
 
@@ -68,7 +73,7 @@ void scaleBarIsPaintedOverTheSlice()
     const QImage withoutBar = view.viewport()->grab().toImage();
 
     constexpr double pc = 3.0856775814913673e18;
-    view.setScaleBarPhysicalWidth(4.0 * pc);
+    view.setScaleBarWidth(4.0 * pc, amrvis::qt::LengthUnit::Centimetre);
     QApplication::processEvents();
     const QImage withBar = view.viewport()->grab().toImage();
 
@@ -91,7 +96,7 @@ void scaleBarIsPaintedIntoExportedComposition()
     const QImage withoutBar = view.composedImage();
 
     constexpr double pc = 3.0856775814913673e18;
-    view.setScaleBarPhysicalWidth(4.0 * pc);
+    view.setScaleBarWidth(4.0 * pc, amrvis::qt::LengthUnit::Centimetre);
     const QImage withBar = view.composedImage();
 
     require(withBar.size() == withoutBar.size(),
@@ -362,7 +367,7 @@ void tearingDownTheSceneForgetsThePointTally()
 int main(int argc, char* argv[])
 {
     QApplication application(argc, argv);
-    scaleBarUsesNaturalAstrophysicalUnits();
+    scaleBarUsesNativeOrExplicitUnits();
     scaleBarIsPaintedOverTheSlice();
     scaleBarIsPaintedIntoExportedComposition();
     scrollBarPanFollowsContentDelta();

--- a/tests/unit/test_image_view_pan.cpp
+++ b/tests/unit/test_image_view_pan.cpp
@@ -1,4 +1,5 @@
 #include "ImageView.hpp"
+#include "ScaleBar.hpp"
 
 #include <QApplication>
 #include <QImage>
@@ -27,6 +28,60 @@ QImage solidImage(int width, int height)
     QImage image(width, height, QImage::Format_RGB32);
     image.fill(Qt::black);
     return image;
+}
+
+void scaleBarUsesNaturalAstrophysicalUnits()
+{
+    constexpr double au = 1.495978707e13;
+    constexpr double pc = 3.0856775814913673e18;
+
+    const auto centimetres = amrvis::qt::chooseScaleBar(8.0e12, 2.4e12, 120.0);
+    require(centimetres && centimetres->label == "2e+12 cm",
+        "a sub-AU view did not use centimetres");
+
+    const auto astronomical = amrvis::qt::chooseScaleBar(8.0 * au,
+        2.4 * au, 120.0);
+    require(astronomical && astronomical->label == "2 AU",
+        "an AU-scale view did not use AU");
+
+    const auto parsecs = amrvis::qt::chooseScaleBar(1.0 * pc,
+        0.26 * pc, 130.0);
+    require(parsecs && parsecs->label == "0.2 pc",
+        "a parsec-scale view did not use pc");
+
+    const auto kiloparsecs = amrvis::qt::chooseScaleBar(4.0e3 * pc,
+        1.2e3 * pc, 120.0);
+    require(kiloparsecs && kiloparsecs->label == "1 kpc",
+        "a kiloparsec-scale view did not use kpc");
+
+    require(!amrvis::qt::chooseScaleBar(0.0, 1.0, 100.0),
+        "a zero-width view produced a scale bar");
+}
+
+void scaleBarIsPaintedOverTheSlice()
+{
+    amrvis::qt::ImageView view;
+    view.resize(400, 300);
+    view.show();
+    view.setImage(solidImage(400, 300));
+    QApplication::processEvents();
+    const QImage withoutBar = view.viewport()->grab().toImage();
+
+    constexpr double pc = 3.0856775814913673e18;
+    view.setScaleBarPhysicalWidth(4.0 * pc);
+    QApplication::processEvents();
+    const QImage withBar = view.viewport()->grab().toImage();
+
+    require(withBar.size() == withoutBar.size(),
+        "painting the scale bar changed the viewport size");
+    int changed = 0;
+    for (int y = 0; y < withBar.height(); ++y) {
+        for (int x = withBar.width() / 2; x < withBar.width(); ++x) {
+            changed += withBar.pixel(x, y) != withoutBar.pixel(x, y) ? 1 : 0;
+        }
+    }
+    require(changed > 50,
+        "setting a physical width did not paint a visible scale bar");
 }
 
 // A scene larger than the viewport pans by its scroll bars, and the delta says
@@ -285,6 +340,8 @@ void tearingDownTheSceneForgetsThePointTally()
 int main(int argc, char* argv[])
 {
     QApplication application(argc, argv);
+    scaleBarUsesNaturalAstrophysicalUnits();
+    scaleBarIsPaintedOverTheSlice();
     scrollBarPanFollowsContentDelta();
     fullyVisibleSceneIgnoresPan();
     arrowKeysRequestPanOnlyWhenFocusedWithAnImage();


### PR DESCRIPTION
Adds a yt-style length scale bar in the 2D slice views.

We need a way to specify the physical units of the plotfile axes. Currently, it assumes they are all cm.