### PR TITLE
Fix Variable menu mnemonic and detect shortcut conflicts

### DIFF
--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -102,6 +102,7 @@ if(AMREXPLORER_BUILD_TESTS)
         SmokeHarnessLifecycle.cpp
         SmokeHarnessRange.cpp
         SmokeHarnessRemote.cpp
+        SmokeHarnessShortcuts.cpp
         SmokeHarnessSequence.cpp
         SmokeHarnessVolume.cpp
         SmokeHarnessZoom.cpp)

--- a/src/qt/MainWindow.cpp
+++ b/src/qt/MainWindow.cpp
@@ -1451,7 +1451,7 @@ void MainWindow::createMenus()
     viewMenu->addMenu(m_themeController->createMenu(this));
 
     // Variable menu: lists all fields with a bullet on the active one.
-    m_variableMenu = menuBar()->addMenu(tr("&Variable"));
+    m_variableMenu = menuBar()->addMenu(tr("Va&riable"));
     // Menus hide action tooltips unless asked: the derived fields carry their
     // expressions there, and the Expression Editor entry carries the reason it
     // is unavailable, neither of which reaches anyone otherwise.

--- a/src/qt/SmokeHarness.cpp
+++ b/src/qt/SmokeHarness.cpp
@@ -43,6 +43,7 @@ Outcome dispatch(Context& context)
              &dispatchRange,
              &dispatchZoom,
              &dispatchFab,
+             &dispatchShortcuts,
              &dispatchSequence,
              &dispatchVolume,
              &dispatchDerived

--- a/src/qt/SmokeHarnessInternal.hpp
+++ b/src/qt/SmokeHarnessInternal.hpp
@@ -39,6 +39,8 @@ Outcome dispatchRange(Context& context);
 Outcome dispatchZoom(Context& context);
 // SmokeHarnessFab.cpp
 Outcome dispatchFab(Context& context);
+// SmokeHarnessShortcuts.cpp
+Outcome dispatchShortcuts(Context& context);
 // SmokeHarnessSequence.cpp
 Outcome dispatchSequence(Context& context);
 // SmokeHarnessVolume.cpp

--- a/src/qt/SmokeHarnessShortcuts.cpp
+++ b/src/qt/SmokeHarnessShortcuts.cpp
@@ -1,0 +1,197 @@
+#include "SmokeHarnessInternal.hpp"
+
+#include "MainWindow.hpp"
+
+#include <QAction>
+#include <QKeySequence>
+#include <QMenu>
+#include <QMenuBar>
+#include <QSet>
+#include <QShortcut>
+#include <QTimer>
+
+#include <filesystem>
+#include <map>
+#include <string_view>
+#include <vector>
+
+// Qt documents this switch but only declares it in headers for QDoc.
+QT_BEGIN_NAMESPACE
+Q_GUI_EXPORT void qt_set_sequence_auto_mnemonic(bool enabled);
+QT_END_NAMESPACE
+
+namespace amrvis::qt::smoke {
+
+namespace {
+
+bool checkMenuMnemonics(const QList<QAction*>& actions, const QString& path,
+    bool topLevel = false)
+{
+    std::map<QKeySequence, QString> siblings;
+    bool valid = true;
+    for (const auto* action : actions) {
+        if (action->isSeparator()) {
+            continue;
+        }
+        const auto label = action->text();
+        const auto key = QKeySequence::mnemonic(label);
+        // Numeric choices and data-derived labels need not have mnemonics.
+        if (!key.isEmpty()) {
+            const auto [previous, inserted] = siblings.emplace(key, label);
+            if (!inserted) {
+                qCritical("%s: '%s' and '%s' share mnemonic %s",
+                    qUtf8Printable(path), qUtf8Printable(previous->second),
+                    qUtf8Printable(label), qUtf8Printable(key.toString()));
+                valid = false;
+            }
+        } else if (topLevel) {
+            qCritical("%s: '%s' has no mnemonic", qUtf8Printable(path),
+                qUtf8Printable(label));
+            valid = false;
+        }
+        // Include disabled menus: they become reachable after opening data.
+        if (const auto* menu = action->menu()) {
+            if (!checkMenuMnemonics(menu->actions(),
+                    path + QStringLiteral(" > ") + label)) {
+                valid = false;
+            }
+        }
+    }
+    if (topLevel && siblings.empty()) {
+        qCritical("No top-level menu mnemonics were checked");
+        valid = false;
+    }
+    return valid;
+}
+
+struct ShortcutBinding {
+    QKeySequence key;
+    QString label;
+    const QObject* owner;
+};
+
+bool checkGlobalShortcuts(MainWindow& window)
+{
+    // Start with attached actions, not every owned QAction: controllers can
+    // retain actions after removing them from a menu. QSet also prevents a
+    // shared menu/toolbar action from being counted twice.
+    QSet<QAction*> actions;
+    const auto collect = [&actions](const QList<QAction*>& entries,
+                             auto&& self) -> void {
+        for (auto* action : entries) {
+            if (actions.contains(action)) {
+                continue;
+            }
+            actions.insert(action);
+            if (const auto* menu = action->menu()) {
+                self(menu->actions(), self);
+            }
+        }
+    };
+    collect(window.menuBar()->actions(), collect);
+    collect(window.actions(), collect);
+    for (const auto* widget : window.findChildren<QWidget*>()) {
+        // Separate top-level windows may legitimately reuse window shortcuts.
+        if (widget->window() == &window) {
+            collect(widget->actions(), collect);
+        }
+    }
+
+    std::vector<ShortcutBinding> bindings;
+    const auto global = [](Qt::ShortcutContext scope) {
+        return scope == Qt::WindowShortcut || scope == Qt::ApplicationShortcut;
+    };
+    for (const auto* action : actions) {
+        if (global(action->shortcutContext())) {
+            for (const auto& key : action->shortcuts()) {
+                if (!key.isEmpty()) {
+                    bindings.push_back({key, action->text(), action});
+                }
+            }
+        }
+    }
+    for (const auto* shortcut : window.findChildren<QShortcut*>()) {
+        const auto* widget = qobject_cast<QWidget*>(shortcut->parent());
+        if (widget != nullptr && widget->window() == &window
+            && global(shortcut->context())) {
+            for (const auto& key : shortcut->keys()) {
+                if (!key.isEmpty()) {
+                    bindings.push_back({key,
+                        QStringLiteral("QShortcut (%1)")
+                            .arg(shortcut->objectName()), shortcut});
+                }
+            }
+        }
+    }
+    // Only menu-bar mnemonics are window-wide Alt shortcuts. Submenu
+    // mnemonics are active inside that menu and are checked among siblings.
+    // In particular, bare B (Boxes) and Alt+B are different bindings.
+    for (const auto* action : window.menuBar()->actions()) {
+        const auto key = QKeySequence::mnemonic(action->text());
+        if (!key.isEmpty()) {
+            bindings.push_back({key,
+                QStringLiteral("Menu %1").arg(action->text()), action});
+        }
+    }
+
+    bool valid = true;
+    for (std::size_t i = 0; i < bindings.size(); ++i) {
+        for (std::size_t j = i + 1; j < bindings.size(); ++j) {
+            const auto& a = bindings[i];
+            const auto& b = bindings[j];
+            if (a.owner == b.owner) {
+                continue;
+            }
+            // Prefixes also conflict: a single-key shortcut can prevent a
+            // longer multi-key sequence from ever completing.
+            if (a.key.matches(b.key) != QKeySequence::NoMatch
+                || b.key.matches(a.key) != QKeySequence::NoMatch) {
+                qCritical("Global shortcuts: '%s' (%s) conflicts with '%s' (%s)",
+                    qUtf8Printable(a.label), qUtf8Printable(a.key.toString()),
+                    qUtf8Printable(b.label), qUtf8Printable(b.key.toString()));
+                valid = false;
+            }
+        }
+    }
+    return valid;
+}
+
+} // namespace
+
+Outcome dispatchShortcuts(Context& context)
+{
+    auto& application = context.application;
+    auto& window = context.window;
+    const int argc = context.argc;
+    char** argv = context.argv;
+
+    if (argc == 3
+        && std::string_view(argv[1]) == "--menu-shortcuts-smoke-test") {
+        // Qt handles escaped && and letter case. Enable extraction on macOS
+        // too, where mnemonics default to off; this process only runs the test.
+        qt_set_sequence_auto_mnemonic(true);
+        const auto check = [&window] {
+            const bool menus = checkMenuMnemonics(window.menuBar()->actions(),
+                QStringLiteral("Menu bar"), true);
+            const bool shortcuts = checkGlobalShortcuts(window);
+            return menus && shortcuts;
+        };
+        if (!check()) {
+            return {true, 1};
+        }
+        // Check again once the Variable and Level menus have been populated.
+        QObject::connect(&window, &amrvis::qt::MainWindow::datasetOpenFinished,
+            &application, [&application, check](bool success) {
+                application.exit(success && check() ? 0 : 1);
+            });
+        QTimer::singleShot(0, &window,
+            [&window, path = std::filesystem::path(argv[2])] {
+                window.openDataset(path, true);
+            });
+    } else {
+        return {false, std::nullopt};
+    }
+    return {true, std::nullopt};
+}
+
+} // namespace amrvis::qt::smoke

--- a/src/qt/SmokeHarnessShortcuts.cpp
+++ b/src/qt/SmokeHarnessShortcuts.cpp
@@ -10,9 +10,11 @@
 #include <QShortcut>
 #include <QTimer>
 
+#include <algorithm>
 #include <filesystem>
 #include <map>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 // Qt documents this switch but only declares it in headers for QDoc.
@@ -24,8 +26,15 @@ namespace amrvis::qt::smoke {
 
 namespace {
 
+struct ShortcutBinding {
+    QKeySequence key;
+    QString label;
+    const QObject* owner;
+    bool mnemonic = false;
+};
+
 bool checkMenuMnemonics(const QList<QAction*>& actions, const QString& path,
-    bool topLevel = false)
+    std::vector<ShortcutBinding>& menuBindings, bool topLevel = false)
 {
     std::map<QKeySequence, QString> siblings;
     bool valid = true;
@@ -44,6 +53,10 @@ bool checkMenuMnemonics(const QList<QAction*>& actions, const QString& path,
                     qUtf8Printable(label), qUtf8Printable(key.toString()));
                 valid = false;
             }
+            if (topLevel && action->isEnabled() && action->isVisible()) {
+                menuBindings.push_back({key,
+                    QStringLiteral("Menu %1").arg(label), action, true});
+            }
         } else if (topLevel) {
             qCritical("%s: '%s' has no mnemonic", qUtf8Printable(path),
                 qUtf8Printable(label));
@@ -52,7 +65,7 @@ bool checkMenuMnemonics(const QList<QAction*>& actions, const QString& path,
         // Include disabled menus: they become reachable after opening data.
         if (const auto* menu = action->menu()) {
             if (!checkMenuMnemonics(menu->actions(),
-                    path + QStringLiteral(" > ") + label)) {
+                    path + QStringLiteral(" > ") + label, menuBindings)) {
                 valid = false;
             }
         }
@@ -64,13 +77,8 @@ bool checkMenuMnemonics(const QList<QAction*>& actions, const QString& path,
     return valid;
 }
 
-struct ShortcutBinding {
-    QKeySequence key;
-    QString label;
-    const QObject* owner;
-};
-
-bool checkGlobalShortcuts(MainWindow& window)
+bool checkGlobalShortcuts(MainWindow& window,
+    std::vector<ShortcutBinding> bindings)
 {
     // Start with attached actions, not every owned QAction: controllers can
     // retain actions after removing them from a menu. QSet also prevents a
@@ -79,11 +87,14 @@ bool checkGlobalShortcuts(MainWindow& window)
     const auto collect = [&actions](const QList<QAction*>& entries,
                              auto&& self) -> void {
         for (auto* action : entries) {
-            if (actions.contains(action)) {
+            if (!action->isEnabled() || !action->isVisible()
+                || actions.contains(action)) {
                 continue;
             }
             actions.insert(action);
             if (const auto* menu = action->menu()) {
+                // A closed popup still contributes window shortcuts. Its
+                // menu action's enabled/visible state controls reachability.
                 self(menu->actions(), self);
             }
         }
@@ -92,12 +103,12 @@ bool checkGlobalShortcuts(MainWindow& window)
     collect(window.actions(), collect);
     for (const auto* widget : window.findChildren<QWidget*>()) {
         // Separate top-level windows may legitimately reuse window shortcuts.
-        if (widget->window() == &window) {
+        if (widget->window() == &window && widget->isEnabled()
+            && widget->isVisible()) {
             collect(widget->actions(), collect);
         }
     }
 
-    std::vector<ShortcutBinding> bindings;
     const auto global = [](Qt::ShortcutContext scope) {
         return scope == Qt::WindowShortcut || scope == Qt::ApplicationShortcut;
     };
@@ -112,7 +123,9 @@ bool checkGlobalShortcuts(MainWindow& window)
     }
     for (const auto* shortcut : window.findChildren<QShortcut*>()) {
         const auto* widget = qobject_cast<QWidget*>(shortcut->parent());
-        if (widget != nullptr && widget->window() == &window
+        if (shortcut->isEnabled() && widget != nullptr
+            && widget->window() == &window && widget->isEnabled()
+            && widget->isVisible()
             && global(shortcut->context())) {
             for (const auto& key : shortcut->keys()) {
                 if (!key.isEmpty()) {
@@ -123,23 +136,14 @@ bool checkGlobalShortcuts(MainWindow& window)
             }
         }
     }
-    // Only menu-bar mnemonics are window-wide Alt shortcuts. Submenu
-    // mnemonics are active inside that menu and are checked among siblings.
-    // In particular, bare B (Boxes) and Alt+B are different bindings.
-    for (const auto* action : window.menuBar()->actions()) {
-        const auto key = QKeySequence::mnemonic(action->text());
-        if (!key.isEmpty()) {
-            bindings.push_back({key,
-                QStringLiteral("Menu %1").arg(action->text()), action});
-        }
-    }
-
     bool valid = true;
     for (std::size_t i = 0; i < bindings.size(); ++i) {
         for (std::size_t j = i + 1; j < bindings.size(); ++j) {
             const auto& a = bindings[i];
             const auto& b = bindings[j];
-            if (a.owner == b.owner) {
+            // Menu/menu conflicts were already diagnosed by the recursive
+            // mnemonic check. Here only compare them with explicit shortcuts.
+            if (a.owner == b.owner || (a.mnemonic && b.mnemonic)) {
                 continue;
             }
             // Prefixes also conflict: a single-key shortcut can prevent a
@@ -171,22 +175,58 @@ Outcome dispatchShortcuts(Context& context)
         // too, where mnemonics default to off; this process only runs the test.
         qt_set_sequence_auto_mnemonic(true);
         const auto check = [&window] {
+            std::vector<ShortcutBinding> menuBindings;
             const bool menus = checkMenuMnemonics(window.menuBar()->actions(),
-                QStringLiteral("Menu bar"), true);
-            const bool shortcuts = checkGlobalShortcuts(window);
+                QStringLiteral("Menu bar"), menuBindings, true);
+            const bool shortcuts = checkGlobalShortcuts(window,
+                std::move(menuBindings));
             return menus && shortcuts;
         };
         if (!check()) {
             return {true, 1};
         }
-        // Check again once the Variable and Level menus have been populated.
+        // Metadata completion precedes menu population. Only a full initial
+        // slice configures the controls and installs the data-driven actions.
         QObject::connect(&window, &amrvis::qt::MainWindow::datasetOpenFinished,
-            &application, [&application, check](bool success) {
-                application.exit(success && check() ? 0 : 1);
+            &application, [&application](bool success) {
+                if (!success) {
+                    qCritical("Menu shortcut test: dataset metadata failed");
+                    application.exit(1);
+                }
             });
+        QObject::connect(&window, &amrvis::qt::MainWindow::initialSliceFinished,
+            &application, [&application, &window, check](bool success) {
+                if (!success) {
+                    qCritical("Menu shortcut test: initial slice failed");
+                    application.exit(1);
+                    return;
+                }
+                // This fixture has two fields and two AMR levels. Assert the
+                // actual menus, so an early signal cannot silently erase the
+                // populated-state coverage again.
+                const auto menus = window.findChildren<QMenu*>();
+                for (const auto* name : {"Variable", "Level"}) {
+                    const auto found = std::find_if(menus.begin(), menus.end(),
+                        [name](const QMenu* menu) {
+                            return QString(menu->title()).remove('&')
+                                == QString::fromLatin1(name);
+                        });
+                    if (found == menus.end() || (*found)->actions().size() < 3) {
+                        qCritical("Menu shortcut test: %s menu was not populated",
+                            name);
+                        application.exit(1);
+                        return;
+                    }
+                }
+                application.exit(check() ? 0 : 1);
+            });
+        QTimer::singleShot(20000, &application, [&application] {
+            qCritical("Menu shortcut test: timed out waiting for initial slice");
+            application.exit(1);
+        });
         QTimer::singleShot(0, &window,
             [&window, path = std::filesystem::path(argv[2])] {
-                window.openDataset(path, true);
+                window.openDataset(path);
             });
     } else {
         return {false, std::nullopt};

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1882,6 +1882,19 @@ if(TARGET amrexplorer_qt)
             -P "${CMAKE_CURRENT_SOURCE_DIR}/qt_smoke_driver.cmake"
     )
     set_tests_properties(qt_spherical_scale_report_smoke PROPERTIES TIMEOUT 30)
+    # Check sibling mnemonics at every menu depth and window-wide shortcuts,
+    # before opening data and after the dynamic menus have been populated.
+    add_test(
+        NAME qt_menu_shortcuts_smoke
+        COMMAND "${CMAKE_COMMAND}"
+            "-DMATERIALIZER=$<TARGET_FILE:fixture_materializer>"
+            "-DAMREXPLORER_QT=$<TARGET_FILE:amrexplorer_qt>"
+            "-DSOURCE=${CMAKE_CURRENT_SOURCE_DIR}/data/plotfile_2d"
+            "-DWORK=${CMAKE_CURRENT_BINARY_DIR}/fixtures_menu_shortcuts"
+            -DMODE=menu-shortcuts
+            -P "${CMAKE_CURRENT_SOURCE_DIR}/qt_smoke_driver.cmake"
+    )
+    set_tests_properties(qt_menu_shortcuts_smoke PROPERTIES TIMEOUT 30)
     # Controls reachable before any dataset is: an Animation panel opened from
     # the View menu with nothing loaded must not survive the next open holding
     # no controls, and Reset Zoom with no views must still report Fit.

--- a/tests/qt_smoke_driver.cmake
+++ b/tests/qt_smoke_driver.cmake
@@ -28,7 +28,7 @@
 #                 derived-field-frames | derived-field-playback |
 #                 scale-state | effective-scale |
 #                 arrow-key-routing | animation-dock-role | open-failure |
-#                 idle-ui-state | sequence-scale-report |
+#                 idle-ui-state | menu-shortcuts | sequence-scale-report |
 #                 spherical-scale-report |
 #                 fixed-scale-centre | fab-overlap-failure |
 #                 fab-direct-open-failure
@@ -58,7 +58,10 @@ macro(run_or_die)
     endif()
 endmacro()
 
-if(MODE STREQUAL "slice")
+if(MODE STREQUAL "menu-shortcuts")
+    run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt")
+    run_or_die("${AMREXPLORER_QT}" --menu-shortcuts-smoke-test "${WORK}/plt")
+elseif(MODE STREQUAL "slice")
     run_or_die("${MATERIALIZER}" "${SOURCE}" "${WORK}/plt")
     run_or_die("${AMREXPLORER_QT}" --slice-smoke-test "${WORK}/plt")
 elseif(MODE STREQUAL "volume")


### PR DESCRIPTION
Use Alt+R for Variable to avoid conflicting with View. Add a Qt smoke test for recursive menu mnemonics and window-wide shortcuts before and after loading data.