### PR TITLE
Let the 3-D camera tumble past the poles

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -207,8 +207,8 @@ The main controls are:
    the screen does not show the same length per pixel along both axes (see
    [Aspect ratio and axis scaling](#aspect-ratio-and-axis-scaling)).
 6. **Isometric view** shows the domain, grid boxes, and current slice planes;
-   **View > Volume Rendering...** opens the same view with the field
-   ray-cast into it.
+   drag to rotate and wheel to zoom. **View > Volume Rendering...** opens the
+   same view with the field ray-cast into it.
 7. **Color Scale** reports the active value-to-color mapping.
 8. **Animation** controls a 3-D plane sweep or an open plotfile sequence.
 
@@ -451,6 +451,8 @@ line of sight, so translucent structure inside the domain shows through. The
 window has its own copy of the isometric view -- drag to rotate, wheel
 to zoom, and the **XY**, **XZ**, **YZ** buttons for the axis-aligned views --
 with the domain outline and the slice planes drawn over the rendered volume.
+A drag tumbles the view freely past the top and the bottom, so the domain,
+the volume and the isosurface can be seen from underneath.
 The AMR grid boxes can be drawn too, though they start off here.
 
 The window follows the main window: the field, the AMR level, the range mode

--- a/src/qt/IsoWidget.cpp
+++ b/src/qt/IsoWidget.cpp
@@ -24,6 +24,14 @@ namespace {
 
 constexpr double pi = 3.14159265358979323846;
 
+// An angle brought into (-pi, pi]: the rotation is periodic, and a long drag
+// would otherwise run the numbers off without bound.
+double wrapAngle(double angle) noexcept
+{
+    const auto turns = std::floor((angle + pi) / (2.0 * pi));
+    return angle - turns * 2.0 * pi;
+}
+
 // Cube corner indexing: bit 0 = x side, bit 1 = y side, bit 2 = z side.
 constexpr std::array<std::array<int, 2>, 12> boxEdges{{
     {{0, 1}}, {{2, 3}}, {{4, 5}}, {{6, 7}},
@@ -376,10 +384,17 @@ void IsoWidget::mouseMoveEvent(QMouseEvent* event)
         // while a drag right slid the near face left -- which reads as the
         // horizontal being backwards, since the vertical is what everything
         // else does too.
-        m_camera.azimuth += static_cast<double>(delta.x()) * sensitivity;
-        m_camera.elevation += static_cast<double>(delta.y()) * sensitivity;
-        m_camera.elevation = std::clamp(
-            m_camera.elevation, -pi / 2.0 + 0.01, pi / 2.0 - 0.01);
+        // Neither angle is limited: a vertical drag tumbles the domain on
+        // through straight-up and straight-down and shows it upside down,
+        // where a horizontal drag, still a turn about the world z axis,
+        // reads the other way on screen -- the nature of an azimuth and
+        // elevation camera, not a fault. The projection, the ray caster and
+        // the wire take any angle; only the drag once stopped short of the
+        // poles.
+        m_camera.azimuth = wrapAngle(
+            m_camera.azimuth + static_cast<double>(delta.x()) * sensitivity);
+        m_camera.elevation = wrapAngle(
+            m_camera.elevation + static_cast<double>(delta.y()) * sensitivity);
         update();
         emit cameraChanged();
         event->accept();

--- a/tests/unit/test_ortho_projection.cpp
+++ b/tests/unit/test_ortho_projection.cpp
@@ -77,6 +77,23 @@ int main()
             "the axis indicator draws +z downward while the view draws it up");
     }
 
+    // Past a pole the camera tumbles on rather than stopping: from the XZ
+    // preset, half a radian short of the pole +y still points up and the +z
+    // face is in front of the viewer; half a radian past it +y hangs down and
+    // the +z face is behind, the domain seen from underneath. The drag no
+    // longer stops at the pole, so the projection must carry on through it.
+    {
+        const auto shortOf = amrvis::OrthoCamera{0.0, -pi / 2.0 + 0.5, 1.0};
+        const auto past = amrvis::OrthoCamera{0.0, -pi / 2.0 - 0.5, 1.0};
+        require(amrvis::projectDirection(shortOf, point(0.0, 1.0, 0.0)).y < 0.0
+                && amrvis::projectDirection(past, point(0.0, 1.0, 0.0)).y > 0.0,
+            "tumbling past the pole did not turn the domain upside down");
+        const auto ceiling = point(1.0, 0.5, 1.0);
+        require(amrvis::projectPoint(shortOf, frame, domain, ceiling).depth > 0.0
+                && amrvis::projectPoint(past, frame, domain, ceiling).depth < 0.0,
+            "tumbling past the pole did not carry the +z face behind the viewer");
+    }
+
     // Pinned from the iso view's projection formula: the upper corner under
     // azimuth 30 deg, elevation 30 deg, zoom 1.
     const amrvis::OrthoCamera oblique{30.0 * pi / 180.0, 30.0 * pi / 180.0, 1.0};
@@ -130,7 +147,8 @@ int main()
     // domain, and points away from the viewer (toward decreasing depth).
     for (const auto& camera : {oblique, zoomed, amrvis::orthoPresetXY,
              amrvis::orthoPresetXZ, amrvis::orthoPresetYZ,
-             amrvis::OrthoCamera{-2.3, 1.1, 0.7}}) {
+             amrvis::OrthoCamera{-2.3, 1.1, 0.7}, amrvis::OrthoCamera{0.4, 2.0, 1.0},
+             amrvis::OrthoCamera{-1.0, -2.5, 1.3}}) {
         for (const auto& target : {point(2.0, 1.0, 1.0), point(0.0, 0.0, 0.0),
                  point(1.3, 0.2, 0.9), point(1.0, 0.5, 0.5)}) {
             const auto projected = amrvis::projectPoint(

--- a/tests/unit/test_volume_controller.cpp
+++ b/tests/unit/test_volume_controller.cpp
@@ -1658,6 +1658,30 @@ int main(int argc, char** argv)
             settle(application, 500);
             waitFor(application, [&] { return !controller.renderInFlight(); },
                 "the renders from the drags did not finish");
+
+            // A drag is not stopped at the poles: 300 px down from the
+            // default view carries the elevation past straight-down, and +z,
+            // drawn upward before, hangs downward -- the domain seen from
+            // underneath. The same drag back restores it, and a drag of any
+            // length leaves both angles wrapped into (-pi, pi].
+            constexpr double kPi = 3.14159265358979323846;
+            const amrvis::Real3 up{{0.0, 0.0, 1.0}};
+            require(amrvis::projectDirection(view->camera(), up).y < 0.0,
+                "the view does not start with +z upward");
+            dragBy(0, 300);
+            require(std::abs(view->camera().elevation) > kPi / 2.0
+                    && amrvis::projectDirection(view->camera(), up).y > 0.0,
+                "a vertical drag stopped at the pole instead of tumbling past it");
+            dragBy(0, -300);
+            require(amrvis::projectDirection(view->camera(), up).y < 0.0,
+                "dragging back did not bring +z upward again");
+            dragBy(2000, 2000);
+            require(std::abs(view->camera().azimuth) <= kPi
+                    && std::abs(view->camera().elevation) <= kPi,
+                "a long drag ran the camera angles off without bound");
+            settle(application, 500);
+            waitFor(application, [&] { return !controller.renderInFlight(); },
+                "the renders from the tumble did not finish");
         }
         controller.closeWindow();
     }


### PR DESCRIPTION
A drag no longer stops the elevation short of straight-up and straight-down; both angles wrap into (-pi, pi]. The box array, the volume and the isosurface share the camera, so all three can be seen from underneath.