### PR TITLE
add a Skin option: System, Light, Dark, Blue, Green or Maroon

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -685,8 +685,16 @@ The **View** menu controls these optional panels:
 - **FAB Selector** lists raw FAB records or the FABs belonging to an open
   standalone MultiFab.
 
-Window geometry, logarithmic mapping, palette, number format, and animation
-speed persist across sessions.
+**View > Skin** chooses the application's appearance. **System** (the default)
+keeps whatever the desktop provides; **Light** and **Dark** apply
+AMReXplorer's own; and **Blue**, **Green** and **Maroon** are Dark in a tint,
+Blue being the application icon's own colors. The change takes effect at once
+and applies to every open window. The image viewports and the color scale keep
+their neutral gray under every skin, so a colormap looks the same whichever
+one you pick.
+
+Window geometry, logarithmic mapping, palette, skin, number format, and
+animation speed persist across sessions.
 
 Each open dataset has a 1 GiB data cache by default, and volume rendering fills
 a second cache of the same size with the grids it samples the field into, so a

--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -67,6 +67,8 @@ add_executable(amrexplorer_qt
     SetContoursDialog.cpp
     SetContoursDialog.hpp
     Theme.hpp
+    ThemeController.cpp
+    ThemeController.hpp
     UserGuideDialog.cpp
     UserGuideDialog.hpp
     VolumeController.cpp

--- a/src/qt/ExpressionEditorDialog.cpp
+++ b/src/qt/ExpressionEditorDialog.cpp
@@ -3,6 +3,7 @@
 #include "Theme.hpp"
 
 #include <QDialogButtonBox>
+#include <QEvent>
 #include <QFormLayout>
 #include <QHBoxLayout>
 #include <QLabel>
@@ -101,9 +102,6 @@ ExpressionEditorDialog::ExpressionEditorDialog(
     // renders anything Qt takes for markup: an expression holding `<` would be
     // shown with a piece missing.
     m_error->setTextFormat(Qt::PlainText);
-    // As SetContoursDialog styles its own warning.
-    m_error->setStyleSheet(
-        QStringLiteral("QLabel { color: %1; }").arg(errorTextColor().name()));
 
     m_applyAnyway = new QPushButton(tr("Apply &anyway"), this);
     m_applyAnyway->setObjectName(QStringLiteral("applyAnywayButton"));
@@ -125,10 +123,7 @@ ExpressionEditorDialog::ExpressionEditorDialog(
     m_warning->setVisible(false);
     // Quotes the user's own text, as the error does.
     m_warning->setTextFormat(Qt::PlainText);
-    // Not the error's red: this one does not stop anything, and colouring the
-    // two alike would say the definition had been refused when it has not.
-    m_warning->setStyleSheet(
-        QStringLiteral("QLabel { color: %1; }").arg(warningTextColor().name()));
+    updateMessageColors();
 
     m_fieldsCaption = new QLabel(tr("Fields in this dataset"), this);
     m_fields = new QListWidget(this);
@@ -351,18 +346,39 @@ void ExpressionEditorDialog::clearRefusal()
     m_refusalRevision.reset();
 }
 
+void ExpressionEditorDialog::changeEvent(QEvent* event)
+{
+    QDialog::changeEvent(event);
+    if (event->type() == QEvent::PaletteChange) {
+        updateMessageColors();
+    }
+}
+
+void ExpressionEditorDialog::updateMessageColors()
+{
+    // Stylesheet colours are explicit: Qt cannot adapt them when a skin
+    // changes. Keep the existing messages and their severity intact.
+    const auto update = [](QLabel* label, const QColor& color) {
+        if (label == nullptr) {
+            return;
+        }
+        const auto style = QStringLiteral("QLabel { color: %1; }")
+                               .arg(color.name());
+        // Setting an identical stylesheet still repolishes the widget.
+        if (label->styleSheet() != style) {
+            label->setStyleSheet(style);
+        }
+    };
+    update(m_error, errorTextColor());
+    update(m_warning, m_warningBlocking ? errorTextColor() : warningTextColor());
+}
+
 void ExpressionEditorDialog::showResolutionWarning(
     const QString& message, bool blocking)
 {
-    // Red for what Apply will refuse, amber for what only this dataset cannot
-    // do. Set with the text rather than once at construction, because the one
-    // label carries both and the colour is the whole of what tells them apart
-    // -- but only when there is text, since setStyleSheet reinstalls the
-    // style and repolishes the widget even for an identical string, and most
-    // calls here only clear the label.
-    if (!message.isEmpty()) {
-        m_warning->setStyleSheet(QStringLiteral("QLabel { color: %1; }")
-                .arg((blocking ? errorTextColor() : warningTextColor()).name()));
+    if (m_warningBlocking != blocking) {
+        m_warningBlocking = blocking;
+        updateMessageColors();
     }
     m_warning->setText(message);
     m_warning->setVisible(!message.isEmpty());
@@ -411,10 +427,6 @@ void ExpressionEditorDialog::showError(const QString& message,
     }
     m_applied->clear();
     m_applied->setVisible(false);
-    // Restyled here, not only at construction: the skin can change while this
-    // modeless dialog is open, and the colour is read from the palette.
-    m_error->setStyleSheet(
-        QStringLiteral("QLabel { color: %1; }").arg(errorTextColor().name()));
     m_error->setText(message);
     m_error->setVisible(true);
     m_applyAnyway->setVisible(offerAnyway);

--- a/src/qt/ExpressionEditorDialog.cpp
+++ b/src/qt/ExpressionEditorDialog.cpp
@@ -1,5 +1,7 @@
 #include "ExpressionEditorDialog.hpp"
 
+#include "Theme.hpp"
+
 #include <QDialogButtonBox>
 #include <QFormLayout>
 #include <QHBoxLayout>
@@ -100,7 +102,8 @@ ExpressionEditorDialog::ExpressionEditorDialog(
     // shown with a piece missing.
     m_error->setTextFormat(Qt::PlainText);
     // As SetContoursDialog styles its own warning.
-    m_error->setStyleSheet(QStringLiteral("QLabel { color: red; }"));
+    m_error->setStyleSheet(
+        QStringLiteral("QLabel { color: %1; }").arg(errorTextColor().name()));
 
     m_applyAnyway = new QPushButton(tr("Apply &anyway"), this);
     m_applyAnyway->setObjectName(QStringLiteral("applyAnywayButton"));
@@ -124,7 +127,8 @@ ExpressionEditorDialog::ExpressionEditorDialog(
     m_warning->setTextFormat(Qt::PlainText);
     // Not the error's red: this one does not stop anything, and colouring the
     // two alike would say the definition had been refused when it has not.
-    m_warning->setStyleSheet(QStringLiteral("QLabel { color: #b8860b; }"));
+    m_warning->setStyleSheet(
+        QStringLiteral("QLabel { color: %1; }").arg(warningTextColor().name()));
 
     m_fieldsCaption = new QLabel(tr("Fields in this dataset"), this);
     m_fields = new QListWidget(this);
@@ -357,9 +361,8 @@ void ExpressionEditorDialog::showResolutionWarning(
     // style and repolishes the widget even for an identical string, and most
     // calls here only clear the label.
     if (!message.isEmpty()) {
-        m_warning->setStyleSheet(blocking
-                ? QStringLiteral("QLabel { color: red; }")
-                : QStringLiteral("QLabel { color: #b8860b; }"));
+        m_warning->setStyleSheet(QStringLiteral("QLabel { color: %1; }")
+                .arg((blocking ? errorTextColor() : warningTextColor()).name()));
     }
     m_warning->setText(message);
     m_warning->setVisible(!message.isEmpty());
@@ -408,6 +411,10 @@ void ExpressionEditorDialog::showError(const QString& message,
     }
     m_applied->clear();
     m_applied->setVisible(false);
+    // Restyled here, not only at construction: the skin can change while this
+    // modeless dialog is open, and the colour is read from the palette.
+    m_error->setStyleSheet(
+        QStringLiteral("QLabel { color: %1; }").arg(errorTextColor().name()));
     m_error->setText(message);
     m_error->setVisible(true);
     m_applyAnyway->setVisible(offerAnyway);

--- a/src/qt/ExpressionEditorDialog.hpp
+++ b/src/qt/ExpressionEditorDialog.hpp
@@ -11,6 +11,7 @@
 #include <optional>
 #include <vector>
 
+class QEvent;
 class QLabel;
 class QLineEdit;
 class QListWidget;
@@ -184,7 +185,11 @@ signals:
     // is to be committed without being held to the open dataset.
     void applyAnywayRequested();
 
+protected:
+    void changeEvent(QEvent* event) override;
+
 private:
+    void updateMessageColors();
     void clearError();
     // Takes any standing refusal and its offer down, whatever it was about.
     // Every change to the draft does this: the verdict was about a list that
@@ -232,6 +237,8 @@ private:
     // rather than momentary -- it describes the draft, not the last thing
     // done -- so clearError leaves it alone, as it does the notice.
     QLabel* m_warning = nullptr;
+    // Preserve the standing warning's severity when the palette changes.
+    bool m_warningBlocking = false;
     QPushButton* m_remove = nullptr;
     QPushButton* m_apply = nullptr;
     QPushButton* m_applyAnyway = nullptr;

--- a/src/qt/ImageView.cpp
+++ b/src/qt/ImageView.cpp
@@ -3,6 +3,7 @@
 
 #include "Theme.hpp"
 
+#include <QEvent>
 #include <QGraphicsLineItem>
 #include <QGraphicsItem>
 #include <QGraphicsPathItem>
@@ -928,6 +929,18 @@ void ImageView::resizeEvent(QResizeEvent* event)
     // A resize changes how much of the raster is on screen even when nothing
     // moved, and in Fit mode fitImage above has just changed the transform.
     emit viewportMoved();
+}
+
+void ImageView::changeEvent(QEvent* event)
+{
+    QGraphicsView::changeEvent(event);
+    // The placeholder is drawn from palette roles, but both the background
+    // brush and the text item's colour are copies taken when it was set, so a
+    // skin changed while a placeholder is up would leave it in the old one.
+    // A view showing a raster keeps the fixed viewport background instead.
+    if (event->type() == QEvent::PaletteChange && !m_placeholderText.isEmpty()) {
+        setPlaceholder(m_placeholderText);
+    }
 }
 
 void ImageView::scrollContentsBy(int dx, int dy)

--- a/src/qt/ImageView.hpp
+++ b/src/qt/ImageView.hpp
@@ -17,6 +17,7 @@
 #include <optional>
 #include <vector>
 
+class QEvent;
 class QGraphicsLineItem;
 class QGraphicsItem;
 class QGraphicsPathItem;
@@ -259,6 +260,9 @@ protected:
     void mouseReleaseEvent(QMouseEvent* event) override;
     void mouseMoveEvent(QMouseEvent* event) override;
     void resizeEvent(QResizeEvent* event) override;
+    // Repaints the placeholder in the new skin's colours; it is drawn from
+    // palette roles, but a QGraphicsTextItem holds the colour it was given.
+    void changeEvent(QEvent* event) override;
     void keyPressEvent(QKeyEvent* event) override;
     void wheelEvent(QWheelEvent* event) override;
     void drawForeground(QPainter* painter, const QRectF& rect) override;

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -37,6 +37,13 @@ MainWindow::MainWindow(QWidget* parent)
     connect(m_paletteController, &PaletteController::loadFileRequested, this,
         [this] { loadPaletteFile(); });
 
+    // The skin is application-wide, so this is built first: constructing it
+    // snapshots the desktop's style and palette, which restoreSettings may
+    // then replace. skinChanged only persists, so it is safe to wire here.
+    m_themeController = new ThemeController(this);
+    connect(m_themeController, &ThemeController::skinChanged, this,
+        [this] { saveSettings(); });
+
     // Derived fields: the controller owns this window's definition list and
     // its editor. It asks the window for the fields a definition may read (the
     // open dataset's stored ones) and for the reload that installs a committed
@@ -1437,6 +1444,9 @@ void MainWindow::createMenus()
     viewMenu->addAction(m_diagnosticsDock->toggleViewAction());
     viewMenu->addAction(m_animationDock->toggleViewAction());
     viewMenu->addAction(m_fabSelectorDock->toggleViewAction());
+    viewMenu->addSeparator();
+    // Application-wide rather than per-view, hence its own group at the end.
+    viewMenu->addMenu(m_themeController->createMenu(this));
 
     // Variable menu: lists all fields with a bullet on the active one.
     m_variableMenu = menuBar()->addMenu(tr("&Variable"));

--- a/src/qt/MainWindow.hpp
+++ b/src/qt/MainWindow.hpp
@@ -84,6 +84,7 @@ class ParticleController;
 class RangeController;
 class RemoteSessionController;
 class SequenceController;
+class ThemeController;
 class VolumeController;
 struct PlaneMapping;
 class UserGuideDialog;
@@ -1216,6 +1217,9 @@ private:
     // Owns the palette selection, its widgets and persistence; palette() is
     // what the renderer, color bar and overlays use.
     PaletteController* m_paletteController = nullptr;
+    // Owns the Skin selection (System/Light/Dark) and its persistence. The
+    // skin it applies is application-wide, so every window shares one.
+    ThemeController* m_themeController = nullptr;
     DerivedFieldController* m_derivedFields = nullptr;
     QString m_numberFormat = defaultNumberFormat();
     bool m_controlsReady = false;

--- a/src/qt/MainWindowDataset.cpp
+++ b/src/qt/MainWindowDataset.cpp
@@ -115,6 +115,8 @@ void MainWindow::restoreSettings()
     }
     m_colorBar->setPalette(&m_paletteController->palette());
 
+    m_themeController->restore(settings);
+
     m_range->showLogarithmic(
         settings.value(QStringLiteral("range/logarithmic"), false).toBool());
     {
@@ -186,6 +188,7 @@ void MainWindow::saveSettings()
     // session would produce unexpected color bars.
     settings.setValue(QStringLiteral("range/logarithmic"), m_range->logarithmic());
     m_paletteController->save(settings);
+    m_themeController->save(settings);
     settings.setValue(QStringLiteral("numberFormat"), m_numberFormat);
     settings.setValue(QStringLiteral("animation/speed"),
         m_animationPanel->speedValue());

--- a/src/qt/MainWindowInternal.hpp
+++ b/src/qt/MainWindowInternal.hpp
@@ -32,6 +32,7 @@
 #include "ScientificDoubleSpinBox.hpp"
 #include "SetContoursDialog.hpp"
 #include "Theme.hpp"
+#include "ThemeController.hpp"
 #include "UserGuideDialog.hpp"
 
 #include <amrexplorer/io/FitsWriter.hpp>

--- a/src/qt/SetContoursDialog.cpp
+++ b/src/qt/SetContoursDialog.cpp
@@ -1,5 +1,7 @@
 #include "SetContoursDialog.hpp"
 
+#include "Theme.hpp"
+
 #include <QAbstractButton>
 #include <QButtonGroup>
 #include <QComboBox>
@@ -143,7 +145,8 @@ SetContoursDialog::SetContoursDialog(const std::vector<std::string>& fieldNames,
     }
     auto* vectorWarning = new QLabel(
         tr("U and V fields must be different"), m_vectorBox);
-    vectorWarning->setStyleSheet("QLabel { color: red; }");
+    vectorWarning->setStyleSheet(
+        QStringLiteral("QLabel { color: %1; }").arg(errorTextColor().name()));
     vectorWarning->setVisible(false);
     vectorLayout->addRow(vectorWarning);
     const auto checkVectorFields = [this, vectorWarning] {

--- a/src/qt/SetContoursDialog.cpp
+++ b/src/qt/SetContoursDialog.cpp
@@ -6,6 +6,7 @@
 #include <QButtonGroup>
 #include <QComboBox>
 #include <QDialogButtonBox>
+#include <QEvent>
 #include <QFormLayout>
 #include <QGroupBox>
 #include <QHBoxLayout>
@@ -143,15 +144,14 @@ SetContoursDialog::SetContoursDialog(const std::vector<std::string>& fieldNames,
         }
         vectorLayout->addRow(tr("W field:"), m_wField);
     }
-    auto* vectorWarning = new QLabel(
+    m_vectorWarning = new QLabel(
         tr("U and V fields must be different"), m_vectorBox);
-    vectorWarning->setStyleSheet(
-        QStringLiteral("QLabel { color: %1; }").arg(errorTextColor().name()));
-    vectorWarning->setVisible(false);
-    vectorLayout->addRow(vectorWarning);
-    const auto checkVectorFields = [this, vectorWarning] {
+    updateWarningColor();
+    m_vectorWarning->setVisible(false);
+    vectorLayout->addRow(m_vectorWarning);
+    const auto checkVectorFields = [this] {
         const bool conflict = m_uField->currentIndex() == m_vField->currentIndex();
-        vectorWarning->setVisible(conflict);
+        m_vectorWarning->setVisible(conflict);
     };
     connect(m_uField, qOverload<int>(&QComboBox::currentIndexChanged),
         this, [checkVectorFields](int) { checkVectorFields(); });
@@ -162,14 +162,14 @@ SetContoursDialog::SetContoursDialog(const std::vector<std::string>& fieldNames,
     auto* buttons = new QDialogButtonBox(QDialogButtonBox::Ok
         | QDialogButtonBox::Apply | QDialogButtonBox::Cancel, this);
     connect(buttons, &QDialogButtonBox::clicked, this,
-        [this, buttons, vectorWarning](QAbstractButton* button) {
+        [this, buttons](QAbstractButton* button) {
             const auto role = buttons->buttonRole(button);
             if (role == QDialogButtonBox::AcceptRole
                 || role == QDialogButtonBox::ApplyRole) {
                 if (m_uField->currentIndex() == m_vField->currentIndex()
                     && m_mode == DisplayMode::VelocityVectors
                     && m_uField->count() > 1) {
-                    vectorWarning->setVisible(true);
+                    m_vectorWarning->setVisible(true);
                     return;
                 }
                 emit applied();
@@ -190,6 +190,26 @@ SetContoursDialog::SetContoursDialog(const std::vector<std::string>& fieldNames,
     const auto [uField, vField, wField] = detectVectorFields(fieldNames);
     setMode(DisplayMode::Raster);
     setVectorFields(uField, vField, wField);
+}
+
+void SetContoursDialog::changeEvent(QEvent* event)
+{
+    QDialog::changeEvent(event);
+    if (event->type() == QEvent::PaletteChange) {
+        updateWarningColor();
+    }
+}
+
+void SetContoursDialog::updateWarningColor()
+{
+    if (m_vectorWarning == nullptr) {
+        return;
+    }
+    const auto style = QStringLiteral("QLabel { color: %1; }")
+                           .arg(errorTextColor().name());
+    if (m_vectorWarning->styleSheet() != style) {
+        m_vectorWarning->setStyleSheet(style);
+    }
 }
 
 void SetContoursDialog::setMode(DisplayMode mode)

--- a/src/qt/SetContoursDialog.hpp
+++ b/src/qt/SetContoursDialog.hpp
@@ -11,7 +11,9 @@
 
 class QButtonGroup;
 class QComboBox;
+class QEvent;
 class QGroupBox;
+class QLabel;
 class QSpinBox;
 
 namespace amrvis::qt {
@@ -52,11 +54,16 @@ public:
 signals:
     void applied();
 
+protected:
+    void changeEvent(QEvent* event) override;
+
 private:
+    void updateWarningColor();
     DisplayMode m_mode = DisplayMode::Raster;
     QButtonGroup* m_modeButtons = nullptr;
     QSpinBox* m_contourCount = nullptr;
     QGroupBox* m_vectorBox = nullptr;
+    QLabel* m_vectorWarning = nullptr;
     QComboBox* m_uField = nullptr;
     QComboBox* m_vField = nullptr;
     QComboBox* m_wField = nullptr;

--- a/src/qt/Theme.hpp
+++ b/src/qt/Theme.hpp
@@ -26,8 +26,8 @@ inline QColor viewportForeground()
 // Text colours for the dialogs' inline error and warning labels. These are
 // stylesheet colours rather than palette roles -- there is no palette role for
 // "this input is wrong" -- so they have to pick their own contrast, which the
-// window colour's lightness decides. Read when the label's text is set, so a
-// dialog opened after a skin change gets the right pair.
+// window colour's lightness decides. Dialogs apply these at construction and
+// on palette changes so standing messages follow a live skin change too.
 namespace detail {
 
 inline bool onLightBackground()

--- a/src/qt/Theme.hpp
+++ b/src/qt/Theme.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <QColor>
+#include <QGuiApplication>
+#include <QPalette>
 
 namespace amrvis::qt {
 
@@ -19,6 +21,35 @@ inline QColor viewportBackground()
 inline QColor viewportForeground()
 {
     return {0x20, 0x20, 0x20};
+}
+
+// Text colours for the dialogs' inline error and warning labels. These are
+// stylesheet colours rather than palette roles -- there is no palette role for
+// "this input is wrong" -- so they have to pick their own contrast, which the
+// window colour's lightness decides. Read when the label's text is set, so a
+// dialog opened after a skin change gets the right pair.
+namespace detail {
+
+inline bool onLightBackground()
+{
+    return QGuiApplication::palette().color(QPalette::Window).lightness() > 127;
+}
+
+} // namespace detail
+
+// Refusal: the input was rejected.
+inline QColor errorTextColor()
+{
+    return detail::onLightBackground() ? QColor(0xc0, 0x00, 0x00)
+                                       : QColor(0xff, 0x6b, 0x6b);
+}
+
+// Caution: the input is accepted but questionable. Deliberately not the error
+// colour, so the two cannot be confused.
+inline QColor warningTextColor()
+{
+    return detail::onLightBackground() ? QColor(0xb8, 0x86, 0x0b)
+                                       : QColor(0xe0, 0xb0, 0x40);
 }
 
 } // namespace amrvis::qt

--- a/src/qt/ThemeController.cpp
+++ b/src/qt/ThemeController.cpp
@@ -193,8 +193,10 @@ public:
         QPainter* painter, const QWidget* widget) const override
     {
         if (element == PE_IndicatorToolBarSeparator) {
-            paintSeparator(option, painter, /*horizontal=*/
-                option->rect.width() < option->rect.height());
+            // The separator's line is perpendicular to the toolbar's axis.
+            paintSeparator(option, painter,
+                (option->state & State_Horizontal) != 0
+                    ? Qt::Vertical : Qt::Horizontal);
             return;
         }
         QProxyStyle::drawPrimitive(element, option, painter, widget);
@@ -225,7 +227,7 @@ public:
         const auto* item = qstyleoption_cast<const QStyleOptionMenuItem*>(option);
         if (element == CE_MenuItem && item != nullptr
             && item->menuItemType == QStyleOptionMenuItem::Separator) {
-            paintSeparator(option, painter, /*horizontal=*/true);
+            paintSeparator(option, painter, Qt::Horizontal);
             return;
         }
         QProxyStyle::drawControl(element, option, painter, widget);
@@ -240,18 +242,24 @@ private:
     }
 
     static void paintSeparator(
-        const QStyleOption* option, QPainter* painter, bool horizontal)
+        const QStyleOption* option, QPainter* painter, Qt::Orientation lineAxis)
     {
         const auto line = rule(option);
         const auto rect = option->rect;
-        if (horizontal) {
+        if (rect.isEmpty()) {
+            return;
+        }
+        const int length = lineAxis == Qt::Horizontal ? rect.width() : rect.height();
+        // Retain at least one pixel even in a compressed separator rectangle.
+        const int inset = std::min(kInset, (length - 1) / 2);
+        if (lineAxis == Qt::Horizontal) {
             const int y = rect.center().y();
-            painter->fillRect(rect.left() + kInset, y,
-                rect.width() - 2 * kInset, 1, line);
+            painter->fillRect(rect.left() + inset, y,
+                rect.width() - 2 * inset, 1, line);
         } else {
             const int x = rect.center().x();
-            painter->fillRect(x, rect.top() + kInset, 1,
-                rect.height() - 2 * kInset, line);
+            painter->fillRect(x, rect.top() + inset, 1,
+                rect.height() - 2 * inset, line);
         }
     }
 

--- a/src/qt/ThemeController.cpp
+++ b/src/qt/ThemeController.cpp
@@ -1,0 +1,440 @@
+#include "ThemeController.hpp"
+
+#include <QAction>
+#include <QActionGroup>
+#include <QApplication>
+#include <QColor>
+#include <QGuiApplication>
+#include <QMenu>
+#include <QPalette>
+#include <QSettings>
+#include <QStyle>
+#include <QPainter>
+#include <QRectF>
+#include <QProxyStyle>
+#include <QStyleFactory>
+#include <QStyleOption>
+#include <QVariant>
+#include <QtGlobal>
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 8, 0)
+#include <QStyleHints>
+#endif
+
+#include <algorithm>
+#include <array>
+#include <vector>
+
+namespace amrvis::qt {
+
+namespace {
+
+// The style and palette the desktop handed us, snapshotted the first time this
+// is called. That call happens in ThemeController's constructor -- i.e. while
+// MainWindow is being built, before any skin has been applied -- so a second
+// window opened after a switch to Dark cannot mistake the dark palette for the
+// system one.
+struct SystemDefaults {
+    QString styleName;
+    QPalette palette;
+};
+
+const SystemDefaults& systemDefaults()
+{
+    static const SystemDefaults defaults{
+        QApplication::style() != nullptr ? QApplication::style()->objectName()
+                                         : QString(),
+        QApplication::palette()};
+    return defaults;
+}
+
+Skin g_currentSkin = Skin::System;
+
+// Every live controller, so a skin picked in one window re-checks the menus of
+// the others. Registration is in the constructor, removal in the destructor.
+std::vector<ThemeController*>& liveControllers()
+{
+    static std::vector<ThemeController*> controllers;
+    return controllers;
+}
+
+// A dark skin's five colours. Everything else a QPalette needs is derived
+// from these, so the four dark skins differ only in this struct and cannot
+// drift apart in the roles nobody remembers to set.
+struct DarkSkinColors {
+    QColor window;   // chrome: menus, toolbars, docks, buttons
+    QColor deep;     // what text is entered and listed on
+    QColor alternate; // alternating rows
+    QColor text;     // on both of the above
+    QColor accent;   // selection and links
+    QColor muted;    // placeholder and disabled text
+};
+
+// Builds the palette. The two-colour QPalette constructor derives the frame
+// shades (Light, Midlight, Mid, Dark, Shadow) from the window colour; hand
+// listing those is how hand-rolled dark modes end up with invisible frames
+// and separators.
+QPalette darkSkinPalette(const DarkSkinColors& colors)
+{
+    QPalette palette(colors.window, colors.window);
+    palette.setColor(QPalette::WindowText, colors.text);
+    palette.setColor(QPalette::ButtonText, colors.text);
+    palette.setColor(QPalette::Base, colors.deep);
+    palette.setColor(QPalette::AlternateBase, colors.alternate);
+    palette.setColor(QPalette::ToolTipBase, colors.deep);
+    palette.setColor(QPalette::ToolTipText, colors.text);
+    palette.setColor(QPalette::Text, colors.text);
+    palette.setColor(QPalette::Link, colors.accent);
+    palette.setColor(QPalette::LinkVisited, colors.accent.lighter(130));
+    palette.setColor(QPalette::Highlight, colors.accent);
+    // Selected text goes against the accent, not with the skin: a light accent
+    // needs the deep colour on it, a dark one needs the text colour. Picking
+    // per skin is how one of them ends up unreadable. The test holds every
+    // skin's three text pairs to WCAG 2.1 AA (4.5:1); disabled text is exempt
+    // under 1.4.3 and is only required to differ from the active colour.
+    palette.setColor(QPalette::HighlightedText,
+        colors.accent.lightness() > 140 ? colors.deep : colors.text);
+    palette.setColor(QPalette::PlaceholderText, colors.muted);
+    // The disabled group has to stay distinguishable from the active one, or
+    // every grayed-out menu entry and spin box reads as enabled.
+    palette.setColor(QPalette::Disabled, QPalette::WindowText, colors.muted);
+    palette.setColor(QPalette::Disabled, QPalette::Text, colors.muted);
+    palette.setColor(QPalette::Disabled, QPalette::ButtonText, colors.muted);
+    palette.setColor(QPalette::Disabled, QPalette::Highlight,
+        colors.window.lighter(140));
+    palette.setColor(QPalette::Disabled, QPalette::HighlightedText,
+        colors.muted);
+    return palette;
+}
+
+// The neutral one: the conventional mid-gray Fusion dark set.
+constexpr DarkSkinColors darkColors{QColor(0x35, 0x35, 0x35),
+    QColor(0x2a, 0x2a, 0x2a), QColor(0x30, 0x30, 0x30), QColor(0xff, 0xff, 0xff),
+    QColor(0x2a, 0x82, 0xda), QColor(0x8a, 0x8a, 0x8a)};
+
+// The tinted skins. Each is the neutral set above at a hue: same lightnesses,
+// deliberately, because Fusion derives menu grounds from Base and separator
+// and check-box outlines from Window, and both derivations are subtle. A
+// tinted skin that put Base well below Window -- an obvious way to write one,
+// and what the first Blue did -- pushed the whole menu onto a near-black
+// ground where those outlines vanished. Keeping the neutral skin's structure
+// is what keeps every frame, separator and check box as legible as Dark's.
+//
+// Blue takes its accent from the application icon's lens (#43C6E8), which is
+// the one colour here that is quoted rather than derived.
+constexpr DarkSkinColors blueColors{QColor(0x20, 0x35, 0x4a),
+    QColor(0x18, 0x2a, 0x3c), QColor(0x1d, 0x30, 0x43), QColor(0xde, 0xe8, 0xf2),
+    QColor(0x4a, 0xc3, 0xe2), QColor(0x70, 0x8a, 0xa4)};
+
+constexpr DarkSkinColors greenColors{QColor(0x20, 0x4a, 0x35),
+    QColor(0x18, 0x3c, 0x2a), QColor(0x1d, 0x43, 0x30), QColor(0xde, 0xf2, 0xe8),
+    QColor(0x5c, 0xd0, 0x96), QColor(0x70, 0xa4, 0x8a)};
+
+constexpr DarkSkinColors maroonColors{QColor(0x4a, 0x20, 0x27),
+    QColor(0x3c, 0x18, 0x1e), QColor(0x43, 0x1d, 0x23), QColor(0xf2, 0xde, 0xe1),
+    QColor(0xe1, 0x87, 0x96), QColor(0xa4, 0x70, 0x79)};
+
+// Qt >= 6.8 can tell the platform which scheme we are in, which is what makes
+// portal-backed native dialogs and standard icons follow the skin. It is an
+// addition to the palette work above, not a replacement: the project builds
+// against Qt 6.4 too, where the palette is the whole mechanism.
+void setColorSchemeHint([[maybe_unused]] Skin skin)
+{
+#if QT_VERSION >= QT_VERSION_CHECK(6, 8, 0)
+    auto* hints = QGuiApplication::styleHints();
+    if (hints == nullptr) {
+        return;
+    }
+    switch (skin) {
+    case Skin::System:
+        // Unknown is "follow the platform", not "no scheme".
+        hints->setColorScheme(Qt::ColorScheme::Unknown);
+        break;
+    case Skin::Light:
+        hints->setColorScheme(Qt::ColorScheme::Light);
+        break;
+    case Skin::Dark:
+    case Skin::Blue:
+    case Skin::Green:
+    case Skin::Maroon:
+        hints->setColorScheme(Qt::ColorScheme::Dark);
+        break;
+    }
+#endif
+}
+
+// Installs a style by factory name, keeping the current one if the name is not
+// one this Qt can build. QApplication takes ownership of the new style and
+// deletes the old, which is why only the name of the system style is kept.
+void setStyleByName(const QString& name)
+{
+    if (name.isEmpty()) {
+        return;
+    }
+    if (auto* style = QStyleFactory::create(name)) {
+        QApplication::setStyle(style);
+    }
+}
+
+// Fusion draws menu and toolbar separators with an outline it derives from the
+// window colour itself (window.darker(140) on a dark palette), which no
+// palette role can reach -- on any dark skin it lands around 1.15:1 and all
+// but disappears. Overriding that one primitive is the whole of this class.
+//
+// A style, not a stylesheet: an application stylesheet with a
+// QMenu::separator rule does make the rule visible, but it hands the whole
+// menu to QStyleSheetStyle, which then drops the sub-elements it has no rule
+// for -- the submenu arrows and the unchecked check boxes both vanished.
+class SeparatorStyle final : public QProxyStyle {
+public:
+    using QProxyStyle::QProxyStyle;
+
+    void drawPrimitive(PrimitiveElement element, const QStyleOption* option,
+        QPainter* painter, const QWidget* widget) const override
+    {
+        if (element == PE_IndicatorToolBarSeparator) {
+            paintSeparator(option, painter, /*horizontal=*/
+                option->rect.width() < option->rect.height());
+            return;
+        }
+        QProxyStyle::drawPrimitive(element, option, painter, widget);
+        // Fusion frames check boxes and radio buttons with the same
+        // disappearing outline. Overdrawing the frame keeps its check mark and
+        // its fill and only makes the empty box findable; drawing the whole
+        // indicator here would mean reproducing the mark as well.
+        if ((element == PE_IndicatorCheckBox
+                || element == PE_IndicatorRadioButton)
+            && (option->state & State_Enabled) != 0) {
+            painter->save();
+            painter->setRenderHint(QPainter::Antialiasing);
+            painter->setPen(rule(option));
+            painter->setBrush(Qt::NoBrush);
+            const QRectF box = QRectF(option->rect).adjusted(0.5, 0.5, -0.5, -0.5);
+            if (element == PE_IndicatorCheckBox) {
+                painter->drawRoundedRect(box, 2, 2);
+            } else {
+                painter->drawEllipse(box);
+            }
+            painter->restore();
+        }
+    }
+
+    void drawControl(ControlElement element, const QStyleOption* option,
+        QPainter* painter, const QWidget* widget) const override
+    {
+        const auto* item = qstyleoption_cast<const QStyleOptionMenuItem*>(option);
+        if (element == CE_MenuItem && item != nullptr
+            && item->menuItemType == QStyleOptionMenuItem::Separator) {
+            paintSeparator(option, painter, /*horizontal=*/true);
+            return;
+        }
+        QProxyStyle::drawControl(element, option, painter, widget);
+    }
+
+private:
+    // Lighter than the chrome, which is the direction that reads on a dark
+    // ground; Fusion's own outline goes darker and disappears into it.
+    static QColor rule(const QStyleOption* option)
+    {
+        return option->palette.window().color().lighter(165);
+    }
+
+    static void paintSeparator(
+        const QStyleOption* option, QPainter* painter, bool horizontal)
+    {
+        const auto line = rule(option);
+        const auto rect = option->rect;
+        if (horizontal) {
+            const int y = rect.center().y();
+            painter->fillRect(rect.left() + kInset, y,
+                rect.width() - 2 * kInset, 1, line);
+        } else {
+            const int x = rect.center().x();
+            painter->fillRect(x, rect.top() + kInset, 1,
+                rect.height() - 2 * kInset, line);
+        }
+    }
+
+    static constexpr int kInset = 4;
+};
+
+// The one list of skins: the settings key and the menu label of each, in menu
+// order. The switches above and below are what force a new enumerator to be
+// handled; this is what makes it reachable.
+struct SkinEntry {
+    Skin skin;
+    const char* key;
+    const char* label;
+};
+
+constexpr std::array<SkinEntry, 6> skinEntries{
+    SkinEntry{Skin::System, "system", "&System"},
+    SkinEntry{Skin::Light, "light", "&Light"},
+    SkinEntry{Skin::Dark, "dark", "&Dark"},
+    SkinEntry{Skin::Blue, "blue", "&Blue"},
+    SkinEntry{Skin::Green, "green", "&Green"},
+    SkinEntry{Skin::Maroon, "maroon", "&Maroon"}};
+
+} // namespace
+
+Skin currentSkin()
+{
+    return g_currentSkin;
+}
+
+QString skinKey(Skin skin)
+{
+    const auto entry = std::ranges::find(skinEntries, skin, &SkinEntry::skin);
+    return entry != skinEntries.end() ? QString::fromLatin1(entry->key)
+                                      : QStringLiteral("system");
+}
+
+Skin skinFromKey(const QString& key)
+{
+    const auto entry = std::ranges::find_if(skinEntries,
+        [&key](const SkinEntry& candidate) {
+            return key == QLatin1String(candidate.key);
+        });
+    return entry != skinEntries.end() ? entry->skin : Skin::System;
+}
+
+bool applySkin(Skin skin)
+{
+    // Snapshot before the first override, whatever the caller asked for.
+    const auto& defaults = systemDefaults();
+    if (skin == g_currentSkin) {
+        return false;
+    }
+    g_currentSkin = skin;
+    // The hint goes first: on Qt >= 6.8 it is itself a theme change, and
+    // letting it land after our palette would undo it.
+    setColorSchemeHint(skin);
+    const auto dark = [](const DarkSkinColors& colors) {
+        // The proxy wraps a fresh Fusion; QApplication takes both.
+        QApplication::setStyle(
+            new SeparatorStyle(QStyleFactory::create(QStringLiteral("Fusion"))));
+        QApplication::setPalette(darkSkinPalette(colors));
+    };
+    switch (skin) {
+    case Skin::System:
+        setStyleByName(defaults.styleName);
+        QApplication::setPalette(defaults.palette);
+        break;
+    case Skin::Light:
+        setStyleByName(QStringLiteral("Fusion"));
+        // Fusion's own light palette, rather than a hand-authored one.
+        QApplication::setPalette(QApplication::style()->standardPalette());
+        break;
+    case Skin::Dark:
+        dark(darkColors);
+        break;
+    case Skin::Blue:
+        dark(blueColors);
+        break;
+    case Skin::Green:
+        dark(greenColors);
+        break;
+    case Skin::Maroon:
+        dark(maroonColors);
+        break;
+    }
+    for (auto* controller : liveControllers()) {
+        controller->syncMenu();
+    }
+    return true;
+}
+
+ThemeController::ThemeController(QObject* parent)
+    : QObject(parent)
+{
+    // Forces the snapshot now, while the desktop's style and palette are still
+    // the ones in effect.
+    static_cast<void>(systemDefaults());
+    liveControllers().push_back(this);
+}
+
+ThemeController::~ThemeController()
+{
+    auto& controllers = liveControllers();
+    controllers.erase(
+        std::remove(controllers.begin(), controllers.end(), this),
+        controllers.end());
+}
+
+QMenu* ThemeController::createMenu(QWidget* parent)
+{
+    auto* menu = new QMenu(tr("S&kin"), parent);
+    m_menuGroup = new QActionGroup(menu);
+    for (const auto& entry : skinEntries) {
+        auto* action = new QAction(tr(entry.label), menu);
+        action->setCheckable(true);
+        action->setActionGroup(m_menuGroup);
+        action->setData(static_cast<int>(entry.skin));
+        // triggered, not toggled: syncMenu's setChecked must not re-enter.
+        connect(action, &QAction::triggered, this,
+            [this, skin = entry.skin] { selectSkin(skin); });
+        menu->addAction(action);
+    }
+    syncMenu();
+    return menu;
+}
+
+void ThemeController::selectSkin(Skin skin)
+{
+    if (!applySkin(skin)) {
+        // Already applied; the click that landed here unchecked nothing, but
+        // resync so a stray state cannot survive.
+        syncMenu();
+        return;
+    }
+    emit skinChanged();
+}
+
+void ThemeController::restore(const QSettings& settings)
+{
+    applySkin(skinFromKey(
+        settings.value(QStringLiteral("theme/skin")).toString()));
+}
+
+void ThemeController::save(QSettings& settings) const
+{
+    settings.setValue(QStringLiteral("theme/skin"), skinKey(currentSkin()));
+}
+
+QStringList ThemeController::menuLabels() const
+{
+    QStringList labels;
+    if (!m_menuGroup) {
+        return labels;
+    }
+    for (const auto* action : m_menuGroup->actions()) {
+        labels.append(action->text());
+    }
+    return labels;
+}
+
+QString ThemeController::checkedMenuLabel() const
+{
+    if (!m_menuGroup) {
+        return {};
+    }
+    for (const auto* action : m_menuGroup->actions()) {
+        if (action->isChecked()) {
+            return action->text();
+        }
+    }
+    return {};
+}
+
+void ThemeController::syncMenu()
+{
+    if (!m_menuGroup) {
+        return;
+    }
+    for (auto* action : m_menuGroup->actions()) {
+        action->setChecked(action->data().toInt()
+            == static_cast<int>(currentSkin()));
+    }
+}
+
+} // namespace amrvis::qt

--- a/src/qt/ThemeController.hpp
+++ b/src/qt/ThemeController.hpp
@@ -1,0 +1,98 @@
+#pragma once
+
+#include <QObject>
+#include <QPointer>
+#include <QString>
+#include <QStringList>
+
+class QActionGroup;
+class QMenu;
+class QSettings;
+class QWidget;
+
+namespace amrvis::qt {
+
+// The application's chrome appearance: menus, docks, dialogs, tables and
+// toolbars. System is the default and reproduces the behaviour this
+// application had before skins existed -- whatever Qt style and palette the
+// desktop provides, untouched. Blue, Green and Maroon are Dark in a tint --
+// Blue in the application icon's own colours.
+//
+// Adding one here is a compile error until every switch over Skin in
+// ThemeController.cpp handles it and skinEntries there lists it; that is the
+// intended guard, so do not give those switches a default case.
+enum class Skin { System, Light, Dark, Blue, Green, Maroon };
+
+// The skin currently applied to QApplication. Application-wide, not per
+// window: File > New Window makes a second MainWindow, and both share one
+// QApplication palette.
+[[nodiscard]] Skin currentSkin();
+
+// Applies a skin to QApplication and returns whether anything changed. Qt
+// propagates the new palette to every widget that has not set an explicit one,
+// so the switch is live -- no restart, no rebuilding of windows. The viewports
+// (see Theme.hpp) do set explicit palettes and brushes, and so keep their
+// neutral gray under every skin, which is intended.
+//
+// System restores the style and palette captured the first time a skin was
+// applied. That is a best effort rather than a true reset: once
+// QApplication::setPalette has been called, Qt stops following later desktop
+// theme changes for the rest of the session.
+bool applySkin(Skin skin);
+
+// The settings string for a skin ("system", "light", "dark"). This value is on
+// disk in every user's settings, so renaming one is a settings-format change.
+[[nodiscard]] QString skinKey(Skin skin);
+// The inverse; anything unrecognised falls back to System.
+[[nodiscard]] Skin skinFromKey(const QString& key);
+
+// The skin selection: the Skin menu that presents it, its QSettings
+// persistence, and the application of the choice. Owned by its host window the
+// way PaletteController is, but the state it drives lives in QApplication, so
+// several instances stay in step: every live controller re-syncs its menu when
+// any of them changes the skin.
+class ThemeController final : public QObject {
+    Q_OBJECT
+
+public:
+    explicit ThemeController(QObject* parent = nullptr);
+    ~ThemeController() override;
+
+    // The "S&kin" menu: one checkable action per skin in an exclusive group.
+    // Owned by `parent`; the controller keeps its checks in step.
+    QMenu* createMenu(QWidget* parent);
+
+    [[nodiscard]] Skin skin() const { return currentSkin(); }
+
+    // Re-selecting the applied skin resyncs the menu but emits nothing, so it
+    // costs no settings write.
+    void selectSkin(Skin skin);
+
+    // The "theme/skin" application setting. restore() applies the stored skin
+    // but does not emit skinChanged: it reproduces a saved selection rather
+    // than changing one, so a host that has wired the signal to saveSettings
+    // is not made to write the settings straight back.
+    void restore(const QSettings& settings);
+    void save(QSettings& settings) const;
+
+    // The menu action labels, in menu order. Empty until the menu exists.
+    [[nodiscard]] QStringList menuLabels() const;
+    // The label of the checked action, empty if none is.
+    [[nodiscard]] QString checkedMenuLabel() const;
+
+signals:
+    // The applied skin changed; the host persists settings.
+    void skinChanged();
+
+private:
+    // applySkin re-checks every live controller's menu, this one included.
+    friend bool applySkin(Skin skin);
+
+    // Re-checks the menu action matching currentSkin(). Never emits, so
+    // applySkin can call it on every live controller.
+    void syncMenu();
+
+    QPointer<QActionGroup> m_menuGroup;
+};
+
+} // namespace amrvis::qt

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -688,6 +688,27 @@ if(TARGET amrexplorer_qt)
         COMMAND "${CMAKE_COMMAND}" -E env QT_QPA_PLATFORM=offscreen
             "$<TARGET_FILE:test_palette_controller>")
 
+    add_executable(test_theme_controller
+        unit/test_theme_controller.cpp
+        "${PROJECT_SOURCE_DIR}/src/qt/ThemeController.cpp"
+        "${PROJECT_SOURCE_DIR}/src/qt/ThemeController.hpp"
+    )
+    set_target_properties(test_theme_controller PROPERTIES AUTOMOC ON)
+    target_include_directories(test_theme_controller
+        PRIVATE "${PROJECT_SOURCE_DIR}/src/qt")
+    target_link_libraries(test_theme_controller
+        PRIVATE
+            amrexplorer::warnings
+            Qt6::Core
+            Qt6::Gui
+            Qt6::Widgets
+    )
+    # Builds a real menu and swaps the application palette, so it needs a QPA
+    # platform; offscreen keeps it headless like the other Qt tests.
+    add_test(NAME theme_controller
+        COMMAND "${CMAKE_COMMAND}" -E env QT_QPA_PLATFORM=offscreen
+            "$<TARGET_FILE:test_theme_controller>")
+
     add_executable(test_range_controller
         unit/test_range_controller.cpp
         "${PROJECT_SOURCE_DIR}/src/qt/RangeController.cpp"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -692,12 +692,17 @@ if(TARGET amrexplorer_qt)
         unit/test_theme_controller.cpp
         "${PROJECT_SOURCE_DIR}/src/qt/ThemeController.cpp"
         "${PROJECT_SOURCE_DIR}/src/qt/ThemeController.hpp"
+        "${PROJECT_SOURCE_DIR}/src/qt/ExpressionEditorDialog.cpp"
+        "${PROJECT_SOURCE_DIR}/src/qt/ExpressionEditorDialog.hpp"
+        "${PROJECT_SOURCE_DIR}/src/qt/SetContoursDialog.cpp"
+        "${PROJECT_SOURCE_DIR}/src/qt/SetContoursDialog.hpp"
     )
     set_target_properties(test_theme_controller PROPERTIES AUTOMOC ON)
     target_include_directories(test_theme_controller
         PRIVATE "${PROJECT_SOURCE_DIR}/src/qt")
     target_link_libraries(test_theme_controller
         PRIVATE
+            amrexplorer::core
             amrexplorer::warnings
             Qt6::Core
             Qt6::Gui

--- a/tests/unit/test_derived_field_controller.cpp
+++ b/tests/unit/test_derived_field_controller.cpp
@@ -1,6 +1,7 @@
 #include "DerivedFieldController.hpp"
 #include "DerivedFieldStore.hpp"
 #include "ExpressionEditorDialog.hpp"
+#include "Theme.hpp"
 
 #include <QApplication>
 #include <QEventLoop>
@@ -575,7 +576,10 @@ int main(int argc, char** argv)
         dialog->setDraft({{"t", "density"}});
         source->setPlainText(QStringLiteral("sqrt("));
         waitUntil([&] { return !warning->text().isEmpty(); });
-        require(warning->styleSheet().contains(QStringLiteral("red")),
+        require(warning->styleSheet().contains(
+                    amrvis::qt::errorTextColor().name())
+                && !warning->styleSheet().contains(
+                    amrvis::qt::warningTextColor().name()),
             "a fault Apply will refuse was shown as advice");
 
         // A field written into the middle of a name is separated from both

--- a/tests/unit/test_theme_controller.cpp
+++ b/tests/unit/test_theme_controller.cpp
@@ -1,14 +1,22 @@
 #include "ThemeController.hpp"
+#include "Theme.hpp"
+#include "ExpressionEditorDialog.hpp"
+#include "SetContoursDialog.hpp"
 
 #include <QApplication>
 #include <QColor>
 #include <QDir>
+#include <QImage>
+#include <QLabel>
 #include <QMenu>
 #include <QPalette>
+#include <QPainter>
 #include <QStyle>
+#include <QStyleOption>
 #include <QSettings>
 #include <QStringList>
 #include <QTemporaryDir>
+#include <QToolBar>
 #include <QWidget>
 
 #include <algorithm>
@@ -51,6 +59,55 @@ double contrast(const QColor& left, const QColor& right)
     return (std::max(first, second) + 0.05) / (std::min(first, second) + 0.05);
 }
 
+void checkToolbarSeparator(Qt::Orientation orientation, QSize size = {})
+{
+    QToolBar toolbar;
+    toolbar.setOrientation(orientation);
+    toolbar.addAction(QStringLiteral("First"));
+    auto* separator = toolbar.addSeparator();
+    toolbar.addAction(QStringLiteral("Second"));
+    toolbar.show();
+    QApplication::processEvents();
+
+    // Use the real toolbar's separator dimensions, but paint the primitive
+    // alone so its pixels cannot be confused with the toolbar background.
+    QStyleOption option;
+    option.initFrom(&toolbar);
+    option.rect = QRect(QPoint(0, 0), toolbar.actionGeometry(separator).size());
+    if (!size.isEmpty()) {
+        option.rect.setSize(size);
+    }
+    option.state.setFlag(QStyle::State_Horizontal,
+        orientation == Qt::Horizontal);
+    require(!option.rect.isEmpty(), "the toolbar separator has no geometry");
+    QImage image(option.rect.size(), QImage::Format_ARGB32);
+    image.fill(Qt::transparent);
+    {
+        QPainter painter(&image);
+        toolbar.style()->drawPrimitive(QStyle::PE_IndicatorToolBarSeparator,
+            &option, &painter, &toolbar);
+    }
+    QRect painted;
+    for (int y = 0; y < image.height(); ++y) {
+        for (int x = 0; x < image.width(); ++x) {
+            if (qAlpha(image.pixel(x, y)) != 0) {
+                painted = painted.united(QRect(x, y, 1, 1));
+            }
+        }
+    }
+    // A horizontal toolbar needs a vertical rule, and vice versa. Checking
+    // span as well as direction catches the negative-width two-pixel dash.
+    if (orientation == Qt::Horizontal) {
+        require(painted.height() >= std::max(1, image.height() / 2)
+                && painted.width() == 1,
+            "a horizontal toolbar has no full-height vertical separator");
+    } else {
+        require(painted.width() >= std::max(1, image.width() / 2)
+                && painted.height() == 1,
+            "a vertical toolbar has no full-width horizontal separator");
+    }
+}
+
 } // namespace
 
 int main(int argc, char** argv)
@@ -66,6 +123,90 @@ int main(int argc, char** argv)
     // The dark skins install a proxy style over Fusion, so System has to put
     // the style back as well as the palette.
     const QString systemStyle = QApplication::style()->objectName();
+
+    // All four dark skins use the proxy painter. Exercise both toolbar axes.
+    {
+        ThemeController controller;
+        for (const auto skin : {Skin::Dark, Skin::Blue, Skin::Green,
+                 Skin::Maroon}) {
+            controller.selectSkin(skin);
+            checkToolbarSeparator(Qt::Horizontal);
+            checkToolbarSeparator(Qt::Vertical);
+            // Shorter than the usual insets, and with an aspect ratio that
+            // contradicts the toolbar's orientation: the state is authoritative.
+            checkToolbarSeparator(Qt::Horizontal, QSize(6, 3));
+            checkToolbarSeparator(Qt::Vertical, QSize(3, 6));
+            checkToolbarSeparator(Qt::Horizontal, QSize(1, 1));
+            checkToolbarSeparator(Qt::Vertical, QSize(1, 1));
+        }
+        controller.selectSkin(Skin::System);
+    }
+
+    // Keep each message on screen throughout a round trip: writing it again
+    // after the switch would conceal stale stylesheet colours.
+    {
+        ThemeController controller;
+        controller.selectSkin(Skin::Light);
+        amrvis::qt::ExpressionEditorDialog errorDialog({}, nullptr);
+        amrvis::qt::ExpressionEditorDialog warningDialog({}, nullptr);
+        errorDialog.showError(QStringLiteral("Invalid expression"), std::nullopt);
+        errorDialog.show();
+        warningDialog.show();
+        auto* error = errorDialog.findChild<QLabel*>(
+            QStringLiteral("expressionError"));
+        auto* warning = warningDialog.findChild<QLabel*>(
+            QStringLiteral("expressionWarning"));
+        require(error != nullptr && warning != nullptr,
+            "the editor's message labels are missing");
+        for (const bool blocking : {false, true, false}) {
+            warningDialog.showResolutionWarning(
+                QStringLiteral("Resolution warning"), blocking);
+            for (const auto skin : {Skin::Light, Skin::Dark, Skin::Light}) {
+                controller.selectSkin(skin);
+                QApplication::processEvents();
+                require(error->isVisible() && warning->isVisible(),
+                    "a palette change hid a standing message");
+                require(error->text() == QLatin1String("Invalid expression")
+                        && warning->text() == QLatin1String("Resolution warning"),
+                    "a palette change changed a standing message");
+                require(error->palette().color(QPalette::WindowText)
+                        == amrvis::qt::errorTextColor(),
+                    "a standing error did not follow the skin");
+                require(warning->palette().color(QPalette::WindowText)
+                        == (blocking ? amrvis::qt::errorTextColor()
+                                     : amrvis::qt::warningTextColor()),
+                    "a standing warning lost its skin colour or severity");
+            }
+        }
+        controller.selectSkin(Skin::System);
+    }
+
+    // Set Contours is modeless too: leave its field-conflict warning visible
+    // while changing skins, without touching the selected vector fields.
+    {
+        ThemeController controller;
+        controller.selectSkin(Skin::Light);
+        amrvis::qt::SetContoursDialog dialog({"u", "v"}, false);
+        dialog.setMode(amrvis::qt::DisplayMode::VelocityVectors);
+        dialog.setVectorFields(0, 0, 0);
+        dialog.show();
+        QLabel* warning = nullptr;
+        for (auto* label : dialog.findChildren<QLabel*>()) {
+            if (label->text() == QLatin1String("U and V fields must be different")) {
+                warning = label;
+            }
+        }
+        require(warning != nullptr, "the vector-field warning is missing");
+        for (const auto skin : {Skin::Light, Skin::Dark, Skin::Light}) {
+            controller.selectSkin(skin);
+            QApplication::processEvents();
+            require(warning->isVisible(), "a palette change hid the vector warning");
+            require(warning->palette().color(QPalette::WindowText)
+                    == amrvis::qt::errorTextColor(),
+                "a standing vector-field warning did not follow the skin");
+        }
+        controller.selectSkin(Skin::System);
+    }
 
     // The keys are the on-disk settings format: pin them as literals.
     {

--- a/tests/unit/test_theme_controller.cpp
+++ b/tests/unit/test_theme_controller.cpp
@@ -1,0 +1,302 @@
+#include "ThemeController.hpp"
+
+#include <QApplication>
+#include <QColor>
+#include <QDir>
+#include <QMenu>
+#include <QPalette>
+#include <QStyle>
+#include <QSettings>
+#include <QStringList>
+#include <QTemporaryDir>
+#include <QWidget>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdlib>
+#include <iostream>
+
+namespace {
+
+void require(bool condition, const char* message)
+{
+    if (!condition) {
+        std::cerr << "FAILED: " << message << '\n';
+        std::exit(1);
+    }
+}
+
+bool isDark(const QPalette& palette)
+{
+    return palette.color(QPalette::Window).lightness() < 128;
+}
+
+// WCAG relative luminance, so a skin cannot pass by being merely different
+// from its background -- 4.5:1 is the readable-body-text threshold.
+double relativeLuminance(const QColor& color)
+{
+    const auto channel = [](double value) {
+        value /= 255.0;
+        return value <= 0.03928 ? value / 12.92
+                                : std::pow((value + 0.055) / 1.055, 2.4);
+    };
+    return 0.2126 * channel(color.red()) + 0.7152 * channel(color.green())
+        + 0.0722 * channel(color.blue());
+}
+
+double contrast(const QColor& left, const QColor& right)
+{
+    const auto first = relativeLuminance(left);
+    const auto second = relativeLuminance(right);
+    return (std::max(first, second) + 0.05) / (std::min(first, second) + 0.05);
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    QApplication application(argc, argv);
+    using amrvis::qt::Skin;
+    using amrvis::qt::ThemeController;
+
+    // The palette the desktop gave us, captured before any controller exists.
+    // Every case below ends back on System, so this is what the application
+    // palette must read as between cases.
+    const QPalette systemPalette = QApplication::palette();
+    // The dark skins install a proxy style over Fusion, so System has to put
+    // the style back as well as the palette.
+    const QString systemStyle = QApplication::style()->objectName();
+
+    // The keys are the on-disk settings format: pin them as literals.
+    {
+        require(amrvis::qt::skinKey(Skin::System) == QLatin1String("system")
+                && amrvis::qt::skinKey(Skin::Light) == QLatin1String("light")
+                && amrvis::qt::skinKey(Skin::Dark) == QLatin1String("dark")
+                && amrvis::qt::skinKey(Skin::Blue) == QLatin1String("blue")
+                && amrvis::qt::skinKey(Skin::Green) == QLatin1String("green")
+                && amrvis::qt::skinKey(Skin::Maroon) == QLatin1String("maroon"),
+            "skin settings keys changed");
+        require(amrvis::qt::skinFromKey(QStringLiteral("dark")) == Skin::Dark,
+            "a stored key did not round-trip");
+        require(amrvis::qt::skinFromKey(QStringLiteral("chartreuse"))
+                == Skin::System,
+            "an unrecognised stored skin did not fall back to System");
+        require(amrvis::qt::skinFromKey(QString()) == Skin::System,
+            "a missing stored skin did not fall back to System");
+    }
+
+    // The menu offers exactly the three skins and checks the applied one.
+    {
+        QWidget parent;
+        ThemeController controller;
+        auto* menu = controller.createMenu(&parent);
+        require(menu != nullptr, "createMenu returned nothing");
+        require(controller.menuLabels()
+                == QStringList{QStringLiteral("&System"),
+                    QStringLiteral("&Light"), QStringLiteral("&Dark"),
+                    QStringLiteral("&Blue"), QStringLiteral("&Green"),
+                    QStringLiteral("&Maroon")},
+            "the Skin menu does not offer exactly the six skins");
+        require(controller.skin() == Skin::System,
+            "the default skin is not System");
+        require(controller.checkedMenuLabel() == QLatin1String("&System"),
+            "the menu does not check the applied skin");
+    }
+
+    // Dark and Light produce the palettes their names promise, and System puts
+    // back the one captured at startup.
+    {
+        QWidget parent;
+        ThemeController controller;
+        controller.createMenu(&parent);
+
+        int changes = 0;
+        QObject::connect(&controller, &ThemeController::skinChanged,
+            [&changes] { ++changes; });
+
+        controller.selectSkin(Skin::Dark);
+        require(changes == 1, "selecting Dark did not emit skinChanged once");
+        require(controller.skin() == Skin::Dark, "Dark was not applied");
+        require(controller.checkedMenuLabel() == QLatin1String("&Dark"),
+            "the menu check did not follow the applied skin");
+        {
+            const auto palette = QApplication::palette();
+            require(isDark(palette), "the Dark skin's window colour is light");
+            require(palette.color(QPalette::WindowText).lightness() > 127,
+                "the Dark skin's window text is not light");
+            require(palette.color(QPalette::Base).lightness() < 128,
+                "the Dark skin's text-entry background is not dark");
+            // A disabled group identical to the active one is the classic
+            // hand-rolled dark palette bug: every grayed-out control reads as
+            // enabled.
+            require(palette.color(QPalette::Disabled, QPalette::WindowText)
+                    != palette.color(QPalette::Active, QPalette::WindowText),
+                "the Dark skin cannot distinguish disabled text");
+            require(palette.color(QPalette::Disabled, QPalette::Text)
+                    != palette.color(QPalette::Active, QPalette::Text),
+                "the Dark skin cannot distinguish disabled item text");
+            // The frame shades have to stay ordered, or separators and sunken
+            // frames vanish into the background.
+            require(palette.color(QPalette::Light).lightness()
+                    > palette.color(QPalette::Dark).lightness(),
+                "the Dark skin's frame shades are not ordered");
+        }
+
+        // Re-selecting the applied skin is a no-op, not a second change.
+        controller.selectSkin(Skin::Dark);
+        require(changes == 1, "re-selecting the applied skin emitted a change");
+        require(controller.checkedMenuLabel() == QLatin1String("&Dark"),
+            "re-selecting the applied skin unchecked its menu action");
+
+        controller.selectSkin(Skin::Light);
+        require(changes == 2, "selecting Light did not emit skinChanged");
+        require(!isDark(QApplication::palette()),
+            "the Light skin's window colour is dark");
+        require(QApplication::palette().color(QPalette::WindowText).lightness()
+                < 128,
+            "the Light skin's window text is not dark");
+
+        // The three tinted skins are the neutral Dark set at a hue, so what
+        // is worth asserting is that the construction holds for each: dark,
+        // legible against both grounds, distinguishable when disabled, and --
+        // the one that actually regressed -- structured like the neutral skin,
+        // whose lightnesses are what keep Fusion's derived separator and
+        // check-box outlines visible. Their exact colours are the palette's
+        // business; only the accent Blue quotes from the icon is pinned.
+        const auto neutral = [&controller] {
+            controller.selectSkin(Skin::Dark);
+            return QApplication::palette();
+        }();
+        int expected = changes;
+        for (const auto skin : {Skin::Blue, Skin::Green, Skin::Maroon}) {
+            controller.selectSkin(skin);
+            ++expected;
+            require(changes == expected, "a tinted skin emitted no change");
+            const auto palette = QApplication::palette();
+            require(isDark(palette), "a tinted skin's window colour is light");
+            require(contrast(palette.color(QPalette::WindowText),
+                        palette.color(QPalette::Window)) >= 4.5,
+                "a tinted skin's text does not contrast with its chrome");
+            require(contrast(palette.color(QPalette::Text),
+                        palette.color(QPalette::Base)) >= 4.5,
+                "a tinted skin's text does not contrast with its entry fields");
+            require(contrast(palette.color(QPalette::HighlightedText),
+                        palette.color(QPalette::Highlight)) >= 4.5,
+                "a tinted skin's selected text does not contrast");
+            require(palette.color(QPalette::Disabled, QPalette::Text)
+                    != palette.color(QPalette::Active, QPalette::Text),
+                "a tinted skin cannot distinguish disabled item text");
+            require(palette.color(QPalette::Light).lightness()
+                    > palette.color(QPalette::Dark).lightness(),
+                "a tinted skin's frame shades are not ordered");
+            // Base above Window is what the first Blue got backwards: it put
+            // the menu ground, which Fusion derives from Base, far below the
+            // chrome, and the separators and check-box frames went with it.
+            require(palette.color(QPalette::Base).lightness()
+                    < palette.color(QPalette::Window).lightness(),
+                "a tinted skin's entry ground is not below its chrome");
+            for (const auto role : {QPalette::Window, QPalette::Base,
+                     QPalette::AlternateBase}) {
+                require(std::abs(palette.color(role).lightness()
+                            - neutral.color(role).lightness()) <= 6,
+                    "a tinted skin left the neutral skin's lightness band");
+            }
+        }
+
+        // The one colour in the tinted skins quoted rather than derived.
+        controller.selectSkin(Skin::Blue);
+        ++expected;
+        require(QApplication::palette().color(QPalette::Highlight)
+                == QColor(0x4a, 0xc3, 0xe2),
+            "the Blue skin's highlight is not the application icon's lens");
+
+        controller.selectSkin(Skin::System);
+        require(changes == expected + 1,
+            "returning to System did not emit skinChanged");
+        require(QApplication::palette() == systemPalette,
+            "System did not restore the palette captured at startup");
+        require(QApplication::style()->objectName() == systemStyle,
+            "System did not restore the style captured at startup");
+    }
+
+    // A skin picked in one window re-checks the menus of the others; the
+    // applied skin is a property of the application, not of a controller.
+    {
+        QWidget firstParent;
+        QWidget secondParent;
+        ThemeController first;
+        ThemeController second;
+        first.createMenu(&firstParent);
+        second.createMenu(&secondParent);
+
+        first.selectSkin(Skin::Dark);
+        require(second.skin() == Skin::Dark,
+            "a second controller did not see the applied skin");
+        require(second.checkedMenuLabel() == QLatin1String("&Dark"),
+            "a second controller's menu did not follow the applied skin");
+
+        second.selectSkin(Skin::System);
+        require(first.checkedMenuLabel() == QLatin1String("&System"),
+            "the first controller's menu did not follow the second's choice");
+    }
+
+    // Settings round-trip, and restore() applies without reporting a change.
+    {
+        QTemporaryDir directory;
+        require(directory.isValid(), "could not create a scratch directory");
+        const auto path = QDir(directory.path()).filePath("settings.ini");
+
+        {
+            QWidget parent;
+            ThemeController controller;
+            controller.createMenu(&parent);
+            controller.selectSkin(Skin::Blue);
+            QSettings settings(path, QSettings::IniFormat);
+            controller.save(settings);
+            settings.sync();
+            controller.selectSkin(Skin::System);
+        }
+        {
+            QSettings settings(path, QSettings::IniFormat);
+            require(settings.value(QStringLiteral("theme/skin")).toString()
+                    == QLatin1String("blue"),
+                "the stored skin is not the documented key");
+        }
+        {
+            QWidget parent;
+            ThemeController controller;
+            controller.createMenu(&parent);
+            int changes = 0;
+            QObject::connect(&controller, &ThemeController::skinChanged,
+                [&changes] { ++changes; });
+            const QSettings settings(path, QSettings::IniFormat);
+            controller.restore(settings);
+            require(controller.skin() == Skin::Blue,
+                "restore did not apply the stored skin");
+            require(changes == 0,
+                "restore emitted skinChanged, which would rewrite settings");
+            require(controller.checkedMenuLabel() == QLatin1String("&Blue"),
+                "restore did not check the stored skin in the menu");
+            controller.selectSkin(Skin::System);
+        }
+        // A settings file with no skin key, and one with a bad value, both
+        // leave the application on System.
+        {
+            const auto emptyPath = QDir(directory.path()).filePath("empty.ini");
+            QWidget parent;
+            ThemeController controller;
+            controller.createMenu(&parent);
+            controller.selectSkin(Skin::Dark);
+            const QSettings settings(emptyPath, QSettings::IniFormat);
+            controller.restore(settings);
+            require(controller.skin() == Skin::System,
+                "an absent stored skin did not restore System");
+        }
+    }
+
+    require(QApplication::palette() == systemPalette,
+        "the tests left the application palette changed");
+
+    std::cout << "theme controller tests passed\n";
+    return 0;
+}


### PR DESCRIPTION
View > Skin switches the application chrome, applied live to every window and persisted as theme/skin. Fusion plus an explicit palette, so it works on the Qt 6.4 minimum; the 6.8 colour-scheme hint is set as well. The three tints are the Dark set at a hue, sharing its lightnesses so they inherit its legibility; text pairs hold to WCAG AA.

Fusion derives separator and check-box outlines from the window colour and goes darker, which no palette role can reach and no dark skin survives, so a QProxyStyle draws them lighter. The viewports keep their fixed gray. ImageView repaints its placeholder on a palette change, and the two dialogs' inline error and warning text picks its contrast from the window.