### PR TITLE
Add symlog colorbar scaling option

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ FAB and MultiFab data.
 - Plotfile-sequence and plane-sweep animation
 - Remote plotfiles and sequences: the client runs its server on the remote
   machine through ssh, no ports or tunnels involved
-- Multiple palettes, logarithmic and user-defined ranges, and PNG/FITS/MP4 export
+- Multiple palettes, logarithmic/symmetric-log and user-defined ranges, and PNG/FITS/MP4 export
 
 ## Documentation
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -533,6 +533,15 @@ Enable **Log** for logarithmic color mapping. The displayed range must have a
 positive minimum. If it does not, AMReXplorer falls back to linear mapping and
 turns **Log** off; use a positive user minimum when necessary.
 
+Enable **Symlog** for Matplotlib-style symmetric logarithmic mapping across
+positive, negative, and zero values. Values from `-linthresh` to `+linthresh`
+are linear; larger magnitudes use base-10 logarithmic mapping in both
+directions. Set **linthresh** to a finite positive value in the field's units.
+The first time Symlog is enabled for a field, AMReXplorer chooses a round
+power of ten two decades below the largest absolute displayed bound. For
+example, a range extending to `7e-8` starts with `linthresh=1e-10`. An edited
+threshold is remembered for that field for the rest of the dataset session.
+
 Built-in palettes include rainbow, turbo, viridis, plasma, parula, coolwarm,
 and blackbody. Use **View > Palette > Load Palette File...** to load a custom
 `.pal` file: a legacy Amrvis sequential palette of 256 red, green and blue

--- a/include/amrexplorer/core/Statistics.hpp
+++ b/include/amrexplorer/core/Statistics.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <amrexplorer/core/ValueMapping.hpp>
 
 #include <amrexplorer/core/Metadata.hpp>
 #include <amrexplorer/core/Request.hpp>
@@ -29,7 +30,7 @@ struct ValueRange {
 // in DisplayCoordinator, and only two of them knew about logarithmic ranges.
 // It lives in core because the data layer resolves a volume's visible range
 // with it too.
-[[nodiscard]] std::pair<double, double> paddedIfDegenerate(
-    double minimum, double maximum, bool logarithmic) noexcept;
+[[nodiscard]] std::pair<double, double> paddedIfDegenerate(double minimum, double maximum,
+                                                           ColorScaleConfig scale) noexcept;
 
 } // namespace amrvis

--- a/include/amrexplorer/core/ValueMapping.hpp
+++ b/include/amrexplorer/core/ValueMapping.hpp
@@ -1,9 +1,26 @@
 #pragma once
 
 #include <cmath>
+#include <cstdint>
 #include <optional>
 
 namespace amrvis {
+
+enum class ColorScale : std::uint8_t { Linear, Logarithmic, SymLogarithmic };
+
+struct ColorScaleConfig {
+    ColorScale scale = ColorScale::Linear;
+    double linearThreshold = 1.0;
+    friend bool operator==(const ColorScaleConfig&,
+        const ColorScaleConfig&) = default;
+};
+
+[[nodiscard]] constexpr ColorScaleConfig effectiveColorScale(
+    bool logarithmic, ColorScaleConfig scale) noexcept
+{
+    return logarithmic
+        ? ColorScaleConfig{ColorScale::Logarithmic, 1.0} : scale;
+}
 
 // Mapping a field value to a slot of a colour lookup -- a palette slot for a
 // slice, a transfer-function entry for a volume. Both renderers map through
@@ -23,16 +40,51 @@ namespace amrvis {
 // only place std::log of the bounds happens: it sets errno, so a compiler
 // cannot hoist it out of a pixel or sample loop on its own.
 struct ResolvedValueRange {
-    double minimum = 0.0;   // already logarithmic when `logarithmic`
+    double minimum = 0.0;   // already transformed by `scale`
     double span = 1.0;      // maximum - minimum, in the same terms
-    bool logarithmic = false;
+    ColorScaleConfig scale;
+    constexpr ResolvedValueRange() = default;
+    constexpr ResolvedValueRange(double minimumIn, double spanIn,
+        bool logarithmic)
+        : minimum(minimumIn), span(spanIn),
+          scale{logarithmic ? ColorScale::Logarithmic : ColorScale::Linear, 1.0}
+    {}
 };
+
+inline constexpr double symmetricLogLinearScale = 10.0 / 9.0;
+
+[[nodiscard]] inline double transformedValue(
+    double value, const ColorScaleConfig& config) noexcept
+{
+    if (config.scale == ColorScale::Logarithmic) return std::log(value);
+    if (config.scale != ColorScale::SymLogarithmic) return value;
+    const auto magnitude = std::abs(value);
+    if (magnitude <= config.linearThreshold) {
+        return value * symmetricLogLinearScale;
+    }
+    return std::copysign(config.linearThreshold
+            * (symmetricLogLinearScale
+                + std::log10(magnitude / config.linearThreshold)), value);
+}
+
+[[nodiscard]] inline double inverseTransformedValue(
+    double value, const ColorScaleConfig& config) noexcept
+{
+    if (config.scale == ColorScale::Logarithmic) return std::exp(value);
+    if (config.scale != ColorScale::SymLogarithmic) return value;
+    const auto limit = config.linearThreshold * symmetricLogLinearScale;
+    const auto magnitude = std::abs(value);
+    if (magnitude <= limit) return value / symmetricLogLinearScale;
+    return std::copysign(config.linearThreshold
+            * std::pow(10.0, magnitude / config.linearThreshold
+                    - symmetricLogLinearScale), value);
+}
 
 // nullopt for a range no value can be mapped through: a non-finite bound, an
 // empty or unordered span, a span so wide it is infinite (every value would
 // land in slot 0), or a logarithmic range reaching to zero.
 [[nodiscard]] inline std::optional<ResolvedValueRange> resolveValueRange(
-    double minimum, double maximum, bool logarithmic) noexcept
+    double minimum, double maximum, ColorScaleConfig scale = {}) noexcept
 {
     // Both bounds are tested for positivity, not just the minimum: this is
     // noexcept and public, so an unordered logarithmic range reaches it, and
@@ -40,13 +92,17 @@ struct ResolvedValueRange {
     // span test below would reject the range anyway -- but not before a build
     // running with feenableexcept(FE_INVALID) had taken SIGFPE.
     if (!std::isfinite(minimum) || !std::isfinite(maximum)
-        || (logarithmic && !(minimum > 0.0 && maximum > 0.0))) {
+        || (scale.scale == ColorScale::Logarithmic
+            && !(minimum > 0.0 && maximum > 0.0))
+        || (scale.scale == ColorScale::SymLogarithmic
+            && !(scale.linearThreshold > 0.0
+                && std::isfinite(scale.linearThreshold)))) {
         return std::nullopt;
     }
     ResolvedValueRange resolved;
-    resolved.logarithmic = logarithmic;
-    resolved.minimum = logarithmic ? std::log(minimum) : minimum;
-    const auto top = logarithmic ? std::log(maximum) : maximum;
+    resolved.scale = scale;
+    resolved.minimum = transformedValue(minimum, scale);
+    const auto top = transformedValue(maximum, scale);
     resolved.span = top - resolved.minimum;
     if (!(resolved.span > 0.0) || !std::isfinite(resolved.span)) {
         return std::nullopt;
@@ -54,12 +110,20 @@ struct ResolvedValueRange {
     return resolved;
 }
 
+[[nodiscard]] inline std::optional<ResolvedValueRange> resolveValueRange(
+    double minimum, double maximum, bool logarithmic) noexcept
+{
+    return resolveValueRange(minimum, maximum,
+        {logarithmic ? ColorScale::Logarithmic : ColorScale::Linear, 1.0});
+}
+
 // Whether the range can map this value at all: non-finite values, and
 // non-positive ones under a logarithmic range, have no slot.
 [[nodiscard]] inline bool mappableValue(
     double value, const ResolvedValueRange& range) noexcept
 {
-    return std::isfinite(value) && !(range.logarithmic && !(value > 0.0));
+    return std::isfinite(value)
+        && !(range.scale.scale == ColorScale::Logarithmic && !(value > 0.0));
 }
 
 // The slot, for a value mappableValue accepts and a slotCount of at least 1.
@@ -84,7 +148,7 @@ struct ResolvedValueRange {
 [[nodiscard]] inline int valueSlot(double value, const ResolvedValueRange& range,
     int slotCount) noexcept
 {
-    const auto mapped = range.logarithmic ? std::log(value) : value;
+    const auto mapped = transformedValue(value, range.scale);
     const auto normalized = (mapped - range.minimum) / range.span;
     if (!(normalized > 0.0)) {
         return 0;

--- a/include/amrexplorer/core/ValueMapping.hpp
+++ b/include/amrexplorer/core/ValueMapping.hpp
@@ -52,9 +52,11 @@ inline constexpr double symmetricLogLinearScale = 10.0 / 9.0;
     if (magnitude <= config.linearThreshold) {
         return value * symmetricLogLinearScale;
     }
+    // The quotient can overflow for a small threshold even though its
+    // logarithm and the transformed value are representable.
     return std::copysign(config.linearThreshold
             * (symmetricLogLinearScale
-                + std::log10(magnitude / config.linearThreshold)), value);
+                + (std::log10(magnitude) - std::log10(config.linearThreshold))), value);
 }
 
 [[nodiscard]] inline double inverseTransformedValue(
@@ -65,9 +67,14 @@ inline constexpr double symmetricLogLinearScale = 10.0 / 9.0;
     const auto limit = config.linearThreshold * symmetricLogLinearScale;
     const auto magnitude = std::abs(value);
     if (magnitude <= limit) return value / symmetricLogLinearScale;
-    return std::copysign(config.linearThreshold
-            * std::pow(10.0, magnitude / config.linearThreshold
-                    - symmetricLogLinearScale), value);
+    const auto exponent = magnitude / config.linearThreshold - symmetricLogLinearScale;
+    // Keep ordinary powers accurate, but combine large powers with the
+    // threshold in log space before exponentiating. The power alone can
+    // overflow even when the final field value is finite.
+    const auto restored = exponent <= 300.0
+        ? config.linearThreshold * std::pow(10.0, exponent)
+        : std::pow(10.0, std::log10(config.linearThreshold) + exponent);
+    return std::copysign(restored, value);
 }
 
 // nullopt for a range no value can be mapped through: a non-finite bound, an

--- a/include/amrexplorer/core/ValueMapping.hpp
+++ b/include/amrexplorer/core/ValueMapping.hpp
@@ -15,13 +15,6 @@ struct ColorScaleConfig {
         const ColorScaleConfig&) = default;
 };
 
-[[nodiscard]] constexpr ColorScaleConfig effectiveColorScale(
-    bool logarithmic, ColorScaleConfig scale) noexcept
-{
-    return logarithmic
-        ? ColorScaleConfig{ColorScale::Logarithmic, 1.0} : scale;
-}
-
 // Mapping a field value to a slot of a colour lookup -- a palette slot for a
 // slice, a transfer-function entry for a volume. Both renderers map through
 // this, because a value must take the same slot in both: a volume rendered
@@ -44,11 +37,8 @@ struct ResolvedValueRange {
     double span = 1.0;      // maximum - minimum, in the same terms
     ColorScaleConfig scale;
     constexpr ResolvedValueRange() = default;
-    constexpr ResolvedValueRange(double minimumIn, double spanIn,
-        bool logarithmic)
-        : minimum(minimumIn), span(spanIn),
-          scale{logarithmic ? ColorScale::Logarithmic : ColorScale::Linear, 1.0}
-    {}
+    constexpr ResolvedValueRange(double minimumIn, double spanIn, ColorScaleConfig scaleConfig)
+        : minimum(minimumIn), span(spanIn), scale(scaleConfig) {}
 };
 
 inline constexpr double symmetricLogLinearScale = 10.0 / 9.0;
@@ -108,13 +98,6 @@ inline constexpr double symmetricLogLinearScale = 10.0 / 9.0;
         return std::nullopt;
     }
     return resolved;
-}
-
-[[nodiscard]] inline std::optional<ResolvedValueRange> resolveValueRange(
-    double minimum, double maximum, bool logarithmic) noexcept
-{
-    return resolveValueRange(minimum, maximum,
-        {logarithmic ? ColorScale::Logarithmic : ColorScale::Linear, 1.0});
 }
 
 // Whether the range can map this value at all: non-finite values, and

--- a/include/amrexplorer/core/Volume.hpp
+++ b/include/amrexplorer/core/Volume.hpp
@@ -31,23 +31,19 @@ struct VolumeTransferFunction {
         const VolumeTransferFunction&) = default;
 };
 
-// The value range the transfer function spans, linear or logarithmic.
+// The value range and color scale the transfer function spans.
 struct VolumeRange {
     double minimum = 0.0;
     double maximum = 1.0;
-    bool logarithmic = false;
     ColorScaleConfig scale;
     constexpr VolumeRange() = default;
     constexpr VolumeRange(double minimumValue, double maximumValue,
-        bool useLogarithmic, ColorScaleConfig scaleConfig = {})
-        : minimum(minimumValue), maximum(maximumValue),
-          logarithmic(useLogarithmic), scale(scaleConfig)
-    {
-    }
+                          ColorScaleConfig scaleConfig = {})
+        : minimum(minimumValue), maximum(maximumValue), scale(scaleConfig) {}
     friend bool operator==(const VolumeRange& lhs, const VolumeRange& rhs)
     {
-        const auto left = effectiveColorScale(lhs.logarithmic, lhs.scale);
-        const auto right = effectiveColorScale(rhs.logarithmic, rhs.scale);
+        const auto left = lhs.scale;
+        const auto right = rhs.scale;
         return lhs.minimum == rhs.minimum && lhs.maximum == rhs.maximum
             && left.scale == right.scale
             && (left.scale != ColorScale::SymLogarithmic
@@ -119,11 +115,10 @@ struct VolumeRenderRequest {
     std::array<int, 2> outputSize{0, 0};   // width, height in pixels
     // The range the colours span; nullopt asks the renderer to use the
     // sampled grid's finite extrema (the "Visible" range) and report them
-    // back, with `logarithmic` as the requested mapping (falling back to
-    // linear when the data is not strictly positive). `logarithmic` is
-    // ignored when `range` is set: the range carries its own mapping.
+    // back, with `scale` as the requested mapping (logarithmic falls back to
+    // linear when the data is not strictly positive). `scale` is ignored
+    // when `range` is set: the range carries its own mapping.
     std::optional<VolumeRange> range;
-    bool logarithmic = false;
     ColorScaleConfig scale;
     VolumeTransferFunction transfer;
     // Ray samples per voxel along the ray (the step is the mean distance a

--- a/include/amrexplorer/core/Volume.hpp
+++ b/include/amrexplorer/core/Volume.hpp
@@ -3,6 +3,7 @@
 #include <amrexplorer/core/Geometry.hpp>
 #include <amrexplorer/core/OrthoProjection.hpp>
 #include <amrexplorer/core/Request.hpp>
+#include <amrexplorer/core/ValueMapping.hpp>
 
 #include <array>
 #include <cstddef>
@@ -35,7 +36,20 @@ struct VolumeRange {
     double minimum = 0.0;
     double maximum = 1.0;
     bool logarithmic = false;
-    friend bool operator==(const VolumeRange&, const VolumeRange&) = default;
+    ColorScaleConfig scale;
+    constexpr VolumeRange() = default;
+    constexpr VolumeRange(double minimumValue, double maximumValue,
+        bool useLogarithmic, ColorScaleConfig scaleConfig = {})
+        : minimum(minimumValue), maximum(maximumValue),
+          logarithmic(useLogarithmic), scale(scaleConfig)
+    {
+    }
+    friend bool operator==(const VolumeRange& lhs, const VolumeRange& rhs)
+    {
+        return lhs.minimum == rhs.minimum && lhs.maximum == rhs.maximum
+            && effectiveColorScale(lhs.logarithmic, lhs.scale)
+                == effectiveColorScale(rhs.logarithmic, rhs.scale);
+    }
 };
 
 inline constexpr int maxVolumeOutputDimension = 4096;
@@ -107,6 +121,7 @@ struct VolumeRenderRequest {
     // ignored when `range` is set: the range carries its own mapping.
     std::optional<VolumeRange> range;
     bool logarithmic = false;
+    ColorScaleConfig scale;
     VolumeTransferFunction transfer;
     // Ray samples per voxel along the ray (the step is the mean distance a
     // view ray spends crossing one voxel divided by this).

--- a/include/amrexplorer/core/Volume.hpp
+++ b/include/amrexplorer/core/Volume.hpp
@@ -46,9 +46,12 @@ struct VolumeRange {
     }
     friend bool operator==(const VolumeRange& lhs, const VolumeRange& rhs)
     {
+        const auto left = effectiveColorScale(lhs.logarithmic, lhs.scale);
+        const auto right = effectiveColorScale(rhs.logarithmic, rhs.scale);
         return lhs.minimum == rhs.minimum && lhs.maximum == rhs.maximum
-            && effectiveColorScale(lhs.logarithmic, lhs.scale)
-                == effectiveColorScale(rhs.logarithmic, rhs.scale);
+            && left.scale == right.scale
+            && (left.scale != ColorScale::SymLogarithmic
+                || left.linearThreshold == right.linearThreshold);
     }
 };
 

--- a/include/amrexplorer/data/LocalDatasetSession.hpp
+++ b/include/amrexplorer/data/LocalDatasetSession.hpp
@@ -47,6 +47,8 @@ struct VolumeGridKeyHash {
 // ReadCancelled when the token stops.
 [[nodiscard]] VolumeRange visibleVolumeRange(
     const VolumeGrid& grid, bool logarithmic, StopToken cancellation = {});
+[[nodiscard]] VolumeRange visibleVolumeRange(
+    const VolumeGrid& grid, ColorScaleConfig scale, StopToken cancellation = {});
 
 class LocalDatasetSession final : public DatasetSession {
 public:
@@ -170,7 +172,7 @@ private:
     // and asks the same question of it -- would otherwise rescan the whole
     // grid before each cast. One entry is enough: the interactive case is the
     // same key and mapping frame after frame.
-    std::optional<std::pair<VolumeGridKey, bool>> m_visibleRangeFor;
+    std::optional<std::pair<VolumeGridKey, ColorScaleConfig>> m_visibleRangeFor;
     VolumeRange m_visibleRange;
 };
 

--- a/include/amrexplorer/data/LocalDatasetSession.hpp
+++ b/include/amrexplorer/data/LocalDatasetSession.hpp
@@ -46,8 +46,6 @@ struct VolumeGridKeyHash {
 // resolveRange -- is worth pinning on its own. Scans the grid, so it throws
 // ReadCancelled when the token stops.
 [[nodiscard]] VolumeRange visibleVolumeRange(
-    const VolumeGrid& grid, bool logarithmic, StopToken cancellation = {});
-[[nodiscard]] VolumeRange visibleVolumeRange(
     const VolumeGrid& grid, ColorScaleConfig scale, StopToken cancellation = {});
 
 class LocalDatasetSession final : public DatasetSession {

--- a/include/amrexplorer/pipeline/DisplayCoordinator.hpp
+++ b/include/amrexplorer/pipeline/DisplayCoordinator.hpp
@@ -70,8 +70,7 @@ public:
     // previously drift-prone copies (executeFrameLoad's shared-range block
     // and syncVisibleRanges).
     [[nodiscard]] static std::optional<std::pair<double, double>>
-    sharedVisibleRange(
-        std::span<const ScalarPlane* const> planes, bool logarithmic);
+    sharedVisibleRange(std::span<const ScalarPlane* const> planes, ColorScaleConfig scale);
 
     // How the view should treat its transform when `incoming` replaces the
     // raster produced by `cached`. Compatible physical geometry preserves the
@@ -107,11 +106,10 @@ public:
     };
     struct SharedRangeSync {
         std::pair<double, double> range;
-        // One log flag for the whole panel set: the requested log mapping,
+        // One color scale for the whole panel set: logarithmic mapping is
         // kept only when the shared range minimum is positive (renderScalarPlane
         // rejects a non-positive log minimum). Callers apply it to every panel
         // and to the shared color bar so all three agree with the raster.
-        bool logarithmic = false;
         ColorScaleConfig scale;
         std::vector<PanelSyncUpdate> panels;  // parallel to the input span
     };
@@ -125,10 +123,6 @@ public:
     // case the caller leaves the panels untouched.
     [[nodiscard]] std::optional<SharedRangeSync> syncPanelsToSharedRange(
         const RangeKey& key, std::span<const PanelSyncInput> panels,
-        bool logarithmic, bool contourMode, int contourCount,
-        const Palette& palette) const;
-    [[nodiscard]] std::optional<SharedRangeSync> syncPanelsToSharedRange(
-        const RangeKey& key, std::span<const PanelSyncInput> panels,
         ColorScaleConfig scale, bool contourMode, int contourCount,
         const Palette& palette) const;
 
@@ -139,11 +133,6 @@ public:
     // Static so the GUI can run it on a worker thread over immutable plane
     // snapshots while the coordinator itself stays confined to the GUI
     // thread (see heavy-work-on-gui-thread, part D).
-    [[nodiscard]] static std::optional<SharedRangeSync>
-    renderPanelsToSharedRange(
-        std::optional<std::pair<double, double>> sharedRange,
-        std::span<const PanelSyncInput> panels, bool logarithmic,
-        bool contourMode, int contourCount, const Palette& palette);
     [[nodiscard]] static std::optional<SharedRangeSync> renderPanelsToSharedRange(
         std::optional<std::pair<double, double>> sharedRange,
         std::span<const PanelSyncInput> panels, ColorScaleConfig scale,

--- a/include/amrexplorer/pipeline/DisplayCoordinator.hpp
+++ b/include/amrexplorer/pipeline/DisplayCoordinator.hpp
@@ -112,6 +112,7 @@ public:
         // rejects a non-positive log minimum). Callers apply it to every panel
         // and to the shared color bar so all three agree with the raster.
         bool logarithmic = false;
+        ColorScaleConfig scale;
         std::vector<PanelSyncUpdate> panels;  // parallel to the input span
     };
 
@@ -126,6 +127,10 @@ public:
         const RangeKey& key, std::span<const PanelSyncInput> panels,
         bool logarithmic, bool contourMode, int contourCount,
         const Palette& palette) const;
+    [[nodiscard]] std::optional<SharedRangeSync> syncPanelsToSharedRange(
+        const RangeKey& key, std::span<const PanelSyncInput> panels,
+        ColorScaleConfig scale, bool contourMode, int contourCount,
+        const Palette& palette) const;
 
     // The pure, coordinator-state-free half of syncPanelsToSharedRange: takes
     // the already-resolved cached range (or nullopt to fall back to the
@@ -138,6 +143,10 @@ public:
     renderPanelsToSharedRange(
         std::optional<std::pair<double, double>> sharedRange,
         std::span<const PanelSyncInput> panels, bool logarithmic,
+        bool contourMode, int contourCount, const Palette& palette);
+    [[nodiscard]] static std::optional<SharedRangeSync> renderPanelsToSharedRange(
+        std::optional<std::pair<double, double>> sharedRange,
+        std::span<const PanelSyncInput> panels, ColorScaleConfig scale,
         bool contourMode, int contourCount, const Palette& palette);
 
     // True when the two planes map pixels to physical units at different

--- a/include/amrexplorer/pipeline/SlicePipeline.hpp
+++ b/include/amrexplorer/pipeline/SlicePipeline.hpp
@@ -77,6 +77,7 @@ struct SliceDisplayResult {
     double minimum = 0.0;
     double maximum = 1.0;
     bool logarithmic = false;
+    ColorScaleConfig scale;
     DisplayMode mode = DisplayMode::Raster;
     std::uint32_t vectorUField = 0;
     std::uint32_t vectorVField = 0;
@@ -143,6 +144,7 @@ struct FrameSliceSpec {
     RangeMode rangeMode = RangeMode::File;
     std::optional<std::pair<double, double>> userRange;
     bool logarithmic = false;
+    ColorScaleConfig scale;
     Palette palette;
     std::uint32_t vectorUField = 0;
     std::uint32_t vectorVField = 0;
@@ -268,6 +270,10 @@ inline constexpr int maxSliceOutputDimension = maxViewOutputDimension;
     RangeMode rangeMode,
     const std::optional<std::pair<double, double>>& userRange,
     bool logarithmic, const Palette& palette, StopToken cancellation);
+[[nodiscard]] SliceDisplayResult executeSlice(
+    const std::shared_ptr<DatasetSession>& dataset, const SliceRequest& request,
+    RangeMode rangeMode, const std::optional<std::pair<double, double>>& userRange,
+    ColorScaleConfig scale, const Palette& palette, StopToken cancellation);
 
 // Vector mode queries the U- and V-component planes independently and
 // derives arrow glyphs from them. Both slices share the raster request's
@@ -291,6 +297,12 @@ void appendVectorGlyphs(const std::shared_ptr<DatasetSession>& dataset,
     bool logarithmic, const Palette& palette, DisplayMode displayMode,
     std::uint32_t vectorUField, std::uint32_t vectorVField, int contourCount,
     StopToken cancellation);
+[[nodiscard]] SliceDisplayResult executeSliceWithFallback(
+    const std::shared_ptr<DatasetSession>& dataset, SliceRequest request,
+    RangeMode rangeMode, const std::optional<std::pair<double, double>>& userRange,
+    ColorScaleConfig scale, const Palette& palette, DisplayMode displayMode,
+    std::uint32_t vectorUField, std::uint32_t vectorVField, int contourCount,
+    StopToken cancellation);
 
 // Extracts contour polylines for the request at data resolution and maps
 // them to display-plane pixel space; caches the contour plane on the result so
@@ -298,6 +310,10 @@ void appendVectorGlyphs(const std::shared_ptr<DatasetSession>& dataset,
 void appendContours(const std::shared_ptr<DatasetSession>& dataset,
     const SliceRequest& request, int contourCount, double minimum,
     double maximum, bool logarithmic, StopToken cancellation,
+    SliceDisplayResult& result);
+void appendContours(const std::shared_ptr<DatasetSession>& dataset,
+    const SliceRequest& request, int contourCount, double minimum,
+    double maximum, ColorScaleConfig scale, StopToken cancellation,
     SliceDisplayResult& result);
 
 // Re-render-from-cache: only palette/log/range/contour-count cosmetics
@@ -317,6 +333,14 @@ void appendContours(const std::shared_ptr<DatasetSession>& dataset,
     bool logarithmic, const Palette& palette, DisplayMode displayMode,
     std::uint32_t vectorUField, std::uint32_t vectorVField,
     int contourCount, bool rasterDirty, StopToken cancellation = {});
+[[nodiscard]] SliceDisplayResult refreshCachedSlice(
+    const std::shared_ptr<DatasetSession>& dataset, const SliceRequest& request,
+    std::shared_ptr<const ScalarPlane> displayPlanePtr,
+    ScalarPlane contourPlane, std::vector<VectorSegment> vectors,
+    RangeMode rangeMode, const std::optional<std::pair<double, double>>& userRange,
+    ColorScaleConfig scale, const Palette& palette, DisplayMode displayMode,
+    std::uint32_t vectorUField, std::uint32_t vectorVField,
+    int contourCount, bool rasterDirty, StopToken cancellation = {});
 
 // Re-extract contour polylines from an already-populated contour plane after
 // the display range is replaced downstream of appendContours/refreshCachedSlice
@@ -329,6 +353,9 @@ void appendContours(const std::shared_ptr<DatasetSession>& dataset,
     const ScalarPlane& plane, double minimum,
     double maximum, bool logarithmic, int contourCount,
     int displayWidth, int displayHeight);
+[[nodiscard]] std::vector<ContourPolyline> recomputeContourPolylines(
+    const ScalarPlane& plane, double minimum, double maximum,
+    ColorScaleConfig scale, int contourCount, int displayWidth, int displayHeight);
 
 // SliceDisplayResult overload: regenerate the polylines to match the result's
 // current (possibly replaced) minimum/maximum. No-op outside contour modes.

--- a/include/amrexplorer/pipeline/SlicePipeline.hpp
+++ b/include/amrexplorer/pipeline/SlicePipeline.hpp
@@ -76,7 +76,6 @@ struct SliceDisplayResult {
     std::string fieldName;
     double minimum = 0.0;
     double maximum = 1.0;
-    bool logarithmic = false;
     ColorScaleConfig scale;
     DisplayMode mode = DisplayMode::Raster;
     std::uint32_t vectorUField = 0;
@@ -143,7 +142,6 @@ struct FrameSliceSpec {
     int levelSelection = -1;  // level combo data: -1 = finest available
     RangeMode rangeMode = RangeMode::File;
     std::optional<std::pair<double, double>> userRange;
-    bool logarithmic = false;
     ColorScaleConfig scale;
     Palette palette;
     std::uint32_t vectorUField = 0;
@@ -267,11 +265,6 @@ inline constexpr int maxSliceOutputDimension = maxViewOutputDimension;
 // Executes the display slice and resolves its range, rendering the raster.
 [[nodiscard]] SliceDisplayResult executeSlice(
     const std::shared_ptr<DatasetSession>& dataset, const SliceRequest& request,
-    RangeMode rangeMode,
-    const std::optional<std::pair<double, double>>& userRange,
-    bool logarithmic, const Palette& palette, StopToken cancellation);
-[[nodiscard]] SliceDisplayResult executeSlice(
-    const std::shared_ptr<DatasetSession>& dataset, const SliceRequest& request,
     RangeMode rangeMode, const std::optional<std::pair<double, double>>& userRange,
     ColorScaleConfig scale, const Palette& palette, StopToken cancellation);
 
@@ -292,13 +285,6 @@ void appendVectorGlyphs(const std::shared_ptr<DatasetSession>& dataset,
 // translated message).
 [[nodiscard]] SliceDisplayResult executeSliceWithFallback(
     const std::shared_ptr<DatasetSession>& dataset, SliceRequest request,
-    RangeMode rangeMode,
-    const std::optional<std::pair<double, double>>& userRange,
-    bool logarithmic, const Palette& palette, DisplayMode displayMode,
-    std::uint32_t vectorUField, std::uint32_t vectorVField, int contourCount,
-    StopToken cancellation);
-[[nodiscard]] SliceDisplayResult executeSliceWithFallback(
-    const std::shared_ptr<DatasetSession>& dataset, SliceRequest request,
     RangeMode rangeMode, const std::optional<std::pair<double, double>>& userRange,
     ColorScaleConfig scale, const Palette& palette, DisplayMode displayMode,
     std::uint32_t vectorUField, std::uint32_t vectorVField, int contourCount,
@@ -307,10 +293,6 @@ void appendVectorGlyphs(const std::shared_ptr<DatasetSession>& dataset,
 // Extracts contour polylines for the request at data resolution and maps
 // them to display-plane pixel space; caches the contour plane on the result so
 // range and contour-count changes can re-extract without a new SliceQuery.
-void appendContours(const std::shared_ptr<DatasetSession>& dataset,
-    const SliceRequest& request, int contourCount, double minimum,
-    double maximum, bool logarithmic, StopToken cancellation,
-    SliceDisplayResult& result);
 void appendContours(const std::shared_ptr<DatasetSession>& dataset,
     const SliceRequest& request, int contourCount, double minimum,
     double maximum, ColorScaleConfig scale, StopToken cancellation,
@@ -323,16 +305,6 @@ void appendContours(const std::shared_ptr<DatasetSession>& dataset,
 // re-rendered; SliceDisplayResult::rasterUnchanged tells the GUI to keep
 // the view's pixmap. Vector glyphs are reused from the cache: they do not
 // depend on palette/log/range.
-[[nodiscard]] SliceDisplayResult refreshCachedSlice(
-    const std::shared_ptr<DatasetSession>& dataset,
-    const SliceRequest& request,
-    std::shared_ptr<const ScalarPlane> displayPlanePtr,
-    ScalarPlane contourPlane, std::vector<VectorSegment> vectors,
-    RangeMode rangeMode,
-    const std::optional<std::pair<double, double>>& userRange,
-    bool logarithmic, const Palette& palette, DisplayMode displayMode,
-    std::uint32_t vectorUField, std::uint32_t vectorVField,
-    int contourCount, bool rasterDirty, StopToken cancellation = {});
 [[nodiscard]] SliceDisplayResult refreshCachedSlice(
     const std::shared_ptr<DatasetSession>& dataset, const SliceRequest& request,
     std::shared_ptr<const ScalarPlane> displayPlanePtr,
@@ -349,10 +321,6 @@ void appendContours(const std::shared_ptr<DatasetSession>& dataset,
 // the range is unusable (non-positive log range, zero extent), so a bad range
 // clears the overlay rather than throwing. See the
 // contours-stale-after-visible-range-sync issue.
-[[nodiscard]] std::vector<ContourPolyline> recomputeContourPolylines(
-    const ScalarPlane& plane, double minimum,
-    double maximum, bool logarithmic, int contourCount,
-    int displayWidth, int displayHeight);
 [[nodiscard]] std::vector<ContourPolyline> recomputeContourPolylines(
     const ScalarPlane& plane, double minimum, double maximum,
     ColorScaleConfig scale, int contourCount, int displayWidth, int displayHeight);

--- a/include/amrexplorer/pipeline/SliceRangeResolver.hpp
+++ b/include/amrexplorer/pipeline/SliceRangeResolver.hpp
@@ -27,7 +27,6 @@ enum class RangeMode {
 struct ResolvedRange {
     double minimum;
     double maximum;
-    bool logarithmic;
     ColorScaleConfig scale;
 };
 
@@ -36,8 +35,8 @@ struct ResolvedRange {
 
 // Finite extrema of a plane, padded so minimum < maximum; nullopt when the
 // plane has no finite valid samples.
-[[nodiscard]] std::optional<std::pair<double, double>> finiteRange(
-    const ScalarPlane& plane, bool logarithmic = false);
+[[nodiscard]] std::optional<std::pair<double, double>> finiteRange(const ScalarPlane& plane,
+                                                                   ColorScaleConfig scale = {});
 
 // The metadata (File/Level) range for the selection, or nullopt when the
 // statistics needed for that mode are unavailable.
@@ -65,27 +64,20 @@ struct ResolvedRange {
 // minimum < maximum always holds. A logarithmic request whose range is not
 // strictly positive throws, so the caller can fall back to linear. Shared by
 // executeSlice and the re-render-from-cache path, which must agree exactly.
-[[nodiscard]] std::pair<double, double> resolveRange(
-    const std::shared_ptr<DatasetSession>& dataset, FieldId field,
-    int maximumLevel, CompositionPolicy composition, RangeMode rangeMode,
-    const std::optional<std::pair<double, double>>& userRange,
-    bool logarithmic, const ScalarPlane& plane, StopToken cancellation = {});
-[[nodiscard]] ResolvedRange resolveDisplayRange(
-    const std::shared_ptr<DatasetSession>& dataset, FieldId field,
-    int maximumLevel, CompositionPolicy composition, RangeMode rangeMode,
-    const std::optional<std::pair<double, double>>& userRange,
-    ColorScaleConfig scale, const ScalarPlane& plane,
-    StopToken cancellation = {});
-
+[[nodiscard]] std::pair<double, double>
+resolveRange(const std::shared_ptr<DatasetSession>& dataset, FieldId field, int maximumLevel,
+             CompositionPolicy composition, RangeMode rangeMode,
+             const std::optional<std::pair<double, double>>& userRange, ColorScaleConfig scale,
+             const ScalarPlane& plane, StopToken cancellation = {});
 // Like resolveRange, but if a logarithmic scale is requested and the range is
 // not strictly positive it falls back to a linear range and reports
-// logarithmic=false, so the caller renders linearly instead of failing the
+// ColorScale::Linear, so the caller renders linearly instead of failing the
 // whole slice. A slice with no finite values uses a neutral positive range and
 // can therefore remain logarithmic.
-[[nodiscard]] ResolvedRange resolveDisplayRange(
-    const std::shared_ptr<DatasetSession>& dataset, FieldId field,
-    int maximumLevel, CompositionPolicy composition, RangeMode rangeMode,
-    const std::optional<std::pair<double, double>>& userRange,
-    bool logarithmic, const ScalarPlane& plane, StopToken cancellation = {});
+[[nodiscard]] ResolvedRange
+resolveDisplayRange(const std::shared_ptr<DatasetSession>& dataset, FieldId field, int maximumLevel,
+                    CompositionPolicy composition, RangeMode rangeMode,
+                    const std::optional<std::pair<double, double>>& userRange,
+                    ColorScaleConfig scale, const ScalarPlane& plane, StopToken cancellation = {});
 
 } // namespace amrvis

--- a/include/amrexplorer/pipeline/SliceRangeResolver.hpp
+++ b/include/amrexplorer/pipeline/SliceRangeResolver.hpp
@@ -4,6 +4,7 @@
 #include <amrexplorer/core/Request.hpp>
 #include <amrexplorer/core/Result.hpp>
 #include <amrexplorer/core/Statistics.hpp>
+#include <amrexplorer/core/ValueMapping.hpp>
 #include <amrexplorer/data/DatasetSession.hpp>
 
 #include <memory>
@@ -27,6 +28,7 @@ struct ResolvedRange {
     double minimum;
     double maximum;
     bool logarithmic;
+    ColorScaleConfig scale;
 };
 
 // paddedIfDegenerate, once declared here, now lives in core/Statistics.hpp
@@ -68,6 +70,12 @@ struct ResolvedRange {
     int maximumLevel, CompositionPolicy composition, RangeMode rangeMode,
     const std::optional<std::pair<double, double>>& userRange,
     bool logarithmic, const ScalarPlane& plane, StopToken cancellation = {});
+[[nodiscard]] ResolvedRange resolveDisplayRange(
+    const std::shared_ptr<DatasetSession>& dataset, FieldId field,
+    int maximumLevel, CompositionPolicy composition, RangeMode rangeMode,
+    const std::optional<std::pair<double, double>>& userRange,
+    ColorScaleConfig scale, const ScalarPlane& plane,
+    StopToken cancellation = {});
 
 // Like resolveRange, but if a logarithmic scale is requested and the range is
 // not strictly positive it falls back to a linear range and reports

--- a/include/amrexplorer/pipeline/VolumePipeline.hpp
+++ b/include/amrexplorer/pipeline/VolumePipeline.hpp
@@ -101,11 +101,6 @@ struct OpacityRamp {
     const std::shared_ptr<DatasetSession>& dataset, FieldId field,
     int maximumLevel, CompositionPolicy composition, RangeMode rangeMode,
     const std::optional<std::pair<double, double>>& userRange,
-    bool logarithmic, StopToken cancellation = {});
-[[nodiscard]] std::optional<VolumeRange> resolveVolumeRange(
-    const std::shared_ptr<DatasetSession>& dataset, FieldId field,
-    int maximumLevel, CompositionPolicy composition, RangeMode rangeMode,
-    const std::optional<std::pair<double, double>>& userRange,
     ColorScaleConfig scale, StopToken cancellation = {});
 
 // How the range is resolved, for the fallback path below, which resolves it
@@ -131,16 +126,12 @@ struct OpacityRamp {
 struct VolumeRangeChoice {
     RangeMode mode = RangeMode::Visible;
     std::optional<std::pair<double, double>> userRange;
-    bool logarithmic = false;
     ColorScaleConfig scale;
     VolumeRangeChoice() = default;
     VolumeRangeChoice(RangeMode selectedMode,
-        std::optional<std::pair<double, double>> selectedUserRange,
-        bool useLogarithmic, ColorScaleConfig scaleConfig = {})
-        : mode(selectedMode), userRange(std::move(selectedUserRange)),
-          logarithmic(useLogarithmic), scale(scaleConfig)
-    {
-    }
+                      std::optional<std::pair<double, double>> selectedUserRange,
+                      ColorScaleConfig scaleConfig = {})
+        : mode(selectedMode), userRange(std::move(selectedUserRange)), scale(scaleConfig) {}
 };
 
 // The bytes a rendered frame of this size costs on the wire, and the size

--- a/include/amrexplorer/pipeline/VolumePipeline.hpp
+++ b/include/amrexplorer/pipeline/VolumePipeline.hpp
@@ -102,6 +102,11 @@ struct OpacityRamp {
     int maximumLevel, CompositionPolicy composition, RangeMode rangeMode,
     const std::optional<std::pair<double, double>>& userRange,
     bool logarithmic, StopToken cancellation = {});
+[[nodiscard]] std::optional<VolumeRange> resolveVolumeRange(
+    const std::shared_ptr<DatasetSession>& dataset, FieldId field,
+    int maximumLevel, CompositionPolicy composition, RangeMode rangeMode,
+    const std::optional<std::pair<double, double>>& userRange,
+    ColorScaleConfig scale, StopToken cancellation = {});
 
 // How the range is resolved, for the fallback path below, which resolves it
 // afresh for whatever level each attempt is about to render.
@@ -127,6 +132,15 @@ struct VolumeRangeChoice {
     RangeMode mode = RangeMode::Visible;
     std::optional<std::pair<double, double>> userRange;
     bool logarithmic = false;
+    ColorScaleConfig scale;
+    VolumeRangeChoice() = default;
+    VolumeRangeChoice(RangeMode selectedMode,
+        std::optional<std::pair<double, double>> selectedUserRange,
+        bool useLogarithmic, ColorScaleConfig scaleConfig = {})
+        : mode(selectedMode), userRange(std::move(selectedUserRange)),
+          logarithmic(useLogarithmic), scale(scaleConfig)
+    {
+    }
 };
 
 // The bytes a rendered frame of this size costs on the wire, and the size

--- a/include/amrexplorer/remote/Connection.hpp
+++ b/include/amrexplorer/remote/Connection.hpp
@@ -48,6 +48,9 @@ inline constexpr const char* volumeSamplingUnsupportedMessage
 inline constexpr const char* derivedFieldsUnsupportedMessage
     = "the remote server predates derived fields (protocol 1.4); install a "
       "current amrexplorer-server";
+inline constexpr const char* symmetricLogUnsupportedMessage
+    = "the remote server predates symmetric-log volume scaling (protocol 1.5); "
+      "install a current amrexplorer-server";
 
 class Connection : public std::enable_shared_from_this<Connection> {
 public:
@@ -91,6 +94,7 @@ public:
     // open request (1.4). A 1.3 peer opens datasets perfectly well; it just
     // cannot be asked to compute a field.
     [[nodiscard]] bool supportsDerivedFields() const noexcept;
+    [[nodiscard]] bool supportsSymmetricLogScale() const noexcept;
     // Renders a volume on the server and returns the frame (protocol 1.2).
     // Ask supportsVolumeRendering() first: this throws when the server
     // negotiated an older protocol.

--- a/include/amrexplorer/remote/Protocol.hpp
+++ b/include/amrexplorer/remote/Protocol.hpp
@@ -34,7 +34,7 @@ inline constexpr std::uint16_t protocolMajor = 1;
 // answer a plain catalog, so the client would show an Expression Editor whose
 // Apply reported success while every slice kept coming back from the stored
 // fields alone.
-inline constexpr std::uint16_t protocolMinorVersion = 4;
+inline constexpr std::uint16_t protocolMinorVersion = 5;
 
 enum class PayloadKind : std::uint8_t {
     None = 0,

--- a/include/amrexplorer/render2d/Contours.hpp
+++ b/include/amrexplorer/render2d/Contours.hpp
@@ -26,10 +26,8 @@ struct ContourPolyline {
 
 // Places count lines at the midpoint of equal-width intervals in either
 // linear value space or logarithmic value space.
-[[nodiscard]] std::vector<double> contourValues(
-    double minimum, double maximum, int count, bool logarithmic = false);
-[[nodiscard]] std::vector<double> contourValues(double minimum, double maximum,
-    int count, ColorScaleConfig scale);
+[[nodiscard]] std::vector<double> contourValues(double minimum, double maximum, int count,
+                                                ColorScaleConfig scale = {});
 
 // Marching squares over the plane's corner samples. A cell is the quad formed
 // by samples (i, j), (i + 1, j), (i, j + 1), (i + 1, j + 1), so segment

--- a/include/amrexplorer/render2d/Contours.hpp
+++ b/include/amrexplorer/render2d/Contours.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <amrexplorer/core/Result.hpp>
+#include <amrexplorer/core/ValueMapping.hpp>
 
 #include <array>
 #include <vector>
@@ -27,6 +28,8 @@ struct ContourPolyline {
 // linear value space or logarithmic value space.
 [[nodiscard]] std::vector<double> contourValues(
     double minimum, double maximum, int count, bool logarithmic = false);
+[[nodiscard]] std::vector<double> contourValues(double minimum, double maximum,
+    int count, ColorScaleConfig scale);
 
 // Marching squares over the plane's corner samples. A cell is the quad formed
 // by samples (i, j), (i + 1, j), (i, j + 1), (i + 1, j + 1), so segment

--- a/include/amrexplorer/render2d/ScalarRenderer.hpp
+++ b/include/amrexplorer/render2d/ScalarRenderer.hpp
@@ -14,7 +14,6 @@ struct ScalarRenderSettings {
     double minimum = 0.0;
     double maximum = 1.0;
     ColorScaleConfig scale;
-    bool logarithmic = false;
     std::uint32_t invalidColor = 0xFF303030U;
     std::uint32_t nanColor = 0xFFFF00FFU;
     // When null, the built-in legacy rainbow palette is used.

--- a/include/amrexplorer/render2d/ScalarRenderer.hpp
+++ b/include/amrexplorer/render2d/ScalarRenderer.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <amrexplorer/core/ValueMapping.hpp>
 
 #include <amrexplorer/core/Result.hpp>
 #include <amrexplorer/render2d/ImageBuffer.hpp>
@@ -12,6 +13,7 @@ namespace amrvis {
 struct ScalarRenderSettings {
     double minimum = 0.0;
     double maximum = 1.0;
+    ColorScaleConfig scale;
     bool logarithmic = false;
     std::uint32_t invalidColor = 0xFF303030U;
     std::uint32_t nanColor = 0xFFFF00FFU;
@@ -24,4 +26,3 @@ struct ScalarRenderSettings {
     const ScalarPlane& plane, const ScalarRenderSettings& settings);
 
 } // namespace amrvis
-

--- a/include/amrexplorer/render2d/VectorGlyphs.hpp
+++ b/include/amrexplorer/render2d/VectorGlyphs.hpp
@@ -27,9 +27,10 @@ struct VectorSegment {
 // head is two short barbs from the tip, each set back 0.25 of the arrow
 // vector and offset 0.125 of it to either side (~26.6 degrees off the shaft,
 // the legacy constants). Samples that are invalid or non-finite in either
-// component are skipped, as are near-zero-length arrows; a plane whose
-// maximum speed is below 1e-8 yields no segments at all. The output lists,
-// per arrow, the shaft segment followed by its two head segments.
+// component are skipped, as are arrows shorter than 1e-6 pixels after scaling.
+// There is no absolute speed cutoff; a plane with no valid nonzero vectors
+// yields no segments. The output lists, per arrow, the shaft segment followed
+// by its two head segments.
 [[nodiscard]] std::vector<VectorSegment> generateVectorGlyphs(
     const ScalarPlane& uComponent, const ScalarPlane& vComponent, int count);
 
@@ -46,9 +47,11 @@ struct VectorSegment {
 // Sampling stride, arrow-length normalization (against the maximum speed
 // hypot(v_r, v_theta)), and head construction follow generateVectorGlyphs;
 // the arrow scale derives from displayRegion's longest side so the on-screen
-// glyph size matches the logical layouts. Output segments are in display
-// physical (R, Z) coordinates with y increasing along +Z -- independent of the
-// warped raster resolution, so a supersample change does not invalidate them.
+// glyph size matches the logical layouts. Arrows shorter than 1e-6 times that
+// scale are skipped, independently of physical length units. Output segments
+// are in display physical (R, Z) coordinates with y increasing along +Z --
+// independent of the warped raster resolution, so a supersample change does
+// not invalidate them.
 [[nodiscard]] std::vector<VectorSegment> generateSphericalRZVectorGlyphs(
     const ScalarPlane& uComponent, const ScalarPlane& vComponent, int count,
     const RealBox& displayRegion);

--- a/include/amrexplorer/render3d/VolumeRaycaster.hpp
+++ b/include/amrexplorer/render3d/VolumeRaycaster.hpp
@@ -66,8 +66,8 @@ struct RaycastSettings {
 // logarithmic), for resolving a "Visible" range; nullopt when there are
 // none. Possibly degenerate (minimum == maximum): the caller pads. Scans the
 // whole grid, so it takes a token and throws ReadCancelled like the render.
-[[nodiscard]] std::optional<std::pair<double, double>> volumeGridRange(
-    const VolumeGrid& grid, bool logarithmic, StopToken cancellation = {});
+[[nodiscard]] std::optional<std::pair<double, double>>
+volumeGridRange(const VolumeGrid& grid, ColorScaleConfig scale, StopToken cancellation = {});
 
 // The threads raycastVolume splits the rows across for a frame of this
 // height, given settings.threadCount (0 = hardware_concurrency): bounded by

--- a/schemas/amrexplorer_wire.fbs
+++ b/schemas/amrexplorer_wire.fbs
@@ -5,6 +5,7 @@ enum SamplingPolicy : ubyte {
   PiecewiseConstant = 1,
   Linear = 2
 }
+enum ColorScale : ubyte { Linear = 0, Logarithmic = 1, SymLogarithmic = 2 }
 
 enum CompositionPolicy : ubyte {
   FinestAvailable = 0,
@@ -401,6 +402,10 @@ table RenderedFrameRequest {
   // a server that predates 1.3 does -- but a 1.3 client never relies on that,
   // because the version gate stops it asking such a server for Linear at all.
   sampling:SamplingPolicy (id: 20);
+  range_scale:ColorScale (id: 21);
+  visible_scale:ColorScale (id: 22);
+  range_linear_threshold:double = 1.0 (id: 23);
+  visible_linear_threshold:double = 1.0 (id: 24);
 }
 
 // Premultiplied 0xAARRGGBB pixels, row 0 at the top, exactly width x height.
@@ -428,6 +433,8 @@ table RenderedFrameResponse {
   cache_fallback_from_level:int = -1 (id: 16);
   cache_fallback_to_level:int = -1 (id: 17);
   cache:CacheState (id: 18);
+  used_scale:ColorScale (id: 19);
+  used_linear_threshold:double = 1.0 (id: 20);
 }
 
 union Payload {

--- a/schemas/amrexplorer_wire.fbs
+++ b/schemas/amrexplorer_wire.fbs
@@ -375,6 +375,10 @@ table DirectoryListing {
 // picture where a logarithmic one was asked for. The transfer function is an explicit lookup: one
 // 0x00RRGGBB colour and one [0, 1] opacity per entry, entry 0 the bottom of
 // the range.
+// Since protocol 1.5 the scale enums and thresholds carry the mapping. The
+// legacy logarithmic flags remain for 1.2-1.4 peers: the codec derives them
+// from the enums when encoding and translates them into enums when decoding
+// older messages. Application state stores only ColorScaleConfig.
 table RenderedFrameRequest {
   dataset_id:ulong (id: 0);
   field:uint (id: 1);

--- a/src/core/Statistics.cpp
+++ b/src/core/Statistics.cpp
@@ -47,13 +47,12 @@ std::optional<ValueRange> metadataValueRange(
     return ValueRange{minimum, maximum};
 }
 
-std::pair<double, double> paddedIfDegenerate(
-    double minimum, double maximum, bool logarithmic) noexcept
-{
+std::pair<double, double> paddedIfDegenerate(double minimum, double maximum,
+                                             ColorScaleConfig scale) noexcept {
     if (minimum != maximum) {
         return {minimum, maximum};
     }
-    if (logarithmic && minimum > 0.0) {
+    if (scale.scale == ColorScale::Logarithmic && minimum > 0.0) {
         return {minimum / (1.0 + 1.0e-6), maximum * (1.0 + 1.0e-6)};
     }
     // Relative to the value, not an absolute floor. The old

--- a/src/core/Volume.cpp
+++ b/src/core/Volume.cpp
@@ -117,15 +117,16 @@ std::vector<std::string> validateVolumeRenderRequest(
     }
     if (request.range) {
         const auto& range = *request.range;
+        const auto scale = effectiveColorScale(range.logarithmic, range.scale);
         if (!std::isfinite(range.minimum) || !std::isfinite(range.maximum)
             || !(range.minimum < range.maximum)
             || !std::isfinite(range.maximum - range.minimum)) {
             errors.emplace_back(
                 "range must be finite with minimum < maximum and a finite span");
-        } else if (range.logarithmic && !(range.minimum > 0.0)) {
+        } else if (scale.scale == ColorScale::Logarithmic && !(range.minimum > 0.0)) {
             errors.emplace_back("a logarithmic range must be strictly positive");
         } else if (!resolveValueRange(
-                       range.minimum, range.maximum, range.logarithmic)) {
+                       range.minimum, range.maximum, scale)) {
             // The renderers map through resolveValueRange, so whatever it
             // cannot resolve has to be refused here too -- otherwise a
             // request a session or a server has already declared valid throws
@@ -133,7 +134,14 @@ std::vector<std::string> validateVolumeRenderRequest(
             // rejected request. The case the tests above miss is a
             // logarithmic range whose bounds share a logarithm.
             errors.emplace_back(
-                "a logarithmic range must span more than one representable logarithm");
+                "a range must span more than one representable scaled value");
+        }
+    } else {
+        const auto scale = effectiveColorScale(request.logarithmic, request.scale);
+        if (scale.scale == ColorScale::SymLogarithmic
+            && !(scale.linearThreshold > 0.0 && std::isfinite(scale.linearThreshold))) {
+            errors.emplace_back(
+                "a symmetric-log linear threshold must be finite and positive");
         }
     }
     for (const auto& error : validateVolumeTransferFunction(request.transfer)) {

--- a/src/core/Volume.cpp
+++ b/src/core/Volume.cpp
@@ -117,7 +117,7 @@ std::vector<std::string> validateVolumeRenderRequest(
     }
     if (request.range) {
         const auto& range = *request.range;
-        const auto scale = effectiveColorScale(range.logarithmic, range.scale);
+        const auto scale = range.scale;
         if (!std::isfinite(range.minimum) || !std::isfinite(range.maximum)
             || !(range.minimum < range.maximum)
             || !std::isfinite(range.maximum - range.minimum)) {
@@ -137,7 +137,7 @@ std::vector<std::string> validateVolumeRenderRequest(
                 "a range must span more than one representable scaled value");
         }
     } else {
-        const auto scale = effectiveColorScale(request.logarithmic, request.scale);
+        const auto scale = request.scale;
         if (scale.scale == ColorScale::SymLogarithmic
             && !(scale.linearThreshold > 0.0 && std::isfinite(scale.linearThreshold))) {
             errors.emplace_back(

--- a/src/data/LocalDatasetSession.cpp
+++ b/src/data/LocalDatasetSession.cpp
@@ -49,13 +49,6 @@ std::optional<ValueRange> compositeMetadataRange(const DatasetMetadata& metadata
 
 } // namespace
 
-VolumeRange visibleVolumeRange(const VolumeGrid& grid, bool logarithmic,
-    StopToken cancellation)
-{
-    return visibleVolumeRange(grid,
-        {logarithmic ? ColorScale::Logarithmic : ColorScale::Linear, 1.0}, cancellation);
-}
-
 VolumeRange visibleVolumeRange(const VolumeGrid& grid, ColorScaleConfig scale,
     StopToken cancellation)
 {
@@ -66,25 +59,24 @@ VolumeRange visibleVolumeRange(const VolumeGrid& grid, ColorScaleConfig scale,
     // The slice path decides it the other way round -- finiteRange keeps
     // every finite value and a non-positive minimum makes resolveRange fall
     // back to linear -- and the two views of one field have to agree.
-    const auto extrema = volumeGridRange(grid, false, cancellation);
+    const auto extrema = volumeGridRange(grid, {ColorScale::Linear}, cancellation);
     if (!extrema) {
         // Nothing finite to show. A logarithmic request still wants a
         // logarithmic axis, so the neutral range keeps the mapping.
-        return scale.scale == ColorScale::Logarithmic
-            ? VolumeRange{1.0, 10.0, true, scale}
-            : VolumeRange{0.0, 1.0, false, scale};
+        return scale.scale == ColorScale::Logarithmic ? VolumeRange{1.0, 10.0, scale}
+                                                      : VolumeRange{0.0, 1.0, scale};
     }
     if (scale.scale == ColorScale::Logarithmic && extrema->first > 0.0) {
-        const auto [minimum, maximum]
-            = paddedIfDegenerate(extrema->first, extrema->second, true);
+        const auto [minimum, maximum] =
+            paddedIfDegenerate(extrema->first, extrema->second, {ColorScale::Logarithmic});
         if (minimum > 0.0 && minimum < maximum) {
-            return {minimum, maximum, true, scale};
+            return {minimum, maximum, scale};
         }
     }
-    const auto [minimum, maximum]
-        = paddedIfDegenerate(extrema->first, extrema->second, false);
+    const auto [minimum, maximum] =
+        paddedIfDegenerate(extrema->first, extrema->second, {ColorScale::Linear});
     if (scale.scale == ColorScale::Logarithmic) scale.scale = ColorScale::Linear;
-    return {minimum, maximum, false, scale};
+    return {minimum, maximum, scale};
 }
 
 std::size_t VolumeGridKeyHash::operator()(const VolumeGridKey& key) const noexcept
@@ -423,7 +415,7 @@ VolumeFrame LocalDatasetSession::renderVolume(const VolumeRenderRequest& request
         // answer from the same grid, so publishing last-writer-wins costs
         // nothing but a duplicated scan in a case that needs two misses on
         // one key at once.
-        const auto requestedScale = effectiveColorScale(request.logarithmic, request.scale);
+        const auto requestedScale = request.scale;
         const auto want = std::pair{key, requestedScale};
         std::optional<VolumeRange> memo;
         {

--- a/src/data/LocalDatasetSession.cpp
+++ b/src/data/LocalDatasetSession.cpp
@@ -52,6 +52,13 @@ std::optional<ValueRange> compositeMetadataRange(const DatasetMetadata& metadata
 VolumeRange visibleVolumeRange(const VolumeGrid& grid, bool logarithmic,
     StopToken cancellation)
 {
+    return visibleVolumeRange(grid,
+        {logarithmic ? ColorScale::Logarithmic : ColorScale::Linear, 1.0}, cancellation);
+}
+
+VolumeRange visibleVolumeRange(const VolumeGrid& grid, ColorScaleConfig scale,
+    StopToken cancellation)
+{
     // One scan, and over every finite value rather than the positive ones.
     // Asking volumeGridRange for the positive extrema first would answer
     // "logarithmic is fine" for any field that merely *contains* positive
@@ -63,19 +70,21 @@ VolumeRange visibleVolumeRange(const VolumeGrid& grid, bool logarithmic,
     if (!extrema) {
         // Nothing finite to show. A logarithmic request still wants a
         // logarithmic axis, so the neutral range keeps the mapping.
-        return logarithmic ? VolumeRange{1.0, 10.0, true}
-                           : VolumeRange{0.0, 1.0, false};
+        return scale.scale == ColorScale::Logarithmic
+            ? VolumeRange{1.0, 10.0, true, scale}
+            : VolumeRange{0.0, 1.0, false, scale};
     }
-    if (logarithmic && extrema->first > 0.0) {
+    if (scale.scale == ColorScale::Logarithmic && extrema->first > 0.0) {
         const auto [minimum, maximum]
             = paddedIfDegenerate(extrema->first, extrema->second, true);
         if (minimum > 0.0 && minimum < maximum) {
-            return {minimum, maximum, true};
+            return {minimum, maximum, true, scale};
         }
     }
     const auto [minimum, maximum]
         = paddedIfDegenerate(extrema->first, extrema->second, false);
-    return {minimum, maximum, false};
+    if (scale.scale == ColorScale::Logarithmic) scale.scale = ColorScale::Linear;
+    return {minimum, maximum, false, scale};
 }
 
 std::size_t VolumeGridKeyHash::operator()(const VolumeGridKey& key) const noexcept
@@ -414,7 +423,8 @@ VolumeFrame LocalDatasetSession::renderVolume(const VolumeRenderRequest& request
         // answer from the same grid, so publishing last-writer-wins costs
         // nothing but a duplicated scan in a case that needs two misses on
         // one key at once.
-        const auto want = std::pair{key, request.logarithmic};
+        const auto requestedScale = effectiveColorScale(request.logarithmic, request.scale);
+        const auto want = std::pair{key, requestedScale};
         std::optional<VolumeRange> memo;
         {
             const std::scoped_lock lock(m_mutex);
@@ -423,7 +433,7 @@ VolumeFrame LocalDatasetSession::renderVolume(const VolumeRenderRequest& request
             }
         }
         if (!memo) {
-            memo = visibleVolumeRange(*grid, request.logarithmic, cancellation);
+            memo = visibleVolumeRange(*grid, requestedScale, cancellation);
             const std::scoped_lock lock(m_mutex);
             m_visibleRange = *memo;
             m_visibleRangeFor = want;

--- a/src/data/SessionValidation.cpp
+++ b/src/data/SessionValidation.cpp
@@ -347,10 +347,17 @@ void validateSessionVolumeResult(const DatasetMetadata& metadata,
         throw std::invalid_argument(
             "volume frame did not use the requested range");
     }
-    if (!request.range && used.scale.scale == ColorScale::Logarithmic &&
-        request.scale.scale != ColorScale::Logarithmic) {
-        throw std::invalid_argument(
-            "volume frame used a logarithmic range that was not requested");
+    if (!request.range) {
+        const bool sameScale = usedScale.scale == request.scale.scale
+            && (usedScale.scale != ColorScale::SymLogarithmic
+                || usedScale.linearThreshold == request.scale.linearThreshold);
+        // Visible logarithmic ranges may fall back when the data is not positive.
+        const bool linearFallback = request.scale.scale == ColorScale::Logarithmic
+            && usedScale.scale == ColorScale::Linear;
+        if (!sameScale && !linearFallback) {
+            throw std::invalid_argument(
+                "volume frame used a scale configuration that was not requested");
+        }
     }
     const auto& metrics = frame.metrics;
     for (const auto extent : metrics.gridDims) {

--- a/src/data/SessionValidation.cpp
+++ b/src/data/SessionValidation.cpp
@@ -336,9 +336,11 @@ void validateSessionVolumeResult(const DatasetMetadata& metadata,
             "volume frame pixel storage does not match its size");
     }
     const auto& used = frame.usedRange;
+    const auto usedScale = effectiveColorScale(used.logarithmic, used.scale);
     if (!std::isfinite(used.minimum) || !std::isfinite(used.maximum)
         || !(used.minimum < used.maximum)
-        || (used.logarithmic && !(used.minimum > 0.0))) {
+        || (usedScale.scale == ColorScale::Logarithmic && !(used.minimum > 0.0))
+        || !resolveValueRange(used.minimum, used.maximum, usedScale)) {
         throw std::invalid_argument("volume frame reports an unusable range");
     }
     if (request.range && !(used == *request.range)) {

--- a/src/data/SessionValidation.cpp
+++ b/src/data/SessionValidation.cpp
@@ -336,7 +336,7 @@ void validateSessionVolumeResult(const DatasetMetadata& metadata,
             "volume frame pixel storage does not match its size");
     }
     const auto& used = frame.usedRange;
-    const auto usedScale = effectiveColorScale(used.logarithmic, used.scale);
+    const auto usedScale = used.scale;
     if (!std::isfinite(used.minimum) || !std::isfinite(used.maximum)
         || !(used.minimum < used.maximum)
         || (usedScale.scale == ColorScale::Logarithmic && !(used.minimum > 0.0))
@@ -347,7 +347,8 @@ void validateSessionVolumeResult(const DatasetMetadata& metadata,
         throw std::invalid_argument(
             "volume frame did not use the requested range");
     }
-    if (!request.range && used.logarithmic && !request.logarithmic) {
+    if (!request.range && used.scale.scale == ColorScale::Logarithmic &&
+        request.scale.scale != ColorScale::Logarithmic) {
         throw std::invalid_argument(
             "volume frame used a logarithmic range that was not requested");
     }

--- a/src/pipeline/DisplayCoordinator.cpp
+++ b/src/pipeline/DisplayCoordinator.cpp
@@ -75,6 +75,9 @@ void DisplayCoordinator::realignArrivalToRange(SliceDisplayResult& result,
     std::pair<double, double> range, const Palette& palette,
     bool realignRasterAndContours)
 {
+    if (result.logarithmic && result.scale.scale == ColorScale::Linear) {
+        result.scale.scale = ColorScale::Logarithmic;
+    }
     result.minimum = range.first;
     result.maximum = range.second;
     // The reused full-domain range is a superset of this arrival's own range,
@@ -83,6 +86,9 @@ void DisplayCoordinator::realignArrivalToRange(SliceDisplayResult& result,
     // degrade to linear otherwise so renderScalarPlane does not reject the
     // non-positive minimum (see shared-log-range-render-throw-fails-load).
     result.logarithmic = result.logarithmic && range.first > 0.0;
+    if (result.scale.scale == ColorScale::Logarithmic && !result.logarithmic) {
+        result.scale.scale = ColorScale::Linear;
+    }
     if (!realignRasterAndContours) {
         return;
     }
@@ -91,7 +97,7 @@ void DisplayCoordinator::realignArrivalToRange(SliceDisplayResult& result,
             ScalarRenderSettings{
                 .minimum = result.minimum,
                 .maximum = result.maximum,
-                .logarithmic = result.logarithmic,
+                .scale = result.scale,
                 .palette = &palette
             });
     }
@@ -104,14 +110,36 @@ DisplayCoordinator::syncPanelsToSharedRange(
     bool logarithmic, bool contourMode, int contourCount,
     const Palette& palette) const
 {
+    return syncPanelsToSharedRange(key, panels,
+        {logarithmic ? ColorScale::Logarithmic : ColorScale::Linear, 1.0},
+        contourMode, contourCount, palette);
+}
+
+std::optional<DisplayCoordinator::SharedRangeSync>
+DisplayCoordinator::syncPanelsToSharedRange(
+    const RangeKey& key, std::span<const PanelSyncInput> panels,
+    ColorScaleConfig scale, bool contourMode, int contourCount,
+    const Palette& palette) const
+{
     return renderPanelsToSharedRange(cachedFullDomainRange(key), panels,
-        logarithmic, contourMode, contourCount, palette);
+        scale, contourMode, contourCount, palette);
 }
 
 std::optional<DisplayCoordinator::SharedRangeSync>
 DisplayCoordinator::renderPanelsToSharedRange(
     std::optional<std::pair<double, double>> sharedRange,
     std::span<const PanelSyncInput> panels, bool logarithmic,
+    bool contourMode, int contourCount, const Palette& palette)
+{
+    return renderPanelsToSharedRange(std::move(sharedRange), panels,
+        {logarithmic ? ColorScale::Logarithmic : ColorScale::Linear, 1.0},
+        contourMode, contourCount, palette);
+}
+
+std::optional<DisplayCoordinator::SharedRangeSync>
+DisplayCoordinator::renderPanelsToSharedRange(
+    std::optional<std::pair<double, double>> sharedRange,
+    std::span<const PanelSyncInput> panels, ColorScaleConfig scale,
     bool contourMode, int contourCount, const Palette& palette)
 {
     auto shared = std::move(sharedRange);
@@ -121,7 +149,7 @@ DisplayCoordinator::renderPanelsToSharedRange(
         for (const auto& panel : panels) {
             planes.push_back(panel.plane);
         }
-        shared = sharedVisibleRange(planes, logarithmic);
+        shared = sharedVisibleRange(planes, scale.scale == ColorScale::Logarithmic);
     }
     if (!shared) {
         return std::nullopt;
@@ -134,7 +162,11 @@ DisplayCoordinator::renderPanelsToSharedRange(
     // union that crosses zero, and renderScalarPlane rejects a non-positive
     // log minimum -- which threw and failed the whole load
     // (see shared-log-range-render-throw-fails-load).
-    sync.logarithmic = logarithmic && sync.range.first > 0.0;
+    sync.scale = scale;
+    if (sync.scale.scale == ColorScale::Logarithmic && !(sync.range.first > 0.0)) {
+        sync.scale.scale = ColorScale::Linear;
+    }
+    sync.logarithmic = sync.scale.scale == ColorScale::Logarithmic;
     sync.panels.resize(panels.size());
     for (std::size_t index = 0; index < panels.size(); ++index) {
         const auto& panel = panels[index];
@@ -150,14 +182,14 @@ DisplayCoordinator::renderPanelsToSharedRange(
             && panel.contourPlane->height > 0) {
             update.contourPolylines = recomputeContourPolylines(
                 *panel.contourPlane,
-                sync.range.first, sync.range.second, sync.logarithmic,
+                sync.range.first, sync.range.second, sync.scale,
                 contourCount, panel.outputSize[0], panel.outputSize[1]);
             update.contoursRecomputed = true;
         }
         update.image = renderScalarPlane(*panel.plane, ScalarRenderSettings{
             .minimum = sync.range.first,
             .maximum = sync.range.second,
-            .logarithmic = sync.logarithmic,
+            .scale = sync.scale,
             .palette = &palette
         });
     }

--- a/src/pipeline/DisplayCoordinator.cpp
+++ b/src/pipeline/DisplayCoordinator.cpp
@@ -29,9 +29,9 @@ void DisplayCoordinator::invalidateRangeCache()
     m_rangeKey.reset();
 }
 
-std::optional<std::pair<double, double>> DisplayCoordinator::sharedVisibleRange(
-    std::span<const ScalarPlane* const> planes, bool logarithmic)
-{
+std::optional<std::pair<double, double>>
+DisplayCoordinator::sharedVisibleRange(std::span<const ScalarPlane* const> planes,
+                                       ColorScaleConfig scale) {
     auto minimum = std::numeric_limits<double>::infinity();
     auto maximum = -std::numeric_limits<double>::infinity();
     for (const auto* plane : planes) {
@@ -50,7 +50,7 @@ std::optional<std::pair<double, double>> DisplayCoordinator::sharedVisibleRange(
     if (!std::isfinite(minimum) || !std::isfinite(maximum)) {
         return std::nullopt;
     }
-    return paddedIfDegenerate(minimum, maximum, logarithmic);
+    return paddedIfDegenerate(minimum, maximum, scale);
 }
 
 ImageTransformPolicy DisplayCoordinator::rasterTransformPolicy(
@@ -75,9 +75,6 @@ void DisplayCoordinator::realignArrivalToRange(SliceDisplayResult& result,
     std::pair<double, double> range, const Palette& palette,
     bool realignRasterAndContours)
 {
-    if (result.logarithmic && result.scale.scale == ColorScale::Linear) {
-        result.scale.scale = ColorScale::Logarithmic;
-    }
     result.minimum = range.first;
     result.maximum = range.second;
     // The reused full-domain range is a superset of this arrival's own range,
@@ -85,8 +82,7 @@ void DisplayCoordinator::realignArrivalToRange(SliceDisplayResult& result,
     // true per panel). Log is only viable when the shared minimum is positive;
     // degrade to linear otherwise so renderScalarPlane does not reject the
     // non-positive minimum (see shared-log-range-render-throw-fails-load).
-    result.logarithmic = result.logarithmic && range.first > 0.0;
-    if (result.scale.scale == ColorScale::Logarithmic && !result.logarithmic) {
+    if (result.scale.scale == ColorScale::Logarithmic && !(range.first > 0.0)) {
         result.scale.scale = ColorScale::Linear;
     }
     if (!realignRasterAndContours) {
@@ -107,33 +103,11 @@ void DisplayCoordinator::realignArrivalToRange(SliceDisplayResult& result,
 std::optional<DisplayCoordinator::SharedRangeSync>
 DisplayCoordinator::syncPanelsToSharedRange(
     const RangeKey& key, std::span<const PanelSyncInput> panels,
-    bool logarithmic, bool contourMode, int contourCount,
-    const Palette& palette) const
-{
-    return syncPanelsToSharedRange(key, panels,
-        {logarithmic ? ColorScale::Logarithmic : ColorScale::Linear, 1.0},
-        contourMode, contourCount, palette);
-}
-
-std::optional<DisplayCoordinator::SharedRangeSync>
-DisplayCoordinator::syncPanelsToSharedRange(
-    const RangeKey& key, std::span<const PanelSyncInput> panels,
     ColorScaleConfig scale, bool contourMode, int contourCount,
     const Palette& palette) const
 {
     return renderPanelsToSharedRange(cachedFullDomainRange(key), panels,
         scale, contourMode, contourCount, palette);
-}
-
-std::optional<DisplayCoordinator::SharedRangeSync>
-DisplayCoordinator::renderPanelsToSharedRange(
-    std::optional<std::pair<double, double>> sharedRange,
-    std::span<const PanelSyncInput> panels, bool logarithmic,
-    bool contourMode, int contourCount, const Palette& palette)
-{
-    return renderPanelsToSharedRange(std::move(sharedRange), panels,
-        {logarithmic ? ColorScale::Logarithmic : ColorScale::Linear, 1.0},
-        contourMode, contourCount, palette);
 }
 
 std::optional<DisplayCoordinator::SharedRangeSync>
@@ -149,14 +123,14 @@ DisplayCoordinator::renderPanelsToSharedRange(
         for (const auto& panel : panels) {
             planes.push_back(panel.plane);
         }
-        shared = sharedVisibleRange(planes, scale.scale == ColorScale::Logarithmic);
+        shared = sharedVisibleRange(planes, scale);
     }
     if (!shared) {
         return std::nullopt;
     }
     SharedRangeSync sync;
     sync.range = *shared;
-    // One log flag for every panel: log only when the shared minimum is
+    // One color scale for every panel: log only when the shared minimum is
     // positive, matching how a single panel degrades to linear. Keeping it
     // per-panel would render an all-positive plane logarithmically against a
     // union that crosses zero, and renderScalarPlane rejects a non-positive
@@ -166,7 +140,6 @@ DisplayCoordinator::renderPanelsToSharedRange(
     if (sync.scale.scale == ColorScale::Logarithmic && !(sync.range.first > 0.0)) {
         sync.scale.scale = ColorScale::Linear;
     }
-    sync.logarithmic = sync.scale.scale == ColorScale::Logarithmic;
     sync.panels.resize(panels.size());
     for (std::size_t index = 0; index < panels.size(); ++index) {
         const auto& panel = panels[index];

--- a/src/pipeline/SlicePipeline.cpp
+++ b/src/pipeline/SlicePipeline.cpp
@@ -290,16 +290,6 @@ void applyDisplayCoordinates(
 } // namespace
 
 SliceDisplayResult executeSlice(const std::shared_ptr<DatasetSession>& dataset,
-    const SliceRequest& request,
-    RangeMode rangeMode,
-    const std::optional<std::pair<double, double>>& userRange,
-    bool logarithmic, const Palette& palette, StopToken cancellation)
-{
-    return executeSlice(dataset, request, rangeMode, userRange,
-        {logarithmic ? ColorScale::Logarithmic : ColorScale::Linear, 1.0}, palette, cancellation);
-}
-
-SliceDisplayResult executeSlice(const std::shared_ptr<DatasetSession>& dataset,
     const SliceRequest& request, RangeMode rangeMode,
     const std::optional<std::pair<double, double>>& userRange,
     ColorScaleConfig scale, const Palette& palette, StopToken cancellation)
@@ -312,7 +302,6 @@ SliceDisplayResult executeSlice(const std::shared_ptr<DatasetSession>& dataset,
         scale, result.displayPlane(), cancellation);
     result.minimum = range.minimum;
     result.maximum = range.maximum;
-    result.logarithmic = range.logarithmic;
     result.scale = range.scale;
     result.fieldName = dataset->metadata().fields[request.field.value].name;
     result.image = renderScalarPlane(result.displayPlane(),
@@ -355,19 +344,6 @@ void appendVectorGlyphs(const std::shared_ptr<DatasetSession>& dataset,
         + vSlice.metrics.cacheHits;
     result.slice.metrics.payloadBytesRead += uSlice.metrics.payloadBytesRead
         + vSlice.metrics.payloadBytesRead;
-}
-
-SliceDisplayResult executeSliceWithFallback(
-    const std::shared_ptr<DatasetSession>& dataset, SliceRequest request,
-    RangeMode rangeMode,
-    const std::optional<std::pair<double, double>>& userRange,
-    bool logarithmic, const Palette& palette, DisplayMode displayMode,
-    std::uint32_t vectorUField, std::uint32_t vectorVField, int contourCount,
-    StopToken cancellation)
-{
-    return executeSliceWithFallback(dataset, std::move(request), rangeMode,
-        userRange, {logarithmic ? ColorScale::Logarithmic : ColorScale::Linear, 1.0},
-        palette, displayMode, vectorUField, vectorVField, contourCount, cancellation);
 }
 
 SliceDisplayResult executeSliceWithFallback(
@@ -438,14 +414,6 @@ SliceDisplayResult executeSliceWithFallback(
 // this cheap extraction (see refreshCachedSlice).
 void appendContours(const std::shared_ptr<DatasetSession>& dataset,
     const SliceRequest& request, int contourCount, double minimum, double maximum,
-    bool logarithmic, StopToken cancellation, SliceDisplayResult& result)
-{
-    appendContours(dataset, request, contourCount, minimum, maximum,
-        {logarithmic ? ColorScale::Logarithmic : ColorScale::Linear, 1.0}, cancellation, result);
-}
-
-void appendContours(const std::shared_ptr<DatasetSession>& dataset,
-    const SliceRequest& request, int contourCount, double minimum, double maximum,
     ColorScaleConfig scale, StopToken cancellation, SliceDisplayResult& result)
 {
     const auto& metadata = dataset->metadata();
@@ -491,23 +459,6 @@ void appendContours(const std::shared_ptr<DatasetSession>& dataset,
 }
 
 SliceDisplayResult refreshCachedSlice(
-    const std::shared_ptr<DatasetSession>& dataset,
-    const SliceRequest& request,
-    std::shared_ptr<const ScalarPlane> displayPlanePtr,
-    ScalarPlane contourPlane, std::vector<VectorSegment> vectors,
-    RangeMode rangeMode,
-    const std::optional<std::pair<double, double>>& userRange,
-    bool logarithmic, const Palette& palette, DisplayMode displayMode,
-    std::uint32_t vectorUField, std::uint32_t vectorVField,
-    int contourCount, bool rasterDirty, StopToken cancellation)
-{
-    return refreshCachedSlice(dataset, request, std::move(displayPlanePtr),
-        std::move(contourPlane), std::move(vectors), rangeMode, userRange,
-        {logarithmic ? ColorScale::Logarithmic : ColorScale::Linear, 1.0}, palette,
-        displayMode, vectorUField, vectorVField, contourCount, rasterDirty, cancellation);
-}
-
-SliceDisplayResult refreshCachedSlice(
     const std::shared_ptr<DatasetSession>& dataset, const SliceRequest& request,
     std::shared_ptr<const ScalarPlane> displayPlanePtr,
     ScalarPlane contourPlane, std::vector<VectorSegment> vectors,
@@ -540,7 +491,6 @@ SliceDisplayResult refreshCachedSlice(
         scale, plane, cancellation);
     result.minimum = range.minimum;
     result.maximum = range.maximum;
-    result.logarithmic = range.logarithmic;
     result.scale = range.scale;
     result.fieldName = dataset->metadata().fields[request.field.value].name;
     result.rasterUnchanged = !rasterDirty;
@@ -566,16 +516,6 @@ SliceDisplayResult refreshCachedSlice(
     }
     applyDisplayCoordinates(dataset->metadata(), result);
     return result;
-}
-
-std::vector<ContourPolyline> recomputeContourPolylines(
-    const ScalarPlane& plane, double minimum,
-    double maximum, bool logarithmic, int contourCount,
-    int displayWidth, int displayHeight)
-{
-    return recomputeContourPolylines(plane, minimum, maximum,
-        {logarithmic ? ColorScale::Logarithmic : ColorScale::Linear, 1.0},
-        contourCount, displayWidth, displayHeight);
 }
 
 std::vector<ContourPolyline> recomputeContourPolylines(
@@ -699,7 +639,7 @@ InitialSliceResult executeSessionFrameLoad(
         try {
             result.displays.clear();
             result.displays.reserve(normals.size());
-            const auto frameScale = effectiveColorScale(spec.logarithmic, spec.scale);
+            const auto frameScale = spec.scale;
             for (std::size_t entry = 0; entry < normals.size(); ++entry) {
                 const auto normal = normals[entry];
                 SliceRequest request;
@@ -789,14 +729,13 @@ InitialSliceResult executeSessionFrameLoad(
                     &result.displays[0].displayPlane(),
                     &result.displays[1].displayPlane(),
                     &result.displays[2].displayPlane()};
-                const auto shared = DisplayCoordinator::sharedVisibleRange(
-                    planes, frameScale.scale == ColorScale::Logarithmic);
+                const auto shared = DisplayCoordinator::sharedVisibleRange(planes, frameScale);
                 // No finite samples anywhere: fall back to a neutral range so
                 // the frame still renders.
                 const auto [globalMin, globalMax] = shared.value_or(
                     frameScale.scale == ColorScale::Logarithmic ? std::pair{1.0, 10.0}
                                      : std::pair{0.0, 1.0});
-                // One log flag for all three panels: log only when the shared
+                // One color scale for all three panels: log only when the shared
                 // minimum is positive, matching how a single panel degrades to
                 // linear. A per-panel flag kept an all-positive plane
                 // logarithmic against a union that crosses zero, and
@@ -807,11 +746,9 @@ InitialSliceResult executeSessionFrameLoad(
                 if (sharedScale.scale == ColorScale::Logarithmic && !(globalMin > 0.0)) {
                     sharedScale.scale = ColorScale::Linear;
                 }
-                const bool sharedLog = sharedScale.scale == ColorScale::Logarithmic;
                 for (auto& d : result.displays) {
                     d.minimum = globalMin;
                     d.maximum = globalMax;
-                    d.logarithmic = sharedLog;
                     d.scale = sharedScale;
                     d.image = renderScalarPlane(d.displayPlane(),
                         ScalarRenderSettings{

--- a/src/pipeline/SlicePipeline.cpp
+++ b/src/pipeline/SlicePipeline.cpp
@@ -295,21 +295,31 @@ SliceDisplayResult executeSlice(const std::shared_ptr<DatasetSession>& dataset,
     const std::optional<std::pair<double, double>>& userRange,
     bool logarithmic, const Palette& palette, StopToken cancellation)
 {
+    return executeSlice(dataset, request, rangeMode, userRange,
+        {logarithmic ? ColorScale::Logarithmic : ColorScale::Linear, 1.0}, palette, cancellation);
+}
+
+SliceDisplayResult executeSlice(const std::shared_ptr<DatasetSession>& dataset,
+    const SliceRequest& request, RangeMode rangeMode,
+    const std::optional<std::pair<double, double>>& userRange,
+    ColorScaleConfig scale, const Palette& palette, StopToken cancellation)
+{
     SliceDisplayResult result;
     result.request = request;
     result.slice = requestSlice(*dataset, request, cancellation);
     const auto range = resolveDisplayRange(dataset, request.field,
         request.maximumLevel, request.composition, rangeMode, userRange,
-        logarithmic, result.displayPlane(), cancellation);
+        scale, result.displayPlane(), cancellation);
     result.minimum = range.minimum;
     result.maximum = range.maximum;
     result.logarithmic = range.logarithmic;
+    result.scale = range.scale;
     result.fieldName = dataset->metadata().fields[request.field.value].name;
     result.image = renderScalarPlane(result.displayPlane(),
         ScalarRenderSettings{
             .minimum = range.minimum,
             .maximum = range.maximum,
-            .logarithmic = range.logarithmic,
+            .scale = range.scale,
             .palette = &palette
         });
     applyDisplayCoordinates(dataset->metadata(), result);
@@ -355,6 +365,18 @@ SliceDisplayResult executeSliceWithFallback(
     std::uint32_t vectorUField, std::uint32_t vectorVField, int contourCount,
     StopToken cancellation)
 {
+    return executeSliceWithFallback(dataset, std::move(request), rangeMode,
+        userRange, {logarithmic ? ColorScale::Logarithmic : ColorScale::Linear, 1.0},
+        palette, displayMode, vectorUField, vectorVField, contourCount, cancellation);
+}
+
+SliceDisplayResult executeSliceWithFallback(
+    const std::shared_ptr<DatasetSession>& dataset, SliceRequest request,
+    RangeMode rangeMode, const std::optional<std::pair<double, double>>& userRange,
+    ColorScaleConfig scale, const Palette& palette, DisplayMode displayMode,
+    std::uint32_t vectorUField, std::uint32_t vectorVField, int contourCount,
+    StopToken cancellation)
+{
     request.outputSize = frameBudgetBoundedOutputSize(
         request.outputSize, dataset->maximumResponseBytes());
     int fallbackFrom = -1;
@@ -362,14 +384,14 @@ SliceDisplayResult executeSliceWithFallback(
     for (;;) {
         try {
             auto result = executeSlice(dataset, request, rangeMode,
-                userRange, logarithmic, palette, cancellation);
+                userRange, scale, palette, cancellation);
             result.mode = displayMode;
             result.vectorUField = vectorUField;
             result.vectorVField = vectorVField;
             result.contourCount = contourCount;
             if (isContourMode(displayMode)) {
                 appendContours(dataset, request, contourCount,
-                    result.minimum, result.maximum, result.logarithmic,
+                    result.minimum, result.maximum, result.scale,
                     cancellation, result);
             }
             if (displayMode == DisplayMode::VelocityVectors) {
@@ -418,6 +440,14 @@ void appendContours(const std::shared_ptr<DatasetSession>& dataset,
     const SliceRequest& request, int contourCount, double minimum, double maximum,
     bool logarithmic, StopToken cancellation, SliceDisplayResult& result)
 {
+    appendContours(dataset, request, contourCount, minimum, maximum,
+        {logarithmic ? ColorScale::Logarithmic : ColorScale::Linear, 1.0}, cancellation, result);
+}
+
+void appendContours(const std::shared_ptr<DatasetSession>& dataset,
+    const SliceRequest& request, int contourCount, double minimum, double maximum,
+    ColorScaleConfig scale, StopToken cancellation, SliceDisplayResult& result)
+{
     const auto& metadata = dataset->metadata();
     const auto level = std::min(request.maximumLevel, metadata.finestLevel);
     const auto axes = slicePlaneAxes(metadata.dimension, request.normalDirection);
@@ -455,7 +485,7 @@ void appendContours(const std::shared_ptr<DatasetSession>& dataset,
     // No supersampling (#56 removed it): the linear plane is already at contour
     // resolution, so contours are extracted from contourPlane directly.
     const auto values = contourValues(
-        minimum, maximum, contourCount, logarithmic);
+        minimum, maximum, contourCount, scale);
     result.contourPolylines = contourPolylinesForDisplay(
         result.contourPlane, values, displayWidth, displayHeight);
 }
@@ -468,6 +498,21 @@ SliceDisplayResult refreshCachedSlice(
     RangeMode rangeMode,
     const std::optional<std::pair<double, double>>& userRange,
     bool logarithmic, const Palette& palette, DisplayMode displayMode,
+    std::uint32_t vectorUField, std::uint32_t vectorVField,
+    int contourCount, bool rasterDirty, StopToken cancellation)
+{
+    return refreshCachedSlice(dataset, request, std::move(displayPlanePtr),
+        std::move(contourPlane), std::move(vectors), rangeMode, userRange,
+        {logarithmic ? ColorScale::Logarithmic : ColorScale::Linear, 1.0}, palette,
+        displayMode, vectorUField, vectorVField, contourCount, rasterDirty, cancellation);
+}
+
+SliceDisplayResult refreshCachedSlice(
+    const std::shared_ptr<DatasetSession>& dataset, const SliceRequest& request,
+    std::shared_ptr<const ScalarPlane> displayPlanePtr,
+    ScalarPlane contourPlane, std::vector<VectorSegment> vectors,
+    RangeMode rangeMode, const std::optional<std::pair<double, double>>& userRange,
+    ColorScaleConfig scale, const Palette& palette, DisplayMode displayMode,
     std::uint32_t vectorUField, std::uint32_t vectorVField,
     int contourCount, bool rasterDirty, StopToken cancellation)
 {
@@ -492,10 +537,11 @@ SliceDisplayResult refreshCachedSlice(
     const auto& plane = *result.reusedPlane;
     const auto range = resolveDisplayRange(dataset, request.field,
         request.maximumLevel, request.composition, rangeMode, userRange,
-        logarithmic, plane, cancellation);
+        scale, plane, cancellation);
     result.minimum = range.minimum;
     result.maximum = range.maximum;
     result.logarithmic = range.logarithmic;
+    result.scale = range.scale;
     result.fieldName = dataset->metadata().fields[request.field.value].name;
     result.rasterUnchanged = !rasterDirty;
     if (rasterDirty) {
@@ -503,14 +549,14 @@ SliceDisplayResult refreshCachedSlice(
             ScalarRenderSettings{
                 .minimum = range.minimum,
                 .maximum = range.maximum,
-                .logarithmic = range.logarithmic,
+                .scale = range.scale,
                 .palette = &palette
             });
     }
     if (isContourMode(displayMode)) {
         result.contourPlane = std::move(contourPlane);
         const auto values = contourValues(
-            range.minimum, range.maximum, contourCount, range.logarithmic);
+            range.minimum, range.maximum, contourCount, range.scale);
         result.contourPolylines = contourPolylinesForDisplay(
             result.contourPlane, values,
             request.outputSize[0], request.outputSize[1]);
@@ -527,13 +573,23 @@ std::vector<ContourPolyline> recomputeContourPolylines(
     double maximum, bool logarithmic, int contourCount,
     int displayWidth, int displayHeight)
 {
+    return recomputeContourPolylines(plane, minimum, maximum,
+        {logarithmic ? ColorScale::Logarithmic : ColorScale::Linear, 1.0},
+        contourCount, displayWidth, displayHeight);
+}
+
+std::vector<ContourPolyline> recomputeContourPolylines(
+    const ScalarPlane& plane, double minimum, double maximum,
+    ColorScaleConfig scale, int contourCount, int displayWidth, int displayHeight)
+{
     if (plane.width <= 0 || plane.height <= 0 || contourCount < 1
-        || !(minimum < maximum) || (logarithmic && !(minimum > 0.0))) {
+        || !(minimum < maximum)
+        || (scale.scale == ColorScale::Logarithmic && !(minimum > 0.0))) {
         return {};
     }
     try {
         const auto values = contourValues(
-            minimum, maximum, contourCount, logarithmic);
+            minimum, maximum, contourCount, scale);
         return contourPolylinesForDisplay(
             plane, values, displayWidth, displayHeight);
     } catch (const std::exception&) {
@@ -548,7 +604,7 @@ void recomputeContourPolylines(SliceDisplayResult& result)
     }
     result.contourPolylines = recomputeContourPolylines(
         result.contourPlane, result.minimum,
-        result.maximum, result.logarithmic, result.contourCount,
+        result.maximum, result.scale, result.contourCount,
         result.request.outputSize[0], result.request.outputSize[1]);
 }
 
@@ -643,6 +699,7 @@ InitialSliceResult executeSessionFrameLoad(
         try {
             result.displays.clear();
             result.displays.reserve(normals.size());
+            const auto frameScale = effectiveColorScale(spec.logarithmic, spec.scale);
             for (std::size_t entry = 0; entry < normals.size(); ++entry) {
                 const auto normal = normals[entry];
                 SliceRequest request;
@@ -696,12 +753,12 @@ InitialSliceResult executeSessionFrameLoad(
                     request.physicalPosition = positions[static_cast<std::size_t>(normal)];
                 }
                 auto display = executeSlice(result.dataset, request, rangeMode,
-                    spec.userRange, spec.logarithmic, spec.palette, cancellation);
+                    spec.userRange, frameScale, spec.palette, cancellation);
                 display.mode = spec.displayMode;
                 display.contourCount = spec.contourCount;
                 if (isContourMode(spec.displayMode)) {
                     appendContours(result.dataset, request, spec.contourCount,
-                        display.minimum, display.maximum, display.logarithmic,
+                        display.minimum, display.maximum, display.scale,
                         cancellation, display);
                 }
                 if (spec.displayMode == DisplayMode::VelocityVectors) {
@@ -733,11 +790,11 @@ InitialSliceResult executeSessionFrameLoad(
                     &result.displays[1].displayPlane(),
                     &result.displays[2].displayPlane()};
                 const auto shared = DisplayCoordinator::sharedVisibleRange(
-                    planes, spec.logarithmic);
+                    planes, frameScale.scale == ColorScale::Logarithmic);
                 // No finite samples anywhere: fall back to a neutral range so
                 // the frame still renders.
                 const auto [globalMin, globalMax] = shared.value_or(
-                    spec.logarithmic ? std::pair{1.0, 10.0}
+                    frameScale.scale == ColorScale::Logarithmic ? std::pair{1.0, 10.0}
                                      : std::pair{0.0, 1.0});
                 // One log flag for all three panels: log only when the shared
                 // minimum is positive, matching how a single panel degrades to
@@ -746,16 +803,21 @@ InitialSliceResult executeSessionFrameLoad(
                 // renderScalarPlane rejects a non-positive log minimum -- which
                 // failed the whole frame load
                 // (see shared-log-range-render-throw-fails-load).
-                const bool sharedLog = spec.logarithmic && globalMin > 0.0;
+                auto sharedScale = frameScale;
+                if (sharedScale.scale == ColorScale::Logarithmic && !(globalMin > 0.0)) {
+                    sharedScale.scale = ColorScale::Linear;
+                }
+                const bool sharedLog = sharedScale.scale == ColorScale::Logarithmic;
                 for (auto& d : result.displays) {
                     d.minimum = globalMin;
                     d.maximum = globalMax;
                     d.logarithmic = sharedLog;
+                    d.scale = sharedScale;
                     d.image = renderScalarPlane(d.displayPlane(),
                         ScalarRenderSettings{
                             .minimum = globalMin,
                             .maximum = globalMax,
-                            .logarithmic = sharedLog,
+                            .scale = sharedScale,
                             .palette = &spec.palette
                         });
                     // Contours were extracted per view before the shared range

--- a/src/pipeline/SliceRangeResolver.cpp
+++ b/src/pipeline/SliceRangeResolver.cpp
@@ -15,9 +15,8 @@ public:
 
 } // namespace
 
-std::optional<std::pair<double, double>> finiteRange(
-    const ScalarPlane& plane, bool logarithmic)
-{
+std::optional<std::pair<double, double>> finiteRange(const ScalarPlane& plane,
+                                                     ColorScaleConfig scale) {
     auto minimum = std::numeric_limits<double>::infinity();
     auto maximum = -std::numeric_limits<double>::infinity();
     for (std::size_t pixel = 0; pixel < plane.values.size(); ++pixel) {
@@ -34,7 +33,7 @@ std::optional<std::pair<double, double>> finiteRange(
     if (!std::isfinite(minimum) || !std::isfinite(maximum)) {
         return std::nullopt;
     }
-    return paddedIfDegenerate(minimum, maximum, logarithmic);
+    return paddedIfDegenerate(minimum, maximum, scale);
 }
 
 std::optional<ValueRange> selectedMetadataRange(
@@ -114,12 +113,12 @@ std::optional<std::pair<double, double>> fabDataRange(
     return std::pair{range->minimum, range->maximum};
 }
 
-std::pair<double, double> resolveRange(
-    const std::shared_ptr<DatasetSession>& dataset, FieldId field,
-    int maximumLevel, CompositionPolicy composition, RangeMode rangeMode,
-    const std::optional<std::pair<double, double>>& userRange,
-    bool logarithmic, const ScalarPlane& plane, StopToken cancellation)
-{
+std::pair<double, double> resolveRange(const std::shared_ptr<DatasetSession>& dataset,
+                                       FieldId field, int maximumLevel,
+                                       CompositionPolicy composition, RangeMode rangeMode,
+                                       const std::optional<std::pair<double, double>>& userRange,
+                                       ColorScaleConfig scale, const ScalarPlane& plane,
+                                       StopToken cancellation) {
     auto selectedRange = userRange;
     if (rangeMode == RangeMode::Level || rangeMode == RangeMode::File) {
         if (rangeMode == RangeMode::File) {
@@ -139,17 +138,16 @@ std::pair<double, double> resolveRange(
             }
         }
     }
-    auto [minimum, maximum] = selectedRange
-        ? *selectedRange
-        : finiteRange(plane, logarithmic).value_or(logarithmic
-              ? std::pair{1.0, 10.0}
-              : std::pair{0.0, 1.0});
-    std::tie(minimum, maximum)
-        = paddedIfDegenerate(minimum, maximum, logarithmic);
+    auto [minimum, maximum] =
+        selectedRange ? *selectedRange
+                      : finiteRange(plane, scale)
+                            .value_or(scale.scale == ColorScale::Logarithmic ? std::pair{1.0, 10.0}
+                                                                             : std::pair{0.0, 1.0});
+    std::tie(minimum, maximum) = paddedIfDegenerate(minimum, maximum, scale);
     if (!(minimum < maximum)) {
         throw std::runtime_error("user scalar range must have positive extent");
     }
-    if (logarithmic && !(minimum > 0.0)) {
+    if (scale.scale == ColorScale::Logarithmic && !(minimum > 0.0)) {
         throw LogarithmicRangeError(
             "logarithmic scalar range must be positive");
     }
@@ -160,37 +158,26 @@ ResolvedRange resolveDisplayRange(
     const std::shared_ptr<DatasetSession>& dataset, FieldId field,
     int maximumLevel, CompositionPolicy composition, RangeMode rangeMode,
     const std::optional<std::pair<double, double>>& userRange,
-    bool logarithmic, const ScalarPlane& plane, StopToken cancellation)
-{
-    return resolveDisplayRange(dataset, field, maximumLevel, composition,
-        rangeMode, userRange,
-        {logarithmic ? ColorScale::Logarithmic : ColorScale::Linear, 1.0},
-        plane, cancellation);
-}
-
-ResolvedRange resolveDisplayRange(
-    const std::shared_ptr<DatasetSession>& dataset, FieldId field,
-    int maximumLevel, CompositionPolicy composition, RangeMode rangeMode,
-    const std::optional<std::pair<double, double>>& userRange,
     ColorScaleConfig scale, const ScalarPlane& plane, StopToken cancellation)
 {
     if (scale.scale == ColorScale::Logarithmic) {
         try {
-            const auto [minimum, maximum] = resolveRange(dataset, field,
-                maximumLevel, composition, rangeMode, userRange, true, plane,
-                cancellation);
-            return {minimum, maximum, true, scale};
+            const auto [minimum, maximum] =
+                resolveRange(dataset, field, maximumLevel, composition, rangeMode, userRange,
+                             {ColorScale::Logarithmic}, plane, cancellation);
+            return {minimum, maximum, scale};
         } catch (const LogarithmicRangeError&) {
             // Log is not viable for this range; fall back to linear below.
         }
     }
-    const auto [minimum, maximum] = resolveRange(dataset, field, maximumLevel,
-        composition, rangeMode, userRange, false, plane, cancellation);
+    const auto [minimum, maximum] =
+        resolveRange(dataset, field, maximumLevel, composition, rangeMode, userRange,
+                     {ColorScale::Linear}, plane, cancellation);
     if (scale.scale == ColorScale::SymLogarithmic
         && resolveValueRange(minimum, maximum, scale)) {
-        return {minimum, maximum, false, scale};
+        return {minimum, maximum, scale};
     }
-    return {minimum, maximum, false, {ColorScale::Linear, scale.linearThreshold}};
+    return {minimum, maximum, {ColorScale::Linear, scale.linearThreshold}};
 }
 
 } // namespace amrvis

--- a/src/pipeline/SliceRangeResolver.cpp
+++ b/src/pipeline/SliceRangeResolver.cpp
@@ -162,19 +162,35 @@ ResolvedRange resolveDisplayRange(
     const std::optional<std::pair<double, double>>& userRange,
     bool logarithmic, const ScalarPlane& plane, StopToken cancellation)
 {
-    if (logarithmic) {
+    return resolveDisplayRange(dataset, field, maximumLevel, composition,
+        rangeMode, userRange,
+        {logarithmic ? ColorScale::Logarithmic : ColorScale::Linear, 1.0},
+        plane, cancellation);
+}
+
+ResolvedRange resolveDisplayRange(
+    const std::shared_ptr<DatasetSession>& dataset, FieldId field,
+    int maximumLevel, CompositionPolicy composition, RangeMode rangeMode,
+    const std::optional<std::pair<double, double>>& userRange,
+    ColorScaleConfig scale, const ScalarPlane& plane, StopToken cancellation)
+{
+    if (scale.scale == ColorScale::Logarithmic) {
         try {
             const auto [minimum, maximum] = resolveRange(dataset, field,
                 maximumLevel, composition, rangeMode, userRange, true, plane,
                 cancellation);
-            return {minimum, maximum, true};
+            return {minimum, maximum, true, scale};
         } catch (const LogarithmicRangeError&) {
             // Log is not viable for this range; fall back to linear below.
         }
     }
     const auto [minimum, maximum] = resolveRange(dataset, field, maximumLevel,
         composition, rangeMode, userRange, false, plane, cancellation);
-    return {minimum, maximum, false};
+    if (scale.scale == ColorScale::SymLogarithmic
+        && resolveValueRange(minimum, maximum, scale)) {
+        return {minimum, maximum, false, scale};
+    }
+    return {minimum, maximum, false, {ColorScale::Linear, scale.linearThreshold}};
 }
 
 } // namespace amrvis

--- a/src/pipeline/VolumePipeline.cpp
+++ b/src/pipeline/VolumePipeline.cpp
@@ -225,6 +225,17 @@ std::optional<VolumeRange> resolveVolumeRange(
     const std::optional<std::pair<double, double>>& userRange,
     bool logarithmic, StopToken cancellation)
 {
+    return resolveVolumeRange(dataset, field, maximumLevel, composition,
+        rangeMode, userRange,
+        {logarithmic ? ColorScale::Logarithmic : ColorScale::Linear, 1.0}, cancellation);
+}
+
+std::optional<VolumeRange> resolveVolumeRange(
+    const std::shared_ptr<DatasetSession>& dataset, FieldId field,
+    int maximumLevel, CompositionPolicy composition, RangeMode rangeMode,
+    const std::optional<std::pair<double, double>>& userRange,
+    ColorScaleConfig scale, StopToken cancellation)
+{
     std::optional<std::pair<double, double>> selected;
     if (rangeMode == RangeMode::User) {
         selected = userRange;
@@ -251,7 +262,8 @@ std::optional<VolumeRange> resolveVolumeRange(
     const auto* source = rangeMode == RangeMode::User ? "user"
         : rangeMode == RangeMode::File ? "file" : "level";
     auto [minimum, maximum]
-        = paddedIfDegenerate(selected->first, selected->second, logarithmic);
+        = paddedIfDegenerate(selected->first, selected->second,
+            scale.scale == ColorScale::Logarithmic);
     if (!(minimum < maximum)) {
         throw std::runtime_error(
             std::string(source) + " scalar range must have positive extent");
@@ -266,13 +278,14 @@ std::optional<VolumeRange> resolveVolumeRange(
         throw std::runtime_error(
             std::string(source) + " scalar range must be finite with a finite span");
     }
-    VolumeRange resolved{minimum, maximum, false};
-    if (logarithmic && minimum > 0.0) {
-        resolved = VolumeRange{minimum, maximum, true};
-    } else if (logarithmic) {
+    VolumeRange resolved{minimum, maximum, false, scale};
+    if (scale.scale == ColorScale::Logarithmic && minimum > 0.0) {
+        resolved = VolumeRange{minimum, maximum, true, scale};
+    } else if (scale.scale == ColorScale::Logarithmic) {
         // Not viable in log: linear, re-padded without the log rule.
         std::tie(resolved.minimum, resolved.maximum)
             = paddedIfDegenerate(selected->first, selected->second, false);
+        resolved.scale.scale = ColorScale::Linear;
     }
     // The last thing the renderers do with a range is resolveValueRange, so
     // one it cannot resolve is this function's error to report. Ordering and
@@ -282,7 +295,7 @@ std::optional<VolumeRange> resolveVolumeRange(
     // validateVolumeRenderRequest would otherwise refuse from inside the
     // render, as an invalid_argument rather than a named range error.
     if (!resolveValueRange(
-            resolved.minimum, resolved.maximum, resolved.logarithmic)) {
+            resolved.minimum, resolved.maximum, resolved.scale)) {
         throw std::runtime_error(std::string(source)
             + " scalar range is too narrow to map: its bounds share a logarithm");
     }
@@ -388,10 +401,16 @@ VolumeDisplayResult renderWithFallback(
                 // modes resolve to the same range every time round, which
                 // costs a statistics lookup and nothing else -- only the
                 // repeat below is worth gating on the mode.
-                request.logarithmic = choice->logarithmic;
+                const auto scale = effectiveColorScale(
+                    choice->logarithmic, choice->scale);
+                request.logarithmic = scale.scale == ColorScale::Logarithmic;
+                // Keep the legacy representation canonical for ordinary log
+                // requests. Only symlog needs the protocol's scale fields.
+                request.scale = scale.scale == ColorScale::SymLogarithmic
+                    ? scale : ColorScaleConfig{};
                 request.range = resolveVolumeRange(dataset, request.field,
                     request.maximumLevel, request.composition, choice->mode,
-                    choice->userRange, choice->logarithmic, cancellation);
+                    choice->userRange, scale, cancellation);
             }
             auto frame = dataset->renderVolume(request, cancellation);
             // A fallback the session made inside this attempt counts the same

--- a/src/pipeline/VolumePipeline.cpp
+++ b/src/pipeline/VolumePipeline.cpp
@@ -223,17 +223,6 @@ std::optional<VolumeRange> resolveVolumeRange(
     const std::shared_ptr<DatasetSession>& dataset, FieldId field,
     int maximumLevel, CompositionPolicy composition, RangeMode rangeMode,
     const std::optional<std::pair<double, double>>& userRange,
-    bool logarithmic, StopToken cancellation)
-{
-    return resolveVolumeRange(dataset, field, maximumLevel, composition,
-        rangeMode, userRange,
-        {logarithmic ? ColorScale::Logarithmic : ColorScale::Linear, 1.0}, cancellation);
-}
-
-std::optional<VolumeRange> resolveVolumeRange(
-    const std::shared_ptr<DatasetSession>& dataset, FieldId field,
-    int maximumLevel, CompositionPolicy composition, RangeMode rangeMode,
-    const std::optional<std::pair<double, double>>& userRange,
     ColorScaleConfig scale, StopToken cancellation)
 {
     std::optional<std::pair<double, double>> selected;
@@ -261,9 +250,7 @@ std::optional<VolumeRange> resolveVolumeRange(
     // level statistics sends the reader to a control that is not the cause.
     const auto* source = rangeMode == RangeMode::User ? "user"
         : rangeMode == RangeMode::File ? "file" : "level";
-    auto [minimum, maximum]
-        = paddedIfDegenerate(selected->first, selected->second,
-            scale.scale == ColorScale::Logarithmic);
+    auto [minimum, maximum] = paddedIfDegenerate(selected->first, selected->second, scale);
     if (!(minimum < maximum)) {
         throw std::runtime_error(
             std::string(source) + " scalar range must have positive extent");
@@ -278,13 +265,11 @@ std::optional<VolumeRange> resolveVolumeRange(
         throw std::runtime_error(
             std::string(source) + " scalar range must be finite with a finite span");
     }
-    VolumeRange resolved{minimum, maximum, false, scale};
-    if (scale.scale == ColorScale::Logarithmic && minimum > 0.0) {
-        resolved = VolumeRange{minimum, maximum, true, scale};
-    } else if (scale.scale == ColorScale::Logarithmic) {
+    VolumeRange resolved{minimum, maximum, scale};
+    if (scale.scale == ColorScale::Logarithmic && !(minimum > 0.0)) {
         // Not viable in log: linear, re-padded without the log rule.
-        std::tie(resolved.minimum, resolved.maximum)
-            = paddedIfDegenerate(selected->first, selected->second, false);
+        std::tie(resolved.minimum, resolved.maximum) =
+            paddedIfDegenerate(selected->first, selected->second, {ColorScale::Linear});
         resolved.scale.scale = ColorScale::Linear;
     }
     // The last thing the renderers do with a range is resolveValueRange, so
@@ -401,13 +386,8 @@ VolumeDisplayResult renderWithFallback(
                 // modes resolve to the same range every time round, which
                 // costs a statistics lookup and nothing else -- only the
                 // repeat below is worth gating on the mode.
-                const auto scale = effectiveColorScale(
-                    choice->logarithmic, choice->scale);
-                request.logarithmic = scale.scale == ColorScale::Logarithmic;
-                // Keep the legacy representation canonical for ordinary log
-                // requests. Only symlog needs the protocol's scale fields.
-                request.scale = scale.scale == ColorScale::SymLogarithmic
-                    ? scale : ColorScaleConfig{};
+                const auto scale = choice->scale;
+                request.scale = scale;
                 request.range = resolveVolumeRange(dataset, request.field,
                     request.maximumLevel, request.composition, choice->mode,
                     choice->userRange, scale, cancellation);

--- a/src/qt/ColorBarWidget.cpp
+++ b/src/qt/ColorBarWidget.cpp
@@ -26,18 +26,26 @@ constexpr int labelCount = 8;
 
 // Value at a given label fraction (0 = top = max, 1 = bottom = min), honoring
 // log spacing so the labels match the drawn gradient.
-double tickValue(double minimum, double maximum, bool logarithmic, double fraction)
+double tickValue(double minimum, double maximum, ColorScaleConfig scale,
+    double fraction)
 {
-    return logarithmic
-        ? minimum * std::pow(maximum / minimum, 1.0 - fraction)
-        : maximum + fraction * (minimum - maximum);
+    if (scale.scale == ColorScale::Linear) {
+        return maximum + fraction * (minimum - maximum);
+    }
+    if (scale.scale == ColorScale::Logarithmic) {
+        return minimum * std::pow(maximum / minimum, 1.0 - fraction);
+    }
+    const auto range = resolveValueRange(minimum, maximum, scale);
+    if (!range) return maximum + fraction * (minimum - maximum);
+    return inverseTransformedValue(
+        range->minimum + (1.0 - fraction) * range->span, scale);
 }
 
 // Pixel width of the widest tick label for the format/range. Because it
 // measures the actual formatted strings, exponent forms (from %e / %g) are
 // included at their full width.
 int maxTickLabelWidth(const QFontMetrics& fm, double minimum, double maximum,
-    bool logarithmic, const QString& format)
+    ColorScaleConfig scale, const QString& format)
 {
     int maxWidth = 0;
     for (int label = 0; label < labelCount; ++label) {
@@ -45,7 +53,7 @@ int maxTickLabelWidth(const QFontMetrics& fm, double minimum, double maximum,
             / static_cast<double>(labelCount - 1);
         maxWidth = std::max(maxWidth,
             fm.horizontalAdvance(formatNumber(
-                tickValue(minimum, maximum, logarithmic, fraction), format)));
+                tickValue(minimum, maximum, scale, fraction), format)));
     }
     return maxWidth;
 }
@@ -89,7 +97,12 @@ void ColorBarWidget::setNumberFormat(QString format)
 
 void ColorBarWidget::setLogarithmic(bool logarithmic)
 {
-    m_logarithmic = logarithmic;
+    setScale({logarithmic ? ColorScale::Logarithmic : ColorScale::Linear, 1.0});
+}
+
+void ColorBarWidget::setScale(ColorScaleConfig scale)
+{
+    m_scale = scale;
     applyPreferredWidth();
     update();
 }
@@ -151,7 +164,7 @@ void ColorBarWidget::paintBar(QPainter* painter, const QRect& target) const
         // In log mode the labels must be geometrically spaced to match the
         // gradient: the color at vertical position `fraction` (from the top)
         // corresponds to min*(max/min)^(1-fraction).
-        const auto value = tickValue(m_minimum, m_maximum, m_logarithmic, fraction);
+        const auto value = tickValue(m_minimum, m_maximum, m_scale, fraction);
         const auto center = bar.top()
             + static_cast<int>(std::lround(fraction * static_cast<double>(rows)));
         const auto top = std::clamp(center - labelHeight / 2, bar.top(),
@@ -176,7 +189,7 @@ int ColorBarWidget::preferredWidth() const
     int labelWidth = 0;
     if (m_hasRange) {
         labelWidth = maxTickLabelWidth(
-            fm, m_minimum, m_maximum, m_logarithmic, m_numberFormat);
+            fm, m_minimum, m_maximum, m_scale, m_numberFormat);
     }
     // The default %g format tops out at 13 characters (e.g. "-1.23456e-308"),
     // so reserving that width keeps the panel stable across ranges while still

--- a/src/qt/ColorBarWidget.cpp
+++ b/src/qt/ColorBarWidget.cpp
@@ -104,11 +104,6 @@ void ColorBarWidget::setNumberFormat(QString format)
     update();
 }
 
-void ColorBarWidget::setLogarithmic(bool logarithmic)
-{
-    setScale({logarithmic ? ColorScale::Logarithmic : ColorScale::Linear, 1.0});
-}
-
 void ColorBarWidget::setScale(ColorScaleConfig scale)
 {
     m_scale = scale;

--- a/src/qt/ColorBarWidget.hpp
+++ b/src/qt/ColorBarWidget.hpp
@@ -25,7 +25,6 @@ public:
     void setPalette(const amrvis::Palette* palette);
     void setFieldRange(QString fieldName, double minimum, double maximum);
     void setNumberFormat(QString format);
-    void setLogarithmic(bool logarithmic);
     void setScale(ColorScaleConfig scale);
     void clearRange();
 

--- a/src/qt/ColorBarWidget.hpp
+++ b/src/qt/ColorBarWidget.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <amrexplorer/core/ValueMapping.hpp>
 
 #include <QPainter>
 #include <QRect>
@@ -25,6 +26,7 @@ public:
     void setFieldRange(QString fieldName, double minimum, double maximum);
     void setNumberFormat(QString format);
     void setLogarithmic(bool logarithmic);
+    void setScale(ColorScaleConfig scale);
     void clearRange();
 
     // Paints the color bar into an arbitrary rect (e.g. for image export),
@@ -49,7 +51,7 @@ private:
     QString m_numberFormat;
     double m_minimum = 0.0;
     double m_maximum = 1.0;
-    bool m_logarithmic = false;
+    ColorScaleConfig m_scale;
     bool m_hasRange = false;
 };
 

--- a/src/qt/DatasetColoring.hpp
+++ b/src/qt/DatasetColoring.hpp
@@ -30,13 +30,6 @@ struct DatasetColoring {
 };
 
 [[nodiscard]] inline DatasetColoring makeDatasetColoring(
-    const Palette& palette, double minimum, double maximum, bool logarithmic)
-{
-    return DatasetColoring{
-        palette, resolveValueRange(minimum, maximum, logarithmic)};
-}
-
-[[nodiscard]] inline DatasetColoring makeDatasetColoring(
     const Palette& palette, double minimum, double maximum,
     ColorScaleConfig scale)
 {

--- a/src/qt/DatasetColoring.hpp
+++ b/src/qt/DatasetColoring.hpp
@@ -36,6 +36,14 @@ struct DatasetColoring {
         palette, resolveValueRange(minimum, maximum, logarithmic)};
 }
 
+[[nodiscard]] inline DatasetColoring makeDatasetColoring(
+    const Palette& palette, double minimum, double maximum,
+    ColorScaleConfig scale)
+{
+    return DatasetColoring{
+        palette, resolveValueRange(minimum, maximum, scale)};
+}
+
 // What a value is drawn in. Mapped through ValueMapping, exactly as
 // renderScalarPlane maps the same value, so the two cannot drift apart at the
 // truncation ties valueSlot documents. Values outside the range take the end

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -1025,11 +1025,13 @@ void MainWindow::setActiveView(PlaneViewState& state)
 void MainWindow::syncActiveViewColorControls(const PlaneViewState& state)
 {
     // The color scale and range boxes track the active view.
-    m_colorBar->setLogarithmic(state.displayLogarithmic);
-    m_colorBar->setFieldRange(state.displayLogarithmic
-        ? state.fieldName + tr(" (log)") : state.fieldName,
+    m_colorBar->setScale(state.displayScale);
+    const auto suffix = state.displayScale.scale == ColorScale::Logarithmic
+        ? tr(" (log)") : state.displayScale.scale == ColorScale::SymLogarithmic
+            ? tr(" (symlog)") : QString();
+    m_colorBar->setFieldRange(state.fieldName + suffix,
         state.displayMinimum, state.displayMaximum);
-    m_range->showLogarithmic(state.displayLogarithmic);
+    m_range->showColorScale(state.displayScale);
     if (m_range->mode() != RangeMode::User) {
         m_range->showDisplayRange(state.displayMinimum, state.displayMaximum);
     }

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -1042,7 +1042,10 @@ void MainWindow::syncActiveViewColorControls(const PlaneViewState& state)
         state.displayMinimum, state.displayMaximum);
     m_range->showColorScale(state.displayScale);
     if (m_range->mode() != RangeMode::User) {
-        m_range->showDisplayRange(state.displayMinimum, state.displayMaximum);
+        if (m_range->showDisplayRange(state.displayMinimum, state.displayMaximum)) {
+            scheduleSliceRequest();
+            m_volumeController->refresh();
+        }
     }
     syncDatasetWindowColors();
 }

--- a/src/qt/MainWindow.hpp
+++ b/src/qt/MainWindow.hpp
@@ -523,6 +523,7 @@ private:
         double displayMinimum = 0.0;
         double displayMaximum = 1.0;
         bool displayLogarithmic = false;
+        ColorScaleConfig displayScale;
         std::vector<VectorSegment> vectorSegments;
         std::vector<SliceGridBox> gridBoxes;
         // The Dataset window cell this view is marking, held so showSlice can

--- a/src/qt/MainWindow.hpp
+++ b/src/qt/MainWindow.hpp
@@ -199,8 +199,8 @@ public:
     // shape that exposed the stale-contour bug: three unequal local ranges
     // reconciled into one shared Visible range. interactiveSlicesSettled fires
     // when that batch finishes.
-    void configureContourSyncForTest(
-        int count, bool logarithmic, std::array<double, 3> slicePositions);
+    void configureContourSyncForTest(int count, ColorScaleConfig scale,
+                                     std::array<double, 3> slicePositions);
 
     // Test-only: drive the visible-range sync staleness guard deterministically.
     // Gate a sync mid-flight, re-render every panel through the cache path
@@ -234,7 +234,7 @@ public:
     struct ContourViewProbe {
         double displayMinimum = 0.0;
         double displayMaximum = 0.0;
-        bool logarithmic = false;
+        ColorScaleConfig scale;
         std::vector<double> contourLevels;
     };
     [[nodiscard]] std::vector<ContourViewProbe> contourViewProbesForTest();
@@ -528,7 +528,6 @@ private:
         std::optional<DisplayCoordinator::RasterGeometry> rasterGeometry;
         double displayMinimum = 0.0;
         double displayMaximum = 1.0;
-        bool displayLogarithmic = false;
         ColorScaleConfig displayScale;
         std::vector<VectorSegment> vectorSegments;
         std::vector<SliceGridBox> gridBoxes;

--- a/src/qt/MainWindowDataset.cpp
+++ b/src/qt/MainWindowDataset.cpp
@@ -534,9 +534,11 @@ QImage MainWindow::composeExportFrame(const ImageView* view, const ExportOptions
     ColorBarWidget colorBar;
     colorBar.setPalette(&m_paletteController->palette());
     colorBar.setNumberFormat(options.numberFormat);
-    colorBar.setLogarithmic(state->displayLogarithmic);
-    colorBar.setFieldRange(state->fieldName +
-                               (state->displayLogarithmic ? tr(" (log)") : QString()),
+    colorBar.setScale(state->displayScale);
+    const auto suffix = state->displayScale.scale == ColorScale::Logarithmic
+        ? tr(" (log)") : state->displayScale.scale == ColorScale::SymLogarithmic
+            ? tr(" (symlog)") : QString();
+    colorBar.setFieldRange(state->fieldName + suffix,
                            state->displayMinimum, state->displayMaximum);
     ExportLayout localLayout;
     auto& layout = frozenLayout != nullptr ? *frozenLayout : localLayout;

--- a/src/qt/MainWindowDataset.cpp
+++ b/src/qt/MainWindowDataset.cpp
@@ -1357,10 +1357,10 @@ void MainWindow::requestInitialSlice(
                         if (levelIndex >= 0) {
                             m_levelSelector->setCurrentIndex(levelIndex);
                         }
-                        m_range->setSelection({restoredSpec->rangeMode, restoredSpec->userRange,
-                                               restoredSpec->scale});
                         m_range->setTrackedField(
                             m_fieldSelector->currentText());
+                        m_range->setSelection({restoredSpec->rangeMode, restoredSpec->userRange,
+                                               restoredSpec->scale});
                         m_range->commitFieldRange(m_range->trackedField());
                         // The menu was rebuilt by configureSliceControls
                         // above, while the combo still sat on field 0; it is

--- a/src/qt/MainWindowDataset.cpp
+++ b/src/qt/MainWindowDataset.cpp
@@ -236,7 +236,6 @@ void MainWindow::saveSettings()
     // Range mode is deliberately not persisted: the correct default (File)
     // depends on the dataset and restoring a different mode from a previous
     // session would produce unexpected color bars.
-    settings.setValue(QStringLiteral("range/logarithmic"), m_range->logarithmic());
     const auto scale = m_range->colorScale();
     settings.setValue(QStringLiteral("range/scale"),
         scale.scale == ColorScale::SymLogarithmic ? QStringLiteral("symlog")
@@ -1358,9 +1357,8 @@ void MainWindow::requestInitialSlice(
                         if (levelIndex >= 0) {
                             m_levelSelector->setCurrentIndex(levelIndex);
                         }
-                        m_range->setSelection({restoredSpec->rangeMode,
-                            restoredSpec->userRange, restoredSpec->logarithmic,
-                            restoredSpec->scale});
+                        m_range->setSelection({restoredSpec->rangeMode, restoredSpec->userRange,
+                                               restoredSpec->scale});
                         m_range->setTrackedField(
                             m_fieldSelector->currentText());
                         m_range->commitFieldRange(m_range->trackedField());

--- a/src/qt/MainWindowDataset.cpp
+++ b/src/qt/MainWindowDataset.cpp
@@ -115,8 +115,13 @@ void MainWindow::restoreSettings()
     }
     m_colorBar->setPalette(&m_paletteController->palette());
 
-    m_range->showLogarithmic(
-        settings.value(QStringLiteral("range/logarithmic"), false).toBool());
+    const auto savedScale = settings.value(QStringLiteral("range/scale"),
+        settings.value(QStringLiteral("range/logarithmic"), false).toBool()
+            ? QStringLiteral("log") : QStringLiteral("linear")).toString();
+    const auto scale = savedScale == QStringLiteral("symlog") ? ColorScale::SymLogarithmic
+        : savedScale == QStringLiteral("log") ? ColorScale::Logarithmic : ColorScale::Linear;
+    m_range->showColorScale({scale,
+        settings.value(QStringLiteral("range/symlogLinearThreshold"), 1.0).toDouble()});
     {
         // A stored format that no longer validates falls back to the default.
         const auto format = settings.value(QStringLiteral("numberFormat"),
@@ -179,6 +184,11 @@ void MainWindow::saveSettings()
     // depends on the dataset and restoring a different mode from a previous
     // session would produce unexpected color bars.
     settings.setValue(QStringLiteral("range/logarithmic"), m_range->logarithmic());
+    const auto scale = m_range->colorScale();
+    settings.setValue(QStringLiteral("range/scale"),
+        scale.scale == ColorScale::SymLogarithmic ? QStringLiteral("symlog")
+        : scale.scale == ColorScale::Logarithmic ? QStringLiteral("log") : QStringLiteral("linear"));
+    settings.setValue(QStringLiteral("range/symlogLinearThreshold"), scale.linearThreshold);
     m_paletteController->save(settings);
     settings.setValue(QStringLiteral("numberFormat"), m_numberFormat);
     settings.setValue(QStringLiteral("animation/speed"),
@@ -642,7 +652,7 @@ void MainWindow::syncDatasetWindowColors()
     m_datasetWindow->setColoring(
         makeDatasetColoring(m_paletteController->palette(),
             m_activeView->displayMinimum, m_activeView->displayMaximum,
-            m_activeView->displayLogarithmic));
+            m_activeView->displayScale));
 }
 
 void MainWindow::refreshDatasetWindow()
@@ -1285,7 +1295,8 @@ void MainWindow::requestInitialSlice(
                             m_levelSelector->setCurrentIndex(levelIndex);
                         }
                         m_range->setSelection({restoredSpec->rangeMode,
-                            restoredSpec->userRange, restoredSpec->logarithmic});
+                            restoredSpec->userRange, restoredSpec->logarithmic,
+                            restoredSpec->scale});
                         m_range->setTrackedField(
                             m_fieldSelector->currentText());
                         m_range->commitFieldRange(m_range->trackedField());

--- a/src/qt/MainWindowInteraction.cpp
+++ b/src/qt/MainWindowInteraction.cpp
@@ -12,15 +12,10 @@ void MainWindow::focusActiveViewForPanning()
     // Both callers run from a watcher's completion, which on a slow open lands
     // well after the file dialog closed and the user moved on to a toolbar
     // control. Move focus only when it is on nothing in particular or on
-    // another image view; a control outranks a convenience.
-    //
-    // What this preserves is that focus stays *out of the view*, not that it
-    // stays exactly where the user put it: the teardown disables the field,
-    // level and range widgets, and Qt moves focus off a disabled focus widget
-    // to a tab-chain neighbour before this runs. That neighbour is still a
-    // control, so the guard declines either way -- which is the outcome that
-    // matters, because the alternative is their next arrow key panning the
-    // image.
+    // another image view; a control outranks a convenience. Teardown disables
+    // the field, level and range widgets, so Qt may already have moved focus
+    // from one of them to a tab-chain neighbour (including an image view).
+    // The guard preserves whichever control still holds focus when we arrive.
     auto* const focused = QApplication::focusWidget();
     const QWidget* probe = focused;
     while (probe != nullptr && qobject_cast<const ImageView*>(probe) == nullptr) {

--- a/src/qt/MainWindowSlice.cpp
+++ b/src/qt/MainWindowSlice.cpp
@@ -576,7 +576,7 @@ void MainWindow::requestSlice(PlaneViewState& state, bool rasterDirty)
     if (rangeMode == RangeMode::User) {
         userRange = selection.userRange;
     }
-    const auto logarithmic = selection.logarithmic;
+    const auto scale = selection.scale;
     const auto palette = m_paletteController->palette();
     const auto displayMode = m_displayMode;
     // Each 3-D panel uses a different pair of vector components:
@@ -645,24 +645,24 @@ void MainWindow::requestSlice(PlaneViewState& state, bool rasterDirty)
             displayPlane = state.plane,
             contourPlane = state.contourPlane,
             vectors = state.vectorSegments,
-            rangeMode, userRange, logarithmic, palette, displayMode,
+            rangeMode, userRange, scale, palette, displayMode,
             vectorUField, vectorVField, contourCount, rasterDirty,
             cancellation]() mutable {
             return refreshCachedSlice(dataset, request, std::move(displayPlane),
                 *contourPlane, std::move(vectors), rangeMode, userRange,
-                logarithmic, palette, displayMode, vectorUField, vectorVField,
+                scale, palette, displayMode, vectorUField, vectorVField,
                 contourCount, rasterDirty, cancellation);
         });
     } else {
         future = QtConcurrent::run(
-            [dataset, request, rangeMode, userRange, logarithmic, palette,
+            [dataset, request, rangeMode, userRange, scale, palette,
                 cancellation, displayMode, vectorUField, vectorVField,
                 contourCount]() mutable {
             // The pipeline owns the whole non-cached slice worker, including
             // the cache-pressure level fallback (see
             // cache-budget-exceeded-hard-fails-after-load).
             return executeSliceWithFallback(dataset, request, rangeMode,
-                userRange, logarithmic, palette, displayMode, vectorUField,
+                userRange, scale, palette, displayMode, vectorUField,
                 vectorVField, contourCount, cancellation);
         });
     }
@@ -1249,6 +1249,7 @@ void MainWindow::showSlice(PlaneViewState& state, SliceDisplayResult display,
     state.displayMinimum = display.minimum;
     state.displayMaximum = display.maximum;
     state.displayLogarithmic = display.logarithmic;
+    state.displayScale = display.scale;
     state.vectorSegments = std::move(display.vectors);
     if (display.slice.gridBoxesIncluded) {
         state.gridBoxes = std::move(display.slice.gridBoxes);
@@ -1516,6 +1517,7 @@ void MainWindow::syncVisibleRanges()
                     // panel's stored flag, and thus the color bar below, in
                     // agreement with the raster the sync just rendered.
                     state->displayLogarithmic = outcome.sync->logarithmic;
+                    state->displayScale = outcome.sync->scale;
                     if (update.contoursRecomputed) {
                         state->contourPolylines
                             = std::move(update.contourPolylines);
@@ -1543,10 +1545,12 @@ void MainWindow::syncVisibleRanges()
                 }
                 if (activeApplied && m_activeView->plane->width > 0) {
                     const auto fieldName = m_fieldSelector->currentText();
-                    const auto label = m_activeView->displayLogarithmic
-                        ? fieldName + tr(" (log)") : fieldName;
-                    m_colorBar->setLogarithmic(
-                        m_activeView->displayLogarithmic);
+                    const auto suffix = m_activeView->displayScale.scale
+                            == ColorScale::Logarithmic ? tr(" (log)")
+                        : m_activeView->displayScale.scale
+                            == ColorScale::SymLogarithmic ? tr(" (symlog)") : QString();
+                    const auto label = fieldName + suffix;
+                    m_colorBar->setScale(m_activeView->displayScale);
                     m_colorBar->setFieldRange(label, globalMin, globalMax);
                     m_range->showDisplayRange(globalMin, globalMax);
                     // The panel loop above wrote this range into every applied
@@ -1605,7 +1609,7 @@ void MainWindow::syncVisibleRanges()
     m_diagnosticsModel->adjustActivity(1);
     try {
         watcher->setFuture(QtConcurrent::run([cachedRange, snapshots,
-            logarithmic = m_range->logarithmic(),
+            scale = m_range->colorScale(),
             contourMode = isContourMode(m_displayMode),
             contourCount = m_contourCount, palette = m_paletteController->palette()] {
 #ifdef AMREXPLORER_QT_TEST_ACCESS
@@ -1623,7 +1627,7 @@ void MainWindow::syncVisibleRanges()
             }
             SyncOutcome outcome;
             outcome.sync = DisplayCoordinator::renderPanelsToSharedRange(
-                cachedRange, inputs, logarithmic, contourMode, contourCount,
+                cachedRange, inputs, scale, contourMode, contourCount,
                 palette);
             if (outcome.sync) {
                 for (std::size_t index = 0; index < inputs.size(); ++index) {
@@ -2060,6 +2064,7 @@ FrameSliceSpec MainWindow::buildFrameSpec()
     {
         const auto selection = m_range->selection();
         spec.logarithmic = selection.logarithmic;
+        spec.scale = selection.scale;
         spec.rangeMode = selection.mode;
         spec.userRange = selection.userRange;
     }

--- a/src/qt/MainWindowSlice.cpp
+++ b/src/qt/MainWindowSlice.cpp
@@ -1298,7 +1298,6 @@ void MainWindow::showSlice(PlaneViewState& state, SliceDisplayResult display,
     state.fieldName = fieldName;
     state.displayMinimum = display.minimum;
     state.displayMaximum = display.maximum;
-    state.displayLogarithmic = display.logarithmic;
     state.displayScale = display.scale;
     state.vectorSegments = std::move(display.vectors);
     if (display.slice.gridBoxesIncluded) {
@@ -1564,9 +1563,8 @@ void MainWindow::syncVisibleRanges()
                     state->displayMaximum = globalMax;
                     // One shared log flag across the panel set (see
                     // shared-log-range-render-throw-fails-load): keep every
-                    // panel's stored flag, and thus the color bar below, in
+                    // panel's stored scale, and thus the color bar below, in
                     // agreement with the raster the sync just rendered.
-                    state->displayLogarithmic = outcome.sync->logarithmic;
                     state->displayScale = outcome.sync->scale;
                     if (update.contoursRecomputed) {
                         state->contourPolylines
@@ -2117,7 +2115,6 @@ FrameSliceSpec MainWindow::buildFrameSpec()
     spec.sphericalDisplay = m_sphericalDisplay;
     {
         const auto selection = m_range->selection();
-        spec.logarithmic = selection.logarithmic;
         spec.scale = selection.scale;
         spec.rangeMode = selection.mode;
         spec.userRange = selection.userRange;

--- a/src/qt/MainWindowSlice.cpp
+++ b/src/qt/MainWindowSlice.cpp
@@ -1602,7 +1602,10 @@ void MainWindow::syncVisibleRanges()
                     const auto label = fieldName + suffix;
                     m_colorBar->setScale(m_activeView->displayScale);
                     m_colorBar->setFieldRange(label, globalMin, globalMax);
-                    m_range->showDisplayRange(globalMin, globalMax);
+                    if (m_range->showDisplayRange(globalMin, globalMax)) {
+                        scheduleSliceRequest();
+                        m_volumeController->refresh();
+                    }
                     // The panel loop above wrote this range into every applied
                     // panel's state, the active one included, so the Dataset
                     // window reads the same numbers the bar just took.

--- a/src/qt/MainWindowTestAccess.cpp
+++ b/src/qt/MainWindowTestAccess.cpp
@@ -198,6 +198,7 @@ bool MainWindow::activeViewRasterMatchesDisplayRangeForTest()
     const auto reference = renderScalarPlane(*state.plane, ScalarRenderSettings{
         .minimum = state.displayMinimum,
         .maximum = state.displayMaximum,
+        .scale = state.displayScale,
         .logarithmic = state.displayLogarithmic,
         .palette = &m_paletteController->palette()
     });

--- a/src/qt/MainWindowTestAccess.cpp
+++ b/src/qt/MainWindowTestAccess.cpp
@@ -90,17 +90,15 @@ std::uint64_t MainWindow::visibleSyncStaleSkipsForTest() const noexcept
     return m_visibleSyncStaleSkips;
 }
 
-void MainWindow::configureContourSyncForTest(
-    int count, bool logarithmic, std::array<double, 3> slicePositions)
-{
+void MainWindow::configureContourSyncForTest(int count, ColorScaleConfig scale,
+                                             std::array<double, 3> slicePositions) {
     if (!m_dataset) {
         return;
     }
     m_slicePosition3d = slicePositions;
     // Set range/log through the controller (requestSlice reads it) without
     // signals, so only the single scheduleSliceRequest below re-slices.
-    m_range->setSelection({RangeMode::Visible, std::nullopt, logarithmic,
-        {logarithmic ? ColorScale::Logarithmic : ColorScale::Linear, 1.0}});
+    m_range->setSelection({RangeMode::Visible, std::nullopt, scale});
     m_displayMode = DisplayMode::RasterContours;
     m_contourCount = count;
     scheduleSliceRequest(false);
@@ -114,7 +112,7 @@ MainWindow::contourViewProbesForTest()
         ContourViewProbe probe;
         probe.displayMinimum = state->displayMinimum;
         probe.displayMaximum = state->displayMaximum;
-        probe.logarithmic = state->displayLogarithmic;
+        probe.scale = state->displayScale;
         for (const auto& polyline : state->contourPolylines) {
             probe.contourLevels.push_back(polyline.value);
         }
@@ -132,8 +130,7 @@ void MainWindow::enableVisibleRasterForTest()
     if (!m_dataset) {
         return;
     }
-    m_range->setSelection({RangeMode::Visible, std::nullopt,
-        m_range->logarithmic(), m_range->colorScale()});
+    m_range->setSelection({RangeMode::Visible, std::nullopt, m_range->colorScale()});
     m_displayMode = DisplayMode::Raster;
     scheduleSliceRequest(false);
 }
@@ -199,7 +196,6 @@ bool MainWindow::activeViewRasterMatchesDisplayRangeForTest()
         .minimum = state.displayMinimum,
         .maximum = state.displayMaximum,
         .scale = state.displayScale,
-        .logarithmic = state.displayLogarithmic,
         .palette = &m_paletteController->palette()
     });
     if (!reference.valid()) {

--- a/src/qt/MainWindowTestAccess.cpp
+++ b/src/qt/MainWindowTestAccess.cpp
@@ -99,7 +99,8 @@ void MainWindow::configureContourSyncForTest(
     m_slicePosition3d = slicePositions;
     // Set range/log through the controller (requestSlice reads it) without
     // signals, so only the single scheduleSliceRequest below re-slices.
-    m_range->setSelection({RangeMode::Visible, std::nullopt, logarithmic});
+    m_range->setSelection({RangeMode::Visible, std::nullopt, logarithmic,
+        {logarithmic ? ColorScale::Logarithmic : ColorScale::Linear, 1.0}});
     m_displayMode = DisplayMode::RasterContours;
     m_contourCount = count;
     scheduleSliceRequest(false);
@@ -131,8 +132,8 @@ void MainWindow::enableVisibleRasterForTest()
     if (!m_dataset) {
         return;
     }
-    m_range->setSelection(
-        {RangeMode::Visible, std::nullopt, m_range->logarithmic()});
+    m_range->setSelection({RangeMode::Visible, std::nullopt,
+        m_range->logarithmic(), m_range->colorScale()});
     m_displayMode = DisplayMode::Raster;
     scheduleSliceRequest(false);
 }

--- a/src/qt/RangeController.cpp
+++ b/src/qt/RangeController.cpp
@@ -214,12 +214,23 @@ void RangeController::setSelection(const Selection& selection)
         m_controlsReady && m_symmetricLogarithmic->isChecked());
 }
 
-void RangeController::showDisplayRange(double minimum, double maximum)
+bool RangeController::showDisplayRange(double minimum, double maximum)
 {
     const QSignalBlocker minBlocker(m_minimum);
     const QSignalBlocker maxBlocker(m_maximum);
     m_minimum->setValue(minimum);
     m_maximum->setValue(maximum);
+    if (m_pendingThresholdInitialization && m_symmetricLogarithmic->isChecked()
+        && !m_trackedField.isEmpty()
+        && !m_symlogThresholds.contains(m_trackedField)) {
+        const auto threshold = defaultSymmetricLogThreshold(minimum, maximum);
+        const QSignalBlocker blocker(m_linearThreshold);
+        m_linearThreshold->setValue(threshold);
+        m_symlogThresholds.insert(m_trackedField, threshold);
+        m_pendingThresholdInitialization = false;
+        return true;
+    }
+    return false;
 }
 
 void RangeController::showLogarithmic(bool logarithmic)
@@ -309,6 +320,11 @@ void RangeController::applyFieldRange(const QString& field)
         const QSignalBlocker blocker(m_linearThreshold);
         m_linearThreshold->setValue(threshold.value());
     }
+    m_pendingThresholdInitialization = m_symmetricLogarithmic->isChecked()
+        && !m_symlogThresholds.contains(field);
+    if (m_pendingThresholdInitialization && range.userRange) {
+        showDisplayRange(range.userRange->first, range.userRange->second);
+    }
     updateUserRangeEnabled();
 }
 
@@ -316,6 +332,7 @@ void RangeController::reset()
 {
     m_fieldRanges.clear();
     m_symlogThresholds.clear();
+    m_pendingThresholdInitialization = false;
     m_trackedField.clear();
     const QSignalBlocker minBlocker(m_minimum);
     const QSignalBlocker maxBlocker(m_maximum);

--- a/src/qt/RangeController.cpp
+++ b/src/qt/RangeController.cpp
@@ -150,7 +150,6 @@ RangeController::Selection RangeController::selection() const
     if (selection.mode == RangeMode::User) {
         selection.userRange = std::pair{m_minimum->value(), m_maximum->value()};
     }
-    selection.logarithmic = logarithmic();
     selection.scale = colorScale();
     return selection;
 }
@@ -158,11 +157,6 @@ RangeController::Selection RangeController::selection() const
 RangeMode RangeController::mode() const
 {
     return static_cast<RangeMode>(m_mode->currentData().toInt());
-}
-
-bool RangeController::logarithmic() const
-{
-    return m_logarithmic->isChecked();
 }
 
 ColorScaleConfig RangeController::colorScale() const
@@ -196,11 +190,7 @@ void RangeController::setSelection(const Selection& selection)
     const QSignalBlocker symlogBlocker(m_symmetricLogarithmic);
     const QSignalBlocker thresholdBlocker(m_linearThreshold);
     setMode(selection.mode);
-    const auto scale = selection.scale.scale != ColorScale::Linear
-        ? selection.scale
-        : ColorScaleConfig{
-            selection.logarithmic ? ColorScale::Logarithmic : ColorScale::Linear,
-            selection.scale.linearThreshold};
+    const auto scale = selection.scale;
     m_logarithmic->setChecked(scale.scale == ColorScale::Logarithmic);
     m_symmetricLogarithmic->setChecked(scale.scale == ColorScale::SymLogarithmic);
     m_linearThreshold->setValue(scale.linearThreshold);
@@ -231,12 +221,6 @@ bool RangeController::showDisplayRange(double minimum, double maximum)
         return true;
     }
     return false;
-}
-
-void RangeController::showLogarithmic(bool logarithmic)
-{
-    showColorScale({logarithmic ? ColorScale::Logarithmic : ColorScale::Linear,
-        m_linearThreshold->value()});
 }
 
 void RangeController::showColorScale(ColorScaleConfig scale)

--- a/src/qt/RangeController.cpp
+++ b/src/qt/RangeController.cpp
@@ -8,10 +8,27 @@
 #include <QStandardItemModel>
 #include <QToolBar>
 
+#include <algorithm>
+#include <cmath>
 #include <limits>
 #include <utility>
 
 namespace amrvis::qt {
+namespace {
+
+double defaultSymmetricLogThreshold(double minimum, double maximum) noexcept
+{
+    const auto magnitude = std::max(std::abs(minimum), std::abs(maximum));
+    if (!(magnitude > 0.0) || !std::isfinite(magnitude)) {
+        return 1.0;
+    }
+    const auto threshold = std::pow(
+        10.0, std::floor(std::log10(magnitude)) - 2.0);
+    return threshold > 0.0 && std::isfinite(threshold)
+        ? threshold : std::numeric_limits<double>::min();
+}
+
+} // namespace
 
 RangeController::RangeController(QObject* parent)
     : QObject(parent)
@@ -43,9 +60,25 @@ void RangeController::createToolbarWidgets(QToolBar* toolbar)
     // per-group separators on the Slice Controls toolbar.
     toolbar->addSeparator();
     m_logarithmic = new QCheckBox(tr("Log"), toolbar);
+    m_logarithmic->setObjectName(QStringLiteral("logarithmicScale"));
     toolbar->addWidget(m_logarithmic);
+    m_symmetricLogarithmic = new QCheckBox(tr("Symlog"), toolbar);
+    m_symmetricLogarithmic->setObjectName(
+        QStringLiteral("symmetricLogarithmicScale"));
+    toolbar->addWidget(m_symmetricLogarithmic);
+    m_linearThreshold = new ScientificDoubleSpinBox(toolbar);
+    m_linearThreshold->setObjectName(QStringLiteral("symlogLinearThreshold"));
+    m_linearThreshold->setPrefix(tr("linthresh "));
+    m_linearThreshold->setRange(std::numeric_limits<double>::min(),
+        std::numeric_limits<double>::max());
+    m_linearThreshold->setValue(1.0);
+    m_linearThreshold->setMinimumWidth(140);
+    toolbar->addWidget(m_linearThreshold);
+    m_linearThreshold->setVisible(false);
     m_mode->setEnabled(false);
     m_logarithmic->setEnabled(false);
+    m_symmetricLogarithmic->setEnabled(false);
+    m_linearThreshold->setEnabled(false);
 
     connect(m_mode, qOverload<int>(&QComboBox::currentIndexChanged), this,
         [this](int) {
@@ -64,8 +97,50 @@ void RangeController::createToolbarWidgets(QToolBar* toolbar)
                 emit userRangeChanged();
             }
         });
-    connect(m_logarithmic, &QCheckBox::toggled, this,
-        [this](bool) { emit logarithmicChanged(); });
+    connect(m_logarithmic, &QCheckBox::toggled, this, [this](bool checked) {
+        if (checked) {
+            const QSignalBlocker blocker(m_symmetricLogarithmic);
+            m_symmetricLogarithmic->setChecked(false);
+        }
+        m_linearThreshold->setVisible(
+            m_symmetricLogarithmic->isChecked());
+        m_linearThreshold->setEnabled(
+            m_controlsReady && m_symmetricLogarithmic->isChecked());
+        emit logarithmicChanged();
+    });
+    connect(m_symmetricLogarithmic, &QCheckBox::toggled, this,
+        [this](bool checked) {
+            if (checked) {
+                const QSignalBlocker blocker(m_logarithmic);
+                m_logarithmic->setChecked(false);
+                auto threshold = defaultSymmetricLogThreshold(
+                    m_minimum->value(), m_maximum->value());
+                if (!m_trackedField.isEmpty()) {
+                    const auto saved
+                        = m_symlogThresholds.constFind(m_trackedField);
+                    if (saved != m_symlogThresholds.constEnd()) {
+                        threshold = saved.value();
+                    } else {
+                        m_symlogThresholds.insert(m_trackedField, threshold);
+                    }
+                }
+                const QSignalBlocker thresholdBlocker(m_linearThreshold);
+                m_linearThreshold->setValue(threshold);
+            }
+            m_linearThreshold->setVisible(checked);
+            m_linearThreshold->setEnabled(m_controlsReady && checked);
+            emit logarithmicChanged();
+        });
+    connect(m_linearThreshold, qOverload<double>(&QDoubleSpinBox::valueChanged),
+        this, [this](double) {
+            if (m_symmetricLogarithmic->isChecked()) {
+                if (!m_trackedField.isEmpty()) {
+                    m_symlogThresholds.insert(
+                        m_trackedField, m_linearThreshold->value());
+                }
+                emit logarithmicChanged();
+            }
+        });
 }
 
 RangeController::Selection RangeController::selection() const
@@ -76,6 +151,7 @@ RangeController::Selection RangeController::selection() const
         selection.userRange = std::pair{m_minimum->value(), m_maximum->value()};
     }
     selection.logarithmic = logarithmic();
+    selection.scale = colorScale();
     return selection;
 }
 
@@ -87,6 +163,16 @@ RangeMode RangeController::mode() const
 bool RangeController::logarithmic() const
 {
     return m_logarithmic->isChecked();
+}
+
+ColorScaleConfig RangeController::colorScale() const
+{
+    if (m_symmetricLogarithmic->isChecked()) {
+        return {ColorScale::SymLogarithmic, m_linearThreshold->value()};
+    }
+    return {
+        m_logarithmic->isChecked() ? ColorScale::Logarithmic : ColorScale::Linear,
+        m_linearThreshold->value()};
 }
 
 void RangeController::setMode(RangeMode mode)
@@ -107,13 +193,25 @@ void RangeController::setSelection(const Selection& selection)
     const QSignalBlocker minBlocker(m_minimum);
     const QSignalBlocker maxBlocker(m_maximum);
     const QSignalBlocker logBlocker(m_logarithmic);
+    const QSignalBlocker symlogBlocker(m_symmetricLogarithmic);
+    const QSignalBlocker thresholdBlocker(m_linearThreshold);
     setMode(selection.mode);
-    m_logarithmic->setChecked(selection.logarithmic);
+    const auto scale = selection.scale.scale != ColorScale::Linear
+        ? selection.scale
+        : ColorScaleConfig{
+            selection.logarithmic ? ColorScale::Logarithmic : ColorScale::Linear,
+            selection.scale.linearThreshold};
+    m_logarithmic->setChecked(scale.scale == ColorScale::Logarithmic);
+    m_symmetricLogarithmic->setChecked(scale.scale == ColorScale::SymLogarithmic);
+    m_linearThreshold->setValue(scale.linearThreshold);
+    m_linearThreshold->setVisible(scale.scale == ColorScale::SymLogarithmic);
     if (selection.userRange) {
         m_minimum->setValue(selection.userRange->first);
         m_maximum->setValue(selection.userRange->second);
     }
     updateUserRangeEnabled();
+    m_linearThreshold->setEnabled(
+        m_controlsReady && m_symmetricLogarithmic->isChecked());
 }
 
 void RangeController::showDisplayRange(double minimum, double maximum)
@@ -126,10 +224,21 @@ void RangeController::showDisplayRange(double minimum, double maximum)
 
 void RangeController::showLogarithmic(bool logarithmic)
 {
-    if (m_logarithmic->isChecked() != logarithmic) {
-        const QSignalBlocker blocker(m_logarithmic);
-        m_logarithmic->setChecked(logarithmic);
-    }
+    showColorScale({logarithmic ? ColorScale::Logarithmic : ColorScale::Linear,
+        m_linearThreshold->value()});
+}
+
+void RangeController::showColorScale(ColorScaleConfig scale)
+{
+    const QSignalBlocker logarithmicBlocker(m_logarithmic);
+    const QSignalBlocker symlogBlocker(m_symmetricLogarithmic);
+    const QSignalBlocker thresholdBlocker(m_linearThreshold);
+    m_logarithmic->setChecked(scale.scale == ColorScale::Logarithmic);
+    m_symmetricLogarithmic->setChecked(scale.scale == ColorScale::SymLogarithmic);
+    m_linearThreshold->setValue(scale.linearThreshold);
+    m_linearThreshold->setVisible(scale.scale == ColorScale::SymLogarithmic);
+    m_linearThreshold->setEnabled(
+        m_controlsReady && scale.scale == ColorScale::SymLogarithmic);
 }
 
 void RangeController::setControlsReady(bool ready)
@@ -137,6 +246,8 @@ void RangeController::setControlsReady(bool ready)
     m_controlsReady = ready;
     m_mode->setEnabled(ready);
     m_logarithmic->setEnabled(ready);
+    m_symmetricLogarithmic->setEnabled(ready);
+    m_linearThreshold->setEnabled(ready && m_symmetricLogarithmic->isChecked());
     updateUserRangeEnabled();
 }
 
@@ -144,6 +255,7 @@ void RangeController::setNumberFormat(const QString& format)
 {
     m_minimum->setNumberFormat(format);
     m_maximum->setNumberFormat(format);
+    m_linearThreshold->setNumberFormat(format);
 }
 
 void RangeController::switchField(const QString& field)
@@ -192,12 +304,18 @@ void RangeController::applyFieldRange(const QString& field)
             m_maximum->setValue(range.userRange->second);
         }
     }
+    if (const auto threshold = m_symlogThresholds.constFind(field);
+        threshold != m_symlogThresholds.constEnd()) {
+        const QSignalBlocker blocker(m_linearThreshold);
+        m_linearThreshold->setValue(threshold.value());
+    }
     updateUserRangeEnabled();
 }
 
 void RangeController::reset()
 {
     m_fieldRanges.clear();
+    m_symlogThresholds.clear();
     m_trackedField.clear();
     const QSignalBlocker minBlocker(m_minimum);
     const QSignalBlocker maxBlocker(m_maximum);

--- a/src/qt/RangeController.cpp
+++ b/src/qt/RangeController.cpp
@@ -195,6 +195,10 @@ void RangeController::setSelection(const Selection& selection)
     m_symmetricLogarithmic->setChecked(scale.scale == ColorScale::SymLogarithmic);
     m_linearThreshold->setValue(scale.linearThreshold);
     m_linearThreshold->setVisible(scale.scale == ColorScale::SymLogarithmic);
+    if (scale.scale == ColorScale::SymLogarithmic && !m_trackedField.isEmpty()) {
+        m_symlogThresholds.insert(m_trackedField, m_linearThreshold->value());
+        m_pendingThresholdInitialization = false;
+    }
     if (selection.userRange) {
         m_minimum->setValue(selection.userRange->first);
         m_maximum->setValue(selection.userRange->second);

--- a/src/qt/RangeController.hpp
+++ b/src/qt/RangeController.hpp
@@ -61,7 +61,8 @@ public:
 
     // Blocked writes: none of these emits a change signal.
     // The whole selection, as a restore does; the min/max are written only
-    // when a User range is given.
+    // when a User range is given. Set the tracked field first so an explicit
+    // Symlog threshold is remembered for the restored field.
     void setSelection(const Selection& selection);
     // The active view's display range and log flag, mirrored into the boxes
     // and checkbox (the min/max unconditionally: the caller decides whether

--- a/src/qt/RangeController.hpp
+++ b/src/qt/RangeController.hpp
@@ -35,16 +35,12 @@ public:
         RangeMode mode = RangeMode::File;
         // The User min/max, present when mode is User.
         std::optional<std::pair<double, double>> userRange;
-        bool logarithmic = false;
         ColorScaleConfig scale;
         Selection() = default;
         Selection(RangeMode selectedMode,
-            std::optional<std::pair<double, double>> selectedUserRange,
-            bool useLogarithmic, ColorScaleConfig scaleConfig = {})
-            : mode(selectedMode), userRange(std::move(selectedUserRange)),
-              logarithmic(useLogarithmic), scale(scaleConfig)
-        {
-        }
+                  std::optional<std::pair<double, double>> selectedUserRange,
+                  ColorScaleConfig scaleConfig = {})
+            : mode(selectedMode), userRange(std::move(selectedUserRange)), scale(scaleConfig) {}
     };
     // Which metadata-backed modes the current field/level can offer.
     struct Availability {
@@ -61,7 +57,6 @@ public:
 
     [[nodiscard]] Selection selection() const;
     [[nodiscard]] RangeMode mode() const;
-    [[nodiscard]] bool logarithmic() const;
     [[nodiscard]] ColorScaleConfig colorScale() const;
 
     // Blocked writes: none of these emits a change signal.
@@ -74,7 +69,6 @@ public:
     // Returns true when a newly selected field initializes its Symlog
     // threshold; the host must recolor using the updated selection.
     bool showDisplayRange(double minimum, double maximum);
-    void showLogarithmic(bool logarithmic);
     void showColorScale(ColorScaleConfig scale);
     // Whether a dataset is open: mode and Log enabled iff ready, min/max iff
     // ready and the mode is User.
@@ -100,7 +94,10 @@ public:
     {
         return m_trackedField;
     }
-    void setTrackedField(const QString& field) { m_trackedField = field; }
+    void setTrackedField(const QString& field) {
+        m_trackedField = field;
+        m_pendingThresholdInitialization = !field.isEmpty() && !m_symlogThresholds.contains(field);
+    }
     // Enables or disables the File and Level entries for what `field` at the
     // current level can offer. A selected mode that became unavailable falls
     // back to Visible (recorded in the field's snapshot) with a status

--- a/src/qt/RangeController.hpp
+++ b/src/qt/RangeController.hpp
@@ -71,7 +71,9 @@ public:
     // The active view's display range and log flag, mirrored into the boxes
     // and checkbox (the min/max unconditionally: the caller decides whether
     // a User range must be left alone).
-    void showDisplayRange(double minimum, double maximum);
+    // Returns true when a newly selected field initializes its Symlog
+    // threshold; the host must recolor using the updated selection.
+    bool showDisplayRange(double minimum, double maximum);
     void showLogarithmic(bool logarithmic);
     void showColorScale(ColorScaleConfig scale);
     // Whether a dataset is open: mode and Log enabled iff ready, min/max iff
@@ -131,6 +133,7 @@ private:
     QCheckBox* m_symmetricLogarithmic = nullptr;
     ScientificDoubleSpinBox* m_linearThreshold = nullptr;
     bool m_controlsReady = false;
+    bool m_pendingThresholdInitialization = false;
     QHash<QString, FieldRange> m_fieldRanges;
     QHash<QString, double> m_symlogThresholds;
     QString m_trackedField;

--- a/src/qt/RangeController.hpp
+++ b/src/qt/RangeController.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <amrexplorer/pipeline/SlicePipeline.hpp>
+#include <amrexplorer/core/ValueMapping.hpp>
 
 #include <QHash>
 #include <QObject>
@@ -35,6 +36,15 @@ public:
         // The User min/max, present when mode is User.
         std::optional<std::pair<double, double>> userRange;
         bool logarithmic = false;
+        ColorScaleConfig scale;
+        Selection() = default;
+        Selection(RangeMode selectedMode,
+            std::optional<std::pair<double, double>> selectedUserRange,
+            bool useLogarithmic, ColorScaleConfig scaleConfig = {})
+            : mode(selectedMode), userRange(std::move(selectedUserRange)),
+              logarithmic(useLogarithmic), scale(scaleConfig)
+        {
+        }
     };
     // Which metadata-backed modes the current field/level can offer.
     struct Availability {
@@ -52,6 +62,7 @@ public:
     [[nodiscard]] Selection selection() const;
     [[nodiscard]] RangeMode mode() const;
     [[nodiscard]] bool logarithmic() const;
+    [[nodiscard]] ColorScaleConfig colorScale() const;
 
     // Blocked writes: none of these emits a change signal.
     // The whole selection, as a restore does; the min/max are written only
@@ -62,6 +73,7 @@ public:
     // a User range must be left alone).
     void showDisplayRange(double minimum, double maximum);
     void showLogarithmic(bool logarithmic);
+    void showColorScale(ColorScaleConfig scale);
     // Whether a dataset is open: mode and Log enabled iff ready, min/max iff
     // ready and the mode is User.
     void setControlsReady(bool ready);
@@ -95,8 +107,8 @@ public:
         const Availability& availability, const QString& field);
 
 signals:
-    // A user's edit of the mode, of a User bound, or of Log. Blocked writes
-    // emit none of these.
+    // A user's edit of the mode, of a User bound, or of the color scale.
+    // Blocked writes emit none of these.
     void modeChanged();
     void userRangeChanged();
     void logarithmicChanged();
@@ -116,8 +128,11 @@ private:
     ScientificDoubleSpinBox* m_minimum = nullptr;
     ScientificDoubleSpinBox* m_maximum = nullptr;
     QCheckBox* m_logarithmic = nullptr;
+    QCheckBox* m_symmetricLogarithmic = nullptr;
+    ScientificDoubleSpinBox* m_linearThreshold = nullptr;
     bool m_controlsReady = false;
     QHash<QString, FieldRange> m_fieldRanges;
+    QHash<QString, double> m_symlogThresholds;
     QString m_trackedField;
 };
 

--- a/src/qt/SmokeHarnessRange.cpp
+++ b/src/qt/SmokeHarnessRange.cpp
@@ -80,17 +80,17 @@ bool contourSyncMatches(amrvis::qt::MainWindow& window)
     // applied and all panels must agree on the shared, positive Visible range.
     const auto& shared = probes.front();
     for (const auto& probe : probes) {
-        if (!probe.logarithmic || !(probe.displayMinimum > 0.0)
-            || !(probe.displayMinimum < probe.displayMaximum)
-            || !within(probe.displayMinimum, shared.displayMinimum)
-            || !within(probe.displayMaximum, shared.displayMaximum)) {
+        if (probe.scale.scale != ColorScale::Logarithmic || !(probe.displayMinimum > 0.0) ||
+            !(probe.displayMinimum < probe.displayMaximum) ||
+            !within(probe.displayMinimum, shared.displayMinimum) ||
+            !within(probe.displayMaximum, shared.displayMaximum)) {
             return false;
         }
     }
     std::vector<double> expected;
     try {
-        expected = amrvis::contourValues(
-            shared.displayMinimum, shared.displayMaximum, 3, true);
+        expected = amrvis::contourValues(shared.displayMinimum, shared.displayMaximum, 3,
+                                         {ColorScale::Logarithmic});
     } catch (const std::exception&) {
         return false;
     }
@@ -220,8 +220,8 @@ Outcome dispatchRange(Context& context)
                     });
                 // YZ(x)@i=3, XZ(y)@j=2, XY(z)@k=1 on the 4^3 cube q=(i+j+k)/9:
                 // local ranges [3/9,1], [2/9,8/9], [1/9,7/9] -> shared [1/9,1].
-                window.configureContourSyncForTest(
-                    3, true, {0.875, 0.625, 0.375});
+                window.configureContourSyncForTest(3, {ColorScale::Logarithmic},
+                                                   {0.875, 0.625, 0.375});
             });
         QTimer::singleShot(0, &window, [&window, path] { window.openDataset(path); });
     } else if (argc == 3
@@ -312,8 +312,8 @@ Outcome dispatchRange(Context& context)
                         poll->start();
                     });
                 // Into 3-D Visible + contours; its re-slice settles into a sync.
-                window.configureContourSyncForTest(
-                    kSetupContours, false, kPositions);
+                window.configureContourSyncForTest(kSetupContours, {ColorScale::Linear},
+                                                   kPositions);
             });
         QObject::connect(poll, &QTimer::timeout, &application,
             [&window, finish, phase, attempts, refreshGen, before, refreshed,
@@ -332,8 +332,8 @@ Outcome dispatchRange(Context& context)
                     // keep their pointers; only the render generations move,
                     // which is what makes the parked sync's outcome stale.
                     *refreshGen = window.activeViewRenderGenerationForTest();
-                    window.configureContourSyncForTest(
-                        kChangedContours, false, kPositions);
+                    window.configureContourSyncForTest(kChangedContours, {ColorScale::Linear},
+                                                       kPositions);
                     return;
                 }
                 if (*phase == 2) {
@@ -427,8 +427,8 @@ Outcome dispatchRange(Context& context)
                     if (!window.visibleSyncWorkerWaitingForTest()) {
                         return;
                     }
-                    window.configureContourSyncForTest(
-                        kSetupContours, false, kPositions);
+                    window.configureContourSyncForTest(kSetupContours, {ColorScale::Linear},
+                                                       kPositions);
                     *phase = 8;
                     return;
                 }

--- a/src/qt/SmokeHarnessZoom.cpp
+++ b/src/qt/SmokeHarnessZoom.cpp
@@ -4,9 +4,11 @@
 
 #include <QAction>
 #include <QApplication>
+#include <QDockWidget>
 #include <QKeyEvent>
 #include <QSignalBlocker>
 #include <QTimer>
+#include <QTreeWidget>
 
 #include <cmath>
 #include <cstdlib>
@@ -543,6 +545,9 @@ Outcome dispatchZoom(Context& context)
             [&window, path] { window.openDataset(path); });
     } else if (argc == 3
         && std::string_view(argv[1]) == "--arrow-key-routing-smoke-test") {
+        // Exercise toolbar overflow, whose tab-chain neighbours vary with
+        // platform fonts and the available width.
+        window.resize(640, 480);
         // The arrow keys pan the focused image view and nothing else. They
         // used to be window-context QShortcuts, which took Up/Down from every
         // toolbar spin box and combo -- Qt line edits claim Left/Right through
@@ -640,16 +645,33 @@ Outcome dispatchZoom(Context& context)
                     // the user is working in. This arrives from a watcher
                     // completion, which on a slow open lands long after the
                     // dialog closed and they moved on.
-                    window.focusLevelSelectorForTest();
+                    // Use a control that stays enabled across an open. The
+                    // level selector is disabled during teardown, so Qt may
+                    // legitimately move its focus into the image when the
+                    // other toolbar controls are hidden in the overflow.
+                    auto* tree = window.findChild<QTreeWidget*>(
+                        QStringLiteral("metadataTree"));
+                    auto* dock = tree == nullptr ? nullptr
+                        : qobject_cast<QDockWidget*>(tree->parentWidget());
+                    if (dock == nullptr) {
+                        qCritical("the metadata tree dock was not found");
+                        application.exit(1);
+                        return;
+                    }
+                    dock->show();
+                    tree->setFocus(::Qt::OtherFocusReason);
+                    if (QApplication::focusWidget() != tree) {
+                        qCritical("the metadata tree did not take focus");
+                        application.exit(1);
+                        return;
+                    }
                     reopen();
                     return;
                 }
-                // Not necessarily the level selector by now -- teardown
-                // disables it and Qt moves focus to a neighbouring control --
-                // but it must not have landed in the view.
-                if (window.activeViewHasFocusForTest()) {
-                    qCritical("an open pulled focus into the view while a "
-                              "control had it");
+                if (QApplication::focusWidget()
+                    != window.findChild<QTreeWidget*>(
+                        QStringLiteral("metadataTree"))) {
+                    qCritical("an open took focus away from the metadata tree");
                     application.exit(1);
                     return;
                 }

--- a/src/qt/VolumeController.cpp
+++ b/src/qt/VolumeController.cpp
@@ -467,7 +467,7 @@ void VolumeController::startRender()
         || (m_hooks.sequencePlaying && m_hooks.sequencePlaying());
     request.outputSize = volumeOutputSize(
         viewSize, m_window->viewDevicePixelRatio(), draft);
-    // No request.logarithmic here: the choice built below carries it, and
+    // The color scale comes from the range choice built below, and
     // the pipeline sets it from there before each attempt's range resolve.
     request.transfer = makeVolumeTransferFunction(
         m_hooks.palette ? m_hooks.palette() : builtinPalette(BuiltinPalette::Rainbow),
@@ -562,8 +562,8 @@ void VolumeController::startRender()
     // and that key cannot be made right -- after a cache fallback the level
     // combo reads "Level 0 only" while the plane came from a finest-available
     // request, so it never matches again.
-    const VolumeRangeChoice rangeChoice{rangeSelection.mode,
-        rangeSelection.userRange, rangeSelection.logarithmic, rangeSelection.scale};
+    const VolumeRangeChoice rangeChoice{rangeSelection.mode, rangeSelection.userRange,
+                                        rangeSelection.scale};
     watcher->setFuture(QtConcurrent::run(
         [dataset, request = std::move(request), rangeChoice,
             cancellation]() mutable {
@@ -602,7 +602,8 @@ QString VolumeController::describe(
         .arg(range.minimum)
         .arg(range.maximum)
         .arg(range.scale.scale == ColorScale::SymLogarithmic ? tr(" symlog")
-            : range.logarithmic ? tr(" log") : QString())
+             : range.scale.scale == ColorScale::Logarithmic  ? tr(" log")
+                                                             : QString())
         .arg(frame.metrics.gridDims[0])
         .arg(frame.metrics.gridDims[1])
         .arg(frame.metrics.gridDims[2])

--- a/src/qt/VolumeController.cpp
+++ b/src/qt/VolumeController.cpp
@@ -563,7 +563,7 @@ void VolumeController::startRender()
     // combo reads "Level 0 only" while the plane came from a finest-available
     // request, so it never matches again.
     const VolumeRangeChoice rangeChoice{rangeSelection.mode,
-        rangeSelection.userRange, rangeSelection.logarithmic};
+        rangeSelection.userRange, rangeSelection.logarithmic, rangeSelection.scale};
     watcher->setFuture(QtConcurrent::run(
         [dataset, request = std::move(request), rangeChoice,
             cancellation]() mutable {
@@ -601,7 +601,8 @@ QString VolumeController::describe(
         .arg(result.request.maximumLevel)
         .arg(range.minimum)
         .arg(range.maximum)
-        .arg(range.logarithmic ? tr(" log") : QString())
+        .arg(range.scale.scale == ColorScale::SymLogarithmic ? tr(" symlog")
+            : range.logarithmic ? tr(" log") : QString())
         .arg(frame.metrics.gridDims[0])
         .arg(frame.metrics.gridDims[1])
         .arg(frame.metrics.gridDims[2])

--- a/src/remote/Codec.cpp
+++ b/src/remote/Codec.cpp
@@ -136,6 +136,20 @@ SamplingPolicy fromWireSampling(fb::SamplingPolicy value)
     }
 }
 
+fb::ColorScale toWireColorScale(ColorScale value)
+{
+    return static_cast<fb::ColorScale>(static_cast<std::uint8_t>(value));
+}
+
+ColorScale fromWireColorScale(fb::ColorScale value)
+{
+    const auto raw = static_cast<std::uint8_t>(value);
+    if (raw > static_cast<std::uint8_t>(ColorScale::SymLogarithmic)) {
+        throw std::invalid_argument("unknown wire color scale");
+    }
+    return static_cast<ColorScale>(raw);
+}
+
 fb::CompositionPolicy toWireComposition(CompositionPolicy value)
 {
     switch (value) {
@@ -1064,6 +1078,14 @@ fb::RenderedFrameRequestT toWire(const VolumeRenderRequest& value)
     wire.maximum = value.range ? value.range->maximum : 0.0;
     wire.range_logarithmic = value.range ? value.range->logarithmic : false;
     wire.visible_logarithmic = value.logarithmic;
+    const auto rangeScale = value.range
+        ? effectiveColorScale(value.range->logarithmic, value.range->scale)
+        : ColorScaleConfig{};
+    const auto visibleScale = effectiveColorScale(value.logarithmic, value.scale);
+    wire.range_scale = toWireColorScale(rangeScale.scale);
+    wire.visible_scale = toWireColorScale(visibleScale.scale);
+    wire.range_linear_threshold = rangeScale.linearThreshold;
+    wire.visible_linear_threshold = visibleScale.linearThreshold;
     wire.transfer_colors = value.transfer.colors;
     wire.transfer_opacities = value.transfer.opacities;
     wire.samples_per_voxel = value.samplesPerVoxel;
@@ -1099,10 +1121,21 @@ VolumeRenderRequest fromWire(const fb::RenderedFrameRequestT& value)
     result.camera = {value.azimuth, value.elevation, value.zoom};
     result.outputSize = {value.width, value.height};
     if (value.has_range) {
-        result.range = VolumeRange{
-            value.minimum, value.maximum, value.range_logarithmic};
+        auto scale = ColorScaleConfig{fromWireColorScale(value.range_scale),
+            value.range_linear_threshold};
+        if (scale.scale == ColorScale::Linear && value.range_logarithmic)
+            scale.scale = ColorScale::Logarithmic;
+        result.range = VolumeRange{value.minimum, value.maximum,
+            scale.scale == ColorScale::Logarithmic,
+            scale.scale == ColorScale::SymLogarithmic ? scale : ColorScaleConfig{}};
     }
-    result.logarithmic = value.visible_logarithmic;
+    auto visibleScale = ColorScaleConfig{fromWireColorScale(value.visible_scale),
+        value.visible_linear_threshold};
+    if (visibleScale.scale == ColorScale::Linear && value.visible_logarithmic)
+        visibleScale.scale = ColorScale::Logarithmic;
+    result.logarithmic = visibleScale.scale == ColorScale::Logarithmic;
+    result.scale = visibleScale.scale == ColorScale::SymLogarithmic
+        ? visibleScale : ColorScaleConfig{};
     result.transfer.colors = value.transfer_colors;
     result.transfer.opacities = value.transfer_opacities;
     result.samplesPerVoxel = value.samples_per_voxel;
@@ -1124,6 +1157,10 @@ fb::RenderedFrameResponseT toWire(
     wire.used_minimum = value.usedRange.minimum;
     wire.used_maximum = value.usedRange.maximum;
     wire.used_logarithmic = value.usedRange.logarithmic;
+    const auto usedScale = effectiveColorScale(
+        value.usedRange.logarithmic, value.usedRange.scale);
+    wire.used_scale = toWireColorScale(usedScale.scale);
+    wire.used_linear_threshold = usedScale.linearThreshold;
     wire.grid_dims.assign(value.metrics.gridDims.begin(), value.metrics.gridDims.end());
     wire.covered_voxels = value.metrics.coveredVoxels;
     wire.sampled_maximum_level = value.metrics.sampledMaximumLevel;
@@ -1160,7 +1197,13 @@ VolumeFrame fromWire(const fb::RenderedFrameResponseT& value)
     result.width = value.width;
     result.height = value.height;
     result.pixels = value.pixels;
-    result.usedRange = {value.used_minimum, value.used_maximum, value.used_logarithmic};
+    auto usedScale = ColorScaleConfig{fromWireColorScale(value.used_scale),
+        value.used_linear_threshold};
+    if (usedScale.scale == ColorScale::Linear && value.used_logarithmic)
+        usedScale.scale = ColorScale::Logarithmic;
+    result.usedRange = {value.used_minimum, value.used_maximum,
+        usedScale.scale == ColorScale::Logarithmic,
+        usedScale.scale == ColorScale::SymLogarithmic ? usedScale : ColorScaleConfig{}};
     result.metrics.gridDims = {value.grid_dims[0], value.grid_dims[1], value.grid_dims[2]};
     result.metrics.coveredVoxels = value.covered_voxels;
     result.metrics.sampledMaximumLevel = value.sampled_maximum_level;

--- a/src/remote/Codec.cpp
+++ b/src/remote/Codec.cpp
@@ -1076,12 +1076,10 @@ fb::RenderedFrameRequestT toWire(const VolumeRenderRequest& value)
     wire.has_range = value.range.has_value();
     wire.minimum = value.range ? value.range->minimum : 0.0;
     wire.maximum = value.range ? value.range->maximum : 0.0;
-    wire.range_logarithmic = value.range ? value.range->logarithmic : false;
-    wire.visible_logarithmic = value.logarithmic;
-    const auto rangeScale = value.range
-        ? effectiveColorScale(value.range->logarithmic, value.range->scale)
-        : ColorScaleConfig{};
-    const auto visibleScale = effectiveColorScale(value.logarithmic, value.scale);
+    wire.range_logarithmic = value.range && value.range->scale.scale == ColorScale::Logarithmic;
+    wire.visible_logarithmic = value.scale.scale == ColorScale::Logarithmic;
+    const auto rangeScale = value.range ? value.range->scale : ColorScaleConfig{};
+    const auto visibleScale = value.scale;
     wire.range_scale = toWireColorScale(rangeScale.scale);
     wire.visible_scale = toWireColorScale(visibleScale.scale);
     wire.range_linear_threshold = rangeScale.linearThreshold;
@@ -1125,17 +1123,13 @@ VolumeRenderRequest fromWire(const fb::RenderedFrameRequestT& value)
             value.range_linear_threshold};
         if (scale.scale == ColorScale::Linear && value.range_logarithmic)
             scale.scale = ColorScale::Logarithmic;
-        result.range = VolumeRange{value.minimum, value.maximum,
-            scale.scale == ColorScale::Logarithmic,
-            scale.scale == ColorScale::SymLogarithmic ? scale : ColorScaleConfig{}};
+        result.range = VolumeRange{value.minimum, value.maximum, scale};
     }
     auto visibleScale = ColorScaleConfig{fromWireColorScale(value.visible_scale),
         value.visible_linear_threshold};
     if (visibleScale.scale == ColorScale::Linear && value.visible_logarithmic)
         visibleScale.scale = ColorScale::Logarithmic;
-    result.logarithmic = visibleScale.scale == ColorScale::Logarithmic;
-    result.scale = visibleScale.scale == ColorScale::SymLogarithmic
-        ? visibleScale : ColorScaleConfig{};
+    result.scale = visibleScale;
     result.transfer.colors = value.transfer_colors;
     result.transfer.opacities = value.transfer_opacities;
     result.samplesPerVoxel = value.samples_per_voxel;
@@ -1156,9 +1150,8 @@ fb::RenderedFrameResponseT toWire(
     wire.pixels = std::move(value.pixels);
     wire.used_minimum = value.usedRange.minimum;
     wire.used_maximum = value.usedRange.maximum;
-    wire.used_logarithmic = value.usedRange.logarithmic;
-    const auto usedScale = effectiveColorScale(
-        value.usedRange.logarithmic, value.usedRange.scale);
+    wire.used_logarithmic = value.usedRange.scale.scale == ColorScale::Logarithmic;
+    const auto usedScale = value.usedRange.scale;
     wire.used_scale = toWireColorScale(usedScale.scale);
     wire.used_linear_threshold = usedScale.linearThreshold;
     wire.grid_dims.assign(value.metrics.gridDims.begin(), value.metrics.gridDims.end());
@@ -1201,9 +1194,7 @@ VolumeFrame fromWire(const fb::RenderedFrameResponseT& value)
         value.used_linear_threshold};
     if (usedScale.scale == ColorScale::Linear && value.used_logarithmic)
         usedScale.scale = ColorScale::Logarithmic;
-    result.usedRange = {value.used_minimum, value.used_maximum,
-        usedScale.scale == ColorScale::Logarithmic,
-        usedScale.scale == ColorScale::SymLogarithmic ? usedScale : ColorScaleConfig{}};
+    result.usedRange = {value.used_minimum, value.used_maximum, usedScale};
     result.metrics.gridDims = {value.grid_dims[0], value.grid_dims[1], value.grid_dims[2]};
     result.metrics.coveredVoxels = value.covered_voxels;
     result.metrics.sampledMaximumLevel = value.sampled_maximum_level;

--- a/src/remote/Connection.cpp
+++ b/src/remote/Connection.cpp
@@ -301,6 +301,10 @@ public:
     {
         return m_selectedMinorVersion >= 4;
     }
+    [[nodiscard]] bool supportsSymmetricLogScale() const noexcept
+    {
+        return m_selectedMinorVersion >= 5;
+    }
 
     VolumeFrame renderVolume(
         const VolumeRenderRequest& request, StopToken cancellation)
@@ -327,6 +331,11 @@ public:
         if (request.sampling == SamplingPolicy::Linear
             && !supportsVolumeSampling()) {
             throw std::runtime_error(volumeSamplingUnsupportedMessage);
+        }
+        const auto usesSymLog = request.scale.scale == ColorScale::SymLogarithmic
+            || (request.range && request.range->scale.scale == ColorScale::SymLogarithmic);
+        if (usesSymLog && !supportsSymmetricLogScale()) {
+            throw std::runtime_error(symmetricLogUnsupportedMessage);
         }
         // Indefinite: the first render of a field samples the plotfile,
         // which can outlast the request timeout; the token still cancels it.
@@ -821,6 +830,10 @@ bool Connection::supportsVolumeSampling() const noexcept
 bool Connection::supportsDerivedFields() const noexcept
 {
     return m_impl->supportsDerivedFields();
+}
+bool Connection::supportsSymmetricLogScale() const noexcept
+{
+    return m_impl->supportsSymmetricLogScale();
 }
 
 VolumeFrame Connection::renderVolume(

--- a/src/remote/Connection.cpp
+++ b/src/remote/Connection.cpp
@@ -332,8 +332,8 @@ public:
             && !supportsVolumeSampling()) {
             throw std::runtime_error(volumeSamplingUnsupportedMessage);
         }
-        const auto usesSymLog = request.scale.scale == ColorScale::SymLogarithmic
-            || (request.range && request.range->scale.scale == ColorScale::SymLogarithmic);
+        const auto effectiveScale = request.range ? request.range->scale : request.scale;
+        const auto usesSymLog = effectiveScale.scale == ColorScale::SymLogarithmic;
         if (usesSymLog && !supportsSymmetricLogScale()) {
             throw std::runtime_error(symmetricLogUnsupportedMessage);
         }

--- a/src/remote/RemoteDatasetSession.cpp
+++ b/src/remote/RemoteDatasetSession.cpp
@@ -216,8 +216,8 @@ VolumeFrame RemoteDatasetSession::renderVolume(
         && !m_connection->supportsVolumeSampling()) {
         throw std::runtime_error(volumeSamplingUnsupportedMessage);
     }
-    const auto usesSymLog = request.scale.scale == ColorScale::SymLogarithmic
-        || (request.range && request.range->scale.scale == ColorScale::SymLogarithmic);
+    const auto effectiveScale = request.range ? request.range->scale : request.scale;
+    const auto usesSymLog = effectiveScale.scale == ColorScale::SymLogarithmic;
     if (usesSymLog && !m_connection->supportsSymmetricLogScale()) {
         throw std::runtime_error(symmetricLogUnsupportedMessage);
     }

--- a/src/remote/RemoteDatasetSession.cpp
+++ b/src/remote/RemoteDatasetSession.cpp
@@ -216,6 +216,11 @@ VolumeFrame RemoteDatasetSession::renderVolume(
         && !m_connection->supportsVolumeSampling()) {
         throw std::runtime_error(volumeSamplingUnsupportedMessage);
     }
+    const auto usesSymLog = request.scale.scale == ColorScale::SymLogarithmic
+        || (request.range && request.range->scale.scale == ColorScale::SymLogarithmic);
+    if (usesSymLog && !m_connection->supportsSymmetricLogScale()) {
+        throw std::runtime_error(symmetricLogUnsupportedMessage);
+    }
     validateSessionVolumeRequest(m_metadata, m_id, request);
     return refusingInvalidResponses(*m_connection, [&] {
         auto frame = m_connection->renderVolume(request, cancellation);

--- a/src/remote/Server.cpp
+++ b/src/remote/Server.cpp
@@ -837,8 +837,8 @@ private:
             throw RemoteError(ErrorCode::UnsupportedProtocol,
                 "smooth volume sampling requires protocol 1.3");
         }
-        const auto usesSymLog = request.scale.scale == ColorScale::SymLogarithmic
-            || (request.range && request.range->scale.scale == ColorScale::SymLogarithmic);
+        const auto effectiveScale = request.range ? request.range->scale : request.scale;
+        const auto usesSymLog = effectiveScale.scale == ColorScale::SymLogarithmic;
         if (usesSymLog && m_selectedMinorVersion < 5) {
             throw RemoteError(ErrorCode::UnsupportedProtocol,
                 "symmetric-log volume scaling requires protocol 1.5");

--- a/src/remote/Server.cpp
+++ b/src/remote/Server.cpp
@@ -837,6 +837,12 @@ private:
             throw RemoteError(ErrorCode::UnsupportedProtocol,
                 "smooth volume sampling requires protocol 1.3");
         }
+        const auto usesSymLog = request.scale.scale == ColorScale::SymLogarithmic
+            || (request.range && request.range->scale.scale == ColorScale::SymLogarithmic);
+        if (usesSymLog && m_selectedMinorVersion < 5) {
+            throw RemoteError(ErrorCode::UnsupportedProtocol,
+                "symmetric-log volume scaling requires protocol 1.5");
+        }
         validateVolumeBound(request);
         // The server's own voxel cap applies on top of the client's budget.
         request.maximumVoxels = std::min<std::uint64_t>(

--- a/src/render2d/Contours.cpp
+++ b/src/render2d/Contours.cpp
@@ -15,12 +15,6 @@
 
 namespace amrvis {
 
-std::vector<double> contourValues(
-    double minimum, double maximum, int count, bool logarithmic)
-{
-    return contourValues(minimum, maximum, count,
-        {logarithmic ? ColorScale::Logarithmic : ColorScale::Linear, 1.0});
-}
 
 std::vector<double> contourValues(double minimum, double maximum, int count,
     ColorScaleConfig scale)

--- a/src/render2d/Contours.cpp
+++ b/src/render2d/Contours.cpp
@@ -18,6 +18,13 @@ namespace amrvis {
 std::vector<double> contourValues(
     double minimum, double maximum, int count, bool logarithmic)
 {
+    return contourValues(minimum, maximum, count,
+        {logarithmic ? ColorScale::Logarithmic : ColorScale::Linear, 1.0});
+}
+
+std::vector<double> contourValues(double minimum, double maximum, int count,
+    ColorScaleConfig scale)
+{
     if (count < 1) {
         throw std::invalid_argument("contour count must be positive");
     }
@@ -29,18 +36,27 @@ std::vector<double> contourValues(
         throw std::invalid_argument(
             "contour range must be finite with a finite span");
     }
-    if (logarithmic && !(minimum > 0.0)) {
+    if (scale.scale == ColorScale::Logarithmic && !(minimum > 0.0)) {
         throw std::invalid_argument("logarithmic contour range must be positive");
     }
+    if (scale.scale == ColorScale::SymLogarithmic
+        && !(scale.linearThreshold > 0.0 && std::isfinite(scale.linearThreshold))) {
+        throw std::invalid_argument(
+            "symmetric-log contour threshold must be finite and positive");
+    }
     std::vector<double> values(static_cast<std::size_t>(count));
-    const double rangeMinimum = logarithmic ? std::log(minimum) : minimum;
-    const double rangeMaximum = logarithmic ? std::log(maximum) : maximum;
+    const double rangeMinimum = transformedValue(minimum, scale);
+    const double rangeMaximum = transformedValue(maximum, scale);
     const double span = rangeMaximum - rangeMinimum;
+    if (!(span > 0.0) || !std::isfinite(span)) {
+        throw std::invalid_argument(
+            "contour range is too narrow after applying its color scale");
+    }
     for (int i = 0; i < count; ++i) {
         const auto value = rangeMinimum
             + (0.5 + static_cast<double>(i)) / count * span;
         values[static_cast<std::size_t>(i)] =
-            logarithmic ? std::exp(value) : value;
+            inverseTransformedValue(value, scale);
     }
     return values;
 }

--- a/src/render2d/ScalarRenderer.cpp
+++ b/src/render2d/ScalarRenderer.cpp
@@ -44,7 +44,7 @@ std::array<std::uint8_t, 3> sampleViridis(double normalized) noexcept
 ImageBuffer renderScalarPlane(
     const ScalarPlane& plane, const ScalarRenderSettings& settings)
 {
-    const auto scale = effectiveColorScale(settings.logarithmic, settings.scale);
+    const auto scale = settings.scale;
     // Check order is pinned by the unit test: positive extent, then the
     // stride representation, then the shared storage-match rule (extent is
     // already vetted here, so AllowEmpty cannot actually pass an empty plane).

--- a/src/render2d/ScalarRenderer.cpp
+++ b/src/render2d/ScalarRenderer.cpp
@@ -44,6 +44,7 @@ std::array<std::uint8_t, 3> sampleViridis(double normalized) noexcept
 ImageBuffer renderScalarPlane(
     const ScalarPlane& plane, const ScalarRenderSettings& settings)
 {
+    const auto scale = effectiveColorScale(settings.logarithmic, settings.scale);
     // Check order is pinned by the unit test: positive extent, then the
     // stride representation, then the shared storage-match rule (extent is
     // already vetted here, so AllowEmpty cannot actually pass an empty plane).
@@ -63,23 +64,32 @@ ImageBuffer renderScalarPlane(
         throw std::invalid_argument(
             "scalar render range must be finite with a finite span");
     }
-    if (settings.logarithmic && !(settings.minimum > 0.0)) {
+    if (scale.scale == ColorScale::Logarithmic && !(settings.minimum > 0.0)) {
         throw std::invalid_argument("logarithmic scalar range must be positive");
+    }
+    if (scale.scale == ColorScale::SymLogarithmic
+        && !(scale.linearThreshold > 0.0 && std::isfinite(scale.linearThreshold))) {
+        throw std::invalid_argument(
+            "symmetric-log scalar threshold must be finite and positive");
     }
 
     // The checks above name the three ways a range is refused; this resolves
     // the mapping itself, shared with the volume ray caster so a value takes
     // the same slot in a slice and in a volume of the same field.
     const auto range = resolveValueRange(
-        settings.minimum, settings.maximum, settings.logarithmic);
+        settings.minimum, settings.maximum, scale);
     if (!range) {
         // Everything the checks above cover has already thrown, so the only
         // way to arrive here is a logarithmic range so narrow that both
         // bounds share a logarithm -- [1e300, nextafter(1e300)] differ by a
         // relative 1e-16, far under an ulp of log(1e300). The span the slots
         // would be spread over is zero, so there is no mapping to make.
+        if (scale.scale == ColorScale::Logarithmic) {
+            throw std::invalid_argument(
+                "logarithmic scalar range is too narrow: its bounds have the same logarithm");
+        }
         throw std::invalid_argument(
-            "logarithmic scalar range is too narrow: its bounds have the same logarithm");
+            "scalar range is too narrow after applying its color scale");
     }
 
     ImageBuffer image;

--- a/src/render2d/VectorGlyphs.cpp
+++ b/src/render2d/VectorGlyphs.cpp
@@ -11,7 +11,6 @@ namespace amrvis {
 
 namespace {
 
-constexpr double minimumMaxSpeed = 1.0e-8;
 constexpr double minimumArrowLength = 1.0e-6;
 constexpr double headBack = 0.25;
 constexpr double headSide = 0.125;
@@ -64,7 +63,7 @@ std::vector<VectorSegment> generateVectorGlyphs(
     const double maxSpeed = std::sqrt(maxSpeedSquared);
 
     std::vector<VectorSegment> segments;
-    if (!(maxSpeed >= minimumMaxSpeed)) {
+    if (!(maxSpeed > 0.0)) {
         return segments;
     }
 
@@ -162,7 +161,7 @@ std::vector<VectorSegment> generateSphericalRZVectorGlyphs(
         }
         maxSpeed = std::max(maxSpeed, std::hypot(u, v));
     }
-    if (!(maxSpeed >= minimumMaxSpeed)) {
+    if (!(maxSpeed > 0.0)) {
         return segments;
     }
 

--- a/src/render3d/VolumeRaycaster.cpp
+++ b/src/render3d/VolumeRaycaster.cpp
@@ -132,8 +132,9 @@ bool clipToBox(const Ray& ray, const SlabAxes& axes, const RealBox& box,
 std::optional<int> transferEntryFor(double value, const VolumeRange& range,
     int entryCount) noexcept
 {
+    const auto scale = effectiveColorScale(range.logarithmic, range.scale);
     const auto resolved = resolveValueRange(
-        range.minimum, range.maximum, range.logarithmic);
+        range.minimum, range.maximum, scale);
     if (entryCount < 1 || !resolved || !mappableValue(value, *resolved)) {
         return std::nullopt;
     }
@@ -232,7 +233,8 @@ VolumeFrame raycastVolume(const VolumeGrid& grid,
         }
     }
     const auto mapping = resolveValueRange(
-        settings.range.minimum, settings.range.maximum, settings.range.logarithmic);
+        settings.range.minimum, settings.range.maximum,
+        effectiveColorScale(settings.range.logarithmic, settings.range.scale));
     if (!mapping) {
         throw std::invalid_argument("volume range must be finite with a finite span, ordered, and positive when logarithmic");
     }

--- a/src/render3d/VolumeRaycaster.cpp
+++ b/src/render3d/VolumeRaycaster.cpp
@@ -132,7 +132,7 @@ bool clipToBox(const Ray& ray, const SlabAxes& axes, const RealBox& box,
 std::optional<int> transferEntryFor(double value, const VolumeRange& range,
     int entryCount) noexcept
 {
-    const auto scale = effectiveColorScale(range.logarithmic, range.scale);
+    const auto scale = range.scale;
     const auto resolved = resolveValueRange(
         range.minimum, range.maximum, scale);
     if (entryCount < 1 || !resolved || !mappableValue(value, *resolved)) {
@@ -159,9 +159,8 @@ int raycastThreadCount(unsigned requested, int height) noexcept
         std::clamp(requested != 0 ? requested : hardware, 1U, ceiling));
 }
 
-std::optional<std::pair<double, double>> volumeGridRange(
-    const VolumeGrid& grid, bool logarithmic, StopToken cancellation)
-{
+std::optional<std::pair<double, double>>
+volumeGridRange(const VolumeGrid& grid, ColorScaleConfig scale, StopToken cancellation) {
     auto minimum = std::numeric_limits<double>::infinity();
     auto maximum = -std::numeric_limits<double>::infinity();
     // The grid runs to the 512^3 budget, half a gigabyte of floats. A scan
@@ -180,7 +179,7 @@ std::optional<std::pair<double, double>> volumeGridRange(
             throw ReadCancelled();
         }
         const auto value = grid.values[index];
-        if (!std::isfinite(value) || (logarithmic && !(value > 0.0F))) {
+        if (!std::isfinite(value) || (scale.scale == ColorScale::Logarithmic && !(value > 0.0F))) {
             continue;
         }
         minimum = std::min(minimum, static_cast<double>(value));
@@ -232,9 +231,8 @@ VolumeFrame raycastVolume(const VolumeGrid& grid,
             throw std::invalid_argument("output dimensions must be within [1, 4096]");
         }
     }
-    const auto mapping = resolveValueRange(
-        settings.range.minimum, settings.range.maximum,
-        effectiveColorScale(settings.range.logarithmic, settings.range.scale));
+    const auto mapping =
+        resolveValueRange(settings.range.minimum, settings.range.maximum, settings.range.scale);
     if (!mapping) {
         throw std::invalid_argument("volume range must be finite with a finite span, ordered, and positive when logarithmic");
     }

--- a/tests/benchmark/bench_volume_render.cpp
+++ b/tests/benchmark/bench_volume_render.cpp
@@ -116,7 +116,7 @@ int main(int argc, char** argv)
     settings.camera = amrvis::orthoPresetXY;
     settings.domain = grid.region;
     settings.outputSize = {outputDim, outputDim};
-    settings.range = {0.0, 1.0, false};
+    settings.range = {0.0, 1.0, {amrvis::ColorScale::Linear}};
     settings.samplesPerVoxel = samplesPerVoxel;
     settings.threadCount = static_cast<unsigned>(std::max(0, threads));
     settings.sampling = linear == 1 ? amrvis::SamplingPolicy::Linear

--- a/tests/fuzz/fuzz_wire_codec.cpp
+++ b/tests/fuzz/fuzz_wire_codec.cpp
@@ -793,7 +793,7 @@ std::vector<std::vector<std::uint8_t>> wireSeeds()
         request.region.upper = {{1.0, 2.0, 3.0}};
         request.camera = {0.5, -0.25, 1.5};
         request.outputSize = {64, 48};
-        request.range = amrvis::VolumeRange{0.5, 2.0, true};
+        request.range = amrvis::VolumeRange{0.5, 2.0, {amrvis::ColorScale::Logarithmic}};
         // Not the *wire* default: Nearest is the schema's zero, which
         // flatbuffers omits from the buffer entirely, so a seed carrying it
         // would be byte-identical to a pre-1.3 request and would exercise
@@ -808,7 +808,7 @@ std::vector<std::vector<std::uint8_t>> wireSeeds()
         frame.width = 2;
         frame.height = 2;
         frame.pixels = {0xFF102030U, 0x80402010U, 0U, 0xFFFFFFFFU};
-        frame.usedRange = {0.5, 2.0, true};
+        frame.usedRange = {0.5, 2.0, {amrvis::ColorScale::Logarithmic}};
         frame.metrics.gridDims = {4, 4, 4};
         frame.metrics.coveredVoxels = 60;
         frame.metrics.sampledMaximumLevel = 1;

--- a/tests/integration/test_display_transitions.cpp
+++ b/tests/integration/test_display_transitions.cpp
@@ -211,6 +211,7 @@ void requireDisplayInvariants(const amrvis::DatasetMetadata& metadata,
             amrvis::ScalarRenderSettings{
                 .minimum = d.minimum,
                 .maximum = d.maximum,
+                .scale = d.scale,
                 .logarithmic = d.logarithmic,
                 .palette = &palette
             });

--- a/tests/integration/test_display_transitions.cpp
+++ b/tests/integration/test_display_transitions.cpp
@@ -195,7 +195,7 @@ void requireDisplayInvariants(const amrvis::DatasetMetadata& metadata,
     const std::string& context)
 {
     require(d.minimum < d.maximum, context + ": range has no extent");
-    if (d.logarithmic) {
+    if ((d.scale.scale == amrvis::ColorScale::Logarithmic)) {
         require(d.minimum > 0.0, context + ": logarithmic range not positive");
     }
     // I5: the request is internally consistent — its output size is the
@@ -212,7 +212,6 @@ void requireDisplayInvariants(const amrvis::DatasetMetadata& metadata,
                 .minimum = d.minimum,
                 .maximum = d.maximum,
                 .scale = d.scale,
-                .logarithmic = d.logarithmic,
                 .palette = &palette
             });
         require(reference.rgba == d.image.rgba,
@@ -221,8 +220,7 @@ void requireDisplayInvariants(const amrvis::DatasetMetadata& metadata,
     // I2: every contour level is one of the levels derived from the
     // displayed range.
     if (!d.contourPolylines.empty()) {
-        const auto expected = amrvis::contourValues(
-            d.minimum, d.maximum, d.contourCount, d.logarithmic);
+        const auto expected = amrvis::contourValues(d.minimum, d.maximum, d.contourCount, d.scale);
         for (const auto& polyline : d.contourPolylines) {
             bool derived = false;
             for (const auto value : expected) {
@@ -453,18 +451,18 @@ int main()
         // non-positive user range it falls back to linear (the whole slice
         // must not fail).
         amrvis::FrameSliceSpec spec;
-        spec.logarithmic = true;
+        spec.scale = {amrvis::ColorScale::Logarithmic};
         const auto log = load2d(spec);
-        require(log.displays.front().logarithmic,
-            "positive-range logarithmic request fell back");
+        require(log.displays.front().scale.scale == amrvis::ColorScale::Logarithmic,
+                "positive-range logarithmic request fell back");
         requireDisplayInvariants(log.dataset->metadata(),
             log.displays.front(), palette, "initial File log");
 
         spec.rangeMode = amrvis::RangeMode::User;
         spec.userRange = std::pair{-1.0, 5.0};
         const auto fallback = load2d(spec);
-        require(!fallback.displays.front().logarithmic,
-            "non-positive logarithmic request did not fall back to linear");
+        require(fallback.displays.front().scale.scale != amrvis::ColorScale::Logarithmic,
+                "non-positive logarithmic request did not fall back to linear");
         requireDisplayInvariants(fallback.dataset->metadata(),
             fallback.displays.front(), palette, "log fallback");
     }
@@ -499,17 +497,17 @@ int main()
         request.maximumLevel = recording->metadata().finestLevel;
         request.outputSize = {16, 16};
         request.includeGridBoxes = true;
-        static_cast<void>(amrvis::executeSliceWithFallback(recording, request,
-            amrvis::RangeMode::File, std::nullopt, false, palette,
-            amrvis::DisplayMode::RasterContours, 0, 0, 4, {}));
+        static_cast<void>(amrvis::executeSliceWithFallback(
+            recording, request, amrvis::RangeMode::File, std::nullopt, {amrvis::ColorScale::Linear},
+            palette, amrvis::DisplayMode::RasterContours, 0, 0, 4, {}));
         require(recording->gridBoxRequests()
                 == std::vector<bool>{true, false},
             "contour mode requested the grid-box list more than once");
 
         recording->clearGridBoxRequests();
-        static_cast<void>(amrvis::executeSliceWithFallback(recording, request,
-            amrvis::RangeMode::File, std::nullopt, false, palette,
-            amrvis::DisplayMode::VelocityVectors, 0, 0, 4, {}));
+        static_cast<void>(amrvis::executeSliceWithFallback(
+            recording, request, amrvis::RangeMode::File, std::nullopt, {amrvis::ColorScale::Linear},
+            palette, amrvis::DisplayMode::VelocityVectors, 0, 0, 4, {}));
         require(recording->gridBoxRequests()
                 == std::vector<bool>{true, false, false},
             "vector mode requested the grid-box list more than once");
@@ -600,7 +598,7 @@ int main()
     {
         amrvis::FrameSliceSpec spec;
         spec.rangeMode = amrvis::RangeMode::Visible;
-        spec.logarithmic = true;
+        spec.scale = {amrvis::ColorScale::Logarithmic};
         spec.displayMode = amrvis::DisplayMode::RasterContours;
         spec.contourCount = 3;
         spec.defaultPositions = false;
@@ -627,7 +625,7 @@ int main()
         // renderScalarPlane threw and executeFrameLoad failed the whole load.
         amrvis::FrameSliceSpec spec;
         spec.rangeMode = amrvis::RangeMode::Visible;
-        spec.logarithmic = true;
+        spec.scale = {amrvis::ColorScale::Logarithmic};
         spec.displayMode = amrvis::DisplayMode::RasterContours;
         spec.contourCount = 3;
         const auto result = amrvis::executeFrameLoad(
@@ -642,8 +640,8 @@ int main()
                     && nearlyEqual(d.maximum, first.maximum),
                 "mixed-sign 3-D panels do not share one range");
             // The whole set degrades to linear together (never per-panel).
-            require(!d.logarithmic,
-                "a panel stayed logarithmic against a union that crosses zero");
+            require(d.scale.scale != amrvis::ColorScale::Logarithmic,
+                    "a panel stayed logarithmic against a union that crosses zero");
             requireDisplayInvariants(result.dataset->metadata(), d, palette,
                 "mixed-sign 3-D shared range");
         }
@@ -665,10 +663,10 @@ int main()
         recording->failRanges(true);
         bool rangeFailurePreserved = false;
         try {
-            static_cast<void>(amrvis::resolveDisplayRange(recording,
-                d0.request.field, d0.request.maximumLevel,
-                d0.request.composition, amrvis::RangeMode::File,
-                std::nullopt, true, d0.slice.plane));
+            static_cast<void>(amrvis::resolveDisplayRange(
+                recording, d0.request.field, d0.request.maximumLevel, d0.request.composition,
+                amrvis::RangeMode::File, std::nullopt, {amrvis::ColorScale::Logarithmic},
+                d0.slice.plane));
         } catch (const std::runtime_error& error) {
             rangeFailurePreserved
                 = std::string(error.what()) == "range transport failed";
@@ -684,13 +682,11 @@ int main()
         stoppedRange.request_stop();
         bool rangeCancellationPreserved = false;
         try {
-            static_cast<void>(amrvis::refreshCachedSlice(recording,
-                d0.request,
-                std::make_shared<const amrvis::ScalarPlane>(d0.slice.plane),
-                d0.contourPlane, {},
-                amrvis::RangeMode::File, std::nullopt, true, palette,
-                amrvis::DisplayMode::RasterContours, 0, 0, 4, true,
-                stoppedRange.get_token()));
+            static_cast<void>(amrvis::refreshCachedSlice(
+                recording, d0.request, std::make_shared<const amrvis::ScalarPlane>(d0.slice.plane),
+                d0.contourPlane, {}, amrvis::RangeMode::File, std::nullopt,
+                {amrvis::ColorScale::Logarithmic}, palette, amrvis::DisplayMode::RasterContours, 0,
+                0, 4, true, stoppedRange.get_token()));
         } catch (const amrvis::ReadCancelled&) {
             rangeCancellationPreserved = true;
         }
@@ -706,11 +702,12 @@ int main()
         // (leaving reusedPlane null) fails here instead of silently.
         const auto reusedInput
             = std::make_shared<const amrvis::ScalarPlane>(d0.slice.plane);
-        const auto log = amrvis::refreshCachedSlice(baseLoad.dataset,
-            d0.request, reusedInput, d0.contourPlane, {},
-            amrvis::RangeMode::File, std::nullopt,
-            true, palette, amrvis::DisplayMode::RasterContours, 0, 0, 4, true);
-        require(log.logarithmic, "cached-plane log toggle fell back");
+        const auto log = amrvis::refreshCachedSlice(
+            baseLoad.dataset, d0.request, reusedInput, d0.contourPlane, {}, amrvis::RangeMode::File,
+            std::nullopt, {amrvis::ColorScale::Logarithmic}, palette,
+            amrvis::DisplayMode::RasterContours, 0, 0, 4, true);
+        require((log.scale.scale == amrvis::ColorScale::Logarithmic),
+                "cached-plane log toggle fell back");
         require(log.reusedPlane.get() == reusedInput.get()
                 && &log.displayPlane() == reusedInput.get(),
             "cached refresh copied the display plane instead of reusing it");
@@ -722,10 +719,10 @@ int main()
         // empty-plane substitution.
         bool nullPlaneRejected = false;
         try {
-            static_cast<void>(amrvis::refreshCachedSlice(baseLoad.dataset,
-                d0.request, nullptr, d0.contourPlane, {},
-                amrvis::RangeMode::File, std::nullopt,
-                false, palette, amrvis::DisplayMode::Raster, 0, 0, 0, true));
+            static_cast<void>(amrvis::refreshCachedSlice(
+                baseLoad.dataset, d0.request, nullptr, d0.contourPlane, {}, amrvis::RangeMode::File,
+                std::nullopt, {amrvis::ColorScale::Linear}, palette, amrvis::DisplayMode::Raster, 0,
+                0, 0, true));
         } catch (const std::invalid_argument&) {
             nullPlaneRejected = true;
         }
@@ -733,12 +730,11 @@ int main()
             "refreshCachedSlice accepted a null display plane");
 
         // A contour-count change with a clean raster leaves the image alone.
-        const auto recount = amrvis::refreshCachedSlice(baseLoad.dataset,
-            d0.request,
-            std::make_shared<const amrvis::ScalarPlane>(d0.slice.plane),
-            d0.contourPlane, {}, amrvis::RangeMode::File, std::nullopt,
-            false, palette, amrvis::DisplayMode::RasterContours, 0, 0, 2,
-            false);
+        const auto recount = amrvis::refreshCachedSlice(
+            baseLoad.dataset, d0.request,
+            std::make_shared<const amrvis::ScalarPlane>(d0.slice.plane), d0.contourPlane, {},
+            amrvis::RangeMode::File, std::nullopt, {amrvis::ColorScale::Linear}, palette,
+            amrvis::DisplayMode::RasterContours, 0, 0, 2, false);
         require(recount.rasterUnchanged && recount.image.width == 0,
             "a contour-only refresh re-rendered the raster");
         require(!recount.contourPolylines.empty(),
@@ -746,11 +742,10 @@ int main()
         requireDisplayInvariants(metadata, recount, palette, "refresh count");
 
         // A range-mode change to User re-renders against the user range.
-        const auto user = amrvis::refreshCachedSlice(baseLoad.dataset,
-            d0.request,
-            std::make_shared<const amrvis::ScalarPlane>(d0.slice.plane),
-            d0.contourPlane, {}, amrvis::RangeMode::User,
-            std::pair{2.0, 3.0}, false, palette,
+        const auto user = amrvis::refreshCachedSlice(
+            baseLoad.dataset, d0.request,
+            std::make_shared<const amrvis::ScalarPlane>(d0.slice.plane), d0.contourPlane, {},
+            amrvis::RangeMode::User, std::pair{2.0, 3.0}, {amrvis::ColorScale::Linear}, palette,
             amrvis::DisplayMode::RasterContours, 0, 0, 4, true);
         require(nearlyEqual(user.minimum, 2.0)
                 && nearlyEqual(user.maximum, 3.0),
@@ -804,13 +799,13 @@ int main()
         request.composition = amrvis::CompositionPolicy::ExactLevel;
         request.maximumLevel = 0;
         request.dataset = measured->id();
-        (void)amrvis::executeSlice(measured, request,
-            amrvis::RangeMode::Visible, std::nullopt, false, palette, {});
+        (void)amrvis::executeSlice(measured, request, amrvis::RangeMode::Visible, std::nullopt,
+                                   {amrvis::ColorScale::Linear}, palette, {});
         const auto coarseBytes = measured->cacheMetrics().residentBytes;
         request.composition = amrvis::CompositionPolicy::FinestAvailable;
         request.maximumLevel = 1;
-        (void)amrvis::executeSlice(measured, request,
-            amrvis::RangeMode::Visible, std::nullopt, false, palette, {});
+        (void)amrvis::executeSlice(measured, request, amrvis::RangeMode::Visible, std::nullopt,
+                                   {amrvis::ColorScale::Linear}, palette, {});
         const auto bothBytes = measured->cacheMetrics().residentBytes;
         const auto fineBytes = bothBytes - coarseBytes;
         require(coarseBytes > 0 && fineBytes > 0,
@@ -826,9 +821,9 @@ int main()
         // the fallback; the result is still internally consistent.
         auto tight = std::make_shared<amrvis::LocalDatasetSession>(root2d,
             amrvis::DatasetId{nextId++}, coarseBytes + fineBytes / 2);
-        const auto fallback = amrvis::executeSliceWithFallback(tight,
-            freshRequest(*tight), amrvis::RangeMode::Visible, std::nullopt,
-            false, palette, amrvis::DisplayMode::Raster, 0, 0, 4, {});
+        const auto fallback = amrvis::executeSliceWithFallback(
+            tight, freshRequest(*tight), amrvis::RangeMode::Visible, std::nullopt,
+            {amrvis::ColorScale::Linear}, palette, amrvis::DisplayMode::Raster, 0, 0, 4, {});
         require(fallback.cacheFallbackFromLevel == 1
                 && fallback.cacheFallbackToLevel == 0
                 && fallback.request.maximumLevel == 0,
@@ -839,9 +834,9 @@ int main()
         // A generous budget records no fallback.
         auto roomy = std::make_shared<amrvis::LocalDatasetSession>(root2d,
             amrvis::DatasetId{nextId++}, bigBudget);
-        const auto normal = amrvis::executeSliceWithFallback(roomy,
-            freshRequest(*roomy), amrvis::RangeMode::Visible, std::nullopt,
-            false, palette, amrvis::DisplayMode::Raster, 0, 0, 4, {});
+        const auto normal = amrvis::executeSliceWithFallback(
+            roomy, freshRequest(*roomy), amrvis::RangeMode::Visible, std::nullopt,
+            {amrvis::ColorScale::Linear}, palette, amrvis::DisplayMode::Raster, 0, 0, 4, {});
         require(normal.cacheFallbackFromLevel == -1
                 && normal.cacheFallbackToLevel == -1,
             "an unpressured slice recorded a fallback");
@@ -854,9 +849,9 @@ int main()
             auto exactRequest = freshRequest(*exact);
             exactRequest.composition = amrvis::CompositionPolicy::ExactLevel;
             exactRequest.maximumLevel = 1;
-            (void)amrvis::executeSliceWithFallback(exact, exactRequest,
-                amrvis::RangeMode::Visible, std::nullopt, false, palette,
-                amrvis::DisplayMode::Raster, 0, 0, 4, {});
+            (void)amrvis::executeSliceWithFallback(
+                exact, exactRequest, amrvis::RangeMode::Visible, std::nullopt,
+                {amrvis::ColorScale::Linear}, palette, amrvis::DisplayMode::Raster, 0, 0, 4, {});
         } catch (const std::exception& error) {
             threw = true;
             require(std::string(error.what()).find("selected slice level")
@@ -870,10 +865,9 @@ int main()
             amrvis::DatasetId{nextId++}, coarseBytes / 2);
         threw = false;
         try {
-            (void)amrvis::executeSliceWithFallback(hopeless,
-                freshRequest(*hopeless), amrvis::RangeMode::Visible,
-                std::nullopt, false, palette, amrvis::DisplayMode::Raster,
-                0, 0, 4, {});
+            (void)amrvis::executeSliceWithFallback(
+                hopeless, freshRequest(*hopeless), amrvis::RangeMode::Visible, std::nullopt,
+                {amrvis::ColorScale::Linear}, palette, amrvis::DisplayMode::Raster, 0, 0, 4, {});
         } catch (const std::exception& error) {
             threw = true;
             require(std::string(error.what()).find("even at level 0")

--- a/tests/integration/test_remote_volume.cpp
+++ b/tests/integration/test_remote_volume.cpp
@@ -65,7 +65,7 @@ amrvis::VolumeRenderRequest requestFor(const amrvis::DatasetSession& dataset)
     request.region = amrvis::datasetSampleBounds(dataset.metadata());
     request.camera = {0.55, 0.35, 1.2};
     request.outputSize = {96, 80};
-    request.range = amrvis::VolumeRange{0.0, 1.0, false};
+    request.range = amrvis::VolumeRange{0.0, 1.0, {amrvis::ColorScale::Linear}};
     // A ramp from transparent to opaque with a bright colour, so the
     // analytic (i + j + k) / 9 field draws something over its whole range.
     for (int entry = 0; entry < 16; ++entry) {
@@ -145,11 +145,10 @@ int main(int argc, char* argv[])
         auto visible = remoteRequest;
         visible.range.reset();
         const auto resolved = remote->renderVolume(visible);
-        require(resolved.usedRange.minimum == 0.0
-                && resolved.usedRange.maximum == 1.0
-                && !resolved.usedRange.logarithmic,
-            "the server did not report the range it resolved");
-        visible.logarithmic = true;
+        require(resolved.usedRange.minimum == 0.0 && resolved.usedRange.maximum == 1.0 &&
+                    resolved.usedRange.scale.scale != amrvis::ColorScale::Logarithmic,
+                "the server did not report the range it resolved");
+        visible.scale = {amrvis::ColorScale::Logarithmic};
         const auto resolvedLog = remote->renderVolume(visible);
         // The field runs down to zero, so a logarithmic range is not viable
         // and the server falls back to linear over every finite value --
@@ -158,11 +157,11 @@ int main(int argc, char* argv[])
         // honest" form of this was a tautology: validateSessionVolumeResult
         // has already thrown on every frame that fails it, so it could not
         // fire.
-        require(!resolvedLog.usedRange.logarithmic
-                && resolvedLog.usedRange.minimum == resolved.usedRange.minimum
-                && resolvedLog.usedRange.maximum == resolved.usedRange.maximum,
-            "asking for a logarithmic Visible range on non-positive data did "
-            "not fall back to the linear one");
+        require(resolvedLog.usedRange.scale.scale != amrvis::ColorScale::Logarithmic &&
+                    resolvedLog.usedRange.minimum == resolved.usedRange.minimum &&
+                    resolvedLog.usedRange.maximum == resolved.usedRange.maximum,
+                "asking for a logarithmic Visible range on non-positive data did "
+                "not fall back to the linear one");
 
         // --- cancellation ------------------------------------------------
         {

--- a/tests/integration/test_remote_volume.cpp
+++ b/tests/integration/test_remote_volume.cpp
@@ -263,6 +263,62 @@ int main(int argc, char* argv[])
             boundedSession->close();
         }
 
+        // Explicit ranges override the Visible scale, even before symlog
+        // support. Exercise the server gate with negotiated protocols 1.2-1.4.
+        for (std::uint16_t minor = 2; minor <= 4; ++minor) {
+            auto socket = connectTo("127.0.0.1", server.port());
+            std::uint64_t requestId = 0;
+            const auto exchange = [&](auto payload) {
+                writeFrame(socket, codec::encode(++requestId, std::move(payload), minor),
+                    defaultMaximumFrameBytes);
+                const auto response = readFrame(socket, defaultMaximumFrameBytes);
+                require(response.has_value(), "the server closed a legacy connection");
+                return codec::decode(*response);
+            };
+            auto envelope = exchange(codec::toWire(HelloRequestData{
+                "volume test", "test", 0, minor,
+                defaultMaximumFrameBytes, server.token(), {}}));
+            require(codec::inspect(*envelope).payload == PayloadKind::HelloResponse
+                    && codec::fromWire(*envelope->payload.AsHelloResponse())
+                            .selectedMinorVersion == minor,
+                "the server did not negotiate the requested legacy protocol");
+            envelope = exchange(codec::toWire(OpenDatasetData{path, 16ULL << 20, {}}));
+            require(codec::inspect(*envelope).payload == PayloadKind::DatasetOpened,
+                "the legacy connection could not open the fixture");
+            const auto opened = codec::fromWire(*envelope->payload.AsDatasetOpened());
+            auto request = requestFor(*remote);
+            request.dataset = opened.id;
+            request.sampling = SamplingPolicy::Nearest;
+            request.scale = {ColorScale::SymLogarithmic, 0.25};
+            for (const auto scale : {ColorScale::Linear, ColorScale::Logarithmic}) {
+                request.range = VolumeRange{0.1, 1.0, {scale}};
+                envelope = exchange(codec::toWire(request));
+                require(codec::inspect(*envelope).payload == PayloadKind::RenderedFrameResponse,
+                    "an inactive Visible symlog scale rejected an explicit legacy range");
+                const auto frame = codec::fromWire(*envelope->payload.AsRenderedFrameResponse());
+                auto expected = request;
+                expected.dataset = local->id();
+                const auto localResult = local->renderVolume(expected);
+                require(frame.pixels == localResult.pixels
+                        && frame.usedRange == localResult.usedRange,
+                    "an explicit legacy range differs from local rendering");
+            }
+            // Active symlog must still be refused, for either range mode.
+            for (const bool explicitRange : {false, true}) {
+                request.range.reset();
+                if (explicitRange) {
+                    request.range = VolumeRange{0.1, 1.0,
+                        {ColorScale::SymLogarithmic, 0.25}};
+                    request.scale = {ColorScale::Linear};
+                }
+                envelope = exchange(codec::toWire(request));
+                require(codec::inspect(*envelope).payload == PayloadKind::ErrorResponse
+                        && codec::fromWire(*envelope->payload.AsErrorResponse()).code
+                            == ErrorCode::UnsupportedProtocol,
+                    "a legacy protocol accepted active symlog scaling");
+            }
+        }
+
         // --- a 1.1 client is told volume rendering needs 1.2 ------------
         {
             auto socket = connectTo("127.0.0.1", server.port());

--- a/tests/integration/test_volume_pipeline.cpp
+++ b/tests/integration/test_volume_pipeline.cpp
@@ -597,6 +597,14 @@ int main()
         require(user && !user->logarithmic && user->minimum == -3.0
                 && user->maximum == 5.0,
             "a non-positive User range did not fall back to linear");
+        const auto symlog = amrvis::resolveVolumeRange(dataset, field, 1,
+            amrvis::CompositionPolicy::FinestAvailable, amrvis::RangeMode::User,
+            std::pair{-3.0, 5.0},
+            {amrvis::ColorScale::SymLogarithmic, 0.25});
+        require(symlog && !symlog->logarithmic
+                && symlog->scale.scale == amrvis::ColorScale::SymLogarithmic
+                && symlog->scale.linearThreshold == 0.25,
+            "a symmetric-log User range did not preserve its mapping");
         const auto degenerate = amrvis::resolveVolumeRange(dataset, field, 1,
             amrvis::CompositionPolicy::FinestAvailable, amrvis::RangeMode::User,
             std::pair{2.0, 2.0}, false);

--- a/tests/integration/test_volume_pipeline.cpp
+++ b/tests/integration/test_volume_pipeline.cpp
@@ -580,46 +580,46 @@ int main()
         // File statistics: [1, 2]; Level 1 (finest available) also [1, 2];
         // User range as given, padded when degenerate; log downgrades on a
         // non-positive range; Visible leaves it to the renderer.
-        const auto file = amrvis::resolveVolumeRange(dataset, field, 1,
-            amrvis::CompositionPolicy::FinestAvailable, amrvis::RangeMode::File,
-            std::nullopt, false);
-        require(file && file->minimum == 1.0 && file->maximum == 2.0
-                && !file->logarithmic,
-            "the File range is not the metadata's");
-        const auto logFile = amrvis::resolveVolumeRange(dataset, field, 1,
-            amrvis::CompositionPolicy::FinestAvailable, amrvis::RangeMode::File,
-            std::nullopt, true);
-        require(logFile && logFile->logarithmic && logFile->minimum == 1.0,
-            "a positive File range did not stay logarithmic");
-        const auto user = amrvis::resolveVolumeRange(dataset, field, 1,
-            amrvis::CompositionPolicy::FinestAvailable, amrvis::RangeMode::User,
-            std::pair{-3.0, 5.0}, true);
-        require(user && !user->logarithmic && user->minimum == -3.0
-                && user->maximum == 5.0,
-            "a non-positive User range did not fall back to linear");
+        const auto file = amrvis::resolveVolumeRange(
+            dataset, field, 1, amrvis::CompositionPolicy::FinestAvailable, amrvis::RangeMode::File,
+            std::nullopt, {amrvis::ColorScale::Linear});
+        require(file && file->minimum == 1.0 && file->maximum == 2.0 &&
+                    file->scale.scale != amrvis::ColorScale::Logarithmic,
+                "the File range is not the metadata's");
+        const auto logFile = amrvis::resolveVolumeRange(
+            dataset, field, 1, amrvis::CompositionPolicy::FinestAvailable, amrvis::RangeMode::File,
+            std::nullopt, {amrvis::ColorScale::Logarithmic});
+        require(logFile && (logFile->scale.scale == amrvis::ColorScale::Logarithmic) &&
+                    logFile->minimum == 1.0,
+                "a positive File range did not stay logarithmic");
+        const auto user = amrvis::resolveVolumeRange(
+            dataset, field, 1, amrvis::CompositionPolicy::FinestAvailable, amrvis::RangeMode::User,
+            std::pair{-3.0, 5.0}, {amrvis::ColorScale::Logarithmic});
+        require(user && user->scale.scale != amrvis::ColorScale::Logarithmic &&
+                    user->minimum == -3.0 && user->maximum == 5.0,
+                "a non-positive User range did not fall back to linear");
         const auto symlog = amrvis::resolveVolumeRange(dataset, field, 1,
             amrvis::CompositionPolicy::FinestAvailable, amrvis::RangeMode::User,
             std::pair{-3.0, 5.0},
             {amrvis::ColorScale::SymLogarithmic, 0.25});
-        require(symlog && !symlog->logarithmic
-                && symlog->scale.scale == amrvis::ColorScale::SymLogarithmic
-                && symlog->scale.linearThreshold == 0.25,
-            "a symmetric-log User range did not preserve its mapping");
-        const auto degenerate = amrvis::resolveVolumeRange(dataset, field, 1,
-            amrvis::CompositionPolicy::FinestAvailable, amrvis::RangeMode::User,
-            std::pair{2.0, 2.0}, false);
+        require(symlog && symlog->scale.scale != amrvis::ColorScale::Logarithmic &&
+                    symlog->scale.scale == amrvis::ColorScale::SymLogarithmic &&
+                    symlog->scale.linearThreshold == 0.25,
+                "a symmetric-log User range did not preserve its mapping");
+        const auto degenerate = amrvis::resolveVolumeRange(
+            dataset, field, 1, amrvis::CompositionPolicy::FinestAvailable, amrvis::RangeMode::User,
+            std::pair{2.0, 2.0}, {amrvis::ColorScale::Linear});
         require(degenerate && degenerate->minimum < 2.0 && degenerate->maximum > 2.0,
             "a degenerate User range was not padded");
         {
             const auto huge = 1.0e300;
             std::string narrow;
             try {
-                static_cast<void>(amrvis::resolveVolumeRange(dataset, field, 1,
-                    amrvis::CompositionPolicy::FinestAvailable,
+                static_cast<void>(amrvis::resolveVolumeRange(
+                    dataset, field, 1, amrvis::CompositionPolicy::FinestAvailable,
                     amrvis::RangeMode::User,
-                    std::pair{huge, std::nextafter(huge,
-                        std::numeric_limits<double>::infinity())},
-                    true));
+                    std::pair{huge, std::nextafter(huge, std::numeric_limits<double>::infinity())},
+                    {amrvis::ColorScale::Logarithmic}));
             } catch (const std::runtime_error& error) {
                 narrow = error.what();
             }
@@ -627,11 +627,11 @@ int main()
                     && narrow.find("logarithm") != std::string::npos,
                 "a logarithmic range too narrow to map was handed to the renderer");
         }
-        require(!amrvis::resolveVolumeRange(dataset, field, 1,
-                    amrvis::CompositionPolicy::FinestAvailable,
-                    amrvis::RangeMode::Visible, std::nullopt, false)
-                    .has_value(),
-            "the Visible range was resolved on the client");
+        require(!amrvis::resolveVolumeRange(
+                     dataset, field, 1, amrvis::CompositionPolicy::FinestAvailable,
+                     amrvis::RangeMode::Visible, std::nullopt, {amrvis::ColorScale::Linear})
+                     .has_value(),
+                "the Visible range was resolved on the client");
 
         // Render: an oblique view of a domain that is 2.0 in its fine
         // block and 1.0 in the coarse remainder, opaque above the middle.
@@ -642,7 +642,7 @@ int main()
         request.region = amrvis::datasetSampleBounds(session->metadata());
         request.camera = {0.6, 0.4, 1.0};
         request.outputSize = {64, 48};
-        request.range = amrvis::VolumeRange{1.0, 2.0, false};
+        request.range = amrvis::VolumeRange{1.0, 2.0, {amrvis::ColorScale::Linear}};
         request.transfer = amrvis::makeVolumeTransferFunction(
             amrvis::builtinPalette(amrvis::BuiltinPalette::Rainbow),
             amrvis::OpacityRamp{0.5, 1.0, 1.0, false, {}});
@@ -676,23 +676,21 @@ int main()
         auto visible = request;
         visible.range.reset();
         const auto resolved = amrvis::executeVolumeRenderWithFallback(dataset, visible);
-        require(resolved.frame.usedRange.minimum < 2.0
-                && resolved.frame.usedRange.maximum > 2.0
-                && resolved.frame.usedRange.maximum - resolved.frame.usedRange.minimum
-                    < 1.0e-4
-                && !resolved.frame.usedRange.logarithmic
-                && resolved.frame.metrics.gridFromCache,
-            "the Visible range was not resolved from the sampled grid");
-        visible.logarithmic = true;
+        require(resolved.frame.usedRange.minimum < 2.0 && resolved.frame.usedRange.maximum > 2.0 &&
+                    resolved.frame.usedRange.maximum - resolved.frame.usedRange.minimum < 1.0e-4 &&
+                    resolved.frame.usedRange.scale.scale != amrvis::ColorScale::Logarithmic &&
+                    resolved.frame.metrics.gridFromCache,
+                "the Visible range was not resolved from the sampled grid");
+        visible.scale = {amrvis::ColorScale::Logarithmic};
         const auto resolvedLog = amrvis::executeVolumeRenderWithFallback(dataset, visible);
-        require(resolvedLog.frame.usedRange.logarithmic
-                && resolvedLog.frame.usedRange.minimum > 0.0
-                && resolvedLog.frame.usedRange.minimum < 2.0
-                && resolvedLog.frame.usedRange.maximum > 2.0,
-            "a positive Visible range did not go logarithmic when asked");
+        require((resolvedLog.frame.usedRange.scale.scale == amrvis::ColorScale::Logarithmic) &&
+                    resolvedLog.frame.usedRange.minimum > 0.0 &&
+                    resolvedLog.frame.usedRange.minimum < 2.0 &&
+                    resolvedLog.frame.usedRange.maximum > 2.0,
+                "a positive Visible range did not go logarithmic when asked");
         // A Visible render at level 0 sees only the coarse 1.0.
         auto coarseVisible = visible;
-        coarseVisible.logarithmic = false;
+        coarseVisible.scale = {amrvis::ColorScale::Linear};
         coarseVisible.maximumLevel = 0;
         const auto coarseResolved
             = amrvis::executeVolumeRenderWithFallback(dataset, coarseVisible);
@@ -785,7 +783,7 @@ int main()
         request.camera = amrvis::orthoPresetXY;
         request.outputSize = {32, 32};
         // Range [0, 1]: the coarse 1.0 maps to the opaque top entry.
-        request.range = amrvis::VolumeRange{0.0, 1.0, false};
+        request.range = amrvis::VolumeRange{0.0, 1.0, {amrvis::ColorScale::Linear}};
         request.transfer.colors = {0x0U, 0xFFFFFFU};
         request.transfer.opacities = {0.0F, 1.0F};
         request.maximumVoxels = 4096;
@@ -802,17 +800,17 @@ int main()
         // alone, so a Level range resolved once up front would colour a
         // level-0 render with level-1's numbers.
         {
-            const auto levelWide = amrvis::resolveVolumeRange(dataset,
-                request.field, 1, request.composition, amrvis::RangeMode::Level,
-                std::nullopt, false);
+            const auto levelWide = amrvis::resolveVolumeRange(
+                dataset, request.field, 1, request.composition, amrvis::RangeMode::Level,
+                std::nullopt, {amrvis::ColorScale::Linear});
             require(levelWide && levelWide->maximum > 1.5,
                 "the level-1 range is not the wider one");
             auto tracking = request;
             tracking.range.reset();
             const auto followed = amrvis::executeVolumeRenderWithFallback(
                 dataset, tracking,
-                amrvis::VolumeRangeChoice{amrvis::RangeMode::Level,
-                    std::nullopt, false});
+                amrvis::VolumeRangeChoice{
+                    amrvis::RangeMode::Level, std::nullopt, {amrvis::ColorScale::Linear}});
             require(followed.request.maximumLevel == 0
                     && followed.frame.usedRange.maximum < 1.5,
                 "the range did not follow the fallback to level 0");
@@ -844,8 +842,8 @@ int main()
             tracked.range.reset();
             const auto followed = amrvis::executeVolumeRenderWithFallback(
                 wrapped, tracked,
-                amrvis::VolumeRangeChoice{amrvis::RangeMode::Level,
-                    std::nullopt, false});
+                amrvis::VolumeRangeChoice{
+                    amrvis::RangeMode::Level, std::nullopt, {amrvis::ColorScale::Linear}});
             require(followed.request.maximumLevel == 0
                     && followed.frame.cacheFallbackFromLevel == 1
                     && followed.frame.cacheFallbackToLevel == 0,
@@ -866,8 +864,8 @@ int main()
             byFile.range.reset();
             const auto fileRange = amrvis::executeVolumeRenderWithFallback(
                 wrapped, byFile,
-                amrvis::VolumeRangeChoice{amrvis::RangeMode::File,
-                    std::nullopt, false});
+                amrvis::VolumeRangeChoice{
+                    amrvis::RangeMode::File, std::nullopt, {amrvis::ColorScale::Linear}});
             require(!fileRange.frame.metrics.gridFromCache,
                 "a File range was repeated even though it ignores the level");
         }

--- a/tests/qt_smoke_driver.cmake
+++ b/tests/qt_smoke_driver.cmake
@@ -39,6 +39,9 @@ foreach(argument MATERIALIZER AMREXPLORER_QT SOURCE WORK MODE)
 endforeach()
 
 set(ENV{QT_QPA_PLATFORM} offscreen)
+# Windows otherwise sends Qt diagnostics to the debugger instead of the
+# stderr stream captured below, leaving failed assertions without a message.
+set(ENV{QT_FORCE_STDERR_LOGGING} 1)
 
 # Isolate QSettings per run: a fresh, empty config directory makes every smoke
 # test start from defaults, so persisted UI state (spherical display mode and

--- a/tests/unit/test_contours.cpp
+++ b/tests/unit/test_contours.cpp
@@ -113,7 +113,7 @@ int main()
     require(nearlyEqual(values.back(), 0.95), "last contour value mismatch");
     require(nearlyEqual(values[5] - values[4], 0.1), "contour spacing mismatch");
 
-    const auto logValues = amrvis::contourValues(1.0, 1000.0, 3, true);
+    const auto logValues = amrvis::contourValues(1.0, 1000.0, 3, {amrvis::ColorScale::Logarithmic});
     require(logValues.size() == 3, "log contourValues returned the wrong count");
     require(nearlyEqual(logValues[0], std::sqrt(10.0)),
         "first logarithmic contour value mismatch");
@@ -127,47 +127,47 @@ int main()
 
     bool threw = false;
     try {
-        (void)amrvis::contourValues(0.0, 1.0, 0, false);
+        (void)amrvis::contourValues(0.0, 1.0, 0, {amrvis::ColorScale::Linear});
     } catch (const std::invalid_argument&) {
         threw = true;
     }
     require(threw, "contourValues accepted a zero count");
     threw = false;
     try {
-        (void)amrvis::contourValues(1.0, 1.0, 4, false);
+        (void)amrvis::contourValues(1.0, 1.0, 4, {amrvis::ColorScale::Linear});
     } catch (const std::invalid_argument&) {
         threw = true;
     }
     require(threw, "contourValues accepted an empty range");
     threw = false;
     try {
-        (void)amrvis::contourValues(0.0, 1.0, 4, true);
+        (void)amrvis::contourValues(0.0, 1.0, 4, {amrvis::ColorScale::Logarithmic});
     } catch (const std::invalid_argument&) {
         threw = true;
     }
     require(threw, "contourValues accepted a non-positive logarithmic range");
     threw = false;
     try {
-        (void)amrvis::contourValues(
-            -std::numeric_limits<double>::max(),
-            std::numeric_limits<double>::max(), 4, false);
+        (void)amrvis::contourValues(-std::numeric_limits<double>::max(),
+                                    std::numeric_limits<double>::max(), 4,
+                                    {amrvis::ColorScale::Linear});
     } catch (const std::invalid_argument&) {
         threw = true;
     }
     require(threw, "contourValues accepted a range whose span overflows to infinity");
     threw = false;
     try {
-        (void)amrvis::contourValues(
-            -std::numeric_limits<double>::infinity(),
-            std::numeric_limits<double>::infinity(), 4, false);
+        (void)amrvis::contourValues(-std::numeric_limits<double>::infinity(),
+                                    std::numeric_limits<double>::infinity(), 4,
+                                    {amrvis::ColorScale::Linear});
     } catch (const std::invalid_argument&) {
         threw = true;
     }
     require(threw, "contourValues accepted an infinite range");
     threw = false;
     try {
-        (void)amrvis::contourValues(
-            std::numeric_limits<double>::quiet_NaN(), 1.0, 4, false);
+        (void)amrvis::contourValues(std::numeric_limits<double>::quiet_NaN(), 1.0, 4,
+                                    {amrvis::ColorScale::Linear});
     } catch (const std::invalid_argument&) {
         threw = true;
     }

--- a/tests/unit/test_contours.cpp
+++ b/tests/unit/test_contours.cpp
@@ -494,5 +494,9 @@ int main()
         }
     }
 
+    const auto symlog = amrvis::contourValues(-100.0, 100.0, 5,
+        {amrvis::ColorScale::SymLogarithmic, 1.0});
+    require(symlog.size() == 5 && std::abs(symlog[2]) < 1.0e-14,
+        "symmetric-log contours did not retain zero");
     return 0;
 }

--- a/tests/unit/test_dataset_colors.cpp
+++ b/tests/unit/test_dataset_colors.cpp
@@ -38,30 +38,23 @@ std::uint32_t argbOf(const QColor& color)
 }
 
 // Every value drawn the way the renderer draws that same value: same palette,
-// same range, same log flag. Values are floats because that is what both the
+// same range, same color scale. Values are floats because that is what both the
 // image plane and the dataset extract hold.
-void requireAgreesWithRenderer(const std::string& what,
-    const std::vector<float>& values, const amrvis::Palette& palette,
-    double minimum, double maximum, bool logarithmic)
-{
+void requireAgreesWithRenderer(const std::string& what, const std::vector<float>& values,
+                               const amrvis::Palette& palette, double minimum, double maximum,
+                               amrvis::ColorScaleConfig scale) {
     amrvis::ScalarPlane plane;
     plane.width = static_cast<int>(values.size());
     plane.height = 1;
     plane.values = values;
     plane.valid.assign(values.size(), 1);
     plane.sourceLevel.assign(values.size(), 0);
-    const auto image = amrvis::renderScalarPlane(plane,
-        amrvis::ScalarRenderSettings{
-            .minimum = minimum,
-            .maximum = maximum,
-            .scale = {},
-            .logarithmic = logarithmic,
-            .palette = &palette
-        });
+    const auto image = amrvis::renderScalarPlane(
+        plane, amrvis::ScalarRenderSettings{
+                   .minimum = minimum, .maximum = maximum, .scale = scale, .palette = &palette});
     require(image.valid(), what + ": the renderer produced no image");
 
-    const auto coloring = amrvis::qt::makeDatasetColoring(
-        palette, minimum, maximum, logarithmic);
+    const auto coloring = amrvis::qt::makeDatasetColoring(palette, minimum, maximum, scale);
     require(coloring.range.has_value(), what + ": the range did not resolve");
     std::size_t distinct = 0;
     for (std::size_t pixel = 0; pixel < values.size(); ++pixel) {
@@ -89,21 +82,21 @@ int main()
     // ValueMapping documents as sensitive to how the normalization is spelled,
     // plus values under and over the range.
     requireAgreesWithRenderer("linear rainbow",
-        {-3.0F, 0.0F, 1.0F, 12.25F, 24.5F, 36.75F, 48.0F, 49.0F, 60.0F},
-        rainbow, 0.0, 49.0, false);
+                              {-3.0F, 0.0F, 1.0F, 12.25F, 24.5F, 36.75F, 48.0F, 49.0F, 60.0F},
+                              rainbow, 0.0, 49.0, {amrvis::ColorScale::Linear});
     requireAgreesWithRenderer("linear reversed viridis",
-        {-3.0F, 0.0F, 1.0F, 12.25F, 24.5F, 36.75F, 48.0F, 49.0F, 60.0F},
-        reversedViridis, 0.0, 49.0, false);
+                              {-3.0F, 0.0F, 1.0F, 12.25F, 24.5F, 36.75F, 48.0F, 49.0F, 60.0F},
+                              reversedViridis, 0.0, 49.0, {amrvis::ColorScale::Linear});
     requireAgreesWithRenderer("logarithmic rainbow",
-        {1e-4F, 1e-3F, 1e-2F, 0.1F, 1.0F, 10.0F, 100.0F, 1e3F},
-        rainbow, 1e-3, 100.0, true);
-    requireAgreesWithRenderer("negative span",
-        {-20.0F, -10.0F, -7.5F, -5.0F, -2.5F, 0.0F, 5.0F},
-        rainbow, -10.0, 0.0, false);
+                              {1e-4F, 1e-3F, 1e-2F, 0.1F, 1.0F, 10.0F, 100.0F, 1e3F}, rainbow, 1e-3,
+                              100.0, {amrvis::ColorScale::Logarithmic});
+    requireAgreesWithRenderer("negative span", {-20.0F, -10.0F, -7.5F, -5.0F, -2.5F, 0.0F, 5.0F},
+                              rainbow, -10.0, 0.0, {amrvis::ColorScale::Linear});
 
     // The ends, named outright: the color bar's bottom and top are the
     // palette's first and last data slots, and the reversal swaps them.
-    const auto linear = amrvis::qt::makeDatasetColoring(rainbow, 2.0, 8.0, false);
+    const auto linear =
+        amrvis::qt::makeDatasetColoring(rainbow, 2.0, 8.0, {amrvis::ColorScale::Linear});
     require(argbOf(amrvis::qt::datasetValueColor(linear, 2.0))
             == rainbow.slotArgb(amrvis::Palette::paletteStart),
         "the minimum is not the palette's first data slot");
@@ -116,8 +109,8 @@ int main()
     require(argbOf(amrvis::qt::datasetValueColor(linear, 100.0))
             == rainbow.slotArgb(amrvis::Palette::paletteEnd),
         "a value over the range does not clamp to the last data slot");
-    const auto reversed = amrvis::qt::makeDatasetColoring(
-        rainbow.reversed(), 2.0, 8.0, false);
+    const auto reversed =
+        amrvis::qt::makeDatasetColoring(rainbow.reversed(), 2.0, 8.0, {amrvis::ColorScale::Linear});
     require(argbOf(amrvis::qt::datasetValueColor(reversed, 2.0))
             == rainbow.slotArgb(amrvis::Palette::paletteEnd),
         "reversal did not swap the low end");
@@ -134,8 +127,8 @@ int main()
     require(argbOf(amrvis::qt::datasetValueColor(
                 linear, std::numeric_limits<double>::infinity())) == nanColor,
         "an infinity is not drawn in the renderer's nan color");
-    const auto logarithmic
-        = amrvis::qt::makeDatasetColoring(rainbow, 1e-3, 100.0, true);
+    const auto logarithmic =
+        amrvis::qt::makeDatasetColoring(rainbow, 1e-3, 100.0, {amrvis::ColorScale::Logarithmic});
     require(argbOf(amrvis::qt::datasetValueColor(logarithmic, 0.0)) == nanColor,
         "zero under a log range is not drawn in the renderer's nan color");
     require(argbOf(amrvis::qt::datasetValueColor(logarithmic, -1.0)) == nanColor,
@@ -144,12 +137,12 @@ int main()
     // A range nothing can be mapped through: no color is meaningful, so the
     // numbers stay legible in the plain viewport foreground instead of all
     // taking the first slot's color.
-    for (const auto& unusable : {
-             amrvis::qt::makeDatasetColoring(rainbow, 5.0, 5.0, false),
-             amrvis::qt::makeDatasetColoring(rainbow, 8.0, 2.0, false),
-             amrvis::qt::makeDatasetColoring(rainbow, -1.0, 10.0, true),
-             amrvis::qt::makeDatasetColoring(rainbow,
-                 std::numeric_limits<double>::quiet_NaN(), 1.0, false)}) {
+    for (const auto& unusable :
+         {amrvis::qt::makeDatasetColoring(rainbow, 5.0, 5.0, {amrvis::ColorScale::Linear}),
+          amrvis::qt::makeDatasetColoring(rainbow, 8.0, 2.0, {amrvis::ColorScale::Linear}),
+          amrvis::qt::makeDatasetColoring(rainbow, -1.0, 10.0, {amrvis::ColorScale::Logarithmic}),
+          amrvis::qt::makeDatasetColoring(rainbow, std::numeric_limits<double>::quiet_NaN(), 1.0,
+                                          {amrvis::ColorScale::Linear})}) {
         require(!unusable.range.has_value(),
             "an unusable range resolved anyway");
         require(amrvis::qt::datasetValueColor(unusable, 5.0)

--- a/tests/unit/test_dataset_colors.cpp
+++ b/tests/unit/test_dataset_colors.cpp
@@ -54,6 +54,7 @@ void requireAgreesWithRenderer(const std::string& what,
         amrvis::ScalarRenderSettings{
             .minimum = minimum,
             .maximum = maximum,
+            .scale = {},
             .logarithmic = logarithmic,
             .palette = &palette
         });

--- a/tests/unit/test_display_coordinator.cpp
+++ b/tests/unit/test_display_coordinator.cpp
@@ -99,8 +99,8 @@ int main()
         const auto a = makePlane({2.0F, 5.0F});
         const auto b = makePlane({-1.0F, 3.0F});
         const std::array<const amrvis::ScalarPlane*, 2> planes{&a, &b};
-        const auto shared = DisplayCoordinator::sharedVisibleRange(
-            planes, false);
+        const auto shared =
+            DisplayCoordinator::sharedVisibleRange(planes, {amrvis::ColorScale::Linear});
         require(shared && nearlyEqual(shared->first, -1.0)
                 && nearlyEqual(shared->second, 5.0),
             "shared range is not the union across panels");
@@ -115,8 +115,8 @@ int main()
         const amrvis::ScalarPlane empty;
         const std::array<const amrvis::ScalarPlane*, 4> planes{
             &a, &b, &empty, nullptr};
-        const auto shared = DisplayCoordinator::sharedVisibleRange(
-            planes, false);
+        const auto shared =
+            DisplayCoordinator::sharedVisibleRange(planes, {amrvis::ColorScale::Linear});
         // Only the 2.0 sample survives, so the degenerate union is padded
         // around it; the masked 50 and the NaN must not have widened it.
         require(shared && shared->first < 2.0 && shared->second > 2.0
@@ -127,19 +127,20 @@ int main()
     {
         const amrvis::ScalarPlane empty;
         const std::array<const amrvis::ScalarPlane*, 1> planes{&empty};
-        require(!DisplayCoordinator::sharedVisibleRange(planes, false),
-            "an all-empty panel set produced a range");
+        require(!DisplayCoordinator::sharedVisibleRange(planes, {amrvis::ColorScale::Linear}),
+                "an all-empty panel set produced a range");
     }
     {
         // Degenerate union: additive pad in linear mode, ratio pad (staying
         // positive) in logarithmic mode.
         const auto constant = makePlane({5.0F, 5.0F});
         const std::array<const amrvis::ScalarPlane*, 1> planes{&constant};
-        const auto linear = DisplayCoordinator::sharedVisibleRange(
-            planes, false);
+        const auto linear =
+            DisplayCoordinator::sharedVisibleRange(planes, {amrvis::ColorScale::Linear});
         require(linear && linear->first < 5.0 && linear->second > 5.0,
             "a constant plane was not padded in linear mode");
-        const auto log = DisplayCoordinator::sharedVisibleRange(planes, true);
+        const auto log =
+            DisplayCoordinator::sharedVisibleRange(planes, {amrvis::ColorScale::Logarithmic});
         require(log && log->first < 5.0 && log->second > 5.0
                 && log->first > 0.0,
             "a constant plane was not ratio-padded in logarithmic mode");
@@ -207,8 +208,8 @@ int main()
         }};
 
         // No cached range: the union across panels drives every update.
-        auto sync = coordinator.syncPanelsToSharedRange(
-            key, inputs, false, true, 3, palette);
+        auto sync = coordinator.syncPanelsToSharedRange(key, inputs, {amrvis::ColorScale::Linear},
+                                                        true, 3, palette);
         require(sync.has_value(), "panel sync found no shared range");
         require(nearlyEqual(sync->range.first, -4.0)
                 && nearlyEqual(sync->range.second, 6.0),
@@ -225,8 +226,8 @@ int main()
 
         // A stored full-domain range takes precedence over the union.
         coordinator.storeFullDomainRange(key, {-100.0, 100.0});
-        sync = coordinator.syncPanelsToSharedRange(
-            key, inputs, false, false, 3, palette);
+        sync = coordinator.syncPanelsToSharedRange(key, inputs, {amrvis::ColorScale::Linear}, false,
+                                                   3, palette);
         require(sync && nearlyEqual(sync->range.first, -100.0)
                 && nearlyEqual(sync->range.second, 100.0),
             "the cached full-domain range did not take precedence");
@@ -235,9 +236,11 @@ int main()
         coordinator.invalidateRangeCache();
         const std::array<DisplayCoordinator::PanelSyncInput, 1> emptyOnly{{
             {&empty, nullptr, {0, 0}}}};
-        require(!coordinator.syncPanelsToSharedRange(
-                key, emptyOnly, false, false, 3, palette).has_value(),
-            "an empty panel set produced a sync");
+        require(!coordinator
+                     .syncPanelsToSharedRange(key, emptyOnly, {amrvis::ColorScale::Linear}, false,
+                                              3, palette)
+                     .has_value(),
+                "an empty panel set produced a sync");
     }
 
     // --- shared log degrades when the union crosses zero --------------------
@@ -255,16 +258,24 @@ int main()
             {&crossing, nullptr, {2, 1}},
         }};
         const auto sync = DisplayCoordinator::renderPanelsToSharedRange(
-            std::nullopt, mixed, true, true, 3, palette);
+            std::nullopt, mixed, {amrvis::ColorScale::Logarithmic}, true, 3, palette);
         require(sync.has_value(), "mixed-sign log sync found no range");
         require(nearlyEqual(sync->range.first, -4.0)
                 && nearlyEqual(sync->range.second, 6.0),
             "mixed-sign log sync range is not the union");
-        require(!sync->logarithmic,
-            "log was not degraded for a union that crosses zero");
+        require(sync->scale.scale != amrvis::ColorScale::Logarithmic,
+                "log was not degraded for a union that crosses zero");
         require(sync->panels[0].image.width > 0
                 && sync->panels[1].image.width > 0,
             "mixed-sign log sync did not render every panel");
+
+        const amrvis::ColorScaleConfig symlog{amrvis::ColorScale::SymLogarithmic, 0.25};
+        const auto symmetricSync = DisplayCoordinator::renderPanelsToSharedRange(
+            std::nullopt, mixed, symlog, true, 3, palette);
+        require(symmetricSync && symmetricSync->scale == symlog
+                && symmetricSync->panels[0].image.valid()
+                && symmetricSync->panels[1].image.valid(),
+            "shared range synchronization lost the Symlog scale or threshold");
 
         // An all-positive union keeps the requested log mapping.
         const auto other = makePlane({3.0F, 5.0F});
@@ -273,29 +284,29 @@ int main()
             {&other, nullptr, {2, 1}},
         }};
         const auto positiveSync = DisplayCoordinator::renderPanelsToSharedRange(
-            std::nullopt, allPositive, true, false, 3, palette);
-        require(positiveSync && positiveSync->logarithmic,
-            "log was dropped over an all-positive union");
+            std::nullopt, allPositive, {amrvis::ColorScale::Logarithmic}, false, 3, palette);
+        require(positiveSync && (positiveSync->scale.scale == amrvis::ColorScale::Logarithmic),
+                "log was dropped over an all-positive union");
 
         // realignArrivalToRange degrades identically: a log arrival realigned
         // to a full-domain range that crosses zero must render linear.
         amrvis::SliceDisplayResult arrival;
         arrival.slice.plane = makePlane({2.0F, 6.0F});
-        arrival.logarithmic = true;
+        arrival.scale = {amrvis::ColorScale::Logarithmic};
         DisplayCoordinator::realignArrivalToRange(
             arrival, {-1.0, 10.0}, palette, true);
-        require(!arrival.logarithmic,
-            "realign kept log against a range that crosses zero");
+        require(arrival.scale.scale != amrvis::ColorScale::Logarithmic,
+                "realign kept log against a range that crosses zero");
         require(arrival.image.valid() && arrival.image.width > 0,
             "realign did not render the degraded raster");
 
         amrvis::SliceDisplayResult positiveArrival;
         positiveArrival.slice.plane = makePlane({2.0F, 6.0F});
-        positiveArrival.logarithmic = true;
+        positiveArrival.scale = {amrvis::ColorScale::Logarithmic};
         DisplayCoordinator::realignArrivalToRange(
             positiveArrival, {0.5, 10.0}, palette, true);
-        require(positiveArrival.logarithmic,
-            "realign dropped log over a positive range");
+        require((positiveArrival.scale.scale == amrvis::ColorScale::Logarithmic),
+                "realign dropped log over a positive range");
     }
 
     // --- planeDensitiesDiffer -----------------------------------------------

--- a/tests/unit/test_range_controller.cpp
+++ b/tests/unit/test_range_controller.cpp
@@ -55,6 +55,8 @@ struct Widgets {
     amrvis::qt::ScientificDoubleSpinBox* minimum = nullptr;
     amrvis::qt::ScientificDoubleSpinBox* maximum = nullptr;
     QCheckBox* logarithmic = nullptr;
+    QCheckBox* symlog = nullptr;
+    amrvis::qt::ScientificDoubleSpinBox* linearThreshold = nullptr;
 };
 
 Widgets widgetsOf(QToolBar& toolbar)
@@ -64,13 +66,16 @@ Widgets widgetsOf(QToolBar& toolbar)
     // ScientificDoubleSpinBox has no Q_OBJECT; find the QDoubleSpinBoxes and
     // downcast (there are exactly the two).
     const auto boxes = toolbar.findChildren<QDoubleSpinBox*>();
-    if (boxes.size() == 2) {
+    if (boxes.size() >= 2) {
         widgets.minimum
             = dynamic_cast<amrvis::qt::ScientificDoubleSpinBox*>(boxes[0]);
         widgets.maximum
             = dynamic_cast<amrvis::qt::ScientificDoubleSpinBox*>(boxes[1]);
     }
     widgets.logarithmic = toolbar.findChild<QCheckBox*>();
+    widgets.symlog = toolbar.findChild<QCheckBox*>(QStringLiteral("symmetricLogarithmicScale"));
+    widgets.linearThreshold = dynamic_cast<amrvis::qt::ScientificDoubleSpinBox*>(
+        toolbar.findChild<QDoubleSpinBox*>(QStringLiteral("symlogLinearThreshold")));
     return widgets;
 }
 
@@ -98,7 +103,8 @@ int main(int argc, char* argv[])
         controller.createToolbarWidgets(&toolbar);
         const auto widgets = widgetsOf(toolbar);
         require(widgets.mode != nullptr && widgets.minimum != nullptr
-                && widgets.maximum != nullptr && widgets.logarithmic != nullptr,
+                && widgets.maximum != nullptr && widgets.logarithmic != nullptr
+                && widgets.symlog != nullptr && widgets.linearThreshold != nullptr,
             "the toolbar widgets were not created");
         require(widgets.mode->objectName() == QStringLiteral("rangeModeSelector")
                 && widgets.mode->count() == 4,
@@ -133,6 +139,14 @@ int main(int argc, char* argv[])
         require(observed.logarithmic == 1 && controller.logarithmic()
                 && controller.selection().logarithmic,
             "Log was not announced");
+        widgets.symlog->setChecked(true);
+        require(widgets.linearThreshold->value() == 0.01,
+            "Symlog did not choose a range-relative initial threshold");
+        widgets.linearThreshold->setValue(0.25);
+        require(controller.colorScale().scale == amrvis::ColorScale::SymLogarithmic
+                && controller.colorScale().linearThreshold == 0.25
+                && !widgets.logarithmic->isChecked(),
+            "Symlog was not selected exclusively with its threshold");
         selectMode(*widgets.mode, RangeMode::Visible);
         require(observed.mode == 2 && !widgets.minimum->isEnabled()
                 && !controller.selection().userRange,
@@ -141,8 +155,34 @@ int main(int argc, char* argv[])
         require(!widgets.mode->isEnabled() && !widgets.logarithmic->isEnabled(),
             "un-readiness left the controls enabled");
         require(observed.mode == 2 && observed.userRange == 1
-                && observed.logarithmic == 1,
+                && observed.logarithmic == 3,
             "readiness changes announced something");
+    }
+
+    // Symlog's first threshold is relative to the field's displayed scale,
+    // and an explicit edit is restored when returning to that field.
+    {
+        QToolBar toolbar;
+        RangeController controller;
+        controller.createToolbarWidgets(&toolbar);
+        controller.setControlsReady(true);
+        controller.setTrackedField(QStringLiteral("density"));
+        const auto widgets = widgetsOf(toolbar);
+        controller.showDisplayRange(-3.0e-8, 7.0e-8);
+        widgets.symlog->setChecked(true);
+        require(widgets.linearThreshold->value() == 1.0e-10,
+            "a sub-unit field kept the fixed Symlog threshold");
+        widgets.linearThreshold->setValue(2.0e-11);
+
+        controller.switchField(QStringLiteral("temperature"));
+        controller.showDisplayRange(-3000.0, 8000.0);
+        widgets.symlog->setChecked(false);
+        widgets.symlog->setChecked(true);
+        require(widgets.linearThreshold->value() == 10.0,
+            "a newly selected field did not get its own Symlog threshold");
+        controller.switchField(QStringLiteral("density"));
+        require(widgets.linearThreshold->value() == 2.0e-11,
+            "a field's edited Symlog threshold was not restored");
     }
 
     // Blocked writes: setSelection, showDisplayRange, showLogarithmic emit

--- a/tests/unit/test_range_controller.cpp
+++ b/tests/unit/test_range_controller.cpp
@@ -110,10 +110,10 @@ int main(int argc, char* argv[])
                 && widgets.mode->count() == 4,
             "the mode combo is not the one the smoke tests look for");
         const auto initial = controller.selection();
-        require(initial.mode == RangeMode::File && !initial.userRange
-                && !initial.logarithmic && widgets.minimum->value() == 0.0
-                && widgets.maximum->value() == 1.0,
-            "the initial selection is not File, 0..1, linear");
+        require(initial.mode == RangeMode::File && !initial.userRange &&
+                    initial.scale.scale != amrvis::ColorScale::Logarithmic &&
+                    widgets.minimum->value() == 0.0 && widgets.maximum->value() == 1.0,
+                "the initial selection is not File, 0..1, linear");
         require(!widgets.mode->isEnabled() && !widgets.logarithmic->isEnabled()
                 && !widgets.minimum->isEnabled() && !widgets.maximum->isEnabled(),
             "the controls start enabled without a dataset");
@@ -136,9 +136,10 @@ int main(int argc, char* argv[])
                     == std::pair{0.25, 4.0},
             "a User bound edit was not announced with the new range");
         widgets.logarithmic->setChecked(true);
-        require(observed.logarithmic == 1 && controller.logarithmic()
-                && controller.selection().logarithmic,
-            "Log was not announced");
+        require(observed.logarithmic == 1 &&
+                    (controller.colorScale().scale == amrvis::ColorScale::Logarithmic) &&
+                    (controller.selection().scale.scale == amrvis::ColorScale::Logarithmic),
+                "Log was not announced");
         widgets.symlog->setChecked(true);
         require(widgets.linearThreshold->value() == 0.01,
             "Symlog did not choose a range-relative initial threshold");
@@ -194,9 +195,18 @@ int main(int argc, char* argv[])
         require(controller.showDisplayRange(-3.0e-15, 8.0e-15)
                 && widgets.linearThreshold->value() == 1.0e-17,
             "switching to a tiny field retained the previous threshold");
+
+        controller.reset();
+        controller.setTrackedField(QStringLiteral("density"));
+        require(controller.showDisplayRange(-3000.0, 8000.0) &&
+                    widgets.linearThreshold->value() == 10.0,
+                "the first field after reset retained the previous dataset threshold");
+        require(!controller.showDisplayRange(-3.0e9, 8.0e9) &&
+                    widgets.linearThreshold->value() == 10.0,
+                "the first field threshold was initialized more than once");
     }
 
-    // Blocked writes: setSelection, showDisplayRange, showLogarithmic emit
+    // Blocked writes: setSelection, showDisplayRange, showColorScale emit
     // nothing and land in the widgets; showDisplayRange writes even in User
     // mode (the caller decides).
     {
@@ -207,14 +217,15 @@ int main(int argc, char* argv[])
         controller.createToolbarWidgets(&toolbar);
         controller.setControlsReady(true);
         const auto widgets = widgetsOf(toolbar);
-        controller.setSelection({RangeMode::User, std::pair{-1.0, 2.0}, true});
+        controller.setSelection(
+            {RangeMode::User, std::pair{-1.0, 2.0}, {amrvis::ColorScale::Logarithmic}});
         require(controller.mode() == RangeMode::User
                 && widgets.minimum->value() == -1.0
                 && widgets.maximum->value() == 2.0
                 && widgets.logarithmic->isChecked()
                 && widgets.minimum->isEnabled(),
             "setSelection did not land in the widgets");
-        controller.setSelection({RangeMode::Level, std::nullopt, false});
+        controller.setSelection({RangeMode::Level, std::nullopt, {amrvis::ColorScale::Linear}});
         require(controller.mode() == RangeMode::Level
                 && widgets.minimum->value() == -1.0
                 && !widgets.logarithmic->isChecked()
@@ -222,11 +233,11 @@ int main(int argc, char* argv[])
             "setSelection without a range touched the bounds, or kept them "
             "enabled");
         controller.showDisplayRange(3.0, 5.0);
-        controller.showLogarithmic(true);
+        controller.showColorScale({amrvis::ColorScale::Logarithmic});
         require(widgets.minimum->value() == 3.0 && widgets.maximum->value() == 5.0
                 && widgets.logarithmic->isChecked(),
             "the display range or log flag was not mirrored");
-        controller.setSelection({RangeMode::User, std::nullopt, true});
+        controller.setSelection({RangeMode::User, std::nullopt, {amrvis::ColorScale::Logarithmic}});
         controller.showDisplayRange(6.0, 7.0);
         require(widgets.minimum->value() == 6.0,
             "showDisplayRange skipped User mode on its own");
@@ -287,7 +298,7 @@ int main(int argc, char* argv[])
             "the other field's snapshot was not kept");
         require(observed.userRange == edits && observed.mode == 2,
             "a field switch announced a change");
-        controller.setSelection({RangeMode::Visible, std::nullopt, false});
+        controller.setSelection({RangeMode::Visible, std::nullopt, {amrvis::ColorScale::Linear}});
         controller.setTrackedField(QStringLiteral("f7"));
         controller.commitFieldRange(QStringLiteral("f7"));
         controller.switchField(QStringLiteral("f0"));

--- a/tests/unit/test_range_controller.cpp
+++ b/tests/unit/test_range_controller.cpp
@@ -206,6 +206,36 @@ int main(int argc, char* argv[])
                 "the first field threshold was initialized more than once");
     }
 
+    // FAB navigation resets the cache and restores a saved selection for
+    // the rendered field, which need not be the first field in the dataset.
+    {
+        QToolBar toolbar;
+        RangeController controller;
+        controller.createToolbarWidgets(&toolbar);
+        Observed observed;
+        observe(controller, observed);
+        for (const double threshold : {2.0e-11, 0.25}) {
+            controller.reset();
+            controller.setTrackedField(QStringLiteral("first"));
+            controller.setTrackedField(QStringLiteral("density"));
+            controller.setSelection({RangeMode::Visible, std::nullopt,
+                {amrvis::ColorScale::SymLogarithmic, threshold}});
+            controller.commitFieldRange(controller.trackedField());
+            require(!controller.showDisplayRange(-3000.0, 8000.0)
+                    && controller.colorScale().linearThreshold == threshold,
+                "navigation replaced an explicitly restored threshold");
+            controller.switchField(QStringLiteral("first"));
+            require(controller.showDisplayRange(-3000.0, 8000.0)
+                    && controller.colorScale().linearThreshold == 10.0,
+                "restoration saved the threshold under the wrong field");
+            controller.switchField(QStringLiteral("density"));
+            require(controller.colorScale().linearThreshold == threshold,
+                "the restored threshold was not cached for field switching");
+        }
+        require(observed.logarithmic == 0,
+            "restoration emitted a user scale edit");
+    }
+
     // Blocked writes: setSelection, showDisplayRange, showColorScale emit
     // nothing and land in the widgets; showDisplayRange writes even in User
     // mode (the caller decides).

--- a/tests/unit/test_range_controller.cpp
+++ b/tests/unit/test_range_controller.cpp
@@ -175,14 +175,25 @@ int main(int argc, char* argv[])
         widgets.linearThreshold->setValue(2.0e-11);
 
         controller.switchField(QStringLiteral("temperature"));
-        controller.showDisplayRange(-3000.0, 8000.0);
-        widgets.symlog->setChecked(false);
-        widgets.symlog->setChecked(true);
+        Observed observed;
+        observe(controller, observed);
+        require(controller.showDisplayRange(-3000.0, 8000.0),
+            "initializing a field threshold did not request recoloring");
+        require(observed.logarithmic == 0,
+            "automatic threshold initialization emitted a user edit");
         require(widgets.linearThreshold->value() == 10.0,
             "a newly selected field did not get its own Symlog threshold");
+        require(!controller.showDisplayRange(-3.0e9, 8.0e9),
+            "a passive range update requested another recoloring");
+        require(widgets.linearThreshold->value() == 10.0,
+            "a passive range update replaced the saved threshold");
         controller.switchField(QStringLiteral("density"));
         require(widgets.linearThreshold->value() == 2.0e-11,
             "a field's edited Symlog threshold was not restored");
+        controller.switchField(QStringLiteral("tiny"));
+        require(controller.showDisplayRange(-3.0e-15, 8.0e-15)
+                && widgets.linearThreshold->value() == 1.0e-17,
+            "switching to a tiny field retained the previous threshold");
     }
 
     // Blocked writes: setSelection, showDisplayRange, showLogarithmic emit

--- a/tests/unit/test_remote_codec.cpp
+++ b/tests/unit/test_remote_codec.cpp
@@ -662,6 +662,17 @@ int main()
     volume.logarithmic = true;
     require(codec::fromWire(codec::toWire(volume)) == volume,
         "a volume request without a range did not round-trip");
+    volume.logarithmic = false;
+    volume.scale = {ColorScale::SymLogarithmic, 0.25};
+    {
+        const auto symlogWire = codec::toWire(volume);
+        require(symlogWire.visible_scale
+                    == amrexplorer::wire::ColorScale::SymLogarithmic
+                && symlogWire.visible_linear_threshold == 0.25,
+            "a symmetric-log Visible mapping was not encoded on the wire");
+        require(codec::fromWire(symlogWire) == volume,
+            "a symmetric-log volume request did not round-trip");
+    }
     auto volumeWire = codec::toWire(volume);
     volumeWire.transfer_opacities.pop_back();
     requireRejected([&] { static_cast<void>(codec::fromWire(volumeWire)); },
@@ -704,6 +715,10 @@ int main()
     frame.cacheFallbackToLevel = 0;
     require(codec::fromWire(codec::toWire(frame, CacheMetrics{})) == frame,
         "a rendered frame did not round-trip");
+    frame.usedRange = {-4.0, 4.0, false,
+        {ColorScale::SymLogarithmic, 0.5}};
+    require(codec::fromWire(codec::toWire(frame, CacheMetrics{})) == frame,
+        "a symmetric-log rendered range did not round-trip");
     // A response that never set the two fallback levels: they default to the
     // no-fallback sentinel, so it decodes as "no fallback" rather than as a
     // fallback from level 0 to level 0 -- which validateSessionVolumeResult

--- a/tests/unit/test_remote_codec.cpp
+++ b/tests/unit/test_remote_codec.cpp
@@ -616,7 +616,7 @@ int main()
     volume.region = RealBox{Real3{{0.0, -1.0, 2.0}}, Real3{{1.0, 1.0, 3.0}}};
     volume.camera = {0.7, -0.2, 2.5};
     volume.outputSize = {320, 200};
-    volume.range = VolumeRange{0.5, 4.0, true};
+    volume.range = VolumeRange{0.5, 4.0, {amrvis::ColorScale::Logarithmic}};
     volume.transfer.colors = {0x0000FFU, 0x00FF00U, 0xFF0000U};
     volume.transfer.opacities = {0.0F, 0.5F, 1.0F};
     volume.samplesPerVoxel = 4;
@@ -625,14 +625,11 @@ int main()
         "a volume request with a range did not round-trip");
     {
         auto linear = volume;
-        linear.range = VolumeRange{0.5, 4.0, false,
-            {ColorScale::Linear, 0.01}};
+        linear.range = VolumeRange{0.5, 4.0, {ColorScale::Linear, 0.01}};
         require(codec::fromWire(codec::toWire(linear)).range == linear.range,
             "an inactive Symlog threshold changed the remote linear range");
-        const VolumeRange symlog{0.5, 4.0, false,
-            {ColorScale::SymLogarithmic, 0.01}};
-        const VolumeRange differentThreshold{0.5, 4.0, false,
-            {ColorScale::SymLogarithmic, 1.0}};
+        const VolumeRange symlog{0.5, 4.0, {ColorScale::SymLogarithmic, 0.01}};
+        const VolumeRange differentThreshold{0.5, 4.0, {ColorScale::SymLogarithmic, 1.0}};
         require(symlog != differentThreshold && symlog != *linear.range,
             "volume range equality ignored an active scale setting");
     }
@@ -664,25 +661,31 @@ int main()
             "range_logarithmic alone");
         auto visible = volume;
         visible.range.reset();
-        visible.logarithmic = true;
+        visible.scale = {amrvis::ColorScale::Logarithmic};
         const auto withoutRange = codec::toWire(visible);
         require(!withoutRange.has_range && withoutRange.visible_logarithmic
                 && !withoutRange.range_logarithmic,
             "a request's Visible logarithmic mapping did not set "
             "visible_logarithmic alone");
+        auto legacyVisible = withoutRange;
+        legacyVisible.visible_scale = amrexplorer::wire::ColorScale::Linear;
+        require(codec::fromWire(legacyVisible).scale.scale == ColorScale::Logarithmic,
+                "a legacy Visible logarithmic request was decoded as linear");
+        auto legacyRange = withRange;
+        legacyRange.range_scale = amrexplorer::wire::ColorScale::Linear;
+        require(codec::fromWire(legacyRange).range == volume.range,
+                "a legacy explicit logarithmic range was decoded as linear");
     }
     volume.range.reset();
-    volume.logarithmic = true;
+    volume.scale = {amrvis::ColorScale::Logarithmic};
     require(codec::fromWire(codec::toWire(volume)) == volume,
         "a volume request without a range did not round-trip");
-    volume.logarithmic = false;
     volume.scale = {ColorScale::SymLogarithmic, 0.25};
     {
         const auto symlogWire = codec::toWire(volume);
-        require(symlogWire.visible_scale
-                    == amrexplorer::wire::ColorScale::SymLogarithmic
-                && symlogWire.visible_linear_threshold == 0.25,
-            "a symmetric-log Visible mapping was not encoded on the wire");
+        require(symlogWire.visible_scale == amrexplorer::wire::ColorScale::SymLogarithmic &&
+                    symlogWire.visible_linear_threshold == 0.25 && !symlogWire.visible_logarithmic,
+                "a symmetric-log Visible mapping was not encoded on the wire");
         require(codec::fromWire(symlogWire) == volume,
             "a symmetric-log volume request did not round-trip");
     }
@@ -713,7 +716,7 @@ int main()
     frame.width = 3;
     frame.height = 2;
     frame.pixels = {0xFF000000U, 0x80112233U, 0U, 0xFFFFFFFFU, 0x01020304U, 0x7F7F7F7FU};
-    frame.usedRange = {0.5, 4.0, true};
+    frame.usedRange = {0.5, 4.0, {amrvis::ColorScale::Logarithmic}};
     frame.metrics.gridDims = {8, 4, 2};
     frame.metrics.coveredVoxels = 60;
     frame.metrics.sampledMaximumLevel = 1;
@@ -728,8 +731,15 @@ int main()
     frame.cacheFallbackToLevel = 0;
     require(codec::fromWire(codec::toWire(frame, CacheMetrics{})) == frame,
         "a rendered frame did not round-trip");
-    frame.usedRange = {-4.0, 4.0, false,
-        {ColorScale::SymLogarithmic, 0.5}};
+    {
+        auto legacyFrame = codec::toWire(frame, CacheMetrics{});
+        require(legacyFrame.used_logarithmic,
+                "a logarithmic frame did not set its legacy wire flag");
+        legacyFrame.used_scale = amrexplorer::wire::ColorScale::Linear;
+        require(codec::fromWire(legacyFrame).usedRange == frame.usedRange,
+                "a legacy logarithmic frame was decoded as linear");
+    }
+    frame.usedRange = {-4.0, 4.0, {ColorScale::SymLogarithmic, 0.5}};
     require(codec::fromWire(codec::toWire(frame, CacheMetrics{})) == frame,
         "a symmetric-log rendered range did not round-trip");
     // A response that never set the two fallback levels: they default to the

--- a/tests/unit/test_remote_codec.cpp
+++ b/tests/unit/test_remote_codec.cpp
@@ -623,6 +623,19 @@ int main()
     volume.maximumVoxels = 1 << 20;
     require(codec::fromWire(codec::toWire(volume)) == volume,
         "a volume request with a range did not round-trip");
+    {
+        auto linear = volume;
+        linear.range = VolumeRange{0.5, 4.0, false,
+            {ColorScale::Linear, 0.01}};
+        require(codec::fromWire(codec::toWire(linear)).range == linear.range,
+            "an inactive Symlog threshold changed the remote linear range");
+        const VolumeRange symlog{0.5, 4.0, false,
+            {ColorScale::SymLogarithmic, 0.01}};
+        const VolumeRange differentThreshold{0.5, 4.0, false,
+            {ColorScale::SymLogarithmic, 1.0}};
+        require(symlog != differentThreshold && symlog != *linear.range,
+            "volume range equality ignored an active scale setting");
+    }
     // The value on the wire, not just that it survives a round trip. Two
     // transposed mappings are inverses of each other, so every round-trip
     // check in the suite passes while a peer on the other side of a real

--- a/tests/unit/test_scalar_renderer.cpp
+++ b/tests/unit/test_scalar_renderer.cpp
@@ -312,5 +312,22 @@ int main()
                 "the symmetric-log transform did not invert");
         }
     }
+    {
+        const amrvis::ColorScaleConfig scale{amrvis::ColorScale::SymLogarithmic, 1.0e-300};
+        const auto range = amrvis::resolveValueRange(-1.0e20, 1.0e20, scale);
+        require(range.has_value(), "an overflowing intermediate ratio rejected a valid symlog range");
+        require(amrvis::valueSlot(0.0, *range, 253) == 126,
+            "an extreme symlog range lost its midpoint");
+        for (const double value : {-1.0e20, -1.0e10, 1.0e10, 1.0e20}) {
+            const auto mapped = amrvis::transformedValue(value, scale);
+            const auto expected = std::copysign(1.0e-300
+                * (amrvis::symmetricLogLinearScale + std::log10(std::abs(value)) + 300.0), value);
+            require(std::abs(mapped / expected - 1.0) < 1.0e-14,
+                "an extreme symlog value transformed incorrectly");
+            const auto roundTrip = amrvis::inverseTransformedValue(expected, scale);
+            require(std::isfinite(roundTrip) && std::abs(roundTrip / value - 1.0) < 1.0e-12,
+                "symlog inversion overflowed an intermediate power");
+        }
+    }
     return 0;
 }

--- a/tests/unit/test_scalar_renderer.cpp
+++ b/tests/unit/test_scalar_renderer.cpp
@@ -299,5 +299,18 @@ int main()
             "the range midpoint did not get the midpoint slot");
     }
 
+    {
+        const amrvis::ColorScaleConfig scale{amrvis::ColorScale::SymLogarithmic, 1.0};
+        const auto range = amrvis::resolveValueRange(-100.0, 100.0, scale);
+        require(range.has_value(), "a valid symmetric-log range was rejected");
+        require(amrvis::valueSlot(0.0, *range, 253) == 126,
+            "zero did not map to the palette midpoint");
+        for (const double value : {-100.0, -1.0, 0.0, 1.0, 100.0}) {
+            const auto roundTrip = amrvis::inverseTransformedValue(
+                amrvis::transformedValue(value, scale), scale);
+            require(std::abs(roundTrip - value) <= 1.0e-12 * std::max(1.0, std::abs(value)),
+                "the symmetric-log transform did not invert");
+        }
+    }
     return 0;
 }

--- a/tests/unit/test_scalar_renderer.cpp
+++ b/tests/unit/test_scalar_renderer.cpp
@@ -62,7 +62,7 @@ int main()
     plane.values = {1.0F, 10.0F, 100.0F, -1.0F};
     settings.minimum = 1.0;
     settings.maximum = 100.0;
-    settings.logarithmic = true;
+    settings.scale = {amrvis::ColorScale::Logarithmic};
     const auto logarithmic = amrvis::renderScalarPlane(plane, settings);
     require(logarithmic.rgba[0] != logarithmic.rgba[1]
             && logarithmic.rgba[1] != logarithmic.rgba[2],
@@ -79,7 +79,7 @@ int main()
     plane.valid = {1, 1, 1, 0};
     settings.minimum = 0.0;
     settings.maximum = 1.0;
-    settings.logarithmic = false;
+    settings.scale = {amrvis::ColorScale::Linear};
     const auto nonFinite = amrvis::renderScalarPlane(plane, settings);
     require(nonFinite.rgba[0] == settings.nanColor,
         "positive infinity pixel color mismatch");
@@ -185,7 +185,7 @@ int main()
     // Logarithmic rendering requires a strictly positive minimum.
     {
         auto badSettings = base;
-        badSettings.logarithmic = true;
+        badSettings.scale = {amrvis::ColorScale::Logarithmic};
         badSettings.minimum = 0.0;
         badSettings.maximum = 10.0;
         expectRejected(good, badSettings, "logarithmic scalar range must be positive",
@@ -221,7 +221,7 @@ int main()
 
         badPlane = good;
         badPlane.values.pop_back();                // storage fault ...
-        badSettings.logarithmic = true;
+        badSettings.scale = {amrvis::ColorScale::Logarithmic};
         badSettings.minimum = -1.0;                // ... and a bad log range
         expectRejected(badPlane, badSettings, "storage does not match",
             "the storage check did not precede the range/log checks");

--- a/tests/unit/test_session_validation.cpp
+++ b/tests/unit/test_session_validation.cpp
@@ -1253,6 +1253,10 @@ int main()
             requireAccepted([&] {
                 validateSessionVolumeResult(metadata, ranged, bad);
             }, "a frame honouring the explicit range was rejected");
+            ranged.range->scale = {ColorScale::Linear, 0.01};
+            requireAccepted([&] {
+                validateSessionVolumeResult(metadata, ranged, bad);
+            }, "an inactive threshold caused a valid linear response to be rejected");
             bad = frame;
             bad.metrics.gridDims = {0, 4, 4};
             requireRejectedWith([&] {

--- a/tests/unit/test_session_validation.cpp
+++ b/tests/unit/test_session_validation.cpp
@@ -1210,7 +1210,7 @@ int main()
         frame.width = 16;
         frame.height = 12;
         frame.pixels.assign(16 * 12, 0U);
-        frame.usedRange = {0.0, 1.0, false};
+        frame.usedRange = {0.0, 1.0, {amrvis::ColorScale::Linear}};
         frame.metrics.gridDims = {4, 4, 4};
         frame.metrics.coveredVoxels = 64;
         frame.metrics.sampledMaximumLevel = 1;
@@ -1229,22 +1229,28 @@ int main()
                 validateSessionVolumeResult(metadata, request, bad);
             }, "storage", "a frame with short pixel storage was accepted");
             bad = frame;
-            bad.usedRange = {1.0, 1.0, false};
+            bad.usedRange = {1.0, 1.0, {amrvis::ColorScale::Linear}};
             requireRejectedWith([&] {
                 validateSessionVolumeResult(metadata, request, bad);
             }, "unusable range", "a frame with an empty range was accepted");
             bad = frame;
-            bad.usedRange = {0.0, 1.0, true};
+            bad.usedRange = {0.0, 1.0, {amrvis::ColorScale::Logarithmic}};
             requireRejectedWith([&] {
                 validateSessionVolumeResult(metadata, request, bad);
             }, "unusable range", "a non-positive logarithmic range was accepted");
             bad = frame;
-            bad.usedRange = {0.5, 2.0, true};
+            bad.usedRange = {0.5, 2.0, {amrvis::ColorScale::Logarithmic}};
             requireRejectedWith([&] {
                 validateSessionVolumeResult(metadata, request, bad);
             }, "not requested", "an unrequested logarithmic range was accepted");
+            auto logarithmic = request;
+            logarithmic.scale = {ColorScale::Logarithmic};
+            requireAccepted([&] { validateSessionVolumeResult(metadata, logarithmic, bad); },
+                            "a requested Visible logarithmic response was rejected");
+            requireAccepted([&] { validateSessionVolumeResult(metadata, logarithmic, frame); },
+                            "a Visible logarithmic request could not fall back to linear");
             auto ranged = request;
-            ranged.range = VolumeRange{0.25, 0.75, false};
+            ranged.range = VolumeRange{0.25, 0.75, {amrvis::ColorScale::Linear}};
             requireRejectedWith([&] {
                 validateSessionVolumeResult(metadata, ranged, frame);
             }, "requested range", "a frame ignoring the explicit range was accepted");
@@ -1328,38 +1334,40 @@ int main()
         // linear -- what resolveRange does for the same data on a plane.
         // Deciding from the positive values alone would answer "logarithmic
         // over [2, 2]" and make every negative voxel vanish.
-        const auto mixed = amrvis::visibleVolumeRange(gridOf({-1.0F, 2.0F}), true);
-        require(!mixed.logarithmic && mixed.minimum <= -1.0
-                && mixed.maximum >= 2.0,
-            "a mixed-sign Visible range went logarithmic");
+        const auto mixed =
+            amrvis::visibleVolumeRange(gridOf({-1.0F, 2.0F}), {amrvis::ColorScale::Logarithmic});
+        require(mixed.scale.scale != amrvis::ColorScale::Logarithmic && mixed.minimum <= -1.0 &&
+                    mixed.maximum >= 2.0,
+                "a mixed-sign Visible range went logarithmic");
         // Strictly positive: logarithmic is viable and is used.
-        const auto positive
-            = amrvis::visibleVolumeRange(gridOf({1.0F, 100.0F}), true);
-        require(positive.logarithmic && positive.minimum > 0.0
-                && positive.maximum >= 100.0,
-            "a positive Visible range did not go logarithmic");
+        const auto positive =
+            amrvis::visibleVolumeRange(gridOf({1.0F, 100.0F}), {amrvis::ColorScale::Logarithmic});
+        require((positive.scale.scale == amrvis::ColorScale::Logarithmic) &&
+                    positive.minimum > 0.0 && positive.maximum >= 100.0,
+                "a positive Visible range did not go logarithmic");
         // The same grid without the logarithmic request stays linear.
-        require(!amrvis::visibleVolumeRange(gridOf({1.0F, 100.0F}), false)
-                     .logarithmic,
-            "a linear Visible request came back logarithmic");
+        require(amrvis::visibleVolumeRange(gridOf({1.0F, 100.0F}), {amrvis::ColorScale::Linear})
+                        .scale.scale == amrvis::ColorScale::Linear,
+                "a linear Visible request came back logarithmic");
         // Degenerate: padded either side rather than left empty.
-        const auto degenerate
-            = amrvis::visibleVolumeRange(gridOf({2.0F, 2.0F}), false);
+        const auto degenerate =
+            amrvis::visibleVolumeRange(gridOf({2.0F, 2.0F}), {amrvis::ColorScale::Linear});
         require(degenerate.minimum < 2.0 && degenerate.maximum > 2.0,
             "a degenerate Visible range was not padded");
         // Nothing finite: a neutral range that keeps the requested mapping.
         const auto quietNaN = std::numeric_limits<float>::quiet_NaN();
-        require(amrvis::visibleVolumeRange(gridOf({quietNaN}), true).logarithmic
-                && !amrvis::visibleVolumeRange(gridOf({quietNaN}), false)
-                        .logarithmic,
-            "an all-NaN grid did not fall back to a neutral range");
+        require(amrvis::visibleVolumeRange(gridOf({quietNaN}), {amrvis::ColorScale::Logarithmic})
+                            .scale.scale == amrvis::ColorScale::Logarithmic &&
+                    amrvis::visibleVolumeRange(gridOf({quietNaN}), {amrvis::ColorScale::Linear})
+                            .scale.scale == amrvis::ColorScale::Linear,
+                "an all-NaN grid did not fall back to a neutral range");
         // The scan honours the token: it walks the whole grid otherwise.
         amrvis::StopSource stop;
         stop.request_stop();
         bool cancelled = false;
         try {
             static_cast<void>(amrvis::visibleVolumeRange(
-                gridOf({1.0F, 2.0F}), false, stop.get_token()));
+                gridOf({1.0F, 2.0F}), {amrvis::ColorScale::Linear}, stop.get_token()));
         } catch (const amrvis::ReadCancelled&) {
             cancelled = true;
         }

--- a/tests/unit/test_session_validation.cpp
+++ b/tests/unit/test_session_validation.cpp
@@ -1249,6 +1249,38 @@ int main()
                             "a requested Visible logarithmic response was rejected");
             requireAccepted([&] { validateSessionVolumeResult(metadata, logarithmic, frame); },
                             "a Visible logarithmic request could not fall back to linear");
+            auto symlog = request;
+            symlog.scale = {ColorScale::SymLogarithmic, 0.01};
+            auto symlogFrame = frame;
+            symlogFrame.usedRange = {-1.0, 1.0, symlog.scale};
+            requireAccepted([&] {
+                validateSessionVolumeResult(metadata, symlog, symlogFrame);
+            }, "a requested Visible symlog response was rejected");
+            for (const auto& other : {request, logarithmic}) {
+                requireRejectedWith([&] {
+                    validateSessionVolumeResult(metadata, other, symlogFrame);
+                }, "not requested", "an unrequested Visible symlog response was accepted");
+            }
+            requireRejectedWith([&] {
+                validateSessionVolumeResult(metadata, symlog, frame);
+            }, "not requested", "a Visible symlog request fell back to linear");
+            requireRejectedWith([&] {
+                validateSessionVolumeResult(metadata, symlog, bad);
+            }, "not requested", "a Visible symlog request accepted a logarithmic response");
+            symlogFrame.usedRange.scale.linearThreshold = 0.1;
+            requireRejectedWith([&] {
+                validateSessionVolumeResult(metadata, symlog, symlogFrame);
+            }, "not requested", "a Visible symlog response changed the requested threshold");
+            for (auto inactiveThreshold : {request, logarithmic}) {
+                inactiveThreshold.scale.linearThreshold = 0.01;
+                requireAccepted([&] {
+                    validateSessionVolumeResult(metadata, inactiveThreshold, frame);
+                }, "an inactive threshold caused a valid Visible linear response to be rejected");
+            }
+            logarithmic.scale.linearThreshold = 0.01;
+            requireAccepted([&] {
+                validateSessionVolumeResult(metadata, logarithmic, bad);
+            }, "an inactive threshold caused a valid Visible logarithmic response to be rejected");
             auto ranged = request;
             ranged.range = VolumeRange{0.25, 0.75, {amrvis::ColorScale::Linear}};
             requireRejectedWith([&] {

--- a/tests/unit/test_slice_range_resolver.cpp
+++ b/tests/unit/test_slice_range_resolver.cpp
@@ -142,17 +142,17 @@ int main()
     // --- resolveRange ------------------------------------------------------
     {
         const auto plane = makePlane({0.5F, 8.0F});
-        const auto [minimum, maximum] = amrvis::resolveRange(noDataset,
-            FieldId{0}, 0, CompositionPolicy::FinestAvailable, RangeMode::User,
-            std::pair{2.0, 6.0}, false, plane);
+        const auto [minimum, maximum] = amrvis::resolveRange(
+            noDataset, FieldId{0}, 0, CompositionPolicy::FinestAvailable, RangeMode::User,
+            std::pair{2.0, 6.0}, {amrvis::ColorScale::Linear}, plane);
         require(nearlyEqual(minimum, 2.0) && nearlyEqual(maximum, 6.0),
             "User range was not passed through");
     }
     {
         const auto plane = makePlane({0.5F, 8.0F});
-        const auto [minimum, maximum] = amrvis::resolveRange(noDataset,
-            FieldId{0}, 0, CompositionPolicy::FinestAvailable,
-            RangeMode::Visible, std::nullopt, false, plane);
+        const auto [minimum, maximum] = amrvis::resolveRange(
+            noDataset, FieldId{0}, 0, CompositionPolicy::FinestAvailable, RangeMode::Visible,
+            std::nullopt, {amrvis::ColorScale::Linear}, plane);
         require(nearlyEqual(minimum, 0.5) && nearlyEqual(maximum, 8.0),
             "Visible range is not the plane extrema");
     }
@@ -160,28 +160,28 @@ int main()
         // No finite samples: neutral fallbacks, linear and logarithmic.
         auto plane = makePlane({1.0F});
         plane.valid.assign(1, 0);
-        const auto linear = amrvis::resolveRange(noDataset, FieldId{0}, 0,
-            CompositionPolicy::FinestAvailable, RangeMode::Visible,
-            std::nullopt, false, plane);
+        const auto linear = amrvis::resolveRange(
+            noDataset, FieldId{0}, 0, CompositionPolicy::FinestAvailable, RangeMode::Visible,
+            std::nullopt, {amrvis::ColorScale::Linear}, plane);
         require(nearlyEqual(linear.first, 0.0) && nearlyEqual(linear.second, 1.0),
             "empty-plane linear fallback is not [0, 1]");
-        const auto log = amrvis::resolveRange(noDataset, FieldId{0}, 0,
-            CompositionPolicy::FinestAvailable, RangeMode::Visible,
-            std::nullopt, true, plane);
+        const auto log = amrvis::resolveRange(
+            noDataset, FieldId{0}, 0, CompositionPolicy::FinestAvailable, RangeMode::Visible,
+            std::nullopt, {amrvis::ColorScale::Logarithmic}, plane);
         require(nearlyEqual(log.first, 1.0) && nearlyEqual(log.second, 10.0),
             "empty-plane logarithmic fallback is not [1, 10]");
     }
     {
         // Degenerate user range: padded additively (linear) or by ratio (log).
         const auto plane = makePlane({1.0F});
-        const auto linear = amrvis::resolveRange(noDataset, FieldId{0}, 0,
-            CompositionPolicy::FinestAvailable, RangeMode::User,
-            std::pair{5.0, 5.0}, false, plane);
+        const auto linear = amrvis::resolveRange(
+            noDataset, FieldId{0}, 0, CompositionPolicy::FinestAvailable, RangeMode::User,
+            std::pair{5.0, 5.0}, {amrvis::ColorScale::Linear}, plane);
         require(linear.first < 5.0 && linear.second > 5.0,
             "degenerate linear range was not padded");
-        const auto log = amrvis::resolveRange(noDataset, FieldId{0}, 0,
-            CompositionPolicy::FinestAvailable, RangeMode::User,
-            std::pair{5.0, 5.0}, true, plane);
+        const auto log = amrvis::resolveRange(
+            noDataset, FieldId{0}, 0, CompositionPolicy::FinestAvailable, RangeMode::User,
+            std::pair{5.0, 5.0}, {amrvis::ColorScale::Logarithmic}, plane);
         require(log.first < 5.0 && log.second > 5.0 && log.first > 0.0,
             "degenerate logarithmic range was not ratio-padded");
         // Zero has no magnitude for the padding to be relative to. Falling back
@@ -189,9 +189,9 @@ int main()
         // which is what the color bar and the seeded User-range spin boxes then
         // show for a uniform plane of zeros -- an ordinary case. The padding
         // has to stay the absolute constant.
-        const auto zero = amrvis::resolveRange(noDataset, FieldId{0}, 0,
-            CompositionPolicy::FinestAvailable, RangeMode::User,
-            std::pair{0.0, 0.0}, false, plane);
+        const auto zero = amrvis::resolveRange(
+            noDataset, FieldId{0}, 0, CompositionPolicy::FinestAvailable, RangeMode::User,
+            std::pair{0.0, 0.0}, {amrvis::ColorScale::Linear}, plane);
         require(nearlyEqual(zero.first, -1.0e-6)
                 && nearlyEqual(zero.second, 1.0e-6),
             "a degenerate range at zero was not padded by the constant");
@@ -199,9 +199,9 @@ int main()
     {
         bool threw = false;
         try {
-            (void)amrvis::resolveRange(noDataset, FieldId{0}, 0,
-                CompositionPolicy::FinestAvailable, RangeMode::User,
-                std::pair{6.0, 2.0}, false, makePlane({1.0F}));
+            (void)amrvis::resolveRange(noDataset, FieldId{0}, 0, CompositionPolicy::FinestAvailable,
+                                       RangeMode::User, std::pair{6.0, 2.0},
+                                       {amrvis::ColorScale::Linear}, makePlane({1.0F}));
         } catch (const std::exception&) {
             threw = true;
         }
@@ -209,9 +209,9 @@ int main()
 
         threw = false;
         try {
-            (void)amrvis::resolveRange(noDataset, FieldId{0}, 0,
-                CompositionPolicy::FinestAvailable, RangeMode::User,
-                std::pair{-1.0, 2.0}, true, makePlane({1.0F}));
+            (void)amrvis::resolveRange(noDataset, FieldId{0}, 0, CompositionPolicy::FinestAvailable,
+                                       RangeMode::User, std::pair{-1.0, 2.0},
+                                       {amrvis::ColorScale::Logarithmic}, makePlane({1.0F}));
         } catch (const std::exception&) {
             threw = true;
         }
@@ -223,20 +223,19 @@ int main()
         // A logarithmic request over a non-positive range falls back to
         // linear and reports logarithmic=false instead of failing the slice.
         const auto plane = makePlane({1.0F});
-        const auto fallback = amrvis::resolveDisplayRange(noDataset, FieldId{0},
-            0, CompositionPolicy::FinestAvailable, RangeMode::User,
-            std::pair{-1.0, 2.0}, true, plane);
-        require(!fallback.logarithmic
-                && nearlyEqual(fallback.minimum, -1.0)
-                && nearlyEqual(fallback.maximum, 2.0),
-            "non-positive logarithmic request did not fall back to linear");
+        const auto fallback = amrvis::resolveDisplayRange(
+            noDataset, FieldId{0}, 0, CompositionPolicy::FinestAvailable, RangeMode::User,
+            std::pair{-1.0, 2.0}, {amrvis::ColorScale::Logarithmic}, plane);
+        require(fallback.scale.scale != amrvis::ColorScale::Logarithmic &&
+                    nearlyEqual(fallback.minimum, -1.0) && nearlyEqual(fallback.maximum, 2.0),
+                "non-positive logarithmic request did not fall back to linear");
 
-        const auto log = amrvis::resolveDisplayRange(noDataset, FieldId{0},
-            0, CompositionPolicy::FinestAvailable, RangeMode::User,
-            std::pair{1.0, 100.0}, true, plane);
-        require(log.logarithmic && nearlyEqual(log.minimum, 1.0)
-                && nearlyEqual(log.maximum, 100.0),
-            "a positive logarithmic request did not stay logarithmic");
+        const auto log = amrvis::resolveDisplayRange(
+            noDataset, FieldId{0}, 0, CompositionPolicy::FinestAvailable, RangeMode::User,
+            std::pair{1.0, 100.0}, {amrvis::ColorScale::Logarithmic}, plane);
+        require((log.scale.scale == amrvis::ColorScale::Logarithmic) &&
+                    nearlyEqual(log.minimum, 1.0) && nearlyEqual(log.maximum, 100.0),
+                "a positive logarithmic request did not stay logarithmic");
     }
 
     return 0;

--- a/tests/unit/test_vector_glyphs.cpp
+++ b/tests/unit/test_vector_glyphs.cpp
@@ -96,6 +96,37 @@ int main()
     const auto zero = amrvis::generateVectorGlyphs(zeroU, zeroV, 10);
     require(zero.empty(), "zero field produced segments");
 
+    // Magnitude is unit-independent: a uniformly tiny nonzero field must
+    // render exactly like the unit-scale field above.
+    const auto tinyU = makePlane(20, 10, 1.0e-20F);
+    const auto tiny = amrvis::generateVectorGlyphs(tinyU, zeroV, 10);
+    require(tiny.size() == 150, "small nonzero field produced no glyphs");
+
+    // A large dynamic range must not turn the small samples into a grid of
+    // zero-length segments: arrowMax = 2.5, so the weaker arrows have length
+    // 2.5e-9 pixels. Only the sample at 1e6 should contribute its three segments.
+    // This pins the previous cutoff behavior, not a general rounding guarantee:
+    // at larger coordinates, float rounding can collapse arrows above 1e-6 too.
+    {
+        auto wideU = makePlane(20, 10, 1.0e-3F);
+        wideU.values[0] = 1.0e6F;
+        const auto wide = amrvis::generateVectorGlyphs(wideU, zeroV, 10);
+        require(wide.size() == 3,
+            "high-dynamic-range field did not suppress near-zero-length arrows");
+        require(std::all_of(wide.begin(), wide.end(), [](const auto& segment) {
+            return segment.x0 != segment.x1 || segment.y0 != segment.y1;
+        }), "high-dynamic-range field produced degenerate segments");
+    }
+
+    // Individual exactly-zero samples are omitted while the tiny maximum-speed
+    // sample remains visible. With count 2 both cells are sampling sites.
+    auto mixedU = makePlane(2, 1, 1.0e-20F);
+    mixedU.values[0] = 0.0F;
+    const auto mixedV = makePlane(2, 1, 0.0F);
+    const auto mixed = amrvis::generateVectorGlyphs(mixedU, mixedV, 2);
+    require(mixed.size() == 3,
+        "exact-zero filtering did not suppress only the zero vector");
+
     // count > longestSide used to give sight = 0 (integer division) and thus
     // zero glyphs; floating-point division keeps sight nonzero. stride is
     // floor(8/10) clamped to 1, so every one of the 8x8 = 64 cells draws an
@@ -162,6 +193,33 @@ int main()
             box.upper[1] = t1;
             return box;
         };
+
+        // The spherical cutoff must scale with the physical display extent.
+        // At each length scale, keep only the strongest sample in a field with
+        // a 1e9 speed ratio, but keep every arrow in a uniformly tiny field.
+        for (const double lengthScale : {1.0e-9, 1.0, 1.0e9}) {
+            auto u = makePlane(20, 10, 1.0e-3F);
+            auto v = makePlane(20, 10, 0.0F);
+            u.values[0] = 1.0e6F;
+            const auto region = logicalBox(
+                lengthScale, 21.0 * lengthScale, 0.0, 1.5707963267948966);
+            u.physicalRegion = region;
+            v.physicalRegion = region;
+            const auto display = amrvis::sphericalDisplayBounds(region);
+            const auto wide = amrvis::generateSphericalRZVectorGlyphs(
+                u, v, 10, display);
+            require(wide.size() == 3,
+                "spherical high-dynamic-range field retained near-zero-length arrows");
+            require(std::all_of(wide.begin(), wide.end(), [](const auto& segment) {
+                return segment.x0 != segment.x1 || segment.y0 != segment.y1;
+            }), "spherical high-dynamic-range field produced degenerate segments");
+
+            std::fill(u.values.begin(), u.values.end(), 1.0e-20F);
+            const auto tinyArrows = amrvis::generateSphericalRZVectorGlyphs(
+                u, v, 10, display);
+            require(tinyArrows.size() == 150,
+                "small nonzero spherical field produced the wrong glyph count");
+        }
 
         // One sample centered at theta ~ 0 (on the +Z axis), pure v_r = 1:
         // the arrow must point along +Z with the full arrowMax length, anchored

--- a/tests/unit/test_volume_controller.cpp
+++ b/tests/unit/test_volume_controller.cpp
@@ -178,7 +178,8 @@ public:
         frame.height = request.outputSize[1];
         frame.pixels.assign(static_cast<std::size_t>(frame.width)
             * static_cast<std::size_t>(frame.height), 0xFF4080C0U);
-        frame.usedRange = request.range.value_or(amrvis::VolumeRange{0.0, 1.0, false});
+        frame.usedRange =
+            request.range.value_or(amrvis::VolumeRange{0.0, 1.0, {amrvis::ColorScale::Linear}});
         frame.metrics.gridDims = {2, 2, 2};
         frame.metrics.coveredVoxels = 8;
         if (sessionFallback && request.maximumLevel > 0) {
@@ -911,11 +912,11 @@ int main(int argc, char** argv)
         controller.closeWindow();
     }
 
-    // The logarithmic flag rides on the VolumeRangeChoice, not on the request
+    // The color scale rides on the VolumeRangeChoice, not on the request
     // the controller hands over: the pipeline sets it per attempt, so nothing
     // here writes it and only the arriving request proves it got through.
     {
-        rangeSelection.logarithmic = true;
+        rangeSelection.scale = {amrvis::ColorScale::Logarithmic};
         VolumeController controller(hooks());
         Observed observed;
         observe(controller, observed);
@@ -923,9 +924,9 @@ int main(int argc, char** argv)
         controller.showWindow(nullptr);
         waitFor(application, [&] { return session->requests == before + 1; },
             "the logarithmic render did not run");
-        require(session->requestsSoFar().back().logarithmic,
-            "the logarithmic flag did not reach the request");
-        rangeSelection.logarithmic = false;
+        require(session->requestsSoFar().back().scale.scale == amrvis::ColorScale::Logarithmic,
+                "the logarithmic scale did not reach the request");
+        rangeSelection.scale = {amrvis::ColorScale::Linear};
         waitFor(application, [&] { return !controller.renderInFlight(); },
             "the logarithmic render did not finish");
         controller.closeWindow();

--- a/tests/unit/test_volume_raycaster.cpp
+++ b/tests/unit/test_volume_raycaster.cpp
@@ -78,7 +78,7 @@ amrvis::RaycastSettings settingsFor(const amrvis::OrthoCamera& camera,
     settings.camera = camera;
     settings.domain = unitBox();
     settings.outputSize = {size, size};
-    settings.range = {0.0, 1.0, false};
+    settings.range = {0.0, 1.0, {amrvis::ColorScale::Linear}};
     settings.transfer = transfer;
     settings.samplesPerVoxel = samplesPerVoxel;
     settings.threadCount = 1;
@@ -384,21 +384,20 @@ int main()
 
     // --- the value mapping is the 2-D renderer's --------------------------
     {
-        const amrvis::VolumeRange linear{0.0, 49.0, false};
+        const amrvis::VolumeRange linear{0.0, 49.0, {amrvis::ColorScale::Linear}};
         require(amrvis::transferEntryFor(24.5, linear, 253) == 126
                 && amrvis::transferEntryFor(49.0, linear, 253) == 252
                 && amrvis::transferEntryFor(-1.0, linear, 253) == 0
                 && amrvis::transferEntryFor(0.0, linear, 253) == 0
                 && amrvis::transferEntryFor(60.0, linear, 253) == 252,
             "the linear mapping does not truncate like the palette");
-        const amrvis::VolumeRange logarithmic{1.0, 100.0, true};
+        const amrvis::VolumeRange logarithmic{1.0, 100.0, {amrvis::ColorScale::Logarithmic}};
         require(amrvis::transferEntryFor(10.0, logarithmic, 253) == 126
                 && amrvis::transferEntryFor(1.0, logarithmic, 253) == 0
                 && !amrvis::transferEntryFor(0.0, logarithmic, 253).has_value()
                 && !amrvis::transferEntryFor(-3.0, logarithmic, 253).has_value(),
             "the logarithmic mapping is wrong");
-        const amrvis::VolumeRange symlog{-100.0, 100.0, false,
-            {amrvis::ColorScale::SymLogarithmic, 1.0}};
+        const amrvis::VolumeRange symlog{-100.0, 100.0, {amrvis::ColorScale::SymLogarithmic, 1.0}};
         require(amrvis::transferEntryFor(0.0, symlog, 253) == 126
                 && amrvis::transferEntryFor(-100.0, symlog, 253) == 0
                 && amrvis::transferEntryFor(100.0, symlog, 253) == 252,
@@ -412,13 +411,16 @@ int main()
         // its own: entry 0 would look like an answer.
         const auto huge = std::numeric_limits<double>::max();
         require(!amrvis::transferEntryFor(
-                    5.0, amrvis::VolumeRange{-1.0, 10.0, true}, 253).has_value()
-                && !amrvis::transferEntryFor(
-                    5.0, amrvis::VolumeRange{1.0, 1.0, false}, 253).has_value()
-                && !amrvis::transferEntryFor(
-                    5.0, amrvis::VolumeRange{-huge, huge, false}, 253).has_value()
-                && !amrvis::transferEntryFor(5.0, linear, 0).has_value(),
-            "a range that can map nothing returned an entry");
+                     5.0, amrvis::VolumeRange{-1.0, 10.0, {amrvis::ColorScale::Logarithmic}}, 253)
+                        .has_value() &&
+                    !amrvis::transferEntryFor(
+                         5.0, amrvis::VolumeRange{1.0, 1.0, {amrvis::ColorScale::Linear}}, 253)
+                         .has_value() &&
+                    !amrvis::transferEntryFor(
+                         5.0, amrvis::VolumeRange{-huge, huge, {amrvis::ColorScale::Linear}}, 253)
+                         .has_value() &&
+                    !amrvis::transferEntryFor(5.0, linear, 0).has_value(),
+                "a range that can map nothing returned an entry");
         // The renderer honours a logarithmic range: value 10 in [1, 100]
         // takes the middle entry's colour.
         auto grid = uniformGrid(4, 10.0F);
@@ -591,7 +593,7 @@ int main()
             const auto expected
                 = (centreX + 3.0 * centreY) / static_cast<double>(4 * (n - 1));
             const auto slot = amrvis::valueSlot(
-                expected, amrvis::ResolvedValueRange{0.0, 1.0, false},
+                expected, amrvis::ResolvedValueRange{0.0, 1.0, {amrvis::ColorScale::Linear}},
                 entryCount);
             const auto seen
                 = static_cast<int>(blueOf(pixelAt(frame, step, step)));
@@ -684,7 +686,7 @@ int main()
             // Half the field's span, so the top entry begins halfway up the
             // ramp -- at the centre of voxel 3.5, which is the middle of the
             // grid -- instead of only at its very top.
-            settings.range = {0.0, 0.5, false};
+            settings.range = {0.0, 0.5, {amrvis::ColorScale::Linear}};
             settings.sampling = amrvis::SamplingPolicy::Linear;
             const auto frame = amrvis::raycastVolume(grid, settings);
             const auto alpha
@@ -741,25 +743,25 @@ int main()
         auto grid = uniformGrid(2, 0.0F);
         grid.values = {-2.0F, 0.0F, 3.0F, std::numeric_limits<float>::quiet_NaN(),
             std::numeric_limits<float>::infinity(), 5.0F, 0.5F, 1.0F};
-        const auto linear = amrvis::volumeGridRange(grid, false);
-        const auto logarithmic = amrvis::volumeGridRange(grid, true);
+        const auto linear = amrvis::volumeGridRange(grid, {amrvis::ColorScale::Linear});
+        const auto logarithmic = amrvis::volumeGridRange(grid, {amrvis::ColorScale::Logarithmic});
         require(linear && linear->first == -2.0 && linear->second == 5.0,
             "the linear grid range is not the finite extrema");
         require(logarithmic && logarithmic->first == 0.5 && logarithmic->second == 5.0,
             "the logarithmic grid range did not skip non-positive values");
         grid.values.assign(8, std::numeric_limits<float>::quiet_NaN());
-        require(!amrvis::volumeGridRange(grid, false).has_value(),
-            "an all-NaN grid reported a range");
+        require(!amrvis::volumeGridRange(grid, {amrvis::ColorScale::Linear}).has_value(),
+                "an all-NaN grid reported a range");
         grid.values.assign(8, -1.0F);
-        require(!amrvis::volumeGridRange(grid, true).has_value()
-                && amrvis::volumeGridRange(grid, false)->first == -1.0,
-            "a non-positive grid reported a logarithmic range");
+        require(!amrvis::volumeGridRange(grid, {amrvis::ColorScale::Logarithmic}).has_value() &&
+                    amrvis::volumeGridRange(grid, {amrvis::ColorScale::Linear})->first == -1.0,
+                "a non-positive grid reported a logarithmic range");
         // The scan runs over the whole grid, so it stops when the token does.
         amrvis::StopSource stop;
         stop.request_stop();
         bool threw = false;
         try {
-            (void)amrvis::volumeGridRange(grid, false, stop.get_token());
+            (void)amrvis::volumeGridRange(grid, {amrvis::ColorScale::Linear}, stop.get_token());
         } catch (const amrvis::ReadCancelled&) {
             threw = true;
         }
@@ -771,7 +773,7 @@ int main()
         empty.region = unitBox();
         threw = false;
         try {
-            (void)amrvis::volumeGridRange(empty, false, stop.get_token());
+            (void)amrvis::volumeGridRange(empty, {amrvis::ColorScale::Linear}, stop.get_token());
         } catch (const amrvis::ReadCancelled&) {
             threw = true;
         }
@@ -809,11 +811,12 @@ int main()
             return false;
         };
         auto bad = settingsFor(amrvis::orthoPresetXY, 32, twoEntries(0xFFU, 1.0F));
-        bad.range = {1.0, 1.0, false};
+        bad.range = {1.0, 1.0, {amrvis::ColorScale::Linear}};
         require(rejects(bad), "an empty range was accepted");
         // An infinite span would map every value to the bottom entry.
         bad.range = {-std::numeric_limits<double>::max(),
-            std::numeric_limits<double>::max(), false};
+                     std::numeric_limits<double>::max(),
+                     {amrvis::ColorScale::Linear}};
         require(rejects(bad), "a range with an infinite span was accepted");
         bad = settingsFor(amrvis::orthoPresetXY, 0, twoEntries(0xFFU, 1.0F));
         require(rejects(bad), "a zero-size output was accepted");

--- a/tests/unit/test_volume_raycaster.cpp
+++ b/tests/unit/test_volume_raycaster.cpp
@@ -397,6 +397,12 @@ int main()
                 && !amrvis::transferEntryFor(0.0, logarithmic, 253).has_value()
                 && !amrvis::transferEntryFor(-3.0, logarithmic, 253).has_value(),
             "the logarithmic mapping is wrong");
+        const amrvis::VolumeRange symlog{-100.0, 100.0, false,
+            {amrvis::ColorScale::SymLogarithmic, 1.0}};
+        require(amrvis::transferEntryFor(0.0, symlog, 253) == 126
+                && amrvis::transferEntryFor(-100.0, symlog, 253) == 0
+                && amrvis::transferEntryFor(100.0, symlog, 253) == 252,
+            "the symmetric-log mapping is wrong");
         require(!amrvis::transferEntryFor(
                     std::numeric_limits<double>::quiet_NaN(), linear, 253).has_value()
                 && !amrvis::transferEntryFor(

--- a/tests/unit/test_volume_types.cpp
+++ b/tests/unit/test_volume_types.cpp
@@ -48,9 +48,9 @@ int main()
     require(!rejected(validRequest()), "a well-formed request was rejected");
     {
         auto request = validRequest();
-        request.range = amrvis::VolumeRange{0.5, 2.0, false};
+        request.range = amrvis::VolumeRange{0.5, 2.0, {amrvis::ColorScale::Linear}};
         require(!rejected(request), "an explicit range was rejected");
-        request.range = amrvis::VolumeRange{0.5, 2.0, true};
+        request.range = amrvis::VolumeRange{0.5, 2.0, {amrvis::ColorScale::Logarithmic}};
         require(!rejected(request), "a positive logarithmic range was rejected");
     }
     {
@@ -124,19 +124,18 @@ int main()
     }
     {
         auto request = validRequest();
-        request.range = amrvis::VolumeRange{2.0, 2.0, false};
+        request.range = amrvis::VolumeRange{2.0, 2.0, {amrvis::ColorScale::Linear}};
         require(rejected(request), "an empty range was accepted");
-        request.range = amrvis::VolumeRange{nan, 2.0, false};
+        request.range = amrvis::VolumeRange{nan, 2.0, {amrvis::ColorScale::Linear}};
         require(rejected(request), "a NaN range was accepted");
-        request.range = amrvis::VolumeRange{-1.0, 2.0, true};
+        request.range = amrvis::VolumeRange{-1.0, 2.0, {amrvis::ColorScale::Logarithmic}};
         require(rejected(request), "a non-positive logarithmic range was accepted");
-        request.range = amrvis::VolumeRange{-1.0, 2.0, false,
-            {amrvis::ColorScale::SymLogarithmic, 0.0}};
+        request.range = amrvis::VolumeRange{-1.0, 2.0, {amrvis::ColorScale::SymLogarithmic, 0.0}};
         require(rejected(request),
             "a symmetric-log range with a zero threshold was accepted");
-        request.range = amrvis::VolumeRange{
-            -std::numeric_limits<double>::max(),
-            std::numeric_limits<double>::max(), false};
+        request.range = amrvis::VolumeRange{-std::numeric_limits<double>::max(),
+                                            std::numeric_limits<double>::max(),
+                                            {amrvis::ColorScale::Linear}};
         require(rejected(request), "a range with an infinite span was accepted");
     }
     {

--- a/tests/unit/test_volume_types.cpp
+++ b/tests/unit/test_volume_types.cpp
@@ -130,6 +130,10 @@ int main()
         require(rejected(request), "a NaN range was accepted");
         request.range = amrvis::VolumeRange{-1.0, 2.0, true};
         require(rejected(request), "a non-positive logarithmic range was accepted");
+        request.range = amrvis::VolumeRange{-1.0, 2.0, false,
+            {amrvis::ColorScale::SymLogarithmic, 0.0}};
+        require(rejected(request),
+            "a symmetric-log range with a zero threshold was accepted");
         request.range = amrvis::VolumeRange{
             -std::numeric_limits<double>::max(),
             std::numeric_limits<double>::max(), false};

--- a/tools/render_equivalence/main.cpp
+++ b/tools/render_equivalence/main.cpp
@@ -342,12 +342,12 @@ void compare(const Options& options, const std::string& token)
                 auto remoteRequest = localRequest;
                 remoteRequest.dataset = remote->id();
 
-                const auto localResult = amrvis::executeSlice(local,
-                    localRequest, amrvis::RangeMode::File, std::nullopt,
-                    false, palette, {});
-                const auto remoteResult = amrvis::executeSlice(remote,
-                    remoteRequest, amrvis::RangeMode::File, std::nullopt,
-                    false, palette, {});
+                const auto localResult =
+                    amrvis::executeSlice(local, localRequest, amrvis::RangeMode::File, std::nullopt,
+                                         {amrvis::ColorScale::Linear}, palette, {});
+                const auto remoteResult =
+                    amrvis::executeSlice(remote, remoteRequest, amrvis::RangeMode::File,
+                                         std::nullopt, {amrvis::ColorScale::Linear}, palette, {});
                 const auto difference = planeDifference(
                     localResult.slice.plane, remoteResult.slice.plane);
                 if (!difference.empty()) {
@@ -356,9 +356,9 @@ void compare(const Options& options, const std::string& token)
                         + std::to_string(normal) + ", "
                         + std::string(state.name) + ": " + difference);
                 }
-                if (localResult.minimum != remoteResult.minimum
-                    || localResult.maximum != remoteResult.maximum
-                    || localResult.logarithmic != remoteResult.logarithmic) {
+                if (localResult.minimum != remoteResult.minimum ||
+                    localResult.maximum != remoteResult.maximum ||
+                    localResult.scale != remoteResult.scale) {
                     throw std::runtime_error("field '"
                         + local->metadata().fields[field].name + "', normal "
                         + std::to_string(normal) + ", "


### PR DESCRIPTION
Adds a matplotlib-style symlog colorbar scaling option.

A lot of code churn is required to change `bool` to `enum` for the color bar scaling settings.

Fixes https://github.com/AMReX-Codes/amrexplorer/issues/226.