### PR TITLE
Remote compute-node workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ FAB and MultiFab data.
   applications
 - **[User Guide](docs/user-guide.md)** — workflows, controls, animation,
   export, shortcuts, and troubleshooting
+- **[Slurm Remote Workflow](docs/slurm-remote.md)** — run the server on an
+  allocated compute node, with an OLCF Riker example
 - **[Developer Build Guide](docs/building.md)** — CMake presets, supported
   compilers, and validation
 - **[Architecture](docs/ARCHITECTURE.md)** — layering, the dataset-session

--- a/docs/slurm-remote.md
+++ b/docs/slurm-remote.md
@@ -1,0 +1,252 @@
+# Remote visualization on a Slurm cluster
+
+Run the AMReXplorer desktop application locally and its server on a compute
+node allocated by Slurm. A small launcher on the cluster discovers a named
+allocation and starts the server with `srun`:
+
+```text
+Local AMReXplorer → SSH → cluster login node → srun → compute-node server
+```
+
+The connection uses stdin/stdout throughout. No VNC, X11, listening port, or
+SSH port forwarding is needed. The allocation's job ID can change between
+sessions without editing the launcher. This workflow uses AMReXplorer's
+existing remote mode; it does not require scheduler support in the client.
+
+## Prerequisites
+
+- A local AMReXplorer client with SSH remote support (macOS or Linux).
+- SSH access to a cluster login node where `squeue` and `srun` are available
+  in noninteractive sessions, and site policy permits launching job steps
+  from that node.
+- A compatible `amrexplorer-server` installed on a filesystem visible to
+  compute nodes. Use the same source revision as the client; see the
+  [server-only build instructions](../INSTALL.md#hpc-systems). The examples
+  assume `~/.local/bin/amrexplorer-server`.
+- Plotfiles on a filesystem visible to the compute node.
+
+Replace `USERNAME`, `PROJECT`, `LOGIN_HOST`, and dataset paths below with your
+cluster's values. Partition names, memory limits, module setup, and allocation
+policies vary by site; consult its documentation.
+
+## 1. Reserve a named allocation
+
+In a terminal, connect to the cluster and request one task with eight CPUs:
+
+```bash
+ssh USERNAME@LOGIN_HOST
+salloc -A PROJECT -p PARTITION -N 1 -n 1 -c 8 \
+    -t 01:00:00 --job-name=amrexplorer
+```
+
+Wait until the allocation is granted. Keep this terminal and its allocation
+shell open while visualizing. Reserve this allocation for the server; another
+job step consuming its CPUs can prevent the server step from starting. Add a
+memory request appropriate to your data and the cluster's policy if needed.
+
+The current client launches the server with eight worker threads, which is
+why both allocation and launcher examples request eight CPUs. One server
+process is sufficient for this workflow; it does not require a GPU allocation.
+
+Use exactly one running allocation named `amrexplorer` per user on the
+cluster. The launcher below rejects zero or multiple matches. For separate
+workflows, use distinct job names and a corresponding launcher for each.
+
+### Example: OLCF Riker
+
+Riker provides CPU resources in the `batch` partition and supports partial-node
+allocations, with cores and memory coupled by site policy. For example:
+
+```bash
+ssh USERNAME@riker-login1.olcf.ornl.gov
+salloc -A PROJECT -p batch -N 1 -n 1 -c 8 \
+    -t 01:00:00 --job-name=amrexplorer
+```
+
+A dataset path might be
+`/lustre/orion/PROJECT/scratch/USERNAME/run/plt00010`. Check the current
+[Riker user guide](https://docs.olcf.ornl.gov/systems/riker_user_guide.html)
+for access, resource requests, and filesystem details.
+
+## 2. Install the launcher once
+
+On the cluster, create the script directory:
+
+```bash
+mkdir -p ~/bin
+```
+
+Save the following as `~/bin/amrexplorer-slurm`:
+
+```bash
+#!/bin/bash
+set -euo pipefail
+
+# Load any required Slurm/server runtime modules here.
+# Send their output to stderr, for example: module load gcc >&2
+
+# A separate SSH session does not inherit the allocation shell's job ID.
+# Query Slurm instead. Capture separately so an squeue failure is fatal.
+job_ids=$(squeue --local --noheader \
+    --user="$(id -un)" \
+    --name=amrexplorer \
+    --states=RUNNING \
+    --format='%A')
+
+jobs=()
+while read -r job_id; do
+    [[ -z "$job_id" ]] || jobs+=("$job_id")
+done <<< "$job_ids"
+
+case ${#jobs[@]} in
+    0)
+        echo "No running 'amrexplorer' allocation. Run salloc first." >&2
+        exit 1
+        ;;
+    1)
+        ;;
+    *)
+        echo "Multiple running 'amrexplorer' allocations; use a unique job name." >&2
+        exit 1
+        ;;
+esac
+
+exec srun --jobid="${jobs[0]}" \
+    --nodes=1 --ntasks=1 --cpus-per-task=8 \
+    "$HOME/.local/bin/amrexplorer-server" "$@"
+```
+
+Make it executable:
+
+```bash
+chmod +x ~/bin/amrexplorer-slurm
+```
+
+Keep `"$@"`: the client passes `--stdio --threads 8` through the launcher to
+the server. The lookup uses only your running jobs on the local Slurm cluster;
+it does not select pending jobs or allocations from other federated clusters.
+See the [Slurm squeue documentation](https://slurm.schedmd.com/squeue.html).
+
+Keep stdout dedicated to the server protocol. Write launcher diagnostics and
+module output to stderr. Do not add `srun --pty`, `--unbuffered`, `--label`,
+`--async`, output-file redirection, or `2>&1`: these can alter or disconnect the
+protocol stream. In particular, Slurm's `--unbuffered` uses a pseudo-terminal.
+See the [Slurm srun documentation](https://slurm.schedmd.com/srun.html).
+
+## Optional: size caches from the job's memory allowance
+
+With a server that supports `--cache-memory-fraction`, add the option to the
+launcher's final command:
+
+```bash
+exec srun --jobid="${jobs[0]}" \
+    --nodes=1 --ntasks=1 --cpus-per-task=8 \
+    "$HOME/.local/bin/amrexplorer-server" \
+    --cache-memory-fraction 0.5 "$@"
+```
+
+Detection happens inside the compute-node server, after `srun` places it in
+the job step. On Linux the server reads its cgroup v2 `memory.max` (or v1
+`memory.limit_in_bytes`), including visible ancestor limits. It also considers
+`SLURM_MEM_PER_NODE`, or `SLURM_MEM_PER_CPU` multiplied by
+`SLURM_CPUS_ON_NODE`, when available. The smallest discovered bound wins,
+limited by physical RAM. Unlimited cgroup values do not count as a bound.
+See the [Linux cgroup documentation](https://docs.kernel.org/admin-guide/cgroup-v2.html)
+and [Slurm environment variables](https://slurm.schedmd.com/sbatch.html).
+
+The fraction must be greater than zero and at most one. `0.5` assigns half
+of that limit to **one shared allowance for cached block data and sampled
+volume grids across every dataset and connection in this server process**.
+A dataset can use available space without dividing the allowance by the
+maximum number of datasets. Under pressure, caches evict unpinned entries;
+entries still used by active requests remain charged until released. If
+space cannot be reclaimed, block queries report cache pressure and volume
+grids can render uncached, as with the existing per-dataset cache limits.
+
+The detected limit and shared allowance are logged to stderr during startup.
+Detection is performed once; it does not track changes to the allocation or
+measure currently free memory. For example, a detected 128 GiB limit with
+`0.5` gives a 64 GiB shared cache allowance. This replaces the client's initial
+block-cache request (normally 1 GiB). Later client budget changes can reduce
+that dataset's budget, but cannot raise it above the shared allowance.
+`--volume-cache-mib` remains an additional per-dataset volume-grid cap.
+
+Leave headroom: the allowance covers cached payloads, **not total process
+memory**. Metadata, particles, in-flight block reads, uncached volume grids,
+rendering buffers, and other job processes consume additional memory. Half
+is a starting policy, not a guarantee against an out-of-memory failure.
+Separate server processes have separate allowances; use one server process
+per allocation with this recipe.
+
+If detection fails, the server refuses startup with an explanation. In a
+Slurm job it will not substitute the whole node's RAM for an unknown job
+limit; an explicit `SLURM_MEM_PER_NODE=0` represents Slurm's all-node-memory
+request. Outside Slurm, Linux physical RAM is the fallback when no finite
+cgroup limit is found. On other operating systems, automatic detection needs
+the Slurm memory variables. Omit the option to retain existing client-selected
+cache budgets; setting `AMREXPLORER_CACHE_SIZE_MB` in the remote launcher does
+not configure the block cache because that variable is read by the local
+client.
+
+## 3. Connect from the local client
+
+```bash
+amrexplorer --ssh USERNAME@LOGIN_HOST \
+    --server '~/bin/amrexplorer-slurm' \
+    /shared/path/to/plt00010
+```
+
+For the Riker example:
+
+```bash
+amrexplorer --ssh USERNAME@riker-login1.olcf.ornl.gov \
+    --server '~/bin/amrexplorer-slurm' \
+    /lustre/orion/PROJECT/scratch/USERNAME/run/plt00010
+```
+
+Alternatively, choose **File > Open Remote Plotfile...** or **File > Open
+Remote Plotfile Sequence...**. Enter the login-node SSH destination and
+`~/bin/amrexplorer-slurm` as the server executable, then use **Browse...** or
+enter the remote path. The client remembers the executable per destination.
+SSH aliases and authentication work as described in the
+[remote-datasets guide](user-guide.md#remote-datasets).
+
+Each new connection discovers the current allocation and starts a server job
+step inside it. You do not need to know the compute-node hostname or start a
+server manually. Use one active server session per allocation with this
+eight-CPU setup; additional sessions may wait for resources.
+
+## 4. Finish and release resources
+
+Close the remote viewer to end its server session. The separately reserved
+Slurm allocation remains active until you release it or its walltime expires.
+Exit the allocation shell in the original terminal, or cancel the allocation
+explicitly using its ID:
+
+```bash
+squeue --local --user="$(id -un)" --name=amrexplorer
+scancel JOB_ID
+```
+
+For the next session, repeat the named `salloc` request and reconnect. The
+launcher requires no changes.
+
+## Troubleshooting
+
+- **No running allocation:** wait for `salloc` to grant resources. Check the
+  job name, owner, and cluster. Pending jobs are intentionally excluded.
+- **Multiple matching allocations:** release the unused allocation or give
+  each workflow a distinct name and update its launcher's `--name` filter.
+- **Connection startup times out:** the client currently allows five minutes
+  for startup, including authentication and server launch. Allocate before
+  connecting and ensure another step is not occupying the reserved CPUs.
+- **Missing command or shared library:** noninteractive SSH may not load the
+  same environment as your terminal. Initialize the site's module system and
+  load required modules in the launcher, with output directed to stderr;
+  verify the server path is accessible from compute nodes.
+- **Allocation ends during use:** walltime expiry or cancellation terminates
+  the server. Obtain a new allocation and reconnect.
+
+An automatic `srun` resource request inside the launcher is possible, but its
+queue wait would count against the client's startup timeout. This workflow
+keeps allocation separate so queue delays do not interrupt connection setup.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -47,6 +47,11 @@ true physical space — see [2-D spherical coordinates](#2-d-spherical-coordinat
 
 ## Remote datasets
 
+For compute nodes managed by a scheduler, see
+[Remote visualization on a Slurm cluster](slurm-remote.md), including an OLCF
+Riker example, a launcher that discovers your allocation automatically, and
+optional cache sizing from the job's memory limit.
+
 AMReXplorer can display plotfiles that live on another Linux machine, such as
 an HPC login node. The client runs `amrexplorer-server` on the remote machine
 through `ssh` and speaks its protocol over that ssh connection's own

--- a/include/amrexplorer/cache/ByteLruCache.hpp
+++ b/include/amrexplorer/cache/ByteLruCache.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <amrexplorer/cache/CacheMetrics.hpp>
+#include <amrexplorer/cache/SharedCacheBudget.hpp>
 
 #include <cstdint>
 #include <functional>
@@ -111,6 +112,18 @@ public:
     {
     }
 
+    // Attach once, before the cache is published or populated.
+    void setSharedBudget(std::shared_ptr<SharedCacheBudget> budget) {
+        std::scoped_lock lock(m_state->mutex);
+        if (!m_state->entries.empty() || m_state->sharedBudget) {
+            throw std::logic_error("shared cache budget must be attached before use");
+        }
+        if (budget) {
+            budget->add(m_state);
+            m_state->sharedBudget = std::move(budget);
+        }
+    }
+
     [[nodiscard]] Handle findAndPin(const Key& key)
     {
         std::scoped_lock lock(m_state->mutex);
@@ -166,10 +179,51 @@ public:
         // If pinned entries alone already leave no room, the insert cannot
         // succeed regardless of eviction; fail before discarding unpinned data
         // that the doomed insert would otherwise evict for nothing.
-        if (m_state->metrics.pinnedBytes + bytes > m_state->metrics.budgetBytes) {
+        if (m_state->metrics.pinnedBytes > m_state->metrics.budgetBytes ||
+            bytes > m_state->metrics.budgetBytes - m_state->metrics.pinnedBytes) {
             throw CacheBudgetExceeded("cache budget is occupied by pinned entries");
         }
         evictFor(*m_state, bytes, doomed);
+
+        if (const auto& shared = m_state->sharedBudget) {
+            // Release evicted payloads before requesting their space again.
+            // In shared mode this occasionally frees memory under the local
+            // lock; cross-cache reclamation uses try_lock to avoid lock cycles.
+            doomed.clear();
+            bool reserved = shared->tryReserve(bytes);
+            if (!reserved) {
+                evictFor(*m_state, m_state->metrics.budgetBytes, doomed);
+                doomed.clear();
+                reserved = shared->reserveWithReclaim(bytes, m_state.get());
+            }
+            if (!reserved) {
+                throw CacheBudgetExceeded(
+                    "server cache budget is occupied by pinned or busy entries");
+            }
+            // Charge until the final payload reference goes away, including
+            // escaped value() references and handles surviving cache closure.
+            struct ChargedValue {
+                std::shared_ptr<SharedCacheBudget> budget;
+                std::uint64_t bytes;
+                std::shared_ptr<const Value> payload;
+                ~ChargedValue() {
+                    payload.reset();
+                    budget->release(bytes);
+                }
+            };
+            std::shared_ptr<ChargedValue> charged;
+            try {
+                charged = std::make_shared<ChargedValue>();
+            } catch (...) {
+                shared->release(bytes);
+                throw;
+            }
+            charged->budget = shared;
+            charged->bytes = bytes;
+            charged->payload = std::move(value);
+            const auto* payload = charged->payload.get();
+            value = std::shared_ptr<const Value>(std::move(charged), payload);
+        }
 
         // Publish first, account second. Both allocating steps -- the LRU node
         // and the map node -- happen before either byte counter moves, so a
@@ -253,12 +307,22 @@ private:
 
     using EntryMap = std::unordered_map<Key, Entry, Hash>;
 
-    struct State {
+    struct State : SharedCacheBudget::Participant {
         explicit State(std::uint64_t budgetBytes)
         {
             metrics.budgetBytes = budgetBytes;
         }
 
+        void reclaimUnpinned() override {
+            std::vector<std::shared_ptr<const Value>> doomed;
+            std::unique_lock lock(mutex, std::try_to_lock);
+            if (!lock.owns_lock()) {
+                return;
+            }
+            evictFor(*this, metrics.budgetBytes, doomed);
+        }
+
+        std::shared_ptr<SharedCacheBudget> sharedBudget;
         mutable std::mutex mutex;
         CacheMetrics metrics;
         std::list<Key> lru;
@@ -313,9 +377,9 @@ private:
         std::vector<std::shared_ptr<const Value>>& doomed)
     {
         auto it = state.lru.end();
-        while (it != state.lru.begin()
-            && state.metrics.residentBytes + incomingBytes
-                > state.metrics.budgetBytes) {
+        while (it != state.lru.begin() &&
+               (state.metrics.residentBytes > state.metrics.budgetBytes ||
+                incomingBytes > state.metrics.budgetBytes - state.metrics.residentBytes)) {
             const auto candidate = std::prev(it);
             const auto found = state.entries.find(*candidate);
             if (found != state.entries.end() && found->second.pinCount == 0) {

--- a/include/amrexplorer/cache/SharedCacheBudget.hpp
+++ b/include/amrexplorer/cache/SharedCacheBudget.hpp
@@ -1,0 +1,81 @@
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <vector>
+
+namespace amrvis {
+
+// Admission control for cached payloads across otherwise independent LRUs.
+// Transient query/render allocations are deliberately outside this allowance.
+class SharedCacheBudget {
+public:
+    struct Participant {
+        virtual ~Participant() = default;
+        // Must not wait for another cache's lock: callers can hold their own.
+        virtual void reclaimUnpinned() = 0;
+    };
+
+    explicit SharedCacheBudget(std::uint64_t bytes)
+        : m_limit(bytes)
+    {
+    }
+    [[nodiscard]] std::uint64_t limit() const noexcept { return m_limit; }
+    [[nodiscard]] std::uint64_t used() const
+    {
+        std::scoped_lock lock(m_mutex);
+        return m_used;
+    }
+    void add(const std::shared_ptr<Participant>& participant)
+    {
+        std::scoped_lock lock(m_mutex);
+        std::erase_if(m_participants, [](const auto& p) { return p.expired(); });
+        m_participants.push_back(participant);
+    }
+    [[nodiscard]] bool tryReserve(std::uint64_t bytes)
+    {
+        std::scoped_lock lock(m_mutex);
+        if (bytes > m_limit - m_used) {
+            return false;
+        }
+        m_used += bytes;
+        return true;
+    }
+    [[nodiscard]] bool reserveWithReclaim(std::uint64_t bytes, const Participant* caller)
+    {
+        if (tryReserve(bytes)) {
+            return true;
+        }
+        if (bytes > m_limit) {
+            return false;
+        }
+        std::vector<std::weak_ptr<Participant>> participants;
+        {
+            std::scoped_lock lock(m_mutex);
+            participants = m_participants;
+        }
+        for (const auto& weak : participants) {
+            if (const auto participant = weak.lock(); participant && participant.get() != caller) {
+                participant->reclaimUnpinned();
+                if (tryReserve(bytes)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+    void release(std::uint64_t bytes) noexcept
+    {
+        std::scoped_lock lock(m_mutex);
+        m_used -= bytes;
+    }
+
+private:
+    const std::uint64_t m_limit;
+    mutable std::mutex m_mutex;
+    std::uint64_t m_used = 0;
+    std::vector<std::weak_ptr<Participant>> m_participants;
+};
+
+} // namespace amrvis

--- a/include/amrexplorer/data/LocalDatasetSession.hpp
+++ b/include/amrexplorer/data/LocalDatasetSession.hpp
@@ -128,6 +128,8 @@ public:
     // which is what a user setting one number wants -- but a server applying
     // a *client's* requested budget must not let it raise the sampled-grid
     // cache past the limit the operator set with --volume-cache-mib.
+    void setSharedCacheBudget(std::shared_ptr<SharedCacheBudget> budget);
+
     [[nodiscard]] bool setBlockCacheBudget(std::uint64_t bytes);
 
     // The sampled-grid pool on its own. cacheMetrics() reports the block

--- a/include/amrexplorer/io/PlotfileDataset.hpp
+++ b/include/amrexplorer/io/PlotfileDataset.hpp
@@ -96,6 +96,7 @@ public:
     [[nodiscard]] CacheMetrics cacheMetrics() const;
     [[nodiscard]] bool setCacheBudget(std::uint64_t bytes);
     void clearUnpinnedCache();
+    void setSharedCacheBudget(std::shared_ptr<SharedCacheBudget> budget);
 
 private:
     // The field list this dataset presents: the stored metadata with one field

--- a/include/amrexplorer/remote/MemoryLimit.hpp
+++ b/include/amrexplorer/remote/MemoryLimit.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <optional>
+#include <string>
+
+namespace amrvis::remote {
+
+// Injectable OS inputs let Linux hierarchy handling be tested on every host.
+struct MemoryLimitInputs {
+    std::string cgroupMembership;
+    std::string mountInfo;
+    std::function<std::optional<std::string>(const std::string&)> readFile;
+    std::function<std::optional<std::string>(const std::string&)> environment;
+    std::optional<std::uint64_t> physicalBytes;
+};
+struct MemoryLimit {
+    std::uint64_t bytes;
+    std::string source;
+};
+[[nodiscard]] std::optional<MemoryLimit> detectMemoryLimit(const MemoryLimitInputs& inputs);
+[[nodiscard]] std::optional<MemoryLimit> detectMemoryLimit();
+[[nodiscard]] double parseCacheMemoryFraction(const std::string& text);
+[[nodiscard]] std::uint64_t cacheBytesForFraction(std::uint64_t bytes, double fraction);
+
+} // namespace amrvis::remote

--- a/include/amrexplorer/remote/Server.hpp
+++ b/include/amrexplorer/remote/Server.hpp
@@ -40,8 +40,8 @@ struct ServerOptions {
     // from. A grid is four bytes per voxel.
     //
     // Each bounds one thing -- one grid, and one dataset's cache -- not the
-    // server's memory in total. The aggregate is these multiplied by
-    // maximumDatasets and maximumConnections, plus one transient grid per
+    // server's memory in total. Without totalCacheBytes, the aggregate is
+    // multiplied by maximumDatasets and maximumConnections, plus one transient grid per
     // request in flight, so an operator sizing a host has to do that
     // arithmetic rather than read either number as a ceiling.
     //
@@ -67,6 +67,10 @@ struct ServerOptions {
     // generates a fresh random token at construction; there is no way to
     // disable the check. See token().
     std::string sessionToken;
+    // Zero preserves client-selected per-dataset budgets. Nonzero enables
+    // automatic block sizing and a shared allowance across all block/grid
+    // caches and connections. This bounds cached payloads, not process RSS.
+    std::uint64_t totalCacheBytes = 0;
 };
 
 class Server {

--- a/resources/user-guide.qrc
+++ b/resources/user-guide.qrc
@@ -1,6 +1,10 @@
 <RCC>
     <qresource prefix="/docs">
         <file alias="user-guide.md">../docs/user-guide.md</file>
+        <file alias="slurm-remote.md">../docs/slurm-remote.md</file>
         <file alias="images/user-guide-overview.png">../docs/images/user-guide-overview.png</file>
+    </qresource>
+    <qresource prefix="/">
+        <file alias="INSTALL.md">../INSTALL.md</file>
     </qresource>
 </RCC>

--- a/src/data/LocalDatasetSession.cpp
+++ b/src/data/LocalDatasetSession.cpp
@@ -450,6 +450,11 @@ bool LocalDatasetSession::setVolumeGridCacheBudget(std::uint64_t bytes)
     return m_volumeGrids.setBudget(bytes);
 }
 
+void LocalDatasetSession::setSharedCacheBudget(std::shared_ptr<SharedCacheBudget> budget) {
+    requireDataset()->setSharedCacheBudget(budget);
+    m_volumeGrids.setSharedBudget(std::move(budget));
+}
+
 bool LocalDatasetSession::setBlockCacheBudget(std::uint64_t bytes)
 {
     return requireDataset()->setCacheBudget(bytes);

--- a/src/io/plotfile/PlotfileDataset.cpp
+++ b/src/io/plotfile/PlotfileDataset.cpp
@@ -433,6 +433,10 @@ CacheMetrics PlotfileDataset::cacheMetrics() const
     return m_cache.metrics();
 }
 
+void PlotfileDataset::setSharedCacheBudget(std::shared_ptr<SharedCacheBudget> budget) {
+    m_cache.setSharedBudget(std::move(budget));
+}
+
 bool PlotfileDataset::setCacheBudget(std::uint64_t bytes)
 {
     return m_cache.setBudget(bytes);

--- a/src/remote/CMakeLists.txt
+++ b/src/remote/CMakeLists.txt
@@ -31,6 +31,7 @@ add_library(amrexplorer_remote
     Codec.hpp
     Connection.cpp
     Frame.cpp
+    MemoryLimit.cpp
     RemoteDatasetSession.cpp
     Server.cpp
     "${amrexplorer_wire_generated}"

--- a/src/remote/MemoryLimit.cpp
+++ b/src/remote/MemoryLimit.cpp
@@ -7,6 +7,8 @@
 #include <filesystem>
 #include <fstream>
 #include <limits>
+#include <locale>
+#include <memory>
 #include <sstream>
 #include <stdexcept>
 #include <string_view>
@@ -178,8 +180,19 @@ std::optional<MemoryLimit> detectMemoryLimit()
     MemoryLimitInputs inputs;
     inputs.readFile = readFile;
     inputs.environment = [](const std::string& name) -> std::optional<std::string> {
+#ifdef _MSC_VER
+        char* value = nullptr;
+        std::size_t size = 0;
+        const auto error = _dupenv_s(&value, &size, name.c_str());
+        const std::unique_ptr<char, decltype(&std::free)> ownedValue(value, &std::free);
+        if (error != 0 || !ownedValue) {
+            return std::nullopt;
+        }
+        return std::string(ownedValue.get());
+#else
         const auto* value = std::getenv(name.c_str());
         return value ? std::optional<std::string>(value) : std::nullopt;
+#endif
     };
 #ifdef __linux__
     inputs.cgroupMembership = readFile("/proc/self/cgroup").value_or("");
@@ -197,9 +210,15 @@ std::optional<MemoryLimit> detectMemoryLimit()
 double parseCacheMemoryFraction(const std::string& text)
 {
     double value = 0;
-    const auto [end, error] = std::from_chars(text.data(), text.data() + text.size(), value);
-    if (error != std::errc{} || end != text.data() + text.size() || !std::isfinite(value) ||
-        value <= 0 || value > 1) {
+    // Older Apple libc++ versions lack floating-point from_chars. Keep parsing
+    // locale-independent and reject whitespace, hex, leading '+', and trailing text.
+    std::istringstream input(text);
+    input.imbue(std::locale::classic());
+    input >> std::noskipws >> value;
+    if (text.empty() || text.front() == '+' ||
+        text.find_first_not_of("0123456789.eE+-") != std::string::npos ||
+        input.fail() || !input.eof() ||
+        !std::isfinite(value) || value <= 0 || value > 1) {
         throw std::invalid_argument("--cache-memory-fraction must be greater than 0 and at most 1");
     }
     return value;

--- a/src/remote/MemoryLimit.cpp
+++ b/src/remote/MemoryLimit.cpp
@@ -1,0 +1,220 @@
+#include <amrexplorer/remote/MemoryLimit.hpp>
+
+#include <algorithm>
+#include <charconv>
+#include <cmath>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <limits>
+#include <sstream>
+#include <stdexcept>
+#include <string_view>
+#include <vector>
+
+#ifdef __linux__
+#include <unistd.h>
+#endif
+
+namespace amrvis::remote {
+namespace {
+std::optional<std::uint64_t> number(std::string_view text)
+{
+    while (!text.empty() && (text.back() == '\n' || text.back() == ' ')) {
+        text.remove_suffix(1);
+    }
+    std::uint64_t value = 0;
+    const auto [end, error] = std::from_chars(text.data(), text.data() + text.size(), value);
+    if (error != std::errc{} || end != text.data() + text.size()) {
+        return std::nullopt;
+    }
+    return value;
+}
+std::optional<std::uint64_t> multiply(std::uint64_t a, std::uint64_t b)
+{
+    if (b && a > std::numeric_limits<std::uint64_t>::max() / b) {
+        return std::nullopt;
+    }
+    return a * b;
+}
+bool contains(const std::string& list, const std::string& item)
+{
+    return ("," + list + ",").find("," + item + ",") != std::string::npos;
+}
+std::string unescape(const std::string& text)
+{
+    std::string result;
+    for (std::size_t i = 0; i < text.size(); ++i) {
+        if (text[i] == '\\' && i + 3 < text.size() && text[i + 1] >= '0' && text[i + 1] <= '7' &&
+            text[i + 2] >= '0' && text[i + 2] <= '7' && text[i + 3] >= '0' && text[i + 3] <= '7') {
+            result += static_cast<char>((text[i + 1] - '0') * 64 + (text[i + 2] - '0') * 8 +
+                                        text[i + 3] - '0');
+            i += 3;
+        } else {
+            result += text[i];
+        }
+    }
+    return result;
+}
+std::optional<std::string> readFile(const std::string& path)
+{
+    std::ifstream file(path);
+    if (!file) {
+        return std::nullopt;
+    }
+    std::string result;
+    char buffer[4096];
+    while (file.read(buffer, sizeof(buffer)) || file.gcount()) {
+        result.append(buffer, static_cast<std::size_t>(file.gcount()));
+        if (result.size() > 1024U * 1024U) {
+            return std::nullopt;
+        }
+    }
+    return result;
+}
+} // namespace
+
+std::optional<MemoryLimit> detectMemoryLimit(const MemoryLimitInputs& inputs)
+{
+    std::optional<MemoryLimit> result;
+    const auto bound = [&result](std::uint64_t bytes, const std::string& source) {
+        if (!result || bytes < result->bytes) {
+            result = MemoryLimit{bytes, source};
+        }
+    };
+    std::istringstream membership(inputs.cgroupMembership);
+    for (std::string line; std::getline(membership, line);) {
+        const auto first = line.find(':');
+        const auto second = line.find(':', first == std::string::npos ? 0 : first + 1);
+        if (first == std::string::npos || second == std::string::npos) {
+            continue;
+        }
+        const auto controllers = line.substr(first + 1, second - first - 1);
+        const bool v2 = controllers.empty();
+        if (!v2 && !contains(controllers, "memory")) {
+            continue;
+        }
+        const std::filesystem::path group = line.substr(second + 1);
+        if (!group.is_absolute()) {
+            continue;
+        }
+        std::istringstream mounts(inputs.mountInfo);
+        for (std::string mount; std::getline(mounts, mount);) {
+            const auto separator = mount.find(" - ");
+            if (separator == std::string::npos) {
+                continue;
+            }
+            std::istringstream tail(mount.substr(separator + 3));
+            std::string type, device, options;
+            tail >> type >> device >> options;
+            if (type != (v2 ? "cgroup2" : "cgroup") || (!v2 && !contains(options, "memory"))) {
+                continue;
+            }
+            std::istringstream head(mount.substr(0, separator));
+            std::string id, parent, majorMinor, rootText, mountText;
+            if (!(head >> id >> parent >> majorMinor >> rootText >> mountText)) {
+                continue;
+            }
+            const std::filesystem::path root = unescape(rootText);
+            const std::filesystem::path mountPoint = unescape(mountText);
+            if (!root.is_absolute() || !mountPoint.is_absolute()) {
+                continue;
+            }
+            const auto relative = group.lexically_relative(root);
+            if (relative.empty() ||
+                std::find(relative.begin(), relative.end(), "..") != relative.end()) {
+                continue;
+            }
+            auto directory = (mountPoint / relative).lexically_normal();
+            // The task may be unlimited while a job/step ancestor is limited.
+            for (;;) {
+                const auto path = directory / (v2 ? "memory.max" : "memory.limit_in_bytes");
+                if (const auto content = inputs.readFile(path.string())) {
+                    if (const auto bytes = number(*content);
+                        bytes && (v2 || *bytes < (1ULL << 60U))) {
+                        bound(*bytes, path.string());
+                    }
+                }
+                if (directory == mountPoint || directory == directory.root_path()) {
+                    break;
+                }
+                directory = directory.parent_path();
+            }
+        }
+    }
+    const auto envNumber = [&inputs](const std::string& name) -> std::optional<std::uint64_t> {
+        const auto value = inputs.environment(name);
+        return value ? number(*value) : std::nullopt;
+    };
+    bool allNodeMemory = false;
+    if (const auto mib = envNumber("SLURM_MEM_PER_NODE")) {
+        allNodeMemory = *mib == 0;
+        if (const auto bytes = multiply(*mib, 1024ULL * 1024ULL); bytes && *bytes) {
+            bound(*bytes, "SLURM_MEM_PER_NODE");
+        }
+    }
+    if (const auto mib = envNumber("SLURM_MEM_PER_CPU")) {
+        // CPUs assigned on this node, not total CPUs across the allocation.
+        if (const auto cpus = envNumber("SLURM_CPUS_ON_NODE")) {
+            if (const auto total = multiply(*mib, *cpus)) {
+                if (const auto bytes = multiply(*total, 1024ULL * 1024ULL); bytes && *bytes) {
+                    bound(*bytes, "SLURM_MEM_PER_CPU * SLURM_CPUS_ON_NODE");
+                }
+            }
+        }
+    }
+    // A Slurm job with no discoverable bound must not inherit the full RAM of
+    // a shared node. --mem=0 explicitly requests all node memory.
+    const bool slurm = inputs.environment("SLURM_JOB_ID").has_value() ||
+                       inputs.environment("SLURM_JOBID").has_value();
+    if (inputs.physicalBytes && (result || !slurm || allNodeMemory)) {
+        bound(*inputs.physicalBytes, "physical memory");
+    }
+    return result;
+}
+
+std::optional<MemoryLimit> detectMemoryLimit()
+{
+    MemoryLimitInputs inputs;
+    inputs.readFile = readFile;
+    inputs.environment = [](const std::string& name) -> std::optional<std::string> {
+        const auto* value = std::getenv(name.c_str());
+        return value ? std::optional<std::string>(value) : std::nullopt;
+    };
+#ifdef __linux__
+    inputs.cgroupMembership = readFile("/proc/self/cgroup").value_or("");
+    inputs.mountInfo = readFile("/proc/self/mountinfo").value_or("");
+    const auto pages = ::sysconf(_SC_PHYS_PAGES);
+    const auto pageSize = ::sysconf(_SC_PAGESIZE);
+    if (pages > 0 && pageSize > 0) {
+        inputs.physicalBytes =
+            multiply(static_cast<std::uint64_t>(pages), static_cast<std::uint64_t>(pageSize));
+    }
+#endif
+    return detectMemoryLimit(inputs);
+}
+
+double parseCacheMemoryFraction(const std::string& text)
+{
+    double value = 0;
+    const auto [end, error] = std::from_chars(text.data(), text.data() + text.size(), value);
+    if (error != std::errc{} || end != text.data() + text.size() || !std::isfinite(value) ||
+        value <= 0 || value > 1) {
+        throw std::invalid_argument("--cache-memory-fraction must be greater than 0 and at most 1");
+    }
+    return value;
+}
+
+std::uint64_t cacheBytesForFraction(std::uint64_t bytes, double fraction)
+{
+    if (!std::isfinite(fraction) || fraction <= 0 || fraction > 1) {
+        throw std::invalid_argument("invalid cache memory fraction");
+    }
+    // Avoid an out-of-range conversion when uint64_max rounds up in double.
+    if (fraction == 1) {
+        return bytes;
+    }
+    const auto scaled = static_cast<long double>(bytes) * fraction;
+    return static_cast<std::uint64_t>(scaled);
+}
+} // namespace amrvis::remote

--- a/src/remote/Server.cpp
+++ b/src/remote/Server.cpp
@@ -324,11 +324,13 @@ ErrorData classifyError(const std::exception& error)
 class Session : public std::enable_shared_from_this<Session> {
 public:
     Session(std::unique_ptr<Channel> channel, ThreadPool& workers,
-        std::atomic<unsigned int>& rendersInFlight, const ServerOptions& options)
+        std::atomic<unsigned int>& rendersInFlight, const ServerOptions& options,
+        std::shared_ptr<SharedCacheBudget> cacheBudget)
         : m_channel(std::move(channel))
         , m_workers(workers)
         , m_rendersInFlight(rendersInFlight)
         , m_options(options)
+        , m_cacheBudget(std::move(cacheBudget))
         , m_handshakeDeadline(
               std::chrono::steady_clock::now() + options.handshakeTimeout)
         , m_maximumFrameBytes(options.maximumFrameBytes)
@@ -642,23 +644,18 @@ private:
             // failing the open -- a list written for another dataset must not
             // make this one unopenable.
             dataset = std::make_shared<LocalDatasetSession>(
-                resolveDatasetPath(open.path), id, open.cacheBudgetBytes,
-                cancellation, std::move(open.derivedFields));
-            // The operator's number, on its own. The constructor has just
-            // seeded the grid pool from cache_budget_bytes, which is the
-            // client's *block* cache budget -- a different pool holding
-            // different things, and no kind of ceiling for this one. Taking
-            // the smaller of the two would mean an operator could never set
-            // the grid pool above whatever the client asked for its blocks,
-            // a client with a small AMREXPLORER_CACHE_SIZE_MB would starve
-            // the pool until every render re-sampled from disk, and a peer
-            // that omitted the field (wire default 0) would zero it.
-            //
-            // So a client cannot ask for a smaller grid pool. That is a real
-            // gap, but it needs a wire field of its own rather than the
-            // block budget standing in for one.
+                resolveDatasetPath(open.path), id,
+                m_cacheBudget ? m_cacheBudget->limit() : open.cacheBudgetBytes, cancellation,
+                std::move(open.derivedFields));
+            if (m_cacheBudget) {
+                dataset->setSharedCacheBudget(m_cacheBudget);
+            }
+            // Volume grids have their own operator-selected per-dataset cap,
+            // independent of the client's block budget. In automatic mode
+            // both pools additionally draw from one server-wide allowance.
             static_cast<void>(dataset->setVolumeGridCacheBudget(
-                m_options.volumeGridCacheBytes));
+                m_cacheBudget ? std::min(m_options.volumeGridCacheBytes, m_cacheBudget->limit())
+                              : m_options.volumeGridCacheBytes));
             OpenedDataset opened;
             opened.id = id;
             opened.catalog = dataset->metadata();
@@ -1027,8 +1024,10 @@ private:
         const auto dataset = requireDataset(DatasetId{request->dataset_id});
         // The block pool only. setCacheBudget moves both, which is what a
         // local user setting one number wants -- but this number comes from
-        // the peer, and the grid pool answers to --volume-cache-mib alone.
-        static_cast<void>(dataset->setBlockCacheBudget(request->budget_bytes));
+        // the peer. Both pools also obey the shared allowance in auto mode.
+        static_cast<void>(dataset->setBlockCacheBudget(
+            m_cacheBudget ? std::min(request->budget_bytes, m_cacheBudget->limit())
+                          : request->budget_bytes));
         sendCache(envelope.request_id, *dataset);
     }
 
@@ -1275,6 +1274,7 @@ private:
     ThreadPool& m_workers;
     std::atomic<unsigned int>& m_rendersInFlight;
     ServerOptions m_options;
+    std::shared_ptr<SharedCacheBudget> m_cacheBudget;
     std::chrono::steady_clock::time_point m_handshakeDeadline;
     std::atomic<std::uint32_t> m_maximumFrameBytes;
     std::atomic_bool m_stopping{false};
@@ -1299,6 +1299,9 @@ public:
     // before either a listener or the worker pool exists.
     Impl(ServerOptions options, std::unique_ptr<Channel> channel)
         : m_options(validated(std::move(options)))
+        , m_cacheBudget(m_options.totalCacheBytes
+                  ? std::make_shared<SharedCacheBudget>(m_options.totalCacheBytes)
+                  : nullptr)
         , m_channel(std::move(channel))
         , m_listener(m_channel ? std::optional<Listener>{}
                                : std::optional<Listener>{
@@ -1340,7 +1343,7 @@ public:
                 auto socket = std::make_unique<Socket>(acceptConnection(
                     m_listener->socket, m_acceptStop.get_token()));
                 auto session = std::make_shared<Session>(
-                    std::move(socket), m_workers, m_rendersInFlight, m_options);
+                    std::move(socket), m_workers, m_rendersInFlight, m_options, m_cacheBudget);
                 std::scoped_lock lock(m_sessionsMutex);
                 std::erase_if(m_sessions,
                     [](const auto& worker) {
@@ -1460,7 +1463,7 @@ private:
                 return;
             }
             session = std::make_shared<Session>(
-                std::move(m_channel), m_workers, m_rendersInFlight, m_options);
+                std::move(m_channel), m_workers, m_rendersInFlight, m_options, m_cacheBudget);
             m_singleSession = session;
         }
         session->run();
@@ -1472,6 +1475,7 @@ private:
     };
 
     ServerOptions m_options;
+    std::shared_ptr<SharedCacheBudget> m_cacheBudget;
     std::unique_ptr<Channel> m_channel;
     std::optional<Listener> m_listener;
     // Before m_workers, deliberately: members die in reverse declaration

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -189,6 +189,10 @@ if(TARGET amrexplorer_remote)
         RUN_SERIAL TRUE
         TIMEOUT 120)
 
+    add_executable(test_memory_limit unit/test_memory_limit.cpp)
+    target_link_libraries(test_memory_limit PRIVATE amrexplorer::remote amrexplorer::warnings)
+    add_test(NAME memory_limit COMMAND test_memory_limit)
+
     add_executable(test_remote_codec unit/test_remote_codec.cpp)
     target_include_directories(test_remote_codec PRIVATE
         "${PROJECT_SOURCE_DIR}/src/remote"

--- a/tests/integration/test_remote_session.cpp
+++ b/tests/integration/test_remote_session.cpp
@@ -154,6 +154,46 @@ int main(int argc, char* argv[])
                     == localSlice.plane.physicalRegion,
             "local and remote slice values differ");
 
+        // One allowance across distinct connections, not a budget per peer.
+        // Size it to hold precisely this fixture's slice working set.
+        {
+            amrvis::remote::ServerOptions sharedOptions;
+            sharedOptions.workerCount = 2;
+            sharedOptions.totalCacheBytes = localDataset.cacheMetrics().residentBytes;
+            require(sharedOptions.totalCacheBytes > 0, "fixture has no cache footprint");
+            amrvis::remote::Server sharedServer(sharedOptions);
+            ServerThread sharedThread(sharedServer);
+            const auto connect = [&] {
+                return std::make_shared<amrvis::remote::Connection>(
+                    "127.0.0.1", sharedServer.port(),
+                    amrvis::remote::ConnectionOptions{.sessionToken = sharedServer.token()});
+            };
+            auto firstConnection = connect();
+            auto secondConnection = connect();
+            auto first = amrvis::remote::RemoteDatasetSession::open(firstConnection, argv[1], 1);
+            auto second = amrvis::remote::RemoteDatasetSession::open(secondConnection, argv[1], 1);
+            require(first->cacheMetrics().budgetBytes == sharedOptions.totalCacheBytes,
+                    "automatic budget did not replace tiny client default");
+            require(first->setCacheBudget(sharedOptions.totalCacheBytes * 10),
+                    "clamped update unexpectedly failed");
+            require(first->cacheMetrics().budgetBytes == sharedOptions.totalCacheBytes,
+                    "client raised the automatic cache allowance");
+            const auto read = [](auto& session) {
+                return std::get<amrvis::SliceQueryResult>(
+                    session->requestView(sliceRequest(*session, 8, 6)));
+            };
+            require(read(first).plane.values == slice.plane.values, "shared first slice differs");
+            require(read(first).metrics.blocksRead == 0, "first slice did not cache");
+            require(read(second).plane.values == slice.plane.values, "shared second slice differs");
+            require(read(first).metrics.blocksRead > 0,
+                    "other connection bypassed the shared limit instead of evicting");
+            // A smaller later client request remains meaningful.
+            require(first->setCacheBudget(sharedOptions.totalCacheBytes / 2),
+                    "smaller client budget failed");
+            require(first->cacheMetrics().budgetBytes == sharedOptions.totalCacheBytes / 2,
+                    "smaller client budget was ignored");
+        }
+
         // Protocol 1.4: a field computed on the server must be the same field
         // a local session computes. The definitions are installed in the same
         // order at both ends, so the derived field takes the same id, and the

--- a/tests/integration/test_remote_stdio.cpp
+++ b/tests/integration/test_remote_stdio.cpp
@@ -287,9 +287,8 @@ void inProcessOverSocketPair(const std::string& datasetPath)
 // The installed binary over pipes, as a wrapper script or a non-Linux sshd
 // would run it: distinct stdin and stdout, a ready line first, frames after,
 // exit 0 once the client hangs up.
-void subprocessOverPipes(
-    const std::string& datasetPath, const std::string& serverBinary)
-{
+void subprocessOverPipes(const std::string& datasetPath, const std::string& serverBinary,
+                         bool automaticCache = false) {
     using namespace amrvis::remote;
 
     int toServer[2] = {-1, -1};
@@ -304,6 +303,16 @@ void subprocessOverPipes(
         ::close(toServer[1]);
         ::close(fromServer[0]);
         ::close(fromServer[1]);
+        if (automaticCache) {
+            // Deterministic fallback on macOS; Linux may have a tighter
+            // cgroup limit, which the detector must still respect.
+            ::setenv("SLURM_MEM_PER_NODE", "1024", 1);
+            ::unsetenv("SLURM_MEM_PER_CPU");
+            ::execl(serverBinary.c_str(), serverBinary.c_str(), "--stdio",
+                    "--cache-memory-fraction", "0.5", "--threads", "2",
+                    static_cast<char*>(nullptr));
+            std::_Exit(127);
+        }
         ::execl(serverBinary.c_str(), serverBinary.c_str(), "--stdio",
             "--threads", "2", static_cast<char*>(nullptr));
         std::_Exit(127);
@@ -381,5 +390,6 @@ int main(int argc, char* argv[])
         std::filesystem::path(datasetPath).parent_path().c_str(), 1);
     inProcessOverSocketPair(datasetPath);
     subprocessOverPipes(datasetPath, argv[2]);
+    subprocessOverPipes(datasetPath, argv[2], true);
     return 0;
 }

--- a/tests/integration/test_remote_volume.cpp
+++ b/tests/integration/test_remote_volume.cpp
@@ -118,6 +118,24 @@ int main(int argc, char* argv[])
         const auto remoteRequest = requestFor(*remote);
         auto localRequest = remoteRequest;
         localRequest.dataset = local->id();
+        // Both block and sampled-grid caches must participate in the same
+        // allowance. Retained grids compete with block data on the next read.
+        {
+            constexpr std::uint64_t sharedBytes = 16ULL * 1024ULL * 1024ULL;
+            auto sharedBudget = std::make_shared<amrvis::SharedCacheBudget>(sharedBytes);
+            auto sharedLocal = std::make_shared<amrvis::LocalDatasetSession>(
+                std::filesystem::path(argv[1]), amrvis::DatasetId{991}, sharedBytes);
+            sharedLocal->setSharedCacheBudget(sharedBudget);
+            static_cast<void>(sharedLocal->renderVolume(requestFor(*sharedLocal)));
+            const auto blocks = sharedLocal->cacheMetrics().residentBytes;
+            const auto grids = sharedLocal->volumeGridCacheMetrics().residentBytes;
+            require(grids > 0, "shared grid did not cache");
+            require(sharedBudget->used() == blocks + grids,
+                    "shared allowance did not charge both blocks and volume grids");
+            sharedLocal->close();
+            require(sharedBudget->used() == 0, "closing dataset leaked shared charges");
+        }
+
         const auto remoteFrame = remote->renderVolume(remoteRequest);
         const auto localFrame = local->renderVolume(localRequest);
         require(remoteFrame.width == 96 && remoteFrame.height == 80

--- a/tests/unit/test_byte_lru_cache.cpp
+++ b/tests/unit/test_byte_lru_cache.cpp
@@ -19,6 +19,29 @@ void require(bool condition, const char* message)
 
 } // namespace
 
+// Fail the map's key copy after the LRU node was successfully allocated.
+struct FailingKey {
+    int value = 0;
+    std::shared_ptr<int> copies;
+    FailingKey() = default;
+    FailingKey(int v, std::shared_ptr<int> count) : value(v), copies(std::move(count)) { }
+    FailingKey(const FailingKey& other) : value(other.value), copies(other.copies)
+    {
+        if (copies && --*copies == 0) {
+            throw std::bad_alloc();
+        }
+    }
+    FailingKey(FailingKey&&) = default;
+    FailingKey& operator=(FailingKey&&) = default;
+    bool operator==(const FailingKey& other) const { return value == other.value; }
+};
+struct FailingKeyHash {
+    std::size_t operator()(const FailingKey& key) const noexcept
+    {
+        return std::hash<int>{}(key.value);
+    }
+};
+
 int main()
 {
     amrvis::ByteLruCache<int, std::string> cache(100);
@@ -222,6 +245,89 @@ int main()
             "the cache exceeded its budget under concurrency");
         require(snapshot.hits + snapshot.misses > 0,
             "the stress test recorded no cache accesses");
+    }
+
+    {
+        auto budget = std::make_shared<amrvis::SharedCacheBudget>(100);
+        amrvis::ByteLruCache<int, std::string> blocks(1000);
+        amrvis::ByteLruCache<int, int> grids(1000);
+        blocks.setSharedBudget(budget);
+        grids.setSharedBudget(budget);
+        auto block = blocks.insertAndPin(1, std::make_shared<const std::string>("data"), 60);
+        require(budget->used() == 60, "shared charge missing");
+        bool rejected = false;
+        try {
+            [[maybe_unused]] auto grid = grids.insertAndPin(1, std::make_shared<const int>(3), 50);
+        } catch (const amrvis::CacheBudgetExceeded&) {
+            rejected = true;
+        }
+        require(rejected && budget->used() == 60, "cross-cache pinned limit bypassed");
+        block = {};
+        auto grid = grids.insertAndPin(1, std::make_shared<const int>(3), 50);
+        require(budget->used() == 50 && !blocks.findAndPin(1), "cross-cache reclaim failed");
+        auto escaped = grid.value();
+        grid = {};
+        grids.clearUnpinned();
+        require(budget->used() == 50, "escaped payload lost its charge");
+        escaped.reset();
+        require(budget->used() == 0, "escaped payload leaked its charge");
+        auto old = blocks.insertAndPin(2, std::make_shared<const std::string>("old"), 70);
+        old = {};
+        auto replacement = blocks.insertAndPin(3, std::make_shared<const std::string>("new"), 80);
+        require(budget->used() == 80 && !blocks.findAndPin(2),
+                "local shared-pressure eviction failed");
+        replacement = {};
+        blocks.clearUnpinned();
+        require(budget->used() == 0, "clear leaked a shared charge");
+        std::shared_ptr<const int> survivor;
+        {
+            amrvis::ByteLruCache<int, int> temporary(100);
+            temporary.setSharedBudget(budget);
+            auto handle = temporary.insertAndPin(1, std::make_shared<const int>(7), 100);
+            survivor = handle.value();
+        }
+        require(budget->used() == 100, "cache destruction released a live payload charge");
+        survivor.reset();
+        require(budget->used() == 0, "cache destruction leaked a charge");
+    }
+    {
+        auto budget = std::make_shared<amrvis::SharedCacheBudget>(100);
+        std::vector<std::thread> workers;
+        for (int index = 0; index < 4; ++index) {
+            workers.emplace_back([budget] {
+                amrvis::ByteLruCache<int, int> workerCache(100);
+                workerCache.setSharedBudget(budget);
+                for (int i = 0; i < 1000; ++i) {
+                    try {
+                        auto handle = workerCache.insertAndPin(i, std::make_shared<const int>(i), 30);
+                        require(budget->used() <= 100,
+                                "concurrent shared admission exceeded limit");
+                    } catch (const amrvis::CacheBudgetExceeded&) {
+                    }
+                }
+            });
+        }
+        for (auto& worker : workers) {
+            worker.join();
+        }
+        require(budget->used() == 0, "concurrent caches leaked shared bytes");
+    }
+
+    {
+        auto budget = std::make_shared<amrvis::SharedCacheBudget>(100);
+        amrvis::ByteLruCache<FailingKey, int, FailingKeyHash> failureCache(100);
+        failureCache.setSharedBudget(budget);
+        bool failed = false;
+        try {
+            [[maybe_unused]] auto value = failureCache.insertAndPin(
+                FailingKey(1, std::make_shared<int>(2)), std::make_shared<const int>(1), 100);
+        } catch (const std::bad_alloc&) {
+            failed = true;
+        }
+        require(failed && budget->used() == 0 && failureCache.metrics().pinnedBytes == 0,
+            "failed insertion leaked a shared reservation");
+        auto value = failureCache.insertAndPin(FailingKey(2, nullptr), std::make_shared<const int>(2), 100);
+        require(*value == 2 && budget->used() == 100, "failed insertion corrupted the cache");
     }
 
     return 0;

--- a/tests/unit/test_memory_limit.cpp
+++ b/tests/unit/test_memory_limit.cpp
@@ -1,0 +1,88 @@
+#include <amrexplorer/remote/MemoryLimit.hpp>
+
+#include <cstdlib>
+#include <iostream>
+#include <limits>
+#include <map>
+#include <stdexcept>
+
+namespace {
+void require(bool condition, const char* message)
+{
+    if (!condition) {
+        std::cerr << "FAILED: " << message << '\n';
+        std::exit(1);
+    }
+}
+} // namespace
+
+int main()
+{
+    using namespace amrvis::remote;
+    constexpr std::uint64_t mib = 1024ULL * 1024ULL;
+    std::map<std::string, std::string> files, env;
+    MemoryLimitInputs inputs;
+    inputs.readFile = [&files](const std::string& path) -> std::optional<std::string> {
+        const auto it = files.find(path);
+        return it == files.end() ? std::nullopt : std::optional(it->second);
+    };
+    inputs.environment = [&env](const std::string& name) -> std::optional<std::string> {
+        const auto it = env.find(name);
+        return it == env.end() ? std::nullopt : std::optional(it->second);
+    };
+    inputs.physicalBytes = 1024 * mib;
+    require(detectMemoryLimit(inputs)->bytes == 1024 * mib, "physical fallback");
+    env["SLURM_JOB_ID"] = "123";
+    require(!detectMemoryLimit(inputs), "Slurm must not inherit the whole node");
+    env["SLURM_MEM_PER_NODE"] = "512";
+    require(detectMemoryLimit(inputs)->bytes == 512 * mib, "Slurm node memory units");
+    env["SLURM_MEM_PER_CPU"] = "32";
+    env["SLURM_CPUS_ON_NODE"] = "4";
+    require(detectMemoryLimit(inputs)->bytes == 128 * mib, "Slurm per-CPU bound");
+    env["SLURM_CPUS_ON_NODE"] = "4(x2)";
+    require(detectMemoryLimit(inputs)->bytes == 512 * mib, "malformed CPU count ignored");
+    env.erase("SLURM_MEM_PER_CPU");
+    inputs.cgroupMembership = "0::/jobs/123/step/task\n";
+    inputs.mountInfo = "29 23 0:26 / /sys/fs/cgroup rw - cgroup2 cgroup rw\n";
+    files["/sys/fs/cgroup/jobs/123/step/task/memory.max"] = "max\n";
+    files["/sys/fs/cgroup/jobs/123/memory.max"] = std::to_string(256 * mib);
+    require(detectMemoryLimit(inputs)->bytes == 256 * mib, "v2 ancestor limit");
+    files["/sys/fs/cgroup/jobs/123/step/memory.max"] = std::to_string(64 * mib);
+    require(detectMemoryLimit(inputs)->bytes == 64 * mib, "tightest v2 limit");
+    files["/sys/fs/cgroup/jobs/123/step/memory.max"] = "0";
+    require(detectMemoryLimit(inputs)->bytes == 0, "zero cgroup limit is binding");
+    files.clear();
+    inputs.mountInfo = "29 23 0:26 /jobs/123 /mounted\\040group rw - cgroup2 cgroup rw\n";
+    files["/mounted group/memory.max"] = "1000\n";
+    require(detectMemoryLimit(inputs)->bytes == 1000, "subtree mount and escaped path");
+    inputs.cgroupMembership = "0::/jobs/1234/task\n";
+    require(detectMemoryLimit(inputs)->bytes == 512 * mib, "mount root requires path boundary");
+    inputs.cgroupMembership = "5:cpu,memory:/jobs/123/task\n";
+    inputs.mountInfo = "29 23 0:26 / /sys/fs/cgroup/memory rw - cgroup cgroup rw,memory\n";
+    files["/sys/fs/cgroup/memory/jobs/123/task/memory.limit_in_bytes"] = "9223372036854771712\n";
+    files["/sys/fs/cgroup/memory/jobs/123/memory.limit_in_bytes"] = "4096\n";
+    require(detectMemoryLimit(inputs)->bytes == 4096, "v1 ancestor with unlimited leaf");
+    inputs.cgroupMembership.clear();
+    env["SLURM_MEM_PER_NODE"] = "18446744073709551615";
+    require(!detectMemoryLimit(inputs), "overflow is not a memory budget");
+    env["SLURM_MEM_PER_NODE"] = "0";
+    require(detectMemoryLimit(inputs)->bytes == 1024 * mib, "explicit all-node memory");
+    inputs.physicalBytes.reset();
+    env.clear();
+    require(!detectMemoryLimit(inputs), "unavailable detection");
+    for (const auto* invalid : {"", "0", "-0.5", "1.01", "nan", "inf", "0.5junk"}) {
+        bool rejected = false;
+        try {
+            static_cast<void>(parseCacheMemoryFraction(invalid));
+        } catch (const std::invalid_argument&) {
+            rejected = true;
+        }
+        require(rejected, "invalid fraction accepted");
+    }
+    require(cacheBytesForFraction(1024, parseCacheMemoryFraction("0.5")) == 512,
+            "fraction scaling");
+    require(cacheBytesForFraction(std::numeric_limits<std::uint64_t>::max(), 1) ==
+                std::numeric_limits<std::uint64_t>::max(),
+            "full uint64 budget");
+    require(cacheBytesForFraction(1, 0.5) == 0, "tiny allowance rounds down");
+}

--- a/tests/unit/test_memory_limit.cpp
+++ b/tests/unit/test_memory_limit.cpp
@@ -3,10 +3,16 @@
 #include <cstdlib>
 #include <iostream>
 #include <limits>
+#include <locale>
 #include <map>
 #include <stdexcept>
 
 namespace {
+class CommaDecimalPoint : public std::numpunct<char> {
+protected:
+    char do_decimal_point() const override { return ','; }
+};
+
 void require(bool condition, const char* message)
 {
     if (!condition) {
@@ -70,17 +76,28 @@ int main()
     inputs.physicalBytes.reset();
     env.clear();
     require(!detectMemoryLimit(inputs), "unavailable detection");
-    for (const auto* invalid : {"", "0", "-0.5", "1.01", "nan", "inf", "0.5junk"}) {
+    const auto previousLocale =
+        std::locale::global(std::locale(std::locale::classic(), new CommaDecimalPoint));
+    for (const auto* invalid : {"", "0", "-0.5", "1.01", "nan", "inf", "0.5junk",
+                                " 0.5", "0.5 ", "\t0.5", "0.5\n", "+0.5", "0,5",
+                                "0x1p-1", "1e", "1e9999", "1e-9999"}) {
         bool rejected = false;
         try {
             static_cast<void>(parseCacheMemoryFraction(invalid));
         } catch (const std::invalid_argument&) {
             rejected = true;
         }
+        if (!rejected) {
+            std::cerr << "Invalid fraction: '" << invalid << "'\n";
+        }
         require(rejected, "invalid fraction accepted");
     }
     require(cacheBytesForFraction(1024, parseCacheMemoryFraction("0.5")) == 512,
             "fraction scaling");
+    require(parseCacheMemoryFraction("5e-1") == 0.5, "scientific notation fraction");
+    require(parseCacheMemoryFraction(".5") == 0.5, "fraction without leading zero");
+    require(parseCacheMemoryFraction("1") == 1, "full fraction");
+    std::locale::global(previousLocale);
     require(cacheBytesForFraction(std::numeric_limits<std::uint64_t>::max(), 1) ==
                 std::numeric_limits<std::uint64_t>::max(),
             "full uint64 budget");

--- a/tools/amrexplorer_server/main.cpp
+++ b/tools/amrexplorer_server/main.cpp
@@ -1,5 +1,6 @@
 #include <amrexplorer/core/StopToken.hpp>
 #include <amrexplorer/core/Version.hpp>
+#include <amrexplorer/remote/MemoryLimit.hpp>
 #include <amrexplorer/remote/Server.hpp>
 
 #include <cerrno>
@@ -9,6 +10,7 @@
 #include <cstdlib>
 #include <iostream>
 #include <limits>
+#include <optional>
 #include <stdexcept>
 #include <string>
 #include <thread>
@@ -46,6 +48,10 @@ void printUsage(std::ostream& output)
         << "                       defaults to the 512^3 ceiling, so this is\n"
         << "                       only for tightening. A request asking for\n"
         << "                       more is clamped, not refused\n"
+        << "  --cache-memory-fraction FRACTION\n"
+        << "                       auto-size a shared block/grid cache allowance\n"
+        << "                       from the process memory limit (0 < value <= 1);\n"
+        << "                       for example 0.5; fails if detection is unavailable\n"
         << "  --volume-cache-mib MIB\n"
         << "                       per-dataset cache of sampled volume grids\n"
         << "  --write-stall-timeout-seconds SECONDS\n"
@@ -188,6 +194,7 @@ int main(int argc, char* argv[])
         amrvis::remote::ServerOptions options;
         // Whether either volume limit was given, for the warning below.
         bool volumeLimitsChosen = false;
+        std::optional<double> cacheMemoryFraction;
         // The same string --version prints, git description and all: it
         // reaches the client in the handshake, which is the one place where
         // "which build is running over there" is otherwise unanswerable.
@@ -214,7 +221,9 @@ int main(int argc, char* argv[])
                     "missing value after " + option);
             }
             const auto* value = argv[++index];
-            if (option == "--port") {
+            if (option == "--cache-memory-fraction") {
+                cacheMemoryFraction = amrvis::remote::parseCacheMemoryFraction(value);
+            } else if (option == "--port") {
                 options.port
                     = parseUnsigned<std::uint16_t>(value, "--port");
                 portGiven = true;
@@ -323,6 +332,21 @@ int main(int argc, char* argv[])
                          "--max-volume-voxels voxels, so a request asking for "
                          "that many will render uncached every time; smaller "
                          "requests still cache normally\n";
+        }
+
+        if (cacheMemoryFraction) {
+            const auto memory = amrvis::remote::detectMemoryLimit();
+            if (!memory) {
+                throw std::runtime_error("cannot detect the job/process memory limit; "
+                                         "check cgroup visibility or Slurm memory variables");
+            }
+            options.totalCacheBytes =
+                amrvis::remote::cacheBytesForFraction(memory->bytes, *cacheMemoryFraction);
+            if (!options.totalCacheBytes) {
+                throw std::runtime_error("cache memory fraction produces a zero-byte allowance");
+            }
+            std::cerr << "memory limit: " << memory->bytes << " bytes (" << memory->source
+                      << "); shared cache allowance: " << options.totalCacheBytes << " bytes\n";
         }
 
         std::signal(SIGINT, handleSignal);


### PR DESCRIPTION
A remote server currently starts each dataset's block cache with the client's budget (normally 1 GiB), regardless of the memory allocated to its Slurm job. This adds opt-in `--cache-memory-fraction 0.5`: the server detects its memory allowance after `srun` launches it and assigns half to cached payloads shared across all datasets and connections.

Linux detection resolves the process's cgroup v1/v2 mount and checks visible ancestor limits, combines those with available Slurm per-node/per-CPU memory information, and bounds the result by physical RAM. A Slurm job with no discoverable limit fails startup instead of assuming it owns the whole node. The detected source and resulting allowance are logged to stderr without disturbing the stdio protocol.

Block and volume-grid caches share admission accounting and reclaim unpinned entries under pressure. Payloads remain charged while requests or escaped shared references retain them, including after dataset closure. Initial block budgets use the detected allowance; subsequent client requests are capped by it. The existing per-dataset volume-grid cap still applies. Omitting the option preserves existing behavior.

Includes a new Slurm workflow guide with a named-allocation launcher, a Riker example, automatic-sizing instructions, cleanup, and troubleshooting, linked from the README and bundled help.

Validation:
- macOS Release builds of the server and Qt client, with compiler warnings treated as errors.
- 17 focused CTest cases passed, including fixtures, memory detection, shared-cache concurrency and allocation-failure rollback, cross-connection reclamation, combined block/grid accounting, the real server over stdio, and existing local query/pipeline regressions.
- Standalone AddressSanitizer/UndefinedBehaviorSanitizer runs passed for the cache and memory-detection tests.
- Bash example syntax, local documentation/resource paths, and whitespace checks passed.

The allowance bounds cached payloads, not process RSS: temporary reads, rendering buffers, particles, and other job processes still require headroom. Detection runs once at startup. Linux hierarchy cases are tested through injected OS inputs; a live Slurm/Riker allocation has not been tested locally.
